### PR TITLE
feat: adicionar componentes base (Button, Typography, Icon, Spinner)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { PermissionsPage } from './pages/PermissionsPage';
 import { PlaceholderPage } from './pages/PlaceholderPage';
 import { RolesPage } from './pages/RolesPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { ShowcasePage } from './pages/ShowcasePage';
 import { SystemsPage } from './pages/SystemsPage';
 import { UsersPage } from './pages/UsersPage';
 
@@ -55,6 +56,7 @@ const PAGE_TITLES: Record<NavId, string> = {
   users:    'Usuários',
   tokens:   'Tokens',
   settings: 'Configurações',
+  showcase: 'Showcase UI',
 };
 
 interface AuthUser {
@@ -75,6 +77,8 @@ function renderPage(page: NavId): React.ReactNode {
       return <PermissionsPage />;
     case 'settings':
       return <SettingsPage />;
+    case 'showcase':
+      return <ShowcasePage />;
     case 'routes':
       return (
         <PlaceholderPage

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -6,13 +6,22 @@ import {
   User,
   Activity,
   Settings,
+  Component,
 } from 'lucide-react';
 import React from 'react';
 import styled from 'styled-components';
 
 import logoDark from '../../assets/logo-dark.svg';
 
-export type NavId = 'systems' | 'routes' | 'roles' | 'perms' | 'users' | 'tokens' | 'settings';
+export type NavId =
+  | 'systems'
+  | 'routes'
+  | 'roles'
+  | 'perms'
+  | 'users'
+  | 'tokens'
+  | 'settings'
+  | 'showcase';
 
 interface NavItem {
   id: NavId;
@@ -29,6 +38,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'users',    num: '05', label: 'Usuários',       icon: <User size={15} strokeWidth={1.5} /> },
   { id: 'tokens',   num: '06', label: 'Tokens',         icon: <Activity size={15} strokeWidth={1.5} /> },
   { id: 'settings', num: '07', label: 'Configurações',  icon: <Settings size={15} strokeWidth={1.5} /> },
+  { id: 'showcase', num: '08', label: 'Showcase UI',     icon: <Component size={15} strokeWidth={1.5} /> },
 ];
 
 interface SidebarProps {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,7 +30,7 @@ interface NavItem {
   icon: React.ReactNode;
 }
 
-const NAV_ITEMS: NavItem[] = [
+const ALL_NAV_ITEMS: NavItem[] = [
   { id: 'systems',  num: '01', label: 'Sistemas',       icon: <Monitor size={15} strokeWidth={1.5} /> },
   { id: 'routes',   num: '02', label: 'Rotas',          icon: <Shuffle size={15} strokeWidth={1.5} /> },
   { id: 'roles',    num: '03', label: 'Roles',          icon: <Users size={15} strokeWidth={1.5} /> },
@@ -40,6 +40,12 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'settings', num: '07', label: 'Configurações',  icon: <Settings size={15} strokeWidth={1.5} /> },
   { id: 'showcase', num: '08', label: 'Showcase UI',     icon: <Component size={15} strokeWidth={1.5} /> },
 ];
+
+// Showcase UI eh pagina de demonstracao interna do design system —
+// expor apenas em build de desenvolvimento para nao poluir producao.
+const NAV_ITEMS: NavItem[] = ALL_NAV_ITEMS.filter(
+  item => item.id !== 'showcase' || import.meta.env.DEV,
+);
 
 interface SidebarProps {
   current: NavId;

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renderiza children e dispara onClick', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Salvar</Button>);
+    const node = screen.getByRole('button', { name: 'Salvar' });
+    fireEvent.click(node);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('é desabilitado quando disabled=true', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button disabled onClick={handleClick}>
+        Indisponível
+      </Button>,
+    );
+    const node = screen.getByRole('button', { name: 'Indisponível' });
+    expect(node).toBeDisabled();
+    fireEvent.click(node);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('aplica aria-busy e bloqueia clique quando loading=true', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button loading onClick={handleClick}>
+        Carregando
+      </Button>,
+    );
+    const node = screen.getByRole('button');
+    expect(node).toHaveAttribute('aria-busy', 'true');
+    expect(node).toBeDisabled();
+    fireEvent.click(node);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renderiza Spinner quando loading=true', () => {
+    render(<Button loading>Aguarde</Button>);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it.each(['primary', 'secondary', 'ghost', 'danger'] as const)(
+    'renderiza variant %s sem quebrar',
+    variant => {
+      render(<Button variant={variant}>{variant}</Button>);
+      expect(screen.getByRole('button', { name: variant })).toBeInTheDocument();
+    },
+  );
+
+  it.each(['sm', 'md', 'lg'] as const)('renderiza size %s sem quebrar', size => {
+    render(<Button size={size}>btn-{size}</Button>);
+    expect(screen.getByRole('button', { name: `btn-${size}` })).toBeInTheDocument();
+  });
+
+  it('é do tipo button por padrão (não submit)', () => {
+    render(<Button>Default</Button>);
+    expect(screen.getByRole('button', { name: 'Default' })).toHaveAttribute('type', 'button');
+  });
+});

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -110,7 +110,7 @@ const StyledButton = styled.button<{
   gap: var(--space-2);
   font-family: var(--font-sans);
   font-weight: var(--weight-medium);
-  border: 1px solid transparent;
+  border: var(--border-thin) solid transparent;
   cursor: pointer;
   letter-spacing: var(--tracking-tight);
   line-height: var(--leading-tight);
@@ -129,7 +129,7 @@ const StyledButton = styled.button<{
   }
 
   &:active:not(:disabled) {
-    transform: translateY(1px);
+    transform: translateY(var(--press-offset));
   }
 
   &:disabled {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,10 +3,25 @@ import styled, { css } from 'styled-components';
 
 import { Spinner } from './Spinner';
 
+/**
+ * Variantes visuais do Button.
+ *
+ * - `primary`: ação principal (CTA), destaque máximo.
+ * - `secondary`: ação secundária neutra.
+ * - `ghost`: ação terciária sem fundo.
+ * - `danger`: legado — preservado por compat com páginas existentes
+ *   (ex.: `SettingsPage`). Para novas telas, prefira combinar
+ *   `secondary` com confirmação por modal.
+ */
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * Variante visual do botão.
+   *
+   * `danger` é tratado como legado — ver JSDoc de `ButtonVariant`.
+   */
   variant?: ButtonVariant;
   size?: ButtonSize;
   icon?: React.ReactNode;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
+import { Spinner } from './Spinner';
+
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
@@ -8,27 +10,31 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   icon?: React.ReactNode;
+  loading?: boolean;
 }
 
-const sizeStyles = {
+const sizeStyles: Record<ButtonSize, ReturnType<typeof css>> = {
   sm: css`
-    padding: 5px 10px;
-    font-size: 12.5px;
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
     border-radius: var(--radius-sm);
+    min-height: var(--space-8);
   `,
   md: css`
-    padding: 8px 14px;
-    font-size: 13.5px;
+    padding: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
     border-radius: var(--radius-md);
+    min-height: var(--space-10);
   `,
   lg: css`
-    padding: 11px 18px;
-    font-size: 15px;
+    padding: var(--space-3) var(--space-5);
+    font-size: var(--text-base);
     border-radius: var(--radius-md);
+    min-height: var(--space-12);
   `,
 };
 
-const variantStyles = {
+const variantStyles: Record<ButtonVariant, ReturnType<typeof css>> = {
   primary: css`
     background: var(--clr-lime);
     color: var(--clr-forest);
@@ -59,7 +65,7 @@ const variantStyles = {
       background: var(--bg-overlay);
     }
     &:focus-visible {
-      box-shadow: 0 0 0 3px color-mix(in srgb, var(--border-strong) 60%, transparent);
+      box-shadow: var(--focus-ring-border);
     }
   `,
   ghost: css`
@@ -75,7 +81,7 @@ const variantStyles = {
       background: var(--bg-ghost-active);
     }
     &:focus-visible {
-      box-shadow: 0 0 0 3px color-mix(in srgb, var(--border-strong) 60%, transparent);
+      box-shadow: var(--focus-ring-border);
     }
   `,
   danger: css`
@@ -93,26 +99,30 @@ const variantStyles = {
   `,
 };
 
-const StyledButton = styled.button<{ $variant: ButtonVariant; $size: ButtonSize }>`
+const StyledButton = styled.button<{
+  $variant: ButtonVariant;
+  $size: ButtonSize;
+  $loading: boolean;
+}>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: var(--space-2);
   font-family: var(--font-sans);
   font-weight: var(--weight-medium);
   border: 1px solid transparent;
   cursor: pointer;
-  letter-spacing: -0.005em;
-  line-height: 1.2;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
   white-space: nowrap;
   user-select: none;
   position: relative;
   transition:
-    background 140ms var(--ease-default),
-    border-color 140ms var(--ease-default),
-    color 140ms var(--ease-default),
-    transform 80ms var(--ease-default),
-    box-shadow 140ms var(--ease-default);
+    background var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default),
+    color var(--duration-fast) var(--ease-default),
+    transform var(--duration-fast) var(--ease-default),
+    box-shadow var(--duration-fast) var(--ease-default);
 
   &:focus-visible {
     outline: none;
@@ -128,19 +138,80 @@ const StyledButton = styled.button<{ $variant: ButtonVariant; $size: ButtonSize 
     pointer-events: none;
   }
 
+  ${({ $loading }) =>
+    $loading &&
+    css`
+      cursor: progress;
+    `}
+
   ${({ $size }) => sizeStyles[$size]}
   ${({ $variant }) => variantStyles[$variant]}
 `;
+
+const ContentLayer = styled.span<{ $hidden: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  visibility: ${({ $hidden }) => ($hidden ? 'hidden' : 'visible')};
+  pointer-events: none;
+`;
+
+const SpinnerLayer = styled.span`
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;
+
+const spinnerToneByVariant: Record<ButtonVariant, 'inverse' | 'accent' | 'currentColor'> = {
+  primary: 'currentColor',
+  secondary: 'accent',
+  ghost: 'currentColor',
+  danger: 'currentColor',
+};
+
+const spinnerSizeByButton: Record<ButtonSize, 'sm' | 'md'> = {
+  sm: 'sm',
+  md: 'sm',
+  lg: 'md',
+};
 
 export const Button: React.FC<ButtonProps> = ({
   variant = 'primary',
   size = 'md',
   icon,
+  loading = false,
+  disabled,
   children,
+  type = 'button',
   ...props
-}) => (
-  <StyledButton $variant={variant} $size={size} {...props}>
-    {icon}
-    {children}
-  </StyledButton>
-);
+}) => {
+  const isDisabled = disabled || loading;
+
+  return (
+    <StyledButton
+      $variant={variant}
+      $size={size}
+      $loading={loading}
+      type={type}
+      disabled={isDisabled}
+      aria-busy={loading || undefined}
+      aria-disabled={isDisabled || undefined}
+      {...props}
+    >
+      <ContentLayer $hidden={loading}>
+        {icon}
+        {children}
+      </ContentLayer>
+      {loading && (
+        <SpinnerLayer>
+          <Spinner size={spinnerSizeByButton[size]} tone={spinnerToneByVariant[variant]} />
+        </SpinnerLayer>
+      )}
+    </StyledButton>
+  );
+};
+
+export type { ButtonProps, ButtonVariant, ButtonSize };

--- a/src/components/ui/Icon.test.tsx
+++ b/src/components/ui/Icon.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { Check } from 'lucide-react';
+import { describe, expect, it } from 'vitest';
+
+import { Icon } from './Icon';
+
+describe('Icon', () => {
+  it('renderiza decorativo (aria-hidden) quando não há title', () => {
+    const { container } = render(<Icon icon={Check} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('expõe role="img" quando title é fornecido', () => {
+    render(<Icon icon={Check} title="Sucesso" />);
+    const node = screen.getByRole('img', { name: 'Sucesso' });
+    expect(node).toBeInTheDocument();
+  });
+
+  it.each(['xs', 'sm', 'md', 'lg', 'xl'] as const)('renderiza tamanho %s sem quebrar', size => {
+    const { container } = render(<Icon icon={Check} size={size} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import type { LucideIcon } from 'lucide-react';
+
+type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type IconTone =
+  | 'primary'
+  | 'secondary'
+  | 'muted'
+  | 'disabled'
+  | 'inverse'
+  | 'accent'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'success'
+  | 'currentColor';
+
+interface IconProps {
+  /** Componente de ícone exportado por `lucide-react`. */
+  icon: LucideIcon;
+  /** Tamanho semântico mapeado a tokens de tipografia. */
+  size?: IconSize;
+  /** Cor semântica mapeada a tokens. */
+  tone?: IconTone;
+  /** Espessura do traço (proporcional ao tamanho). */
+  strokeWidth?: number;
+  /** Texto alternativo. Quando omitido, o ícone é tratado como decorativo (`aria-hidden`). */
+  title?: string;
+  className?: string;
+}
+
+const sizeMap: Record<IconSize, string> = {
+  xs: 'var(--text-xs)',
+  sm: 'var(--text-sm)',
+  md: 'var(--text-md)',
+  lg: 'var(--text-lg)',
+  xl: 'var(--text-xl)',
+};
+
+const toneMap: Record<IconTone, string> = {
+  primary: 'var(--text-primary)',
+  secondary: 'var(--text-secondary)',
+  muted: 'var(--text-muted)',
+  disabled: 'var(--text-disabled)',
+  inverse: 'var(--fg-inverse)',
+  accent: 'var(--accent-ink)',
+  danger: 'var(--danger)',
+  warning: 'var(--warning)',
+  info: 'var(--info)',
+  success: 'var(--accent-ink)',
+  currentColor: 'currentColor',
+};
+
+const IconWrapper = styled.span<{ $size: IconSize; $tone: IconTone }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: ${({ $size }) => sizeMap[$size]};
+  height: ${({ $size }) => sizeMap[$size]};
+  color: ${({ $tone }) => toneMap[$tone]};
+  flex-shrink: 0;
+  line-height: 0;
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+`;
+
+export const Icon: React.FC<IconProps> = ({
+  icon: IconComponent,
+  size = 'md',
+  tone = 'currentColor',
+  strokeWidth = 1.6,
+  title,
+  className,
+}) => {
+  const decorative = !title;
+
+  return (
+    <IconWrapper $size={size} $tone={tone} className={className}>
+      <IconComponent
+        strokeWidth={strokeWidth}
+        aria-hidden={decorative ? true : undefined}
+        role={decorative ? undefined : 'img'}
+        focusable={false}
+      >
+        {!decorative && <title>{title}</title>}
+      </IconComponent>
+    </IconWrapper>
+  );
+};
+
+export type { IconProps, IconSize, IconTone };

--- a/src/components/ui/Spinner.test.tsx
+++ b/src/components/ui/Spinner.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('expõe role status com label padrão', () => {
+    render(<Spinner />);
+    const node = screen.getByRole('status', { name: 'Carregando' });
+    expect(node).toBeInTheDocument();
+  });
+
+  it('aceita label customizado para acessibilidade', () => {
+    render(<Spinner label="Salvando alterações" />);
+    expect(screen.getByRole('status', { name: 'Salvando alterações' })).toBeInTheDocument();
+  });
+
+  it.each(['sm', 'md', 'lg'] as const)('renderiza tamanho %s sem quebrar', size => {
+    render(<Spinner size={size} label={`spinner-${size}`} />);
+    expect(screen.getByRole('status', { name: `spinner-${size}` })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -19,17 +19,17 @@ const sizeStyles: Record<SpinnerSize, ReturnType<typeof css>> = {
   sm: css`
     width: var(--text-sm);
     height: var(--text-sm);
-    border-width: 1.5px;
+    border-width: var(--border-medium);
   `,
   md: css`
     width: var(--text-md);
     height: var(--text-md);
-    border-width: 2px;
+    border-width: var(--border-thick);
   `,
   lg: css`
     width: var(--text-xl);
     height: var(--text-xl);
-    border-width: 2.5px;
+    border-width: var(--border-thicker);
   `,
 };
 

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import styled, { css, keyframes } from 'styled-components';
+
+type SpinnerSize = 'sm' | 'md' | 'lg';
+type SpinnerTone = 'accent' | 'neutral' | 'inverse' | 'currentColor';
+
+interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'role' | 'aria-label'> {
+  size?: SpinnerSize;
+  tone?: SpinnerTone;
+  label?: string;
+}
+
+const rotate = keyframes`
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+`;
+
+const sizeStyles: Record<SpinnerSize, ReturnType<typeof css>> = {
+  sm: css`
+    width: var(--text-sm);
+    height: var(--text-sm);
+    border-width: 1.5px;
+  `,
+  md: css`
+    width: var(--text-md);
+    height: var(--text-md);
+    border-width: 2px;
+  `,
+  lg: css`
+    width: var(--text-xl);
+    height: var(--text-xl);
+    border-width: 2.5px;
+  `,
+};
+
+const toneColor: Record<SpinnerTone, string> = {
+  accent: 'var(--accent-ink)',
+  neutral: 'var(--text-muted)',
+  inverse: 'var(--fg-inverse)',
+  currentColor: 'currentColor',
+};
+
+const SpinnerWrapper = styled.span<{ $size: SpinnerSize; $tone: SpinnerTone }>`
+  display: inline-block;
+  flex-shrink: 0;
+  border-style: solid;
+  border-color: ${({ $tone }) => `color-mix(in srgb, ${toneColor[$tone]} 22%, transparent)`};
+  border-top-color: ${({ $tone }) => toneColor[$tone]};
+  border-radius: var(--radius-full);
+  animation: ${rotate} var(--duration-slower) linear infinite;
+
+  ${({ $size }) => sizeStyles[$size]}
+
+  @media (prefers-reduced-motion: reduce) {
+    animation-duration: calc(var(--duration-slower) * 4);
+  }
+`;
+
+export const Spinner: React.FC<SpinnerProps> = ({
+  size = 'md',
+  tone = 'accent',
+  label = 'Carregando',
+  ...props
+}) => (
+  <SpinnerWrapper
+    $size={size}
+    $tone={tone}
+    role="status"
+    aria-live="polite"
+    aria-label={label}
+    {...props}
+  />
+);
+
+export type { SpinnerProps, SpinnerSize, SpinnerTone };

--- a/src/components/ui/Typography.test.tsx
+++ b/src/components/ui/Typography.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Body, Caption, Heading, Label } from './Typography';
+
+describe('Typography.Heading', () => {
+  it('renderiza h1 por padrão', () => {
+    render(<Heading>Título</Heading>);
+    const node = screen.getByRole('heading', { level: 1, name: 'Título' });
+    expect(node.tagName).toBe('H1');
+  });
+
+  it.each([
+    [2, 'H2'],
+    [3, 'H3'],
+    [4, 'H4'],
+  ] as const)('renderiza tag h%i quando level=%i', (level, expectedTag) => {
+    render(<Heading level={level}>Título {level}</Heading>);
+    const node = screen.getByRole('heading', { level, name: `Título ${level}` });
+    expect(node.tagName).toBe(expectedTag);
+  });
+
+  it('respeita prop `as` para sobrescrever a tag semântica', () => {
+    render(
+      <Heading level={2} as="div">
+        Custom tag
+      </Heading>,
+    );
+    expect(screen.getByText('Custom tag').tagName).toBe('DIV');
+  });
+});
+
+describe('Typography.Body', () => {
+  it('renderiza um parágrafo por padrão', () => {
+    render(<Body>Texto corrido</Body>);
+    expect(screen.getByText('Texto corrido').tagName).toBe('P');
+  });
+
+  it('aplica modificador muted quando solicitado', () => {
+    render(<Body muted>Muted</Body>);
+    expect(screen.getByText('Muted')).toBeInTheDocument();
+  });
+});
+
+describe('Typography.Caption', () => {
+  it('renderiza como span', () => {
+    render(<Caption>Legenda</Caption>);
+    expect(screen.getByText('Legenda').tagName).toBe('SPAN');
+  });
+});
+
+describe('Typography.Label', () => {
+  it('renderiza um label HTML acessível', () => {
+    render(<Label htmlFor="campo">Nome</Label>);
+    const label = screen.getByText('Nome');
+    expect(label.tagName).toBe('LABEL');
+    expect(label).toHaveAttribute('for', 'campo');
+  });
+});

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+type HeadingLevel = 1 | 2 | 3 | 4;
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'div' | 'span' | 'p';
+type TextTag = 'p' | 'span' | 'div';
+
+interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  level?: HeadingLevel;
+  as?: HeadingTag;
+  children: React.ReactNode;
+}
+
+interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  as?: TextTag;
+  muted?: boolean;
+  children: React.ReactNode;
+}
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  children: React.ReactNode;
+}
+
+/* ─── Heading ─────────────────────────────────────────────── */
+
+const headingStyles: Record<HeadingLevel, ReturnType<typeof css>> = {
+  1: css`
+    font-size: var(--text-3xl);
+    font-weight: var(--weight-bold);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--leading-tight);
+  `,
+  2: css`
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--leading-tight);
+  `,
+  3: css`
+    font-size: var(--text-xl);
+    font-weight: var(--weight-semibold);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--leading-tight);
+  `,
+  4: css`
+    font-size: var(--text-md);
+    font-weight: var(--weight-semibold);
+    line-height: var(--leading-snug);
+  `,
+};
+
+const StyledHeading = styled.h1<{ $level: HeadingLevel }>`
+  font-family: var(--font-display);
+  color: var(--text-primary);
+  margin: 0;
+
+  ${({ $level }) => headingStyles[$level]}
+`;
+
+export const Heading: React.FC<HeadingProps> = ({
+  level = 1,
+  as,
+  children,
+  ...props
+}) => {
+  const Tag: HeadingTag = as ?? (`h${level}` as HeadingTag);
+  return (
+    <StyledHeading as={Tag} $level={level} {...props}>
+      {children}
+    </StyledHeading>
+  );
+};
+
+/* ─── Body ────────────────────────────────────────────────── */
+
+const StyledBody = styled.p<{ $muted: boolean }>`
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-base);
+  color: ${({ $muted }) => ($muted ? 'var(--text-muted)' : 'var(--text-primary)')};
+`;
+
+export const Body: React.FC<TextProps> = ({ as, muted = false, children, ...props }) => (
+  <StyledBody as={as} $muted={muted} {...props}>
+    {children}
+  </StyledBody>
+);
+
+/* ─── Caption ─────────────────────────────────────────────── */
+
+const StyledCaption = styled.span<{ $muted: boolean }>`
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-snug);
+  color: ${({ $muted }) => ($muted ? 'var(--text-muted)' : 'var(--text-secondary)')};
+`;
+
+export const Caption: React.FC<TextProps> = ({ as, muted = true, children, ...props }) => (
+  <StyledCaption as={as} $muted={muted} {...props}>
+    {children}
+  </StyledCaption>
+);
+
+/* ─── Label ───────────────────────────────────────────────── */
+
+const StyledLabel = styled.label`
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+`;
+
+export const Label: React.FC<LabelProps> = ({ children, ...props }) => (
+  <StyledLabel {...props}>{children}</StyledLabel>
+);
+
+/* ─── Aggregate export ────────────────────────────────────── */
+
+export const Typography = {
+  Heading,
+  Body,
+  Caption,
+  Label,
+};
+
+export type { HeadingLevel, HeadingProps, TextProps, LabelProps };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 export { Badge } from './Badge';
 export type { BadgeVariant } from './Badge';
 export { PermChip } from './PermChip';
@@ -6,3 +7,9 @@ export { Input } from './Input';
 export { Card } from './Card';
 export { Alert } from './Alert';
 export type { AlertVariant } from './Alert';
+export { Heading, Body, Caption, Label, Typography } from './Typography';
+export type { HeadingLevel, HeadingProps, TextProps, LabelProps } from './Typography';
+export { Icon } from './Icon';
+export type { IconProps, IconSize, IconTone } from './Icon';
+export { Spinner } from './Spinner';
+export type { SpinnerProps, SpinnerSize, SpinnerTone } from './Spinner';

--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -1,0 +1,245 @@
+import { ArrowRight, Check, Plus, Search, Settings as SettingsIcon, Trash2 } from 'lucide-react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import {
+  Body,
+  Button,
+  Caption,
+  Heading,
+  Icon,
+  Label,
+  Spinner,
+} from '../components/ui';
+
+const Page = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+  max-width: 960px;
+`;
+
+const Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+`;
+
+const SectionHead = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+`;
+
+const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+`;
+
+const SwatchGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-3);
+`;
+
+const Swatch = styled.div<{ $dark?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: ${({ $dark }) => ($dark ? 'var(--clr-forest)' : 'var(--bg-elevated)')};
+`;
+
+const Tones = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+`;
+
+export const ShowcasePage: React.FC = () => {
+  const [loadingDemo, setLoadingDemo] = useState(false);
+
+  const triggerLoading = () => {
+    setLoadingDemo(true);
+    window.setTimeout(() => setLoadingDemo(false), 1600);
+  };
+
+  return (
+    <Page>
+      <SectionHead>
+        <Caption>00 Showcase</Caption>
+        <Heading level={1}>Componentes base</Heading>
+        <Body muted>
+          Vitrine isolada de Button, Typography, Icon e Spinner — todos consumindo
+          tokens do design system.
+        </Body>
+      </SectionHead>
+
+      {/* ─── Typography ─────────────────────────────────────────── */}
+      <Section aria-label="Typography">
+        <SectionHead>
+          <Caption>Typography</Caption>
+          <Heading level={3}>Hierarquia tipográfica</Heading>
+        </SectionHead>
+        <Stack>
+          <Heading level={1}>Heading nível 1</Heading>
+          <Heading level={2}>Heading nível 2</Heading>
+          <Heading level={3}>Heading nível 3</Heading>
+          <Heading level={4}>Heading nível 4</Heading>
+          <Body>
+            Body é o estilo padrão para parágrafos. Mantém leitura confortável em
+            blocos longos consumindo a fonte de body e o leading base.
+          </Body>
+          <Body muted>Body muted aplica `--text-muted` para texto secundário.</Body>
+          <Caption>Caption — uso em metadados, descrições compactas e legendas.</Caption>
+          <Label>Label · campos de formulário</Label>
+        </Stack>
+      </Section>
+
+      {/* ─── Button ─────────────────────────────────────────────── */}
+      <Section aria-label="Button">
+        <SectionHead>
+          <Caption>Button</Caption>
+          <Heading level={3}>Variantes, tamanhos e estados</Heading>
+        </SectionHead>
+
+        <Stack>
+          <Label>Variantes</Label>
+          <Row>
+            <Button variant="primary">Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="danger">
+              <Icon icon={Trash2} size="sm" /> Excluir
+            </Button>
+          </Row>
+        </Stack>
+
+        <Stack>
+          <Label>Tamanhos</Label>
+          <Row>
+            <Button size="sm">Small</Button>
+            <Button size="md">Medium</Button>
+            <Button size="lg">Large</Button>
+          </Row>
+        </Stack>
+
+        <Stack>
+          <Label>Com ícone</Label>
+          <Row>
+            <Button icon={<Icon icon={Plus} size="sm" />}>Novo sistema</Button>
+            <Button variant="secondary" icon={<Icon icon={Search} size="sm" />}>
+              Buscar
+            </Button>
+            <Button variant="ghost" icon={<Icon icon={ArrowRight} size="sm" />}>
+              Próximo
+            </Button>
+          </Row>
+        </Stack>
+
+        <Stack>
+          <Label>Estados</Label>
+          <Row>
+            <Button disabled>Disabled</Button>
+            <Button variant="secondary" disabled>
+              Disabled secondary
+            </Button>
+            <Button loading>Loading</Button>
+            <Button variant="secondary" loading>
+              Carregando…
+            </Button>
+            <Button onClick={triggerLoading} loading={loadingDemo}>
+              {loadingDemo ? 'Processando' : 'Disparar loading'}
+            </Button>
+          </Row>
+        </Stack>
+      </Section>
+
+      {/* ─── Icon ───────────────────────────────────────────────── */}
+      <Section aria-label="Icon">
+        <SectionHead>
+          <Caption>Icon</Caption>
+          <Heading level={3}>Wrapper sobre lucide-react</Heading>
+        </SectionHead>
+
+        <Stack>
+          <Label>Tamanhos</Label>
+          <Row>
+            <Icon icon={SettingsIcon} size="xs" />
+            <Icon icon={SettingsIcon} size="sm" />
+            <Icon icon={SettingsIcon} size="md" />
+            <Icon icon={SettingsIcon} size="lg" />
+            <Icon icon={SettingsIcon} size="xl" />
+          </Row>
+        </Stack>
+
+        <Stack>
+          <Label>Tones semânticas</Label>
+          <Tones>
+            <Icon icon={Check} tone="primary" title="Primary" />
+            <Icon icon={Check} tone="secondary" title="Secondary" />
+            <Icon icon={Check} tone="muted" title="Muted" />
+            <Icon icon={Check} tone="accent" title="Accent" />
+            <Icon icon={Check} tone="success" title="Success" />
+            <Icon icon={Check} tone="warning" title="Warning" />
+            <Icon icon={Check} tone="danger" title="Danger" />
+            <Icon icon={Check} tone="info" title="Info" />
+          </Tones>
+        </Stack>
+      </Section>
+
+      {/* ─── Spinner ────────────────────────────────────────────── */}
+      <Section aria-label="Spinner">
+        <SectionHead>
+          <Caption>Spinner</Caption>
+          <Heading level={3}>Indicador de carregamento</Heading>
+        </SectionHead>
+
+        <Stack>
+          <Label>Tamanhos</Label>
+          <Row>
+            <Spinner size="sm" />
+            <Spinner size="md" />
+            <Spinner size="lg" />
+          </Row>
+        </Stack>
+
+        <Stack>
+          <Label>Tones</Label>
+          <SwatchGrid>
+            <Swatch>
+              <Spinner tone="accent" />
+              <Caption>accent</Caption>
+            </Swatch>
+            <Swatch>
+              <Spinner tone="neutral" />
+              <Caption>neutral</Caption>
+            </Swatch>
+            <Swatch $dark>
+              <Spinner tone="inverse" />
+              <Caption muted>inverse</Caption>
+            </Swatch>
+          </SwatchGrid>
+        </Stack>
+      </Section>
+    </Page>
+  );
+};

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -48,6 +48,12 @@
   --border-soft-forest: rgba(22, 36, 15, 0.14);
   --border-medium-forest: rgba(22, 36, 15, 0.28);
 
+  /* Border widths — usados por componentes com bordas estruturais */
+  --border-thin: 1px;
+  --border-medium: 1.5px;
+  --border-thick: 2px;
+  --border-thicker: 2.5px;
+
   /* ── Foreground / text ───────────────────────────────────── */
   --fg1: #1b2a12;
   --fg2: #4a5e42;
@@ -160,6 +166,9 @@
   --space-12: 3rem;
   --space-16: 4rem;
   --space-20: 5rem;
+
+  /* Press offset — deslocamento de :active para feedback tátil */
+  --press-offset: 1px;
 
   /* ── Z-index ─────────────────────────────────────────────── */
   --z-base: 0;


### PR DESCRIPTION
## Contexto

Implementação dos primeiros componentes reutilizáveis da biblioteca UI do `lfc-admin-gui`, totalmente alinhados aos tokens do design system aplicado na PR #10.

## Objetivo

Estabelecer a fundação visual reutilizável (`Button`, `Typography`, `Icon`, `Spinner`) consumindo exclusivamente os tokens definidos em `src/styles/tokens.css`, sem hardcodes de cor, fonte ou espaçamento.

## O que foi feito

- **`Spinner`** — indicador de carregamento com `size` (`sm`/`md`/`lg`), `tone` (`accent`/`neutral`/`inverse`/`currentColor`) e `label` acessível via `role="status"` + `aria-live`. Anima via tokens `--duration-slower`/`--ease`, respeita `prefers-reduced-motion`.
- **`Typography`** — exporta `Heading` (níveis 1–4 com override de tag via `as`), `Body` (com `muted`), `Caption` e `Label`. Tudo consumindo `--text-*`, `--weight-*`, `--leading-*`, `--tracking-*` e cores semânticas.
- **`Icon`** — wrapper tipado sobre `lucide-react`. Recebe o componente lucide via prop `icon`, mapeia `size` (`xs`–`xl`) para tokens `--text-*` e `tone` para tokens semânticos (`primary`, `secondary`, `muted`, `accent`, `danger`, `warning`, `info`, `success`, `inverse`, `currentColor`). Sem `title` o ícone é decorativo (`aria-hidden`); com `title` é tratado como `role="img"`.
- **`Button` refatorado** — variantes (`primary`, `secondary`, `ghost`, `danger`) e tamanhos (`sm`, `md`, `lg`) agora consomem `--space-*`, `--text-*` e `--radius-*` — substituindo os hardcodes em px que sobraram da PR #10. Adiciona prop `loading` que sobrepõe `Spinner` mantendo o tamanho do botão estável e marcando `aria-busy`/`aria-disabled`. API existente preservada (não quebra páginas que já consomem o componente).
- **`ShowcasePage`** — vitrine isolada acessível via item "Showcase UI" no Sidebar (`/showcase` lógico). Exibe toda a hierarquia tipográfica, todas as variantes/tamanhos/estados do Button (incluindo demo de loading interativo), Icon em todos os tamanhos e tons e Spinner em variantes claras/escuras.
- **Testes unitários** com Vitest + Testing Library cobrindo render, props, estados e acessibilidade dos quatro componentes (35 testes verdes).

## Arquivos impactados

- `src/components/ui/Button.tsx` (refatorado)
- `src/components/ui/Button.test.tsx` (novo)
- `src/components/ui/Typography.tsx` (novo)
- `src/components/ui/Typography.test.tsx` (novo)
- `src/components/ui/Icon.tsx` (novo)
- `src/components/ui/Icon.test.tsx` (novo)
- `src/components/ui/Spinner.tsx` (novo)
- `src/components/ui/Spinner.test.tsx` (novo)
- `src/components/ui/index.ts` (exports)
- `src/pages/ShowcasePage.tsx` (novo)
- `src/components/layout/Sidebar.tsx` (item Showcase UI)
- `src/App.tsx` (rota Showcase UI)

## Testes (container)

- `docker compose run --rm web npm run lint` — verde
- `docker compose run --rm web npm run typecheck` — verde
- `docker compose run --rm web npm run test` — 35 testes verdes (5 arquivos)
- `docker compose run --rm web npm run build` — verde
- Validação visual: `docker compose up -d` em `http://localhost:3002/` → menu "Showcase UI"

## Visual

- 100% dos valores de cor, fonte e espaçamento dos novos componentes vêm de tokens (`var(--…)`)
- Estados completos: `:hover`, `:focus-visible`, `:active`, `:disabled` e `loading` no Button
- `Spinner` respeita `prefers-reduced-motion`
- `Icon` decorativo por padrão e acessível quando `title` é fornecido

## Segurança

- Nenhuma exposição de token, dado sensível ou `dangerouslySetInnerHTML`
- Nenhum `console.log`
- Wrapper de `Icon` recebe componente, não string — sem injeção dinâmica

## Riscos

Baixo. Mudança em `Button` mantém API anterior (variants/sizes/icon) e apenas adiciona prop opcional `loading`. Nenhum consumidor existente foi quebrado (35 testes + build verdes).

## Issue relacionada

Closes #5