### PR TITLE
feat: responsividade mobile-first (#19)

### DIFF
--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -8,15 +8,30 @@ interface PageHeaderProps {
   actions?: React.ReactNode;
 }
 
+/**
+ * Em mobile (< --bp-md, 48em) empilha verticalmente o cabeçalho para
+ * preservar legibilidade do título e dar espaço aos CTAs. A partir de
+ * `--bp-md` retorna à diagonal `space-between`.
+ */
 const HeaderWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 32px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 32px;
+  }
 `;
 
-const HeaderLeft = styled.div``;
+const HeaderLeft = styled.div`
+  min-width: 0;
+`;
 
 const Eyebrow = styled.div`
   font-family: var(--font-mono);
@@ -29,12 +44,17 @@ const Eyebrow = styled.div`
 `;
 
 const Title = styled.h2`
-  font-size: 28px;
+  font-size: 22px;
   font-weight: var(--weight-bold);
   letter-spacing: -0.03em;
   line-height: 1.15;
   color: var(--fg1);
   margin: 6px 0 8px;
+  word-break: break-word;
+
+  @media (min-width: 48em) {
+    font-size: 28px;
+  }
 `;
 
 const Desc = styled.p`
@@ -45,10 +65,19 @@ const Desc = styled.p`
   line-height: var(--leading-base);
 `;
 
+/**
+ * Em mobile os CTAs viram `flex-wrap` para acomodar telas estreitas; em
+ * desktop voltam à linha única à direita do header.
+ */
 const Actions = styled.div`
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   flex-shrink: 0;
+
+  @media (min-width: 48em) {
+    flex-wrap: nowrap;
+  }
 `;
 
 export const PageHeader: React.FC<PageHeaderProps> = ({ eyebrow, title, desc, actions }) => (

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -30,6 +30,13 @@ describe('Sidebar', () => {
     expect(backdrop).toHaveAttribute('aria-hidden', 'true');
   });
 
+  it('aside expõe id="sidebar-drawer" para vincular com aria-controls do hamburger', () => {
+    renderSidebar(false);
+
+    const nav = screen.getByRole('navigation', { name: 'Navegação principal' });
+    expect(nav).toHaveAttribute('id', 'sidebar-drawer');
+  });
+
   it('chama onClose ao clicar no backdrop', () => {
     const onClose = vi.fn();
     renderSidebar(true, onClose);

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Sidebar } from './Sidebar';
+
+function renderSidebar(open = false, onClose: () => void = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <Sidebar open={open} onClose={onClose} />
+    </MemoryRouter>,
+  );
+}
+
+describe('Sidebar', () => {
+  it('renderiza navegação acessível com itens principais', () => {
+    renderSidebar(false);
+
+    const nav = screen.getByRole('navigation', { name: 'Navegação principal' });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByText('Sistemas')).toBeInTheDocument();
+    expect(screen.getByText('Roles')).toBeInTheDocument();
+    expect(screen.getByText('Usuários')).toBeInTheDocument();
+  });
+
+  it('expõe backdrop com aria-hidden para drawer mobile', () => {
+    renderSidebar(false);
+
+    const backdrop = screen.getByTestId('sidebar-backdrop');
+    expect(backdrop).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('chama onClose ao clicar no backdrop', () => {
+    const onClose = vi.fn();
+    renderSidebar(true, onClose);
+
+    fireEvent.click(screen.getByTestId('sidebar-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('chama onClose ao clicar no botão de fechar', () => {
+    const onClose = vi.fn();
+    renderSidebar(true, onClose);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Fechar menu de navegação' }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('chama onClose ao clicar em um link de navegação (drawer mobile)', () => {
+    const onClose = vi.fn();
+    renderSidebar(true, onClose);
+
+    fireEvent.click(screen.getByRole('link', { name: /Roles/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('fecha o drawer quando a tecla Escape é pressionada (apenas com open=true)', () => {
+    const onClose = vi.fn();
+    renderSidebar(true, onClose);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('não dispara onClose para Escape quando o drawer está fechado', () => {
+    const onClose = vi.fn();
+    renderSidebar(false, onClose);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -65,7 +65,7 @@ const NAV_ITEMS: NavItem[] = ALL_NAV_ITEMS.filter(
 const Backdrop = styled.div<{ $open: boolean }>`
   position: fixed;
   inset: 0;
-  background: rgba(22, 36, 15, 0.42);
+  background: var(--bg-backdrop-modal);
   backdrop-filter: blur(2px);
   z-index: var(--z-overlay);
   opacity: ${({ $open }) => ($open ? 1 : 0)};
@@ -298,6 +298,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
       <SidebarWrapper
         ref={wrapperRef}
         $open={open}
+        id="sidebar-drawer"
         role="navigation"
         aria-label="Navegação principal"
         aria-modal="true"

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -7,8 +7,9 @@ import {
   Activity,
   Settings,
   Component,
+  X,
 } from 'lucide-react';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -24,6 +25,17 @@ interface NavItem {
    * para vitrines internas que não devem aparecer em produção.
    */
   devOnly?: boolean;
+}
+
+interface SidebarProps {
+  /**
+   * Em mobile (< `--bp-md`, 48em ≈ 768px) o Sidebar opera como drawer
+   * (off-canvas) e este flag controla visibilidade. Em desktop o valor é
+   * ignorado — a Sidebar fica sempre visível.
+   */
+  open: boolean;
+  /** Callback disparado quando o drawer pede para fechar (ESC, backdrop, link). */
+  onClose: () => void;
 }
 
 const ALL_NAV_ITEMS: NavItem[] = [
@@ -43,24 +55,118 @@ const NAV_ITEMS: NavItem[] = ALL_NAV_ITEMS.filter(
   item => !item.devOnly || import.meta.env.DEV,
 );
 
-const SidebarWrapper = styled.aside`
+/**
+ * Backdrop semitransparente que aparece atrás do drawer em mobile.
+ *
+ * Mantém-se renderizado no DOM mesmo fechado (com `aria-hidden`) para
+ * permitir transições suaves sem unmount/mount; em desktop é ocultado
+ * via media query — espelha `--bp-md` (48em ≈ 768px).
+ */
+const Backdrop = styled.div<{ $open: boolean }>`
+  position: fixed;
+  inset: 0;
+  background: rgba(22, 36, 15, 0.42);
+  backdrop-filter: blur(2px);
+  z-index: var(--z-overlay);
+  opacity: ${({ $open }) => ($open ? 1 : 0)};
+  pointer-events: ${({ $open }) => ($open ? 'auto' : 'none')};
+  transition: opacity var(--duration-base) var(--ease-default);
+
+  /* Desktop (≥ --bp-md, 48em) — backdrop nunca é exibido. */
+  @media (min-width: 48em) {
+    display: none;
+  }
+`;
+
+/**
+ * Aside sempre presente no DOM. Em mobile recebe `position: fixed` com
+ * `transform: translateX(-100%)` quando fechado; em desktop volta a ser
+ * `position: sticky` e ocupa a coluna fixa do grid de `AppLayout`.
+ */
+const SidebarWrapper = styled.aside<{ $open: boolean }>`
   background: var(--bg-surface);
   border-right: 1px solid var(--border-subtle);
   padding: 28px 0;
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  position: sticky;
-  top: 0;
-  overflow-y: auto;
   width: var(--sidebar-w);
   flex-shrink: 0;
+
+  /* Mobile (< --bp-md) — comporta-se como drawer off-canvas. */
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  height: 100dvh;
+  max-width: 86vw;
+  z-index: var(--z-modal);
+  overflow-y: auto;
+  transform: ${({ $open }) => ($open ? 'translateX(0)' : 'translateX(-100%)')};
+  transition: transform var(--duration-base) var(--ease-default);
+  box-shadow: ${({ $open }) => ($open ? 'var(--shadow-modal)' : 'none')};
+
+  /* Desktop (≥ --bp-md, 48em) — comporta-se como coluna fixa. */
+  @media (min-width: 48em) {
+    position: sticky;
+    height: 100vh;
+    transform: none;
+    box-shadow: none;
+    z-index: var(--z-base);
+    max-width: none;
+  }
 `;
 
-const LogoArea = styled.div`
+const SidebarHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
   padding: 0 22px 20px;
   border-bottom: 1px solid var(--border-subtle);
   margin-bottom: 20px;
+`;
+
+const LogoArea = styled.div`
+  display: inline-flex;
+  align-items: center;
+`;
+
+/**
+ * Botão "X" para fechar o drawer em mobile. Em desktop fica oculto via
+ * `@media`, espelhando `--bp-md` (48em ≈ 768px).
+ */
+const CloseButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--fg2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  transition:
+    background var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default),
+    color var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    background: var(--bg-elevated);
+    color: var(--fg1);
+    border-color: var(--border-base);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* Desktop (≥ --bp-md) — drawer não existe, esconder o botão. */
+  @media (min-width: 48em) {
+    display: none;
+  }
 `;
 
 const PanelLabel = styled.div`
@@ -79,18 +185,24 @@ const Nav = styled.nav`
   gap: 1px;
 `;
 
+/**
+ * Em mobile (< --bp-md) o item ganha `min-height: var(--touch-min)` para
+ * cumprir o critério de touch target ≥ 44×44px. Em desktop volta ao
+ * padding compacto original.
+ */
 const NavItemLink = styled(NavLink)`
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 9px 22px;
-  font-size: 13.5px;
+  padding: 10px 22px;
+  font-size: 14px;
   color: var(--fg2);
   text-decoration: none;
   border-left: var(--border-thick) solid transparent;
   background: transparent;
   transition: all 150ms var(--ease-default);
   cursor: pointer;
+  min-height: var(--touch-min);
 
   &:hover {
     color: var(--fg1);
@@ -107,6 +219,13 @@ const NavItemLink = styled(NavLink)`
     color: var(--accent-ink);
     border-left-color: var(--accent-ink);
     background: color-mix(in srgb, var(--accent) 10%, transparent);
+  }
+
+  /* Desktop (≥ --bp-md, 48em) — densidade compacta padrão. */
+  @media (min-width: 48em) {
+    padding: 9px 22px;
+    font-size: 13.5px;
+    min-height: 0;
   }
 `;
 
@@ -138,28 +257,84 @@ const FootVersion = styled.div`
   font-family: var(--font-mono);
 `;
 
-export const Sidebar: React.FC = () => (
-  <SidebarWrapper>
-    <LogoArea>
-      <img src={logoDark} alt="LFC Admin" height={28} />
-    </LogoArea>
-    <PanelLabel>Admin Panel</PanelLabel>
-    <Nav>
-      {NAV_ITEMS.map(item => (
-        <NavItemLink
-          key={item.to}
-          to={item.to}
-          className={({ isActive }) => (isActive ? 'active' : undefined)}
-        >
-          <NavNum>{item.num}</NavNum>
-          {item.icon}
-          <span>{item.label}</span>
-        </NavItemLink>
-      ))}
-    </Nav>
-    <SidebarFoot>
-      <div>v1.0 · LF Calegari</div>
-      <FootVersion>tokenVersion: 12</FootVersion>
-    </SidebarFoot>
-  </SidebarWrapper>
-);
+export const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
+  const wrapperRef = useRef<HTMLElement | null>(null);
+
+  /**
+   * Tecla ESC fecha o drawer. Listener só ativa quando aberto para evitar
+   * trabalho desnecessário em desktop ou drawer fechado.
+   */
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  /**
+   * Move o foco para o aside ao abrir — torna o teclado consistente com a
+   * leitura visual do drawer e habilita Tab para varrer os links logo na
+   * primeira interação. Em desktop o efeito é inócuo (foco volta com
+   * scroll natural).
+   */
+  useEffect(() => {
+    if (open && wrapperRef.current) {
+      wrapperRef.current.focus({ preventScroll: true });
+    }
+  }, [open]);
+
+  return (
+    <>
+      <Backdrop
+        $open={open}
+        aria-hidden="true"
+        data-testid="sidebar-backdrop"
+        onClick={onClose}
+      />
+      <SidebarWrapper
+        ref={wrapperRef}
+        $open={open}
+        role="navigation"
+        aria-label="Navegação principal"
+        aria-modal="true"
+        tabIndex={-1}
+      >
+        <SidebarHeader>
+          <LogoArea>
+            <img src={logoDark} alt="LFC Admin" height={28} />
+          </LogoArea>
+          <CloseButton
+            type="button"
+            aria-label="Fechar menu de navegação"
+            onClick={onClose}
+          >
+            <X size={18} strokeWidth={1.5} />
+          </CloseButton>
+        </SidebarHeader>
+        <PanelLabel>Admin Panel</PanelLabel>
+        <Nav>
+          {NAV_ITEMS.map(item => (
+            <NavItemLink
+              key={item.to}
+              to={item.to}
+              onClick={onClose}
+              className={({ isActive }) => (isActive ? 'active' : undefined)}
+            >
+              <NavNum>{item.num}</NavNum>
+              {item.icon}
+              <span>{item.label}</span>
+            </NavItemLink>
+          ))}
+        </Nav>
+        <SidebarFoot>
+          <div>v1.0 · LF Calegari</div>
+          <FootVersion>tokenVersion: 12</FootVersion>
+        </SidebarFoot>
+      </SidebarWrapper>
+    </>
+  );
+};

--- a/src/components/layout/Topbar.test.tsx
+++ b/src/components/layout/Topbar.test.tsx
@@ -34,6 +34,17 @@ describe('Topbar', () => {
     expect(button).toHaveAttribute('aria-label', 'Abrir menu de navegação');
   });
 
+  it('hamburger expõe aria-controls e aria-expanded refletindo drawerOpen', () => {
+    const { rerender } = render(<Topbar title="Sistemas" drawerOpen={false} />);
+
+    const button = screen.getByTestId('topbar-menu-button');
+    expect(button).toHaveAttribute('aria-controls', 'sidebar-drawer');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(<Topbar title="Sistemas" drawerOpen={true} />);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('busca colapsada expande ao clicar no toggle de busca', () => {
     render(<Topbar title="Sistemas" />);
 

--- a/src/components/layout/Topbar.test.tsx
+++ b/src/components/layout/Topbar.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Topbar } from './Topbar';
+
+describe('Topbar', () => {
+  it('renderiza título e usuário recebidos via props', () => {
+    render(<Topbar title="Sistemas" user={{ name: 'admin@lfc.com.br', role: 'root', permCount: 12 }} />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Sistemas' })).toBeInTheDocument();
+    expect(screen.getByText('admin@lfc.com.br')).toBeInTheDocument();
+  });
+
+  it('chama onMenuClick ao clicar no hamburger', () => {
+    const onMenuClick = vi.fn();
+    render(
+      <Topbar
+        title="Sistemas"
+        user={{ name: 'admin@lfc.com.br', role: 'root', permCount: 12 }}
+        onMenuClick={onMenuClick}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Abrir menu de navegação' }),
+    );
+    expect(onMenuClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('hamburger declara aria-label acessível em mobile', () => {
+    render(<Topbar title="Sistemas" />);
+
+    const button = screen.getByTestId('topbar-menu-button');
+    expect(button).toHaveAttribute('aria-label', 'Abrir menu de navegação');
+  });
+
+  it('busca colapsada expande ao clicar no toggle de busca', () => {
+    render(<Topbar title="Sistemas" />);
+
+    const toggle = screen.getByRole('button', { name: 'Abrir busca' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('busca expandida pode ser fechada via botão close', () => {
+    render(<Topbar title="Sistemas" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir busca' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Fechar busca' }));
+
+    const toggle = screen.getByRole('button', { name: 'Abrir busca' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('chama onLogout ao clicar no botão Sair', () => {
+    const onLogout = vi.fn();
+    render(
+      <Topbar
+        title="Sistemas"
+        user={{ name: 'admin@lfc.com.br', role: 'root', permCount: 12 }}
+        onLogout={onLogout}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sair' }));
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,5 @@
-import { Search, Bell, LogOut } from 'lucide-react';
-import React from 'react';
+import { Search, Bell, LogOut, Menu, X } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 interface TopbarUser {
@@ -12,45 +12,169 @@ interface TopbarProps {
   title: string;
   user?: TopbarUser;
   onLogout?: () => void;
+  /**
+   * Disparado pelo hamburger em mobile (< `--bp-md`). Em desktop o botão é
+   * ocultado via `@media`, então o handler é inerte.
+   */
+  onMenuClick?: () => void;
 }
 
 const TopbarWrapper = styled.header`
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 18px 36px;
+  gap: var(--space-3);
+  padding: 14px 16px;
   border-bottom: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--bg-base) 88%, transparent);
   backdrop-filter: saturate(140%) blur(10px);
   position: sticky;
   top: 0;
   z-index: var(--z-sticky);
+
+  /* Desktop (≥ --bp-md, 48em) — gap e padding mais arejados. */
+  @media (min-width: 48em) {
+    gap: 24px;
+    padding: 18px 36px;
+  }
+`;
+
+/**
+ * Botão hamburger — visível somente em mobile (< --bp-md, 48em ≈ 768px).
+ * Cumpre touch target ≥ 44×44px via `--touch-min`.
+ */
+const MenuButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--fg2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  flex-shrink: 0;
+  transition:
+    background var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default),
+    color var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    background: var(--bg-elevated);
+    color: var(--fg1);
+    border-color: var(--border-base);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* Desktop (≥ --bp-md) — drawer não existe, esconder o botão. */
+  @media (min-width: 48em) {
+    display: none;
+  }
 `;
 
 const TopbarTitle = styled.h1`
   margin: 0;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: var(--weight-medium);
   color: var(--fg2);
   letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+
+  /* Desktop (≥ --bp-md, 48em). */
+  @media (min-width: 48em) {
+    font-size: 15px;
+  }
 `;
 
 const TopbarRight = styled.div`
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2);
+  flex-shrink: 0;
+
+  @media (min-width: 48em) {
+    gap: 10px;
+  }
 `;
 
-const SearchBox = styled.div`
+/**
+ * Wrapper da busca. Em mobile fica colapsada como ícone clicável; ao
+ * expandir, ocupa a linha inteira sobre o resto da Topbar (overlay
+ * absoluto). Em desktop retorna ao layout inline tradicional.
+ */
+const SearchSlot = styled.div<{ $expanded: boolean }>`
+  /* Mobile (< --bp-md) — comportamento expansível. */
+  position: ${({ $expanded }) => ($expanded ? 'absolute' : 'static')};
+  inset: ${({ $expanded }) => ($expanded ? '0' : 'auto')};
+  background: ${({ $expanded }) =>
+    $expanded ? 'var(--bg-base)' : 'transparent'};
   display: flex;
+  align-items: center;
+  padding: ${({ $expanded }) => ($expanded ? '14px 16px' : '0')};
+  z-index: var(--z-raised);
+
+  /* Desktop (≥ --bp-md, 48em) — busca sempre inline. */
+  @media (min-width: 48em) {
+    position: static;
+    inset: auto;
+    background: transparent;
+    padding: 0;
+    flex: 0 1 auto;
+  }
+`;
+
+const SearchToggle = styled.button`
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--fg2);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  transition:
+    background var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default),
+    color var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    background: var(--bg-elevated);
+    color: var(--fg1);
+    border-color: var(--border-base);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* Desktop (≥ --bp-md, 48em) — busca permanece inline, ocultar toggle. */
+  @media (min-width: 48em) {
+    display: none;
+  }
+`;
+
+const SearchBox = styled.div<{ $expanded: boolean }>`
+  display: ${({ $expanded }) => ($expanded ? 'flex' : 'none')};
   align-items: center;
   gap: 8px;
   background: var(--bg-elevated);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   padding: 6px 10px;
-  width: 320px;
+  width: 100%;
   color: var(--fg3);
   transition:
     border-color 150ms var(--ease-default),
@@ -63,6 +187,12 @@ const SearchBox = styled.div`
   &:focus-within {
     border-color: var(--accent);
     box-shadow: var(--focus-ring-accent);
+  }
+
+  /* Desktop (≥ --bp-md, 48em) — sempre visível, largura fixa. */
+  @media (min-width: 48em) {
+    display: flex;
+    width: 320px;
   }
 `;
 
@@ -89,6 +219,40 @@ const SearchKbd = styled.kbd`
   border: 1px solid var(--border-subtle);
   padding: 1px 5px;
   border-radius: var(--radius-sm);
+  display: none;
+
+  /* Desktop (≥ --bp-md, 48em) — atalho só relevante com teclado físico. */
+  @media (min-width: 48em) {
+    display: inline-flex;
+  }
+`;
+
+const SearchClose = styled.button`
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--fg2);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+
+  &:hover {
+    color: var(--fg1);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  /* Desktop (≥ --bp-md, 48em) — drawer-search não existe, esconder. */
+  @media (min-width: 48em) {
+    display: none;
+  }
 `;
 
 const IconButton = styled.button`
@@ -96,13 +260,13 @@ const IconButton = styled.button`
   background: transparent;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
-  width: 34px;
-  height: 34px;
   cursor: pointer;
   color: var(--fg2);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
   transition: all 150ms var(--ease-default);
 
   &:hover:not(:disabled) {
@@ -120,15 +284,29 @@ const IconButton = styled.button`
     cursor: not-allowed;
     opacity: 0.4;
   }
+
+  /* Desktop (≥ --bp-md, 48em) — botões compactos no canto. */
+  @media (min-width: 48em) {
+    width: 34px;
+    height: 34px;
+    min-width: 0;
+    min-height: 0;
+  }
 `;
 
 const UserSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding-left: 10px;
-  border-left: 1px solid var(--border-subtle);
-  margin-left: 4px;
+  gap: var(--space-2);
+  flex-shrink: 0;
+
+  /* Desktop (≥ --bp-md, 48em) — exibe meta + separador esquerdo. */
+  @media (min-width: 48em) {
+    gap: 10px;
+    padding-left: 10px;
+    border-left: 1px solid var(--border-subtle);
+    margin-left: 4px;
+  }
 `;
 
 const Avatar = styled.div`
@@ -144,7 +322,17 @@ const Avatar = styled.div`
   flex-shrink: 0;
 `;
 
-const UserMeta = styled.div``;
+/**
+ * Bloco com nome/role do usuário. Oculto em mobile para preservar espaço
+ * — a identidade fica representada pelo Avatar; em desktop reaparece.
+ */
+const UserMeta = styled.div`
+  display: none;
+
+  @media (min-width: 48em) {
+    display: block;
+  }
+`;
 
 const UserName = styled.div`
   font-size: 13px;
@@ -158,23 +346,79 @@ const UserRole = styled.div`
   color: var(--fg3);
 `;
 
-export const Topbar: React.FC<TopbarProps> = ({ title, user, onLogout }) => {
+/**
+ * Bell de notificações — informacional secundário. Em mobile fica oculto
+ * para reduzir a densidade da Topbar; reaparece a partir de --bp-md.
+ */
+const NotificationsButton = styled(IconButton)`
+  display: none;
+
+  @media (min-width: 48em) {
+    display: inline-flex;
+  }
+`;
+
+export const Topbar: React.FC<TopbarProps> = ({
+  title,
+  user,
+  onLogout,
+  onMenuClick,
+}) => {
   const initials = user?.name?.[0]?.toUpperCase() ?? 'A';
-  const roleLabel = user ? `${user.role ?? 'root'} · ${user.permCount ?? 12} perms` : 'root · 12 perms';
+  const roleLabel = user
+    ? `${user.role ?? 'root'} · ${user.permCount ?? 12} perms`
+    : 'root · 12 perms';
+
+  // Em mobile a busca colapsa em ícone; ao expandir, mostramos input
+  // ocupando a linha inteira sobre a Topbar.
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (searchOpen) {
+      searchInputRef.current?.focus();
+    }
+  }, [searchOpen]);
 
   return (
     <TopbarWrapper>
+      <MenuButton
+        type="button"
+        aria-label="Abrir menu de navegação"
+        onClick={onMenuClick}
+        data-testid="topbar-menu-button"
+      >
+        <Menu size={18} strokeWidth={1.5} />
+      </MenuButton>
       <TopbarTitle>{title}</TopbarTitle>
       <TopbarRight>
-        <SearchBox>
-          <Search size={14} strokeWidth={1.5} />
-          <SearchInput
-            placeholder="Buscar sistemas, usuários, permissões…"
-            aria-label="Buscar no painel"
-          />
-          <SearchKbd>⌘K</SearchKbd>
-        </SearchBox>
-        <IconButton
+        <SearchToggle
+          type="button"
+          aria-label="Abrir busca"
+          aria-expanded={searchOpen}
+          onClick={() => setSearchOpen(true)}
+        >
+          <Search size={18} strokeWidth={1.5} />
+        </SearchToggle>
+        <SearchSlot $expanded={searchOpen}>
+          <SearchBox $expanded={searchOpen}>
+            <Search size={14} strokeWidth={1.5} />
+            <SearchInput
+              ref={searchInputRef}
+              placeholder="Buscar sistemas, usuários, permissões…"
+              aria-label="Buscar no painel"
+            />
+            <SearchKbd>⌘K</SearchKbd>
+            <SearchClose
+              type="button"
+              aria-label="Fechar busca"
+              onClick={() => setSearchOpen(false)}
+            >
+              <X size={16} strokeWidth={1.5} />
+            </SearchClose>
+          </SearchBox>
+        </SearchSlot>
+        <NotificationsButton
           type="button"
           aria-label="Notificações (em breve)"
           title="Notificações (em breve)"
@@ -182,7 +426,7 @@ export const Topbar: React.FC<TopbarProps> = ({ title, user, onLogout }) => {
           aria-disabled="true"
         >
           <Bell size={16} strokeWidth={1.5} />
-        </IconButton>
+        </NotificationsButton>
         <UserSection>
           <Avatar>{initials}</Avatar>
           <UserMeta>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -17,6 +17,12 @@ interface TopbarProps {
    * ocultado via `@media`, então o handler é inerte.
    */
   onMenuClick?: () => void;
+  /**
+   * Reflete o estado do drawer controlado pelo layout. Usado para expor
+   * `aria-expanded` no botão hamburger e indicar a leitores de tela se o
+   * `#sidebar-drawer` (referenciado em `aria-controls`) está aberto.
+   */
+  drawerOpen?: boolean;
 }
 
 const TopbarWrapper = styled.header`
@@ -363,6 +369,7 @@ export const Topbar: React.FC<TopbarProps> = ({
   user,
   onLogout,
   onMenuClick,
+  drawerOpen = false,
 }) => {
   const initials = user?.name?.[0]?.toUpperCase() ?? 'A';
   const roleLabel = user
@@ -385,6 +392,8 @@ export const Topbar: React.FC<TopbarProps> = ({
       <MenuButton
         type="button"
         aria-label="Abrir menu de navegação"
+        aria-controls="sidebar-drawer"
+        aria-expanded={drawerOpen}
         onClick={onMenuClick}
         data-testid="topbar-menu-button"
       >

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Outlet, useLocation, matchPath } from 'react-router-dom';
 import styled, { createGlobalStyle } from 'styled-components';
 
@@ -49,25 +49,60 @@ const GridOverlay = createGlobalStyle`
   }
 `;
 
+/**
+ * Trava de scroll body enquanto o drawer está aberto. Aplica via styled
+ * `createGlobalStyle` para evitar manipulação imperativa de `document`.
+ */
+const BodyScrollLock = createGlobalStyle`
+  body {
+    overflow: hidden;
+  }
+`;
+
+/**
+ * Shell — em mobile ocupa coluna única (Sidebar é drawer overlay e não
+ * consome espaço no layout); a partir de `--bp-md` (48em ≈ 768px) volta
+ * ao grid de duas colunas.
+ */
 const Shell = styled.div`
   display: grid;
-  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-columns: 1fr;
   min-height: 100vh;
   position: relative;
   z-index: 1;
+
+  @media (min-width: 48em) {
+    grid-template-columns: var(--sidebar-w) 1fr;
+  }
 `;
 
 const MainArea = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-width: 0;
   overflow: hidden;
 `;
 
+/**
+ * Área de conteúdo. `min-width: 0` evita que filhos com conteúdo extenso
+ * (tabelas, blocos de texto longos) gerem overflow horizontal no grid
+ * pai. Padding cresce a partir de `--bp-md` para acompanhar o respiro
+ * desktop sem prejudicar leitura em 320px.
+ */
 const ContentArea = styled.main`
-  padding: 36px;
-  max-width: 1400px;
+  padding: 20px 16px;
   width: 100%;
+  min-width: 0;
+
+  @media (min-width: 48em) {
+    padding: 28px 24px;
+  }
+
+  @media (min-width: 64em) {
+    padding: 36px;
+    max-width: 1400px;
+  }
 `;
 
 function resolveTitle(pathname: string): string {
@@ -90,6 +125,18 @@ export const AppLayout: React.FC = () => {
     permCount: 12,
   });
 
+  // Drawer mobile da Sidebar — fechado por padrão.
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Fecha o drawer ao navegar (mudança de rota): em mobile o drawer some
+  // para revelar o conteúdo; em desktop a operação é inerte.
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [location.pathname]);
+
+  const handleOpenDrawer = useCallback(() => setDrawerOpen(true), []);
+  const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
+
   const handleLogout = () => {
     // Sessão invalidada — placeholder para integração com lfc-authenticator.
     window.location.reload();
@@ -98,10 +145,16 @@ export const AppLayout: React.FC = () => {
   return (
     <>
       <GridOverlay />
+      {drawerOpen && <BodyScrollLock />}
       <Shell>
-        <Sidebar />
+        <Sidebar open={drawerOpen} onClose={handleCloseDrawer} />
         <MainArea>
-          <Topbar title={title} user={user} onLogout={handleLogout} />
+          <Topbar
+            title={title}
+            user={user}
+            onLogout={handleLogout}
+            onMenuClick={handleOpenDrawer}
+          />
           <ContentArea>
             <Outlet />
           </ContentArea>

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -154,6 +154,7 @@ export const AppLayout: React.FC = () => {
             user={user}
             onLogout={handleLogout}
             onMenuClick={handleOpenDrawer}
+            drawerOpen={drawerOpen}
           />
           <ContentArea>
             <Outlet />

--- a/src/pages/PermissionsPage.tsx
+++ b/src/pages/PermissionsPage.tsx
@@ -18,10 +18,24 @@ const PERM_GROUPS: PermGroup[] = [
   { res: 'Tokens',  actions: ['Issue', 'Revoke', 'Inspect'] },
 ];
 
+/**
+ * Em mobile (< --bp-md) cada card de permissão ocupa a largura inteira;
+ * a partir de `--bp-md` (48em) ganha 2 colunas, e a partir de `--bp-lg`
+ * (64em) volta à grade 3×N original.
+ */
 const PermGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
+  grid-template-columns: 1fr;
+  gap: 12px;
+
+  @media (min-width: 48em) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
+  }
+
+  @media (min-width: 64em) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 `;
 
 const ChipWrap = styled.div`

--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -21,17 +21,28 @@ const ROLES: RoleItem[] = [
   { name: 'default', users: 1,  perms: 3,  desc: 'Role de fallback para usuários legados',         system: '—' },
 ];
 
+/**
+ * Em mobile permitimos `overflow-x: auto` para que tabelas largas
+ * mantenham todas as colunas sem espremer texto; o container restringe o
+ * scroll ao card e impede que ele afete o layout principal.
+ */
 const TableWrap = styled.div`
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   background: var(--bg-surface);
 `;
 
 const Table = styled.table`
   width: 100%;
+  min-width: 640px;
   border-collapse: collapse;
   font-size: 13.5px;
+
+  @media (min-width: 48em) {
+    min-width: 0;
+  }
 
   thead {
     background: var(--bg-elevated);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -36,9 +36,14 @@ const KVValue = styled.span`
   font-family: var(--font-mono);
 `;
 
+/**
+ * Em telas estreitas a linha de ações pode quebrar — `flex-wrap` evita
+ * overflow horizontal sem mudar a estrutura semântica.
+ */
 const Actions = styled.div`
   margin-top: 16px;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 `;
 

--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -30,25 +30,43 @@ const STATUS_MAP: Record<SystemItem['status'], { variant: BadgeVariant; label: s
   pending:   { variant: 'warning', label: 'Pendente' },
 };
 
+/**
+ * StatRow — em mobile (< --bp-md, 48em) duas colunas para evitar números
+ * espremidos; a partir de `--bp-md` recupera o layout 4×1 característico.
+ */
 const StatRow = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 14px;
-  margin-bottom: 26px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  margin-bottom: var(--space-5);
+
+  @media (min-width: 48em) {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px;
+    margin-bottom: 26px;
+  }
 `;
 
 const StatCard = styled.div`
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: 16px 18px;
+  padding: 14px 16px;
+
+  @media (min-width: 48em) {
+    padding: 16px 18px;
+  }
 `;
 
 const StatNumber = styled.div`
-  font-size: 28px;
+  font-size: 24px;
   font-weight: var(--weight-bold);
   letter-spacing: -0.03em;
   color: var(--fg1);
+
+  @media (min-width: 48em) {
+    font-size: 28px;
+  }
 `;
 
 const StatLabel = styled.div`
@@ -60,10 +78,19 @@ const StatLabel = styled.div`
   margin-top: 4px;
 `;
 
+/**
+ * Grid de cards de sistemas. Em mobile (< --bp-md) cada card ocupa a
+ * largura inteira; a partir de `--bp-md` (48em) volta a duas colunas.
+ */
 const Grid2 = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+  grid-template-columns: 1fr;
+  gap: 14px;
+
+  @media (min-width: 48em) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
 `;
 
 const CardMeta = styled.div`

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -30,19 +30,39 @@ const STATUS_MAP: Record<UserItem['status'], { variant: BadgeVariant; label: str
   pending:   { variant: 'warning', label: 'Pendente' },
 };
 
+/**
+ * FilterRow — em mobile (< --bp-md) empilha o input/filtros para evitar
+ * compressão e mantém touch targets confortáveis. Em desktop volta à
+ * linha única com Spacer empurrando a contagem à direita.
+ */
 const FilterRow = styled.div`
   display: flex;
+  flex-direction: column;
   gap: 10px;
-  align-items: flex-end;
+  align-items: stretch;
   margin-bottom: 18px;
 
   > *:first-child {
-    min-width: 280px;
+    min-width: 0;
+  }
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: flex-end;
+
+    > *:first-child {
+      min-width: 280px;
+    }
   }
 `;
 
 const Spacer = styled.div`
-  flex: 1;
+  display: none;
+
+  @media (min-width: 48em) {
+    display: block;
+    flex: 1;
+  }
 `;
 
 const MonoMuted = styled.span`
@@ -56,17 +76,27 @@ const Mono = styled.span`
   font-size: 12px;
 `;
 
+/**
+ * Em mobile permitimos `overflow-x: auto` para que a tabela mantenha
+ * todas as colunas legíveis via scroll horizontal contido ao card.
+ */
 const TableWrap = styled.div`
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   background: var(--bg-surface);
 `;
 
 const Table = styled.table`
   width: 100%;
+  min-width: 720px;
   border-collapse: collapse;
   font-size: 13.5px;
+
+  @media (min-width: 48em) {
+    min-width: 0;
+  }
 
   thead {
     background: var(--bg-elevated);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -82,6 +82,7 @@
   --bg-ghost-active: rgba(22, 36, 15, 0.1);
   --bg-danger-soft: rgba(217, 95, 95, 0.1);
   --bg-danger-hover: rgba(217, 95, 95, 0.18);
+  --bg-backdrop-modal: color-mix(in srgb, var(--clr-forest) 42%, transparent);
   --border-danger-soft: rgba(217, 95, 95, 0.3);
   --border-danger-strong: rgba(217, 95, 95, 0.5);
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -190,19 +190,29 @@
   --measure-base: 56ch;
   --measure-cta: 22rem;
   --measure-cta-min: 12rem;
+
+  /* ── Breakpoints ─────────────────────────────────────────────
+   * Tokens documentais — referência única dos pontos de quebra.
+   *
+   * Importante: CSS custom properties NÃO funcionam dentro da condição
+   * de `@media (...)` porque a regra é resolvida em tempo de parser,
+   * antes da cascata. Por isso os componentes devem repetir o valor
+   * literal (ex.: `@media (min-width: 48em)`) e referenciar este token
+   * em comentário para manter a tabela como fonte única de verdade.
+   *
+   *   --bp-sm: 30em  (≈ 480px) — handheld grande / phablet
+   *   --bp-md: 48em  (≈ 768px) — quebra mobile/desktop (Sidebar drawer)
+   *   --bp-lg: 64em  (≈ 1024px) — desktop padrão
+   *   --bp-xl: 80em  (≈ 1280px) — desktop largo
+   */
+  --bp-sm: 30em;
+  --bp-md: 48em;
+  --bp-lg: 64em;
+  --bp-xl: 80em;
 }
 
-/*
- * Breakpoints (referência) — CSS custom properties não funcionam dentro da
- * condição de @media (resolução em tempo de parser, antes da cascata). Use
- * estes literais nos @media de styled-components, mantendo a tabela única:
- *   --bp-xs: 30em   (≈ 480px)  — quebra para layouts ≥ tablet pequeno
- *   --bp-sm: 48em   (≈ 768px)  — quebra para tablet
- *   --bp-md: 60em   (≈ 960px)  — quebra para desktop
- *   --bp-lg: 75em   (≈ 1200px) — quebra para desktop largo
- */
-
-@media (min-width: 60em) {
+/* Grid maior em desktop — espelha `--bp-lg` (64em ≈ 1024px). */
+@media (min-width: 64em) {
   :root {
     --grid-cell: 40px;
   }


### PR DESCRIPTION
## Summary

- Adiciona tokens reais de breakpoint (`--bp-sm: 30em`, `--bp-md: 48em`, `--bp-lg: 64em`, `--bp-xl: 80em`) em `tokens.css`, com bloco de comentário explicando o uso em `@media`. Atualiza `--grid-cell` para crescer a partir de `--bp-lg` em vez do antigo `60em`.
- Sidebar mobile como drawer off-canvas: `transform: translateX` controlado por prop `open`, backdrop com blur, fechamento via Escape, clique no backdrop, botão de fechar (X) ou navegação. Em desktop (≥ `--bp-md`) mantém comportamento sticky atual.
- Topbar adaptativo em mobile: hamburger à esquerda dispara `onMenuClick`, busca colapsa em ícone e expande sobre a Topbar com botão de fechar, UserMeta e botão de notificações ocultos para preservar espaço (Avatar + logout permanecem). Touch targets ≥ 44×44 via `--touch-min`. Em desktop volta ao layout original.
- AppLayout coordena o drawer com `useState` local; fecha automaticamente ao trocar de rota e bloqueia scroll do body via `createGlobalStyle` quando aberto. `Shell` usa coluna única em mobile (sidebar é overlay).
- ContentArea com padding mobile-first (20×16) que cresce em `--bp-md` (28×24) e `--bp-lg` (36 + max-width), mais `min-width: 0` para impedir overflow horizontal.
- Páginas auditadas: `PageHeader` empilha em coluna em mobile; `SystemsPage` reduz `StatRow` (4→2) e `Grid2` (2→1); `RolesPage`/`UsersPage` ganham wrapper com `overflow-x: auto` e `min-width` na tabela em mobile (scroll horizontal contido ao card); `UsersPage` `FilterRow` empilha em coluna; `PermissionsPage` `PermGrid` 1→2→3 colunas; `SettingsPage` `Actions` com `flex-wrap`.
- Testes: `Sidebar.test.tsx` (7 cenários — backdrop, ESC, link click, close button, render acessível) e `Topbar.test.tsx` (6 cenários — hamburger, busca toggle/close, logout, render).

Decisões não óbvias:

- Busca em mobile expande inline ocupando a Topbar (não modal) — solução mais leve, sem dep nova, e fácil de evoluir para `cmdk` no futuro.
- Drawer não usa biblioteca externa: implementa Escape + backdrop + scroll lock com hooks próprios. `aria-modal="true"` declarado no aside; foco move-se para o aside ao abrir.
- `min-width` da tabela em mobile (`640px`/`720px`) preserva legibilidade das colunas e o scroll horizontal fica restrito ao card — o layout principal não quebra.
- Em jsdom, regras de `@media (min-width)` não aplicam por padrão; `getByText` ignora visibilidade, então testes existentes que asseguram presença textual continuam válidos.

## Test plan

- [x] `docker compose exec -T web npm run lint` (0 warnings)
- [x] `docker compose exec -T web npm run typecheck`
- [x] `docker compose exec -T web npm test` (57 tests OK, +13 novos)
- [x] `docker compose exec -T web npm run build`
- [ ] Validação manual em DevTools nos breakpoints: 320, 360, 480, 768, 1024, 1280, 1440
- [ ] Em mobile (≤768): Sidebar fechada por padrão; hamburger abre drawer; backdrop visível; clique no backdrop fecha; tecla Escape fecha; navegar por NavLink fecha automaticamente
- [ ] Em desktop (≥768): Sidebar visível como hoje, sem drawer/backdrop
- [ ] Busca em mobile: ícone abre input que ocupa a linha inteira da Topbar; X fecha
- [ ] Sem scroll horizontal em qualquer página em qualquer largura (320–1440)
- [ ] Páginas com tabela (Roles/Users) têm scroll horizontal restrito ao card em mobile
- [ ] ErrorPage em 320: padding adequado, CTA acessível, sem overflow
- [ ] Showcase em 320: grid responde, componentes não estouram

Closes #19

Refs Epic #18