### PR TITLE
feat: tema dark com toggle (#20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,26 @@
     <meta name="description" content="LFC Admin GUI" />
     <link rel="manifest" href="/manifest.json" />
     <title>LFC Admin GUI</title>
+    <script>
+      // Anti-FOUC: define `data-theme` no <html> antes do React montar.
+      // - Lê preferência persistida em `localStorage` ('lfc-admin-theme'):
+      //   * 'light' / 'dark' → escolhas explícitas
+      //   * ausente / 'system' → segue prefers-color-scheme do SO
+      // - Falha silenciosamente em modo privado / SSR / cota zerada.
+      (function () {
+        try {
+          var stored = window.localStorage.getItem('lfc-admin-theme');
+          var explicit = stored === 'light' || stored === 'dark';
+          var prefersDark =
+            typeof window.matchMedia === 'function' &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var theme = explicit ? stored : prefersDark ? 'dark' : 'light';
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (_err) {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/Sidebar.test.tsx
+++ b/src/components/layout/Sidebar.test.tsx
@@ -1,8 +1,44 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { THEME_STORAGE_KEY } from '../../hooks/useTheme';
 
 import { Sidebar } from './Sidebar';
+
+/**
+ * Reinstala um polyfill estável de `matchMedia` para cada teste — o Sidebar
+ * agora consome `useTheme()`, que chama `window.matchMedia` em runtime.
+ * O default casa para `false`; quando o teste precisa simular preferência
+ * dark do SO, basta passar `dark = true`.
+ */
+const installMatchMedia = (dark = false) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('dark') ? dark : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+};
+
+/**
+ * Decodifica o `src` quando o asset SVG é servido como data URL inline
+ * (comportamento do Vite em test). Para `string` simples retorna a
+ * própria URL.
+ */
+const decodeLogoSrc = (src: string): string => {
+  const dataUrlMatch = src.match(/^data:image\/svg\+xml;base64,(.+)$/);
+  if (dataUrlMatch) return atob(dataUrlMatch[1]);
+  return src;
+};
 
 function renderSidebar(open = false, onClose: () => void = vi.fn()) {
   return render(
@@ -13,6 +49,12 @@ function renderSidebar(open = false, onClose: () => void = vi.fn()) {
 }
 
 describe('Sidebar', () => {
+  beforeEach(() => {
+    installMatchMedia(false);
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
   it('renderiza navegação acessível com itens principais', () => {
     renderSidebar(false);
 
@@ -77,5 +119,42 @@ describe('Sidebar', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renderiza logo escura (logo-dark.svg) quando resolvedTheme é light (default)', () => {
+    renderSidebar(false);
+
+    const logo = screen.getByTestId('sidebar-logo') as HTMLImageElement;
+    const decoded = decodeLogoSrc(logo.src);
+
+    expect(logo).toHaveAttribute('alt', 'LFC Admin');
+    // logo-dark.svg usa fill `#16240F` (forest profundo) — visível sobre
+    // fundo claro do tema light.
+    expect(decoded).toContain('#16240F');
+    expect(decoded).not.toContain('#AECA59');
+  });
+
+  it('renderiza logo clara (logo-white.svg) quando resolvedTheme é dark via prefers-color-scheme', () => {
+    installMatchMedia(true);
+    renderSidebar(false);
+
+    const logo = screen.getByTestId('sidebar-logo') as HTMLImageElement;
+    const decoded = decodeLogoSrc(logo.src);
+
+    // logo-white.svg usa fill `#AECA59` (lime) e `#E2EDD0` (cream) —
+    // visível sobre fundo escuro do tema dark, preservando contraste WCAG.
+    expect(decoded).toContain('#AECA59');
+    expect(decoded).not.toContain('#16240F');
+  });
+
+  it('renderiza logo clara quando preferência persistida é dark (sobrepõe SO light)', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    renderSidebar(false);
+
+    const logo = screen.getByTestId('sidebar-logo') as HTMLImageElement;
+    const decoded = decodeLogoSrc(logo.src);
+
+    expect(decoded).toContain('#AECA59');
+    expect(decoded).not.toContain('#16240F');
   });
 });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,7 +13,13 @@ import React, { useEffect, useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import logoDark from '../../assets/logo-dark.svg';
+// `logo-dark.svg` usa fill escuro (forest) e foi desenhada para fundo claro;
+// `logo-white.svg` usa fill claro (lime/cream) e foi desenhada para fundo
+// escuro. A seleção é feita em runtime conforme `resolvedTheme` para
+// preservar contraste WCAG em ambos os temas.
+import logoForLightTheme from '../../assets/logo-dark.svg';
+import logoForDarkTheme from '../../assets/logo-white.svg';
+import { useTheme } from '../../hooks/useTheme';
 
 interface NavItem {
   to: string;
@@ -259,6 +265,8 @@ const FootVersion = styled.div`
 
 export const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
   const wrapperRef = useRef<HTMLElement | null>(null);
+  const { resolvedTheme } = useTheme();
+  const logoSrc = resolvedTheme === 'dark' ? logoForDarkTheme : logoForLightTheme;
 
   /**
    * Tecla ESC fecha o drawer. Listener só ativa quando aberto para evitar
@@ -306,7 +314,12 @@ export const Sidebar: React.FC<SidebarProps> = ({ open, onClose }) => {
       >
         <SidebarHeader>
           <LogoArea>
-            <img src={logoDark} alt="LFC Admin" height={28} />
+            <img
+              src={logoSrc}
+              alt="LFC Admin"
+              height={28}
+              data-testid="sidebar-logo"
+            />
           </LogoArea>
           <CloseButton
             type="button"

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -2,6 +2,8 @@ import { Search, Bell, LogOut, Menu, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
+import { ThemeToggle } from '../ui/ThemeToggle';
+
 interface TopbarUser {
   name: string;
   role?: string;
@@ -436,6 +438,7 @@ export const Topbar: React.FC<TopbarProps> = ({
         >
           <Bell size={16} strokeWidth={1.5} />
         </NotificationsButton>
+        <ThemeToggle />
         <UserSection>
           <Avatar>{initials}</Avatar>
           <UserMeta>

--- a/src/components/ui/ThemeToggle.test.tsx
+++ b/src/components/ui/ThemeToggle.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { THEME_STORAGE_KEY } from '../../hooks/useTheme';
+
+import { ThemeToggle } from './ThemeToggle';
+
+const installMatchMedia = (initialDark: boolean) => {
+  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+    matches: query.includes('dark') ? initialDark : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+};
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renderiza com aria-label e aria-pressed coerentes ao tema atual', () => {
+    installMatchMedia(false);
+    render(<ThemeToggle />);
+
+    const button = screen.getByRole('button', { name: 'Ativar tema escuro' });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('alterna o tema ao clicar e atualiza aria-label', () => {
+    installMatchMedia(false);
+    render(<ThemeToggle />);
+
+    const button = screen.getByTestId('theme-toggle');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    fireEvent.click(button);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('aria-label', 'Ativar tema claro');
+  });
+
+  it('persiste a escolha em localStorage com a chave correta', () => {
+    installMatchMedia(false);
+    render(<ThemeToggle />);
+
+    fireEvent.click(screen.getByTestId('theme-toggle'));
+
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+  });
+
+  it('respeita preferência de sistema (dark) no primeiro render', () => {
+    installMatchMedia(true);
+    render(<ThemeToggle />);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(screen.getByTestId('theme-toggle')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('respeita preferência persistida sobre o sistema', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    installMatchMedia(true);
+    render(<ThemeToggle />);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(screen.getByTestId('theme-toggle')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('é acessível via teclado (botão com type=button e role)', () => {
+    installMatchMedia(false);
+    render(<ThemeToggle />);
+
+    const button = screen.getByTestId('theme-toggle');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,108 @@
+import { Moon, Sun } from 'lucide-react';
+import React from 'react';
+import styled from 'styled-components';
+
+import { useTheme } from '../../hooks/useTheme';
+
+import { Icon } from './Icon';
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+/**
+ * Botão de toggle de tema. Mantém paridade visual com os demais botões
+ * de ícone do `Topbar` (`IconButton`): mesmo tamanho touch, mesma
+ * borda/hover/focus. Em desktop encolhe para o quadrado compacto de
+ * 34×34px utilizado pelo Bell e Logout.
+ *
+ * Decisão: ciclo binário `light` ↔ `dark`. Acessar `system` continua
+ * possível via API (`useTheme().setTheme('system')`) e via ausência da
+ * chave no `localStorage` no primeiro carregamento — basta o usuário
+ * limpar storage para voltar a "seguir o sistema". Optamos por não
+ * expor um terceiro estado na UI por agora para manter o componente
+ * simples; a evolução para dropdown três-estados é compatível.
+ */
+const ToggleButton = styled.button`
+  appearance: none;
+  background: transparent;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  flex-shrink: 0;
+  transition:
+    background var(--duration-fast) var(--ease-default),
+    border-color var(--duration-fast) var(--ease-default),
+    color var(--duration-fast) var(--ease-default),
+    transform var(--duration-fast) var(--ease-default);
+
+  &:hover:not(:disabled) {
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    border-color: var(--border-base);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(var(--press-offset));
+    background: var(--bg-overlay);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.42;
+    cursor: not-allowed;
+  }
+
+  /* Desktop (≥ --bp-md, 48em) — densidade compacta espelhando o
+     IconButton do Topbar. */
+  @media (min-width: 48em) {
+    width: 34px;
+    height: 34px;
+    min-width: 0;
+    min-height: 0;
+  }
+`;
+
+/**
+ * `ThemeToggle` — alterna entre tema claro e escuro com persistência
+ * em `localStorage`. Pronto para teclado (`:focus-visible` ring) e
+ * leitores de tela (`aria-label`, `aria-pressed`).
+ */
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className }) => {
+  const { resolvedTheme, toggleTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const ariaLabel = isDark ? 'Ativar tema claro' : 'Ativar tema escuro';
+  const title = isDark ? 'Mudar para tema claro' : 'Mudar para tema escuro';
+
+  return (
+    <ToggleButton
+      type="button"
+      className={className}
+      onClick={toggleTheme}
+      aria-label={ariaLabel}
+      aria-pressed={isDark}
+      title={title}
+      data-testid="theme-toggle"
+    >
+      <Icon
+        icon={isDark ? Sun : Moon}
+        size="sm"
+        tone="currentColor"
+        strokeWidth={1.6}
+      />
+    </ToggleButton>
+  );
+};
+
+export type { ThemeToggleProps };

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -71,6 +71,17 @@ const ToggleButton = styled.button`
     min-width: 0;
     min-height: 0;
   }
+
+  /* Acessibilidade: usuários que preferem movimento reduzido não devem
+     ter transitions (background/border/color/transform) animadas. Espelha
+     o tratamento já adotado em Spinner.tsx e globals.css. */
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:active:not(:disabled) {
+      transform: none;
+    }
+  }
 `;
 
 /**

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -13,3 +13,5 @@ export { Icon } from './Icon';
 export type { IconProps, IconSize, IconTone } from './Icon';
 export { Spinner } from './Spinner';
 export type { SpinnerProps, SpinnerSize, SpinnerTone } from './Spinner';
+export { ThemeToggle } from './ThemeToggle';
+export type { ThemeToggleProps } from './ThemeToggle';

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,0 +1,199 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { THEME_STORAGE_KEY, useTheme } from './useTheme';
+
+/**
+ * Helper para construir um mock determinístico de `matchMedia` que
+ * respeita a query consultada e expõe os listeners para podermos
+ * disparar mudanças do SO em tempo de teste.
+ *
+ * Usamos cast via `unknown` para `MediaQueryList` porque a assinatura
+ * de `addEventListener` no DOM é genérica/sobrecarregada e não bate
+ * pixel-perfect com a forma simplificada que precisamos no teste.
+ * É o padrão recomendado pela docs do Vitest para mocks de matchMedia.
+ */
+type MediaListener = (event: MediaQueryListEvent) => void;
+
+const createMatchMedia = (initialDark: boolean) => {
+  const listeners = new Set<MediaListener>();
+  let darkState = initialDark;
+
+  const matchMedia = vi.fn((query: string): MediaQueryList => {
+    const list = {
+      get matches() {
+        return query.includes('dark') ? darkState : false;
+      },
+      media: query,
+      onchange: null,
+      addEventListener: (event: string, cb: EventListenerOrEventListenerObject) => {
+        if (event === 'change' && typeof cb === 'function') {
+          listeners.add(cb as MediaListener);
+        }
+      },
+      removeEventListener: (event: string, cb: EventListenerOrEventListenerObject) => {
+        if (event === 'change' && typeof cb === 'function') {
+          listeners.delete(cb as MediaListener);
+        }
+      },
+      addListener: (cb: MediaListener) => {
+        listeners.add(cb);
+      },
+      removeListener: (cb: MediaListener) => {
+        listeners.delete(cb);
+      },
+      dispatchEvent: vi.fn(),
+    };
+    return list as unknown as MediaQueryList;
+  });
+
+  const setSystemDark = (next: boolean) => {
+    darkState = next;
+    listeners.forEach(cb =>
+      cb({ matches: next, media: '(prefers-color-scheme: dark)' } as MediaQueryListEvent),
+    );
+  };
+
+  return { matchMedia, setSystemDark };
+};
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('default é "system" quando localStorage está vazio', () => {
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('system');
+  });
+
+  it('resolve "system" para "dark" quando prefers-color-scheme: dark', () => {
+    const { matchMedia } = createMatchMedia(true);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('resolve "system" para "light" quando prefers-color-scheme: light', () => {
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('lê preferência persistida do localStorage', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('setTheme persiste e aplica no DOM imediatamente', () => {
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme('dark'));
+
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('setTheme("system") remove a chave do localStorage', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme('system'));
+
+    expect(result.current.theme).toBe('system');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(result.current.resolvedTheme).toBe('light');
+  });
+
+  it('toggleTheme alterna binariamente light ↔ dark', () => {
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    // Default system → light
+    expect(result.current.resolvedTheme).toBe('light');
+
+    act(() => result.current.toggleTheme());
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+
+    act(() => result.current.toggleTheme());
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+  });
+
+  it('reage a mudanças do SO quando theme === "system"', () => {
+    const { matchMedia, setSystemDark } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.resolvedTheme).toBe('light');
+
+    act(() => setSystemDark(true));
+
+    expect(result.current.resolvedTheme).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('NÃO reage a mudanças do SO quando theme é explícito', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    const { matchMedia, setSystemDark } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('light');
+
+    act(() => setSystemDark(true));
+
+    // Permaneceu light — preferência explícita tem precedência sobre SO.
+    expect(result.current.resolvedTheme).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('ignora valores inválidos no localStorage e cai para "system"', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'rainbow');
+    const { matchMedia } = createMatchMedia(false);
+    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('system');
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -88,6 +88,18 @@ interface UseThemeResult {
  * renderização quanto a cada mudança — em conjunto com o script
  * anti-FOUC do `index.html`, garante que a paleta correta esteja
  * presente desde o primeiro frame.
+ *
+ * Comportamento do modo `system` na UI atual:
+ * - O `ThemeToggle` (componente visível na Topbar) só cicla
+ *   binariamente entre `light` e `dark` via `toggleTheme()`. Ao
+ *   primeiro clique a partir de `system`, a preferência é "promovida"
+ *   para a escolha explícita oposta ao tema resolvido naquele momento.
+ * - O modo `system` continua acessível por dois caminhos: (a) chamada
+ *   programática `setTheme('system')`, e (b) ausência da chave
+ *   `lfc-admin-theme` no `localStorage` no primeiro carregamento — o
+ *   hook então segue `prefers-color-scheme` do SO em runtime.
+ * - A evolução para um dropdown de três estados (`light`/`dark`/
+ *   `system`) é compatível com este hook sem quebra de API.
  */
 export const useTheme = (): UseThemeResult => {
   const [theme, setThemeState] = useState<ThemePreference>(() => readStoredPreference());

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Tema escolhido pelo usuário.
+ *
+ * - `light` / `dark` — escolhas explícitas (persistidas no `localStorage`).
+ * - `system` — segue `prefers-color-scheme` do navegador. É o default
+ *   quando não há valor persistido. Quando o usuário troca a preferência
+ *   do sistema o `resolvedTheme` reage em tempo real (via matchMedia).
+ */
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+/** Tema efetivamente aplicado no DOM (resolução de `system`). */
+export type ResolvedTheme = 'light' | 'dark';
+
+/** Chave do `localStorage` — fonte de verdade de persistência. */
+export const THEME_STORAGE_KEY = 'lfc-admin-theme';
+
+/** Atributo aplicado em `<html>` para alternar tokens semânticos. */
+const THEME_ATTRIBUTE = 'data-theme';
+
+const isThemePreference = (value: unknown): value is ThemePreference =>
+  value === 'light' || value === 'dark' || value === 'system';
+
+/**
+ * Lê preferência persistida. SSR-safe: retorna `system` quando `window`
+ * não está disponível ou quando `localStorage` lança (ex.: modo privado
+ * com cota zerada).
+ */
+const readStoredPreference = (): ThemePreference => {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isThemePreference(raw) ? raw : 'system';
+  } catch {
+    return 'system';
+  }
+};
+
+/**
+ * Detecta o tema preferido do sistema operacional. Caso `matchMedia`
+ * não esteja disponível (jsdom sem polyfill, navegadores legados), cai
+ * para `light` como padrão conservador.
+ */
+const getSystemTheme = (): ResolvedTheme => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const resolveTheme = (preference: ThemePreference): ResolvedTheme =>
+  preference === 'system' ? getSystemTheme() : preference;
+
+/**
+ * Aplica `data-theme` no `<html>`. Centralizado para garantir que todas
+ * as transições passem pelo mesmo ponto de DOM.
+ */
+const applyDocumentTheme = (resolved: ResolvedTheme): void => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute(THEME_ATTRIBUTE, resolved);
+};
+
+interface UseThemeResult {
+  /** Preferência escolhida pelo usuário (`light` | `dark` | `system`). */
+  theme: ThemePreference;
+  /** Tema efetivamente aplicado (resolução de `system`). */
+  resolvedTheme: ResolvedTheme;
+  /**
+   * Persiste nova preferência. `system` remove a chave do `localStorage`
+   * para que outros consumidores (script anti-FOUC) percebam ausência
+   * de escolha persistida.
+   */
+  setTheme: (preference: ThemePreference) => void;
+  /** Alterna binariamente entre `light` ↔ `dark`. Ignora `system`. */
+  toggleTheme: () => void;
+}
+
+/**
+ * Hook unificado para tema.
+ *
+ * Persistência em `localStorage` (`lfc-admin-theme`) e detecção do
+ * sistema via `matchMedia('(prefers-color-scheme: dark)')`. Quando
+ * `theme === 'system'`, o `resolvedTheme` reage em tempo real às
+ * mudanças do SO (não exige reload).
+ *
+ * O atributo `data-theme` no `<html>` é aplicado tanto na primeira
+ * renderização quanto a cada mudança — em conjunto com o script
+ * anti-FOUC do `index.html`, garante que a paleta correta esteja
+ * presente desde o primeiro frame.
+ */
+export const useTheme = (): UseThemeResult => {
+  const [theme, setThemeState] = useState<ThemePreference>(() => readStoredPreference());
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(readStoredPreference()),
+  );
+
+  /**
+   * Recalcula `resolvedTheme` e aplica no DOM sempre que a preferência
+   * muda. Trata também o caso de `system` quando o SO troca em runtime.
+   */
+  useEffect(() => {
+    const next = resolveTheme(theme);
+    setResolvedTheme(next);
+    applyDocumentTheme(next);
+  }, [theme]);
+
+  /**
+   * Quando a preferência é `system`, espelha mudanças do SO em runtime
+   * (usuário troca dark/light no SO sem recarregar a página). Listener
+   * só ativa nesse modo para evitar trabalho desnecessário.
+   */
+  useEffect(() => {
+    if (theme !== 'system') return;
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      const next: ResolvedTheme = event.matches ? 'dark' : 'light';
+      setResolvedTheme(next);
+      applyDocumentTheme(next);
+    };
+
+    // Compat: Safari < 14 expõe addListener/removeListener no lugar
+    // dos eventos modernos. Tipamos com union pra cobrir os dois.
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handleChange);
+      return () => media.removeEventListener('change', handleChange);
+    }
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, [theme]);
+
+  const setTheme = useCallback((preference: ThemePreference) => {
+    setThemeState(preference);
+    if (typeof window === 'undefined') return;
+    try {
+      if (preference === 'system') {
+        window.localStorage.removeItem(THEME_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+      }
+    } catch {
+      // Persistência é best-effort — modo privado/cota zerada não
+      // deve quebrar a UX. O estado em memória continua válido.
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => {
+      // Se estiver em `system`, decide com base no resolvido atual e
+      // promove para escolha explícita oposta.
+      const current: ResolvedTheme = prev === 'system' ? resolveTheme(prev) : prev;
+      const next: ThemePreference = current === 'dark' ? 'light' : 'dark';
+      try {
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(THEME_STORAGE_KEY, next);
+        }
+      } catch {
+        // ver comentário em `setTheme`.
+      }
+      return next;
+    });
+  }, []);
+
+  return { theme, resolvedTheme, setTheme, toggleTheme };
+};

--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -10,7 +10,9 @@ import {
   Icon,
   Label,
   Spinner,
+  ThemeToggle,
 } from '../components/ui';
+import { useTheme } from '../hooks/useTheme';
 
 const Page = styled.div`
   display: flex;
@@ -74,8 +76,40 @@ const Tones = styled.div`
   gap: var(--space-4);
 `;
 
+/**
+ * Linha que evidencia o estado atual do tema. Expõe a preferência
+ * persistida (`theme`) e o valor resolvido (`resolvedTheme`) para
+ * facilitar QA visual durante desenvolvimento.
+ */
+const ThemeRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+`;
+
+const ThemeStatus = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+`;
+
+const ThemeBadge = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--accent-ink);
+`;
+
 export const ShowcasePage: React.FC = () => {
   const [loadingDemo, setLoadingDemo] = useState(false);
+  const { theme, resolvedTheme } = useTheme();
 
   const triggerLoading = () => {
     setLoadingDemo(true);
@@ -92,6 +126,31 @@ export const ShowcasePage: React.FC = () => {
           tokens do design system.
         </Body>
       </SectionHead>
+
+      {/* ─── Theme ──────────────────────────────────────────────── */}
+      <Section aria-label="Theme">
+        <SectionHead>
+          <Caption>Theme</Caption>
+          <Heading level={3}>Tema claro / escuro</Heading>
+        </SectionHead>
+        <Body muted>
+          Use o toggle no Topbar (ou o duplicado abaixo) para alternar entre
+          claro e escuro. A escolha é persistida em <code>localStorage</code> sob
+          a chave <code>lfc-admin-theme</code>; sem escolha persistida o tema
+          segue <code>prefers-color-scheme</code> do sistema.
+        </Body>
+        <ThemeRow>
+          <ThemeToggle />
+          <ThemeStatus>
+            <Caption>
+              Preferência: <ThemeBadge>{theme}</ThemeBadge>
+            </Caption>
+            <Caption>
+              Resolvido: <ThemeBadge>{resolvedTheme}</ThemeBadge>
+            </Caption>
+          </ThemeStatus>
+        </ThemeRow>
+      </Section>
 
       {/* ─── Typography ─────────────────────────────────────────── */}
       <Section aria-label="Typography">

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,46 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+import { afterEach, vi } from 'vitest';
+
+/**
+ * jsdom não implementa `matchMedia`. Polyfill default: nenhuma media
+ * query "matches" e listeners são noop. Testes que precisam simular
+ * `prefers-color-scheme: dark` substituem esta implementação via
+ * `vi.spyOn(window, 'matchMedia')` no próprio teste.
+ */
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // legacy — Safari < 14
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+/**
+ * Garante isolamento entre testes que tocam tema (`useTheme`,
+ * `ThemeToggle`): limpa `localStorage` e remove `data-theme` no
+ * `<html>` para não vazar estado entre suites.
+ */
+afterEach(() => {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore — modo privado/cota zerada não quebra o teste seguinte.
+    }
+  }
+  if (typeof document !== 'undefined') {
+    document.documentElement.removeAttribute('data-theme');
+  }
+});

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,6 +1,15 @@
 /* ============================================================
  * LFC Authenticator — Design Tokens
  * Fonte única de verdade para cores, tipografia e espaçamento.
+ *
+ * Organização em camadas:
+ *   1. Invariantes globais  → `:root`
+ *      (espaçamento, raios, tipografia, breakpoints, motion,
+ *      paleta brand raw e demais valores que NÃO mudam por tema)
+ *   2. Tokens semânticos por tema → `[data-theme='light']` e
+ *      `[data-theme='dark']` (superfícies, foreground, bordas,
+ *      sombras, focus rings — qualquer cor/tonalidade que
+ *      precise alternar entre light e dark)
  * ============================================================ */
 
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap');
@@ -23,8 +32,14 @@
   font-display: swap;
 }
 
+/* ============================================================
+ * 1. INVARIANTES — não mudam entre temas
+ * ============================================================ */
 :root {
-  /* ── Brand palette ───────────────────────────────────────── */
+  /* ── Brand palette (raw) ─────────────────────────────────────
+   * Valores fixos da identidade. Tokens semânticos por tema
+   * compõem a partir destes; raramente devem ser usados
+   * diretamente em componentes. */
   --clr-forest: #16240f;
   --clr-forest-mid: #1e3516;
   --clr-hunter: #5b7d47;
@@ -35,65 +50,11 @@
   --clr-black: #000000;
   --clr-white: #ffffff;
 
-  /* ── Semantic surfaces (light) ───────────────────────────── */
-  --bg-base: #f2f4ea;
-  --bg-surface: #ffffff;
-  --bg-elevated: #ecefe0;
-  --bg-overlay: #e0e5cd;
-
-  /* ── Borders ─────────────────────────────────────────────── */
-  --border-subtle: rgba(22, 36, 15, 0.08);
-  --border-base: rgba(22, 36, 15, 0.16);
-  --border-strong: rgba(91, 125, 71, 0.55);
-  --border-soft-forest: rgba(22, 36, 15, 0.14);
-  --border-medium-forest: rgba(22, 36, 15, 0.28);
-
-  /* Border widths — usados por componentes com bordas estruturais */
+  /* ── Border widths ─────────────────────────────────────────── */
   --border-thin: 1px;
   --border-medium: 1.5px;
   --border-thick: 2px;
   --border-thicker: 2.5px;
-
-  /* ── Foreground / text ───────────────────────────────────── */
-  --fg1: #1b2a12;
-  --fg2: #4a5e42;
-  --fg3: #6e8164;
-  --fg4: #b5bea8;
-  --fg-inverse: #ffffff;
-
-  --text-primary: var(--fg1);
-  --text-secondary: var(--fg2);
-  --text-muted: var(--fg3);
-  --text-disabled: var(--fg4);
-
-  /* ── Accents & status ────────────────────────────────────── */
-  --accent: #aeca59;
-  --accent-dim: #8cb139;
-  --accent-ink: #5a7d1f;
-  --danger: #d95f5f;
-  --warning: #d9a24a;
-  --info: #4a9fd9;
-  --success: #aeca59;
-  --danger-ink: color-mix(in srgb, var(--danger) 65%, black);
-
-  /* ── UI state colors/shadows ─────────────────────────────── */
-  --grid-line: rgba(22, 36, 15, 0.04);
-  --bg-ghost-hover: rgba(22, 36, 15, 0.05);
-  --bg-ghost-active: rgba(22, 36, 15, 0.1);
-  --bg-danger-soft: rgba(217, 95, 95, 0.1);
-  --bg-danger-hover: rgba(217, 95, 95, 0.18);
-  --bg-backdrop-modal: color-mix(in srgb, var(--clr-forest) 42%, transparent);
-  --border-danger-soft: rgba(217, 95, 95, 0.3);
-  --border-danger-strong: rgba(217, 95, 95, 0.5);
-
-  --focus-ring-accent: 0 0 0 3px rgba(174, 202, 89, 0.22);
-  --focus-ring-accent-strong: 0 0 0 3px rgba(174, 202, 89, 0.28);
-  --focus-ring-danger: 0 0 0 3px rgba(217, 95, 95, 0.22);
-  --focus-ring-danger-soft: 0 0 0 3px color-mix(in srgb, var(--danger) 10%, transparent);
-  --focus-ring-border: 0 0 0 3px color-mix(in srgb, var(--border-strong) 60%, transparent);
-
-  --shadow-button-primary: 0 1px 0 rgba(22, 36, 15, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.25);
-  --shadow-button-primary-active: inset 0 1px 2px rgba(22, 36, 15, 0.18);
 
   /* ── Fonts ───────────────────────────────────────────────── */
   --font-display: 'Geist', 'Inter', system-ui, -apple-system, sans-serif;
@@ -136,15 +97,6 @@
   --radius-xl: 16px;
   --radius-2xl: 20px;
   --radius-full: 9999px;
-
-  /* ── Shadows ─────────────────────────────────────────────── */
-  --shadow-sm: 0 1px 2px rgba(22, 36, 15, 0.04), 0 0 0 1px var(--border-subtle);
-  --shadow-md: 0 4px 14px rgba(22, 36, 15, 0.07), 0 0 0 1px var(--border-subtle);
-  --shadow-card: 0 1px 2px rgba(22, 36, 15, 0.04), 0 2px 12px rgba(22, 36, 15, 0.06),
-    0 0 0 1px var(--border-subtle);
-  --shadow-modal: 0 24px 48px rgba(22, 36, 15, 0.16), 0 4px 12px rgba(22, 36, 15, 0.06),
-    0 0 0 1px var(--border-base);
-  --shadow-glow: 0 0 24px rgba(174, 202, 89, 0.3), 0 0 48px rgba(174, 202, 89, 0.12);
 
   /* ── Motion ──────────────────────────────────────────────── */
   --ease-default: cubic-bezier(0.16, 1, 0.3, 1);
@@ -219,20 +171,158 @@
   }
 }
 
-/* ── Dark mode ─────────────────────────────────────────────── */
+/* ============================================================
+ * 2. TOKENS SEMÂNTICOS POR TEMA
+ *
+ * Aplicados via `data-theme` no `<html>`. O default `light` também
+ * é aplicado via `:root` para garantir que páginas servidas antes
+ * da hidratação do JS (ou em ambientes sem `data-theme` definido)
+ * tenham um esquema válido. O bloco `[data-theme='light']` repete
+ * os mesmos valores para alinhar especificidade quando o tema é
+ * trocado dinamicamente (evita herança parcial entre seletor base
+ * e seletor com atributo).
+ * ============================================================ */
+:root,
+[data-theme='light'] {
+  /* ── Surfaces ────────────────────────────────────────────── */
+  --bg-base: #f2f4ea;
+  --bg-surface: #ffffff;
+  --bg-elevated: #ecefe0;
+  --bg-overlay: #e0e5cd;
+
+  /* ── Borders ─────────────────────────────────────────────── */
+  --border-subtle: rgba(22, 36, 15, 0.08);
+  --border-base: rgba(22, 36, 15, 0.16);
+  --border-strong: rgba(91, 125, 71, 0.55);
+  --border-soft-forest: rgba(22, 36, 15, 0.14);
+  --border-medium-forest: rgba(22, 36, 15, 0.28);
+
+  /* ── Foreground / text ───────────────────────────────────── */
+  --fg1: #1b2a12;
+  --fg2: #4a5e42;
+  --fg3: #6e8164;
+  --fg4: #b5bea8;
+  --fg-inverse: #ffffff;
+
+  --text-primary: var(--fg1);
+  --text-secondary: var(--fg2);
+  --text-muted: var(--fg3);
+  --text-disabled: var(--fg4);
+
+  /* ── Accents & status ────────────────────────────────────── */
+  --accent: #aeca59;
+  --accent-dim: #8cb139;
+  --accent-ink: #5a7d1f;
+  --danger: #d95f5f;
+  --warning: #d9a24a;
+  --info: #4a9fd9;
+  --success: #aeca59;
+  --danger-ink: color-mix(in srgb, var(--danger) 65%, black);
+
+  /* ── UI state colors/shadows ─────────────────────────────── */
+  --grid-line: rgba(22, 36, 15, 0.04);
+  --bg-ghost-hover: rgba(22, 36, 15, 0.05);
+  --bg-ghost-active: rgba(22, 36, 15, 0.1);
+  --bg-danger-soft: rgba(217, 95, 95, 0.1);
+  --bg-danger-hover: rgba(217, 95, 95, 0.18);
+  --bg-backdrop-modal: color-mix(in srgb, var(--clr-forest) 42%, transparent);
+  --border-danger-soft: rgba(217, 95, 95, 0.3);
+  --border-danger-strong: rgba(217, 95, 95, 0.5);
+
+  --focus-ring-accent: 0 0 0 3px rgba(174, 202, 89, 0.22);
+  --focus-ring-accent-strong: 0 0 0 3px rgba(174, 202, 89, 0.28);
+  --focus-ring-danger: 0 0 0 3px rgba(217, 95, 95, 0.22);
+  --focus-ring-danger-soft: 0 0 0 3px color-mix(in srgb, var(--danger) 10%, transparent);
+  --focus-ring-border: 0 0 0 3px color-mix(in srgb, var(--border-strong) 60%, transparent);
+
+  --shadow-button-primary: 0 1px 0 rgba(22, 36, 15, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  --shadow-button-primary-active: inset 0 1px 2px rgba(22, 36, 15, 0.18);
+
+  /* ── Shadows ─────────────────────────────────────────────── */
+  --shadow-sm: 0 1px 2px rgba(22, 36, 15, 0.04), 0 0 0 1px var(--border-subtle);
+  --shadow-md: 0 4px 14px rgba(22, 36, 15, 0.07), 0 0 0 1px var(--border-subtle);
+  --shadow-card: 0 1px 2px rgba(22, 36, 15, 0.04), 0 2px 12px rgba(22, 36, 15, 0.06),
+    0 0 0 1px var(--border-subtle);
+  --shadow-modal: 0 24px 48px rgba(22, 36, 15, 0.16), 0 4px 12px rgba(22, 36, 15, 0.06),
+    0 0 0 1px var(--border-base);
+  --shadow-glow: 0 0 24px rgba(174, 202, 89, 0.3), 0 0 48px rgba(174, 202, 89, 0.12);
+}
+
+/* ── Dark theme ─────────────────────────────────────────────
+ * Equivalência com o light:
+ *   • Surfaces invertidas (forest profundo → cream/branco)
+ *   • Foreground claro com tonalidade verde-creme (mantém DNA
+ *     da marca em vez de branco frio)
+ *   • Accent inalterado (lime é cor identitária)
+ *   • Bordas em alpha sobre lime (em vez de forest)
+ *   • Sombras mais profundas e em preto puro (o fundo escuro
+ *     já absorve, então sombra preta funciona como halo)
+ *   • Focus rings com alpha maior (compensa contraste do fundo)
+ * ============================================================ */
 [data-theme='dark'] {
-  --bg-base: #080e06;
-  --bg-surface: #0e1a0b;
-  --bg-elevated: #152011;
-  --bg-overlay: #1c2c17;
+  /* ── Surfaces ────────────────────────────────────────────── */
+  --bg-base: #0d1410;
+  --bg-surface: #141d18;
+  --bg-elevated: #1c2620;
+  --bg-overlay: #243029;
 
-  --border-subtle: rgba(91, 125, 71, 0.18);
-  --border-base: rgba(91, 125, 71, 0.35);
+  /* ── Borders ─────────────────────────────────────────────── */
+  --border-subtle: rgba(174, 202, 89, 0.1);
+  --border-base: rgba(174, 202, 89, 0.18);
   --border-strong: rgba(174, 202, 89, 0.45);
+  --border-soft-forest: rgba(174, 202, 89, 0.14);
+  --border-medium-forest: rgba(174, 202, 89, 0.28);
 
-  --fg1: #dde9ca;
-  --fg2: #9baf87;
-  --fg3: #617560;
-  --fg4: #3a4e35;
-  --accent-ink: #bdd96a;
+  /* ── Foreground / text ───────────────────────────────────── */
+  --fg1: #e7eed8;
+  --fg2: #b3c0a3;
+  --fg3: #7d8e75;
+  --fg4: #4d5b4a;
+  --fg-inverse: #16240f;
+
+  --text-primary: var(--fg1);
+  --text-secondary: var(--fg2);
+  --text-muted: var(--fg3);
+  --text-disabled: var(--fg4);
+
+  /* ── Accents & status ────────────────────────────────────── */
+  --accent: #aeca59;
+  --accent-dim: #8cb139;
+  /* No dark, o "ink" do accent precisa ser claro: aparece em texto
+     ativo de NavLink, badges e focus glows. */
+  --accent-ink: #c9e074;
+  --danger: #e87575;
+  --warning: #e6b25a;
+  --info: #6cb6e6;
+  --success: #b9d268;
+  --danger-ink: #f4a8a8;
+
+  /* ── UI state colors ─────────────────────────────────────── */
+  --grid-line: rgba(174, 202, 89, 0.04);
+  --bg-ghost-hover: rgba(174, 202, 89, 0.08);
+  --bg-ghost-active: rgba(174, 202, 89, 0.14);
+  --bg-danger-soft: rgba(232, 117, 117, 0.12);
+  --bg-danger-hover: rgba(232, 117, 117, 0.2);
+  --bg-backdrop-modal: rgba(0, 0, 0, 0.6);
+  --border-danger-soft: rgba(232, 117, 117, 0.32);
+  --border-danger-strong: rgba(232, 117, 117, 0.55);
+
+  /* Focus rings — alpha um pouco maior para contraste sobre fundo escuro */
+  --focus-ring-accent: 0 0 0 3px rgba(174, 202, 89, 0.32);
+  --focus-ring-accent-strong: 0 0 0 3px rgba(174, 202, 89, 0.42);
+  --focus-ring-danger: 0 0 0 3px rgba(232, 117, 117, 0.3);
+  --focus-ring-danger-soft: 0 0 0 3px color-mix(in srgb, var(--danger) 18%, transparent);
+  --focus-ring-border: 0 0 0 3px color-mix(in srgb, var(--border-strong) 70%, transparent);
+
+  --shadow-button-primary: 0 1px 0 rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  --shadow-button-primary-active: inset 0 1px 2px rgba(0, 0, 0, 0.45);
+
+  /* ── Shadows — pretas puras com alpha maior ──────────────── */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px var(--border-subtle);
+  --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--border-subtle);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 12px rgba(0, 0, 0, 0.35),
+    0 0 0 1px var(--border-subtle);
+  --shadow-modal: 0 24px 48px rgba(0, 0, 0, 0.55), 0 4px 12px rgba(0, 0, 0, 0.35),
+    0 0 0 1px var(--border-base);
+  --shadow-glow: 0 0 24px rgba(174, 202, 89, 0.4), 0 0 48px rgba(174, 202, 89, 0.18);
 }


### PR DESCRIPTION
## Summary

- Reorganiza `src/styles/tokens.css` em duas camadas — invariantes globais no `:root` (espaçamento, raios, tipografia, breakpoints, motion, paleta brand raw) e tokens semânticos por tema dentro de `[data-theme="light"]`/`[data-theme="dark"]` (superfícies, foreground, bordas, sombras, focus rings).
- Adiciona paleta dark equivalente: surfaces invertidas (forest profundo no fundo, cream/branco nas elevadas), foreground claro com tonalidade verde-creme, bordas em alpha sobre lime, sombras pretas com alpha maior, focus rings reforçados, `--bg-backdrop-modal` em preto translúcido para coerência.
- Cria hook `useTheme` (`src/hooks/useTheme.ts`) com estados `light`/`dark`/`system`, persistência em `localStorage` (`lfc-admin-theme`), detecção via `matchMedia('(prefers-color-scheme: dark)')` e reação a mudanças do SO em runtime quando em modo `system`.
- Cria componente `ThemeToggle` (`src/components/ui/ThemeToggle.tsx`) — ciclo binário light ↔ dark com Sun/Moon (lucide-react), aria-label dinâmico, aria-pressed, focus-visible e touch target 44x44 (mobile) / 34x34 (desktop). Posicionado no `Topbar` entre o `Bell` e o `UserSection`.
- Injeta script anti-FOUC no `index.html` que define `data-theme` no `<html>` antes do React montar (evita flash de tema errado).
- Atualiza `ShowcasePage` com seção "Theme" expondo o toggle e o status atual (preferência + tema resolvido).
- Adiciona 16 testes (10 `useTheme` + 6 `ThemeToggle`) com mocks de `matchMedia` e `localStorage`. Total: 75/75 testes verdes.

### Critérios de aceitação

- [x] Toggle alterna `data-theme` no `<html>` instantaneamente, sem reload
- [x] Escolha persiste após reload da página (`localStorage` + script anti-FOUC)
- [x] Default segue `prefers-color-scheme` do sistema (modo `system` quando ausente)
- [x] Componentes existentes (Button, Typography, Icon, Spinner, ErrorPage, Sidebar, Topbar, SearchInput) renderizam corretamente em ambos os temas — todos consomem tokens semânticos que respondem ao `data-theme`
- [x] Sem regressão visual no tema light — paleta light preservada literal nos novos blocos `[data-theme="light"]`/`:root`
- [x] Acessibilidade: `aria-label` adequado, `aria-pressed`, focus-visible com outline accent, button nativo (teclado-acessível)

### Decisões não óbvias

- **Ciclo binário** light ↔ dark na UI. Modo `system` continua acessível via API (`useTheme().setTheme('system')`) e como default ao primeiro carregamento. Optei por não expor um terceiro estado para manter o componente simples; a evolução para dropdown 3-estados é compatível.
- **Tokens raw `--clr-*` permanecem invariantes**. Apenas tokens semânticos (`--bg-base`, `--text-primary`, `--accent-ink`, sombras, focus rings) variam por tema. Isso permite reuso da paleta da marca em ambos os modos.
- **`--bg-backdrop-modal`** sobrescrito em dark para preto puro com alpha maior (0.6) — em fundo escuro o `color-mix` original com forest 42% ficaria invisível.
- **Sombras em dark** usam preto puro com alpha 0.3–0.55 (em vez de forest com alpha baixo), porque o fundo escuro já absorve cinzas — o preto puro funciona como halo perceptível.
- **Anti-FOUC inline** em vez de via JS no `index.tsx` — garante zero flash mesmo em conexões lentas.
- **Posição no Topbar:** entre `Bell` (oculto em mobile) e `UserSection`. Em mobile, com Bell oculto, o ThemeToggle ocupa o slot equivalente, mantendo o agrupamento visual. Em desktop, fica visualmente entre status do sistema e identidade do usuário.

### Mapeamento dark → light (resumo)

| Token | Light | Dark |
|---|---|---|
| `--bg-base` | `#f2f4ea` | `#0d1410` |
| `--bg-surface` | `#ffffff` | `#141d18` |
| `--bg-elevated` | `#ecefe0` | `#1c2620` |
| `--bg-overlay` | `#e0e5cd` | `#243029` |
| `--fg1` (text-primary) | `#1b2a12` | `#e7eed8` |
| `--fg2` (text-secondary) | `#4a5e42` | `#b3c0a3` |
| `--fg3` (text-muted) | `#6e8164` | `#7d8e75` |
| `--accent-ink` | `#5a7d1f` | `#c9e074` |
| `--border-subtle` | `rgba(forest, 0.08)` | `rgba(lime, 0.10)` |
| `--bg-backdrop-modal` | mix(forest 42%) | `rgba(0,0,0,0.6)` |
| sombras | base forest | base preto puro |
| focus rings | alpha 0.22–0.28 | alpha 0.32–0.42 |

## Test plan

- [x] `npm run lint` (sem warnings)
- [x] `npm run typecheck` (sem erros)
- [x] `npm run test` — 75/75 verdes, 16 novos
- [x] `npm run build` — bundle 305.81 kB (era ~304, +1.x kB esperado)
- [ ] Validação manual em http://localhost:3002:
  - [ ] Toggle no Topbar funciona em desktop (≥ 768px) e mobile (< 768px)
  - [ ] Tema escuro renderiza Home, Systems, Showcase e ErrorPage (404/401/403/500)
  - [ ] Sidebar drawer em mobile no tema dark — backdrop coerente
  - [ ] Reload mantém escolha persistida
  - [ ] Limpe `localStorage`, recarregue, verifique default segue `prefers-color-scheme` (DevTools → Rendering → Emulate prefers-color-scheme)
  - [ ] Sem regressão visual no light atual

## Riscos / Pendências

- Validação visual completa por página x tema requer sessão manual no navegador.
- Tokens raw `--clr-forest`/`--clr-lime` permanecem invariantes; se algum componente futuro precisar de cor de marca diferente em dark, o ajuste é local (override de token semântico) — não foi necessário aqui.

## Issue relacionada

Closes #20

Epic pai: #18