### PR TITLE
chore(sonar): excluir identity/** do escopo de analise (#83)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=LF-Calegari_lfc-admin-gui
+sonar.organization=lf-calegari
+
+sonar.sources=src
+sonar.tests=tests
+
+sonar.exclusions=identity/**,**/*.test.*,**/*.spec.*
+sonar.test.inclusions=tests/**/*.{test,spec}.{ts,tsx}
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Adiciona `sonar-project.properties` na raiz com:
- `sonar.sources=src`
- `sonar.tests=tests` (alinhado com PR #87 que centralizou testes em `tests/`)
- `sonar.exclusions=identity/**,**/*.test.*,**/*.spec.*`
- `sonar.test.inclusions=tests/**/*.{test,spec}.{ts,tsx}`

Resultado esperado: proxima analise mostra zero issues vindas de `identity/**` (HTML estatico de preview e UI kits em `.jsx`), reduzindo o ruido de ~180 issues falsas.

## Test plan

- [x] Arquivo versionado na raiz
- [x] Sintaxe `.properties` valida (chave=valor, sem aspas, comentarios com #)
- [x] `sonar.sources` aponta para `src` apenas
- [x] `sonar.tests` aponta para `tests` (resultado da PR #87)
- [ ] Validar no proximo run de CI/SonarCloud que `identity/**` ficou fora do escopo (post-merge)

Closes #83