### PR TITLE
fix: zerar code smells residuais em src/ (#84)

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -139,7 +139,7 @@ export const AppLayout: React.FC = () => {
 
   const handleLogout = () => {
     // Sessão invalidada — placeholder para integração com lfc-authenticator.
-    window.location.reload();
+    globalThis.location.reload();
   };
 
   return (

--- a/src/pages/InternalErrorPage.tsx
+++ b/src/pages/InternalErrorPage.tsx
@@ -5,7 +5,7 @@ import { ErrorPage } from '../components/ErrorPage';
 /**
  * 500 — Erro interno.
  *
- * Usa `window.location.reload()` (reload completo) em vez de `navigate(0)`:
+ * Usa `globalThis.location.reload()` (reload completo) em vez de `navigate(0)`:
  * em caso de erro do servidor ou estado corrompido do SPA, o reload total
  * reinicia bundle, contexto e cache de rede — é a recuperação mais robusta
  * possível sem orquestração de estado dedicada.
@@ -16,6 +16,6 @@ export const InternalErrorPage: React.FC = () => (
     title="Erro interno"
     description="Algo inesperado aconteceu do lado do servidor. Tente novamente em instantes — se o problema persistir, contate o suporte."
     actionLabel="Tentar novamente"
-    onAction={() => window.location.reload()}
+    onAction={() => globalThis.location.reload()}
   />
 );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -5,13 +5,13 @@ import styled from 'styled-components';
 import { PageHeader } from '../components/layout/PageHeader';
 import { Button, Badge, Card } from '../components/ui';
 
-const KV = styled.div`
+const Kv = styled.div`
   display: grid;
   grid-template-columns: 1fr;
   gap: 10px;
 `;
 
-const KVRow = styled.div`
+const KvRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -23,14 +23,14 @@ const KVRow = styled.div`
   }
 `;
 
-const KVKey = styled.span`
+const KvKey = styled.span`
   font-family: var(--font-mono);
   font-size: 11.5px;
   color: var(--fg3);
   letter-spacing: 0.04em;
 `;
 
-const KVValue = styled.span`
+const KvValue = styled.span`
   font-size: 13.5px;
   font-weight: var(--weight-medium);
   font-family: var(--font-mono);
@@ -55,20 +55,20 @@ export const SettingsPage: React.FC = () => (
       desc="Tema, idioma e preferências de sessão."
     />
     <Card title="Sessão">
-      <KV>
-        <KVRow>
-          <KVKey>tokenVersion</KVKey>
-          <KVValue>12</KVValue>
-        </KVRow>
-        <KVRow>
-          <KVKey>Expira em</KVKey>
-          <KVValue>14 min</KVValue>
-        </KVRow>
-        <KVRow>
-          <KVKey>Refresh automático</KVKey>
+      <Kv>
+        <KvRow>
+          <KvKey>tokenVersion</KvKey>
+          <KvValue>12</KvValue>
+        </KvRow>
+        <KvRow>
+          <KvKey>Expira em</KvKey>
+          <KvValue>14 min</KvValue>
+        </KvRow>
+        <KvRow>
+          <KvKey>Refresh automático</KvKey>
           <Badge variant="success" dot>Ativo</Badge>
-        </KVRow>
-      </KV>
+        </KvRow>
+      </Kv>
       <Actions>
         <Button variant="secondary" icon={<RefreshCw size={14} strokeWidth={1.5} />}>Renovar agora</Button>
         <Button variant="danger" icon={<LogOut size={14} strokeWidth={1.5} />}>Invalidar todas as sessões</Button>

--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -113,7 +113,7 @@ export const ShowcasePage: React.FC = () => {
 
   const triggerLoading = () => {
     setLoadingDemo(true);
-    window.setTimeout(() => setLoadingDemo(false), 1600);
+    globalThis.setTimeout(() => setLoadingDemo(false), 1600);
   };
 
   return (

--- a/src/pages/UnauthorizedPage.tsx
+++ b/src/pages/UnauthorizedPage.tsx
@@ -7,14 +7,13 @@ import { ErrorPage } from '../components/ErrorPage';
  * 401 — Não autenticado.
  *
  * Ainda não existe rota `/login` no SPA — a autenticação será feita pelo
- * `lfc-authenticator` em uma issue futura. Enquanto isso, a ação reaproveita
- * o redirect padrão da raiz (`/` → `/systems`) para devolver o usuário a um
- * ponto seguro do painel. O `// TODO` documenta a integração futura.
+ * `lfc-authenticator` na Epic #44. Enquanto isso, a ação reaproveita o
+ * redirect padrão da raiz (`/` → `/systems`) para devolver o usuário a um
+ * ponto seguro do painel.
  */
 export const UnauthorizedPage: React.FC = () => {
   const navigate = useNavigate();
 
-  // TODO: integrar com lfc-authenticator quando rota de login estiver disponível.
   return (
     <ErrorPage
       code="401"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';


### PR DESCRIPTION
## Summary

Resolve os 7 code smells residuais apontados pelo SonarCloud em `src/` e `vite.config.ts`:

- `src/pages/InternalErrorPage.tsx:19` — `window` -> `globalThis` (S7764)
- `src/layouts/AppLayout.tsx:142` — `window` -> `globalThis` (S7764)
- `src/pages/ShowcasePage.tsx:116` — `window` -> `globalThis` (S7764)
- `src/pages/SettingsPage.tsx` — `KV`/`KVRow`/`KVKey`/`KVValue` -> `Kv`/`KvRow`/`KvKey`/`KvValue` (S6770)
- `src/pages/UnauthorizedPage.tsx:12,17` — TODOs removidos, referencia movida para Epic #44 (S1135)
- `vite.config.ts:1` — `import path from 'path'` -> `import path from 'node:path'` (S7772)

Combinado com PR #88 (excluiu `identity/**` do escopo Sonar), o dashboard deve zerar.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` 78/78
- [x] `npm run build` OK (sem regressao funcional — substituicoes literal-por-equivalente)
- [ ] Validar zero issues no SonarCloud apos merge (post-merge)

Closes #84