### PR TITLE
feat: showcase de tokens visuais — Colors/Radii/Shadows/Spacing/Logo (#23-#30)

### DIFF
--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -14,6 +14,15 @@ import {
 } from '../components/ui';
 import { useTheme } from '../hooks/useTheme';
 
+import { ColorsBrand } from './showcase/ColorsBrand';
+import { ColorsStatus } from './showcase/ColorsStatus';
+import { ColorsSurfaces } from './showcase/ColorsSurfaces';
+import { ColorsText } from './showcase/ColorsText';
+import { Logo } from './showcase/Logo';
+import { Radii } from './showcase/Radii';
+import { Shadows } from './showcase/Shadows';
+import { Spacing } from './showcase/Spacing';
+
 const Page = styled.div`
   display: flex;
   flex-direction: column;
@@ -122,8 +131,9 @@ export const ShowcasePage: React.FC = () => {
         <Caption>00 Showcase</Caption>
         <Heading level={1}>Componentes base</Heading>
         <Body muted>
-          Vitrine isolada de Button, Typography, Icon e Spinner — todos consumindo
-          tokens do design system.
+          Vitrine isolada do design system: tokens visuais (cores, raios,
+          sombras, espaçamento, logo) e componentes base — todos consumindo
+          tokens definidos em <code>src/styles/tokens.css</code>.
         </Body>
       </SectionHead>
 
@@ -151,6 +161,16 @@ export const ShowcasePage: React.FC = () => {
           </ThemeStatus>
         </ThemeRow>
       </Section>
+
+      {/* ─── Tokens visuais (Epic #22 / PR-A1) ──────────────────── */}
+      <ColorsBrand />
+      <ColorsStatus />
+      <ColorsSurfaces />
+      <ColorsText />
+      <Radii />
+      <Shadows />
+      <Spacing />
+      <Logo />
 
       {/* ─── Typography ─────────────────────────────────────────── */}
       <Section aria-label="Typography">

--- a/src/pages/showcase/ColorsBrand.tsx
+++ b/src/pages/showcase/ColorsBrand.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { ShowcaseSection, Swatch, SwatchGrid } from './_shared';
+
+/**
+ * Issue #23 — Colors / Brand.
+ *
+ * Espelha `identity/preview/colors-brand.html`. Mostra a paleta bruta
+ * de marca (raw) que vive em `:root` do `tokens.css`. Estes valores
+ * não mudam com o tema; tokens semânticos (`--bg-base`, `--accent`,
+ * etc.) é que compõem a partir desta paleta.
+ *
+ * Cada swatch exibe nome amigável, token CSS e valor hex.
+ */
+
+interface BrandColor {
+  name: string;
+  token: string;
+  value: string;
+  /**
+   * Quando `true`, força borda no chip — usado para o cream, que sumiria
+   * sobre `--bg-surface` claro.
+   */
+  borderedChip?: boolean;
+}
+
+const BRAND_COLORS: ReadonlyArray<BrandColor> = [
+  { name: 'Forest',     token: '--clr-forest',     value: '#16240F' },
+  { name: 'Forest Mid', token: '--clr-forest-mid', value: '#1E3516' },
+  { name: 'Hunter',     token: '--clr-hunter',     value: '#5B7D47' },
+  { name: 'Green',      token: '--clr-green',      value: '#8CB139' },
+  { name: 'Lime ★',     token: '--clr-lime',       value: '#AECA59' },
+  { name: 'Sage',       token: '--clr-sage',       value: '#809A96' },
+  { name: 'Cream',      token: '--clr-cream',      value: '#DDE9CA', borderedChip: true },
+];
+
+export const ColorsBrand: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Colors"
+    title="Brand"
+    description="Paleta bruta da identidade. Tokens semânticos por tema compõem a partir destes valores — raramente devem ser usados diretamente em componentes."
+    ariaLabel="Colors Brand"
+  >
+    <SwatchGrid $min={160}>
+      {BRAND_COLORS.map(color => (
+        <Swatch
+          key={color.token}
+          background={`var(${color.token})`}
+          name={color.name}
+          token={color.token}
+          value={color.value}
+          borderedChip={color.borderedChip}
+        />
+      ))}
+    </SwatchGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/ColorsStatus.tsx
+++ b/src/pages/showcase/ColorsStatus.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, Swatch, SwatchGrid } from './_shared';
+
+/**
+ * Issue #24 — Colors / Status.
+ *
+ * Espelha `identity/preview/colors-status.html`. Mostra os tokens de
+ * status (success/warning/danger/info) com:
+ *   - Swatch principal — chip preenchido com o token, nome amigável,
+ *     token CSS e valor de referência.
+ *   - Exemplo de uso — palavra renderizada sobre o fundo do token,
+ *     ilustrando contraste do texto sobre a cor de status.
+ *
+ * Os hex exibidos correspondem ao tema light. No tema dark os tokens
+ * resolvem para variantes mais claras (ver `tokens.css`); a descrição
+ * da seção sinaliza essa dependência de tema.
+ */
+
+type Contrast = 'forest' | 'white';
+
+/**
+ * Token CSS usado para o texto sobre o chip — escolhido para garantir
+ * contraste WCAG AA contra o fundo de cada status. A escolha é binária
+ * (forest vs. white) porque os 4 status colors caem em duas faixas de
+ * luminância distintas.
+ */
+const CONTRAST_TOKEN: Record<Contrast, string> = {
+  forest: 'var(--clr-forest)',
+  white: 'var(--clr-white)',
+};
+
+const ChipLabel = styled.span<{ $contrast: Contrast }>`
+  display: flex;
+  align-items: flex-end;
+  height: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: ${({ $contrast }) => CONTRAST_TOKEN[$contrast]};
+`;
+
+interface StatusColor {
+  name: string;
+  token: string;
+  /** Valor de referência no tema light. */
+  value: string;
+  /** Esquema de contraste do label sobre o chip. */
+  contrast: Contrast;
+  /** Texto curto para amostra de uso. */
+  sample: string;
+}
+
+const STATUS_COLORS: ReadonlyArray<StatusColor> = [
+  { name: 'Success', token: '--success', value: '#AECA59', contrast: 'forest', sample: 'success' },
+  { name: 'Danger',  token: '--danger',  value: '#D95F5F', contrast: 'white',  sample: 'danger'  },
+  { name: 'Warning', token: '--warning', value: '#D9A24A', contrast: 'forest', sample: 'warning' },
+  { name: 'Info',    token: '--info',    value: '#4A9FD9', contrast: 'white',  sample: 'info'    },
+];
+
+export const ColorsStatus: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Colors"
+    title="Status"
+    description="Tokens semânticos para feedback de estado. Resolvem para variantes mais claras no tema dark; valores hex abaixo correspondem ao tema light."
+    ariaLabel="Colors Status"
+  >
+    <SwatchGrid $min={180}>
+      {STATUS_COLORS.map(color => (
+        <Swatch
+          key={color.token}
+          background={`var(${color.token})`}
+          name={color.name}
+          token={color.token}
+          value={color.value}
+        >
+          <ChipLabel $contrast={color.contrast}>{color.sample}</ChipLabel>
+        </Swatch>
+      ))}
+    </SwatchGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/ColorsSurfaces.tsx
+++ b/src/pages/showcase/ColorsSurfaces.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { ShowcaseSection, Swatch, SwatchGrid } from './_shared';
+
+/**
+ * Issue #25 — Colors / Surfaces.
+ *
+ * Espelha `identity/preview/colors-surfaces.html`. Tokens de superfície
+ * (`--bg-*`) e bordas (`--border-*`) que mudam por tema. Os valores hex
+ * exibidos correspondem ao tema light — no tema dark cada token resolve
+ * para a tonalidade equivalente em forest profundo (ver `tokens.css`).
+ *
+ * Como contrastam? Surfaces formam a hierarquia de profundidade:
+ *   base (página) → surface (cards) → elevated (hover) → overlay (pressed).
+ * As bordas formam o eixo de ênfase visual:
+ *   subtle (hairline) → base (default) → strong (acento).
+ */
+
+interface SurfaceColor {
+  name: string;
+  token: string;
+  /** Valor de referência no tema light. */
+  value: string;
+  /** Uso típico do token (sufixo da meta). */
+  hint: string;
+  /**
+   * Quando `true`, força borda no chip — usado para `--bg-surface`
+   * (branco puro no light) que sumiria sobre o card de surface.
+   */
+  borderedChip?: boolean;
+}
+
+const SURFACE_COLORS: ReadonlyArray<SurfaceColor> = [
+  { name: 'Base',     token: '--bg-base',     value: '#F2F4EA', hint: 'page' },
+  { name: 'Surface',  token: '--bg-surface',  value: '#FFFFFF', hint: 'cards', borderedChip: true },
+  { name: 'Elevated', token: '--bg-elevated', value: '#ECEFE0', hint: 'hover' },
+  { name: 'Overlay',  token: '--bg-overlay',  value: '#E0E5CD', hint: 'pressed' },
+];
+
+const BORDER_COLORS: ReadonlyArray<SurfaceColor> = [
+  { name: 'Subtle', token: '--border-subtle', value: 'rgba(22,36,15,0.08)', hint: 'hairline' },
+  { name: 'Base',   token: '--border-base',   value: 'rgba(22,36,15,0.16)', hint: 'default' },
+  { name: 'Strong', token: '--border-strong', value: 'rgba(91,125,71,0.55)', hint: 'accent' },
+];
+
+export const ColorsSurfaces: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Colors"
+    title="Surfaces & borders"
+    description="Tokens de superfície e borda — tema-dependentes. Alterne o tema acima para ver as variantes dark."
+    ariaLabel="Colors Surfaces"
+  >
+    <SwatchGrid $min={170}>
+      {SURFACE_COLORS.map(color => (
+        <Swatch
+          key={color.token}
+          background={`var(${color.token})`}
+          name={`${color.name} · ${color.hint}`}
+          token={color.token}
+          value={color.value}
+          borderedChip={color.borderedChip}
+        />
+      ))}
+    </SwatchGrid>
+    <SwatchGrid $min={170}>
+      {BORDER_COLORS.map(color => (
+        <Swatch
+          key={color.token}
+          background={`var(${color.token})`}
+          name={`${color.name} · ${color.hint}`}
+          token={color.token}
+          value={color.value}
+        />
+      ))}
+    </SwatchGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/ColorsText.tsx
+++ b/src/pages/showcase/ColorsText.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #26 — Colors / Text.
+ *
+ * Espelha `identity/preview/colors-text.html`. Lista os tokens de cor
+ * tipográfica com:
+ *   - Token CSS aplicado ao texto (lado esquerdo).
+ *   - Amostra de texto pintada com o token (centro), com bolinha
+ *     decorativa do mesmo tom como reforço visual.
+ *   - Valor de referência no tema light (lado direito).
+ *
+ * Inclui `--fg-inverse` em uma linha sobre `--clr-forest` para mostrar
+ * o caso de texto sobre fundo escuro (ex.: dentro de um botão primary
+ * ou de um chip preenchido com a marca).
+ */
+
+const RowsCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-surface);
+`;
+
+const Row = styled.div<{ $inverse?: boolean }>`
+  display: grid;
+  grid-template-columns: minmax(140px, 0.6fr) 1fr minmax(120px, 0.5fr);
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  background: ${({ $inverse }) =>
+    $inverse ? 'var(--clr-forest)' : 'var(--bg-surface)'};
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  /* Em telas estreitas a grade de 3 colunas vira pilha — espelha --bp-sm (30em ≈ 480px). */
+  @media (max-width: 30em) {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+    padding: var(--space-3);
+  }
+`;
+
+const Sample = styled.span<{ $colorToken: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  color: ${({ $colorToken }) => `var(${$colorToken})`};
+`;
+
+const Dot = styled.span<{ $colorToken: string }>`
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-sm);
+  background: ${({ $colorToken }) => `var(${$colorToken})`};
+`;
+
+const ValueCell = styled.span`
+  display: flex;
+  justify-content: flex-end;
+
+  @media (max-width: 30em) {
+    justify-content: flex-start;
+  }
+`;
+
+interface TextColor {
+  token: string;
+  /** Valor de referência no tema light. */
+  value: string;
+  /** Frase ilustrativa do uso. */
+  sample: string;
+  /** Quando `true`, renderiza a linha sobre fundo `--clr-forest`. */
+  inverseRow?: boolean;
+}
+
+const TEXT_COLORS: ReadonlyArray<TextColor> = [
+  { token: '--text-primary',   value: '#1B2A12', sample: 'Conteúdo principal do sistema' },
+  { token: '--text-secondary', value: '#4A5E42', sample: 'Labels e textos de suporte' },
+  { token: '--text-muted',     value: '#6E8164', sample: 'Placeholders, hints e meta-informação' },
+  { token: '--text-disabled',  value: '#B5BEA8', sample: 'Texto em estado desabilitado' },
+  { token: '--accent-ink',     value: '#5A7D1F', sample: 'Link / acento com contraste WCAG AA' },
+  { token: '--fg-inverse',     value: '#FFFFFF', sample: 'Texto sobre fundo escuro (botão primary)', inverseRow: true },
+];
+
+export const ColorsText: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Colors"
+    title="Text"
+    description="Hierarquia de cor tipográfica. Os valores hex correspondem ao tema light; no dark cada token resolve para a variante creme correspondente."
+    ariaLabel="Colors Text"
+  >
+    <RowsCard>
+      {TEXT_COLORS.map(color => (
+        <Row key={color.token} $inverse={color.inverseRow}>
+          <TokenName>{color.token}</TokenName>
+          <Sample $colorToken={color.token}>
+            <Dot $colorToken={color.token} aria-hidden="true" />
+            {color.sample}
+          </Sample>
+          <ValueCell>
+            <TokenValue>{color.value}</TokenValue>
+          </ValueCell>
+        </Row>
+      ))}
+    </RowsCard>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/Logo.tsx
+++ b/src/pages/showcase/Logo.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import logoDarkUrl from '../../assets/logo-dark.svg';
+import logoWhiteUrl from '../../assets/logo-white.svg';
+import { useTheme } from '../../hooks/useTheme';
+
+import { ShowcaseSection, SwatchGrid, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #30 — Logo.
+ *
+ * Espelha `identity/preview/logo.html`. Mostra:
+ *   - Variantes do logo full sobre fundos claro e escuro.
+ *   - Tamanhos mínimos recomendados, com o logo renderizado em cada
+ *     altura para validar legibilidade.
+ *
+ * Os SVGs vivem em `src/assets/` (já consumidos pelo Sidebar). Reusar
+ * a mesma fonte garante coerência entre Sidebar e Showcase.
+ */
+
+const VariantCard = styled.figure`
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--bg-surface);
+`;
+
+const VariantPreview = styled.div<{ $variant: 'light' | 'dark' }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 140px;
+  padding: var(--space-6);
+  background: ${({ $variant }) =>
+    $variant === 'dark' ? 'var(--clr-forest)' : 'var(--clr-white)'};
+`;
+
+const VariantMeta = styled.figcaption`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface);
+  border-top: var(--border-thin) solid var(--border-subtle);
+
+  > strong {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--text-primary);
+    letter-spacing: var(--tracking-tight);
+  }
+`;
+
+const SizeCard = styled.figure`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  margin: 0;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+`;
+
+const SizePreview = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 72px;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+`;
+
+const SizeMeta = styled.figcaption`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+
+  > strong {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--text-primary);
+  }
+`;
+
+interface LogoVariant {
+  name: string;
+  description: string;
+  src: string;
+  alt: string;
+  variant: 'light' | 'dark';
+  surfaceLabel: string;
+}
+
+const LOGO_VARIANTS: ReadonlyArray<LogoVariant> = [
+  {
+    name: 'Logo White',
+    description: 'Versão clara do logo, sobre fundo escuro.',
+    src: logoWhiteUrl,
+    alt: 'LFC Authenticator logo (versão clara)',
+    variant: 'dark',
+    surfaceLabel: 'bg: --clr-forest',
+  },
+  {
+    name: 'Logo Dark',
+    description: 'Versão escura do logo, sobre fundo claro.',
+    src: logoDarkUrl,
+    alt: 'LFC Authenticator logo (versão escura)',
+    variant: 'light',
+    surfaceLabel: 'bg: --clr-white',
+  },
+];
+
+interface LogoSize {
+  /** Altura em px aplicada ao `<img height>`. */
+  height: number;
+  /** Rótulo amigável — ex.: "Sidebar". */
+  name: string;
+  /** Uso típico. */
+  usage: string;
+}
+
+const LOGO_SIZES: ReadonlyArray<LogoSize> = [
+  { height: 24, name: 'Mínimo', usage: 'tamanho mínimo legível · favicon expandido' },
+  { height: 32, name: 'Compact', usage: 'topbars densas e drawers' },
+  { height: 38, name: 'Sidebar', usage: 'altura padrão usada hoje no Sidebar' },
+  { height: 56, name: 'Hero', usage: 'cabeçalhos de página e telas de auth' },
+];
+
+export const Logo: React.FC = () => {
+  // Os swatches "Logo White / Logo Dark" são intencionalmente fixos —
+  // mostram cada variante sobre seu fundo canônico (`--clr-forest` /
+  // `--clr-white`). Já a régua de tamanhos renderiza sobre `--bg-surface`,
+  // que muda por tema, portanto seleciona o asset com contraste correto
+  // em runtime — mesma estratégia usada pelo Sidebar.
+  const { resolvedTheme } = useTheme();
+  const surfaceLogo = resolvedTheme === 'dark' ? logoWhiteUrl : logoDarkUrl;
+
+  return (
+    <ShowcaseSection
+      eyebrow="Brand"
+      title="Logo"
+      description="Variantes oficiais do logo e tamanhos mínimos recomendados. Use sempre a versão de contraste correto sobre o fundo onde for aplicada."
+      ariaLabel="Logo"
+    >
+      <SwatchGrid $min={260}>
+        {LOGO_VARIANTS.map(variant => (
+          <VariantCard key={variant.name} aria-label={variant.name}>
+            <VariantPreview $variant={variant.variant}>
+              <img src={variant.src} alt={variant.alt} height={38} />
+            </VariantPreview>
+            <VariantMeta>
+              <strong>{variant.name}</strong>
+              <TokenName>{variant.surfaceLabel}</TokenName>
+              <TokenValue>{variant.description}</TokenValue>
+            </VariantMeta>
+          </VariantCard>
+        ))}
+      </SwatchGrid>
+      <SwatchGrid $min={200}>
+        {LOGO_SIZES.map(size => (
+          <SizeCard key={size.height} aria-label={`${size.name} ${size.height}px`}>
+            <SizePreview>
+              <img
+                src={surfaceLogo}
+                alt={`Logo em ${size.height}px de altura`}
+                height={size.height}
+              />
+            </SizePreview>
+            <SizeMeta>
+              <strong>{size.name}</strong>
+              <TokenName>{`${size.height}px`}</TokenName>
+              <TokenValue>{size.usage}</TokenValue>
+            </SizeMeta>
+          </SizeCard>
+        ))}
+      </SwatchGrid>
+    </ShowcaseSection>
+  );
+};

--- a/src/pages/showcase/Radii.tsx
+++ b/src/pages/showcase/Radii.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, SwatchGrid, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #27 — Radii.
+ *
+ * Espelha `identity/preview/radii.html`. Cada célula apresenta o token
+ * `--radius-*` com:
+ *   - O próprio cartão usando o raio (borda externa).
+ *   - Um chip preenchido em accent reforçando o raio aplicado.
+ *   - Token CSS e valor.
+ *
+ * Os tokens vêm direto de `tokens.css`; valores ao lado são meramente
+ * informativos (espelham os literais definidos lá).
+ */
+
+const RadiusCard = styled.figure<{ $radiusToken: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  margin: 0;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: ${({ $radiusToken }) => `var(${$radiusToken})`};
+  background: var(--bg-elevated);
+`;
+
+const RadiusChip = styled.span<{ $radiusToken: string }>`
+  width: 48px;
+  height: 48px;
+  background: var(--accent);
+  border: var(--border-thin) solid var(--accent-dim);
+  border-radius: ${({ $radiusToken }) => `var(${$radiusToken})`};
+`;
+
+const RadiusMeta = styled.figcaption`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+`;
+
+interface RadiusToken {
+  token: string;
+  value: string;
+  /** Uso típico — aparece após o valor. */
+  hint?: string;
+}
+
+const RADIUS_TOKENS: ReadonlyArray<RadiusToken> = [
+  { token: '--radius-sm',   value: '4px' },
+  { token: '--radius-md',   value: '8px',    hint: 'default' },
+  { token: '--radius-lg',   value: '12px',   hint: 'cards' },
+  { token: '--radius-xl',   value: '16px' },
+  { token: '--radius-2xl',  value: '20px' },
+  { token: '--radius-full', value: '9999px', hint: 'pills' },
+];
+
+export const Radii: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Tokens"
+    title="Radii"
+    description="Escala de bordas arredondadas. O cartão e o chip refletem o mesmo token, facilitando a leitura visual da progressão."
+    ariaLabel="Radii"
+  >
+    <SwatchGrid $min={150}>
+      {RADIUS_TOKENS.map(radius => (
+        <RadiusCard
+          key={radius.token}
+          $radiusToken={radius.token}
+          aria-label={radius.token}
+        >
+          <RadiusChip $radiusToken={radius.token} aria-hidden="true" />
+          <RadiusMeta>
+            <TokenName>{radius.token}</TokenName>
+            <TokenValue>
+              {radius.value}
+              {radius.hint ? ` · ${radius.hint}` : ''}
+            </TokenValue>
+          </RadiusMeta>
+        </RadiusCard>
+      ))}
+    </SwatchGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/Shadows.tsx
+++ b/src/pages/showcase/Shadows.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, SwatchGrid, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #28 — Shadows.
+ *
+ * Espelha `identity/preview/shadows.html`. Mostra a escala xs→xl mais
+ * tokens semânticos pré-existentes (`--shadow-card`, `--shadow-modal`,
+ * `--shadow-glow`).
+ *
+ * Todas as sombras são **tema-dependentes**: no tema light usam preto
+ * com alpha baixo; no dark usam preto puro com alpha mais alto para
+ * compensar o fundo escuro (ver `tokens.css`).
+ */
+
+const ShadowCard = styled.figure<{ $shadowToken: string }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: 110px;
+  padding: var(--space-4);
+  margin: 0;
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  box-shadow: ${({ $shadowToken }) => `var(${$shadowToken})`};
+`;
+
+const ShadowMeta = styled.figcaption`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+`;
+
+interface ShadowToken {
+  token: string;
+  /** Uso típico ou descrição curta. */
+  hint: string;
+}
+
+/**
+ * Escala incremental — base recomendada para componentes que crescem
+ * em elevação (xs hairline → xl page-level overlay).
+ */
+const SHADOW_SCALE: ReadonlyArray<ShadowToken> = [
+  { token: '--shadow-xs', hint: 'hairline · cells' },
+  { token: '--shadow-sm', hint: 'subtle · chips' },
+  { token: '--shadow-md', hint: 'cards · hover' },
+  { token: '--shadow-lg', hint: 'popover · sheets' },
+  { token: '--shadow-xl', hint: 'modal · 24px drop' },
+];
+
+/**
+ * Tokens semânticos — usados por componentes específicos. Mantidos
+ * separados para deixar claro que não fazem parte da escala numérica.
+ */
+const SHADOW_SEMANTIC: ReadonlyArray<ShadowToken> = [
+  { token: '--shadow-card',  hint: 'Card · elevação base' },
+  { token: '--shadow-modal', hint: 'Modal · overlay' },
+  { token: '--shadow-glow',  hint: 'Accent · focus glow' },
+];
+
+export const Shadows: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Tokens"
+    title="Shadows"
+    description="Escala de elevação (xs→xl) e sombras semânticas. Tema-dependentes: ficam mais profundas no dark para compensar o fundo escuro."
+    ariaLabel="Shadows"
+  >
+    <SwatchGrid $min={180}>
+      {SHADOW_SCALE.map(shadow => (
+        <ShadowCard
+          key={shadow.token}
+          $shadowToken={shadow.token}
+          aria-label={shadow.token}
+        >
+          <ShadowMeta>
+            <TokenName>{shadow.token}</TokenName>
+            <TokenValue>{shadow.hint}</TokenValue>
+          </ShadowMeta>
+        </ShadowCard>
+      ))}
+    </SwatchGrid>
+    <SwatchGrid $min={180}>
+      {SHADOW_SEMANTIC.map(shadow => (
+        <ShadowCard
+          key={shadow.token}
+          $shadowToken={shadow.token}
+          aria-label={shadow.token}
+        >
+          <ShadowMeta>
+            <TokenName>{shadow.token}</TokenName>
+            <TokenValue>{shadow.hint}</TokenValue>
+          </ShadowMeta>
+        </ShadowCard>
+      ))}
+    </SwatchGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/Spacing.tsx
+++ b/src/pages/showcase/Spacing.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #29 — Spacing.
+ *
+ * Espelha `identity/preview/spacing.html`. Régua visual de cada token
+ * `--space-*`:
+ *   - Coluna 1 — nome do token CSS.
+ *   - Coluna 2 — barra preenchida com `--accent`, com a largura igual
+ *     ao token (ex.: `width: var(--space-4)` rende uma barra de 16px).
+ *   - Coluna 3 — valor em rem/px.
+ *   - Coluna 4 — uso típico.
+ *
+ * A barra é dimensionada via `var(--…)` direto na largura, então a
+ * própria régua valida o valor do token (sem hardcode).
+ */
+
+const RowsCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-surface);
+`;
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: minmax(110px, 0.6fr) 1fr minmax(110px, 0.5fr) minmax(160px, 1fr);
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  /* Em telas estreitas vira pilha — espelha --bp-sm (30em ≈ 480px). */
+  @media (max-width: 30em) {
+    grid-template-columns: 1fr;
+    gap: var(--space-1);
+  }
+`;
+
+const BarTrack = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+`;
+
+const Bar = styled.span<{ $token: string }>`
+  display: block;
+  width: ${({ $token }) => `var(${$token})`};
+  height: 6px;
+  background: var(--accent);
+  border-radius: var(--radius-full);
+`;
+
+const UsageText = styled.span`
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+`;
+
+interface SpacingToken {
+  token: string;
+  /** Valor em rem (definição) e px (referência) — ex.: `0.25rem · 4px`. */
+  value: string;
+  /** Uso típico. */
+  usage: string;
+}
+
+const SPACING_TOKENS: ReadonlyArray<SpacingToken> = [
+  { token: '--space-1',  value: '0.25rem · 4px',   usage: 'Gaps mínimos' },
+  { token: '--space-2',  value: '0.5rem · 8px',    usage: 'Padding interno de badges' },
+  { token: '--space-3',  value: '0.75rem · 12px',  usage: 'Gap entre itens de lista' },
+  { token: '--space-4',  value: '1rem · 16px',     usage: 'Padding de botões' },
+  { token: '--space-5',  value: '1.25rem · 20px',  usage: 'Card body padding' },
+  { token: '--space-6',  value: '1.5rem · 24px',   usage: 'Gap entre cards' },
+  { token: '--space-8',  value: '2rem · 32px',     usage: 'Padding de seção interna' },
+  { token: '--space-10', value: '2.5rem · 40px',   usage: 'Gap entre seções de página' },
+  { token: '--space-12', value: '3rem · 48px',     usage: 'Margem entre seções' },
+  { token: '--space-16', value: '4rem · 64px',     usage: 'Cabeçalhos hero' },
+  { token: '--space-20', value: '5rem · 80px',     usage: 'Espaçamento de página máximo' },
+];
+
+export const Spacing: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Tokens"
+    title="Spacing"
+    description="Régua de espaçamento. Cada barra é dimensionada via var(--space-*) — a própria régua valida o valor do token."
+    ariaLabel="Spacing"
+  >
+    <RowsCard>
+      {SPACING_TOKENS.map(spacing => (
+        <Row key={spacing.token}>
+          <TokenName>{spacing.token}</TokenName>
+          <BarTrack>
+            <Bar $token={spacing.token} aria-hidden="true" />
+          </BarTrack>
+          <TokenValue>{spacing.value}</TokenValue>
+          <UsageText>{spacing.usage}</UsageText>
+        </Row>
+      ))}
+    </RowsCard>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/_shared.tsx
+++ b/src/pages/showcase/_shared.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Caption, Heading } from '../../components/ui';
+
+/**
+ * Helpers compartilhados pelas seções de tokens visuais do Showcase.
+ *
+ * Estes wrappers replicam a estrutura usada em `ShowcasePage` (Section,
+ * SectionHead, SectionBody) e introduzem primitivas específicas do
+ * Showcase de tokens — `Swatch`, `TokenLabel`, `TokenName`, `TokenValue`.
+ *
+ * Convenções:
+ *   - Tudo consome tokens de `tokens.css` via `var(--…)`.
+ *   - Nenhuma cor hard-coded; valores hex aparecem apenas como labels
+ *     informativas (texto), nunca aplicados como `background`/`color`.
+ *   - Componentes funcionais; props com prefixo `$` para transient props.
+ */
+
+/* ─── Section primitives ─────────────────────────────────── */
+
+const StyledSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+`;
+
+const StyledSectionHead = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-bottom: var(--space-3);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+`;
+
+interface ShowcaseSectionProps {
+  /** Caption acima do título (ex.: "Colors", "Radii"). */
+  eyebrow: string;
+  /** Título da seção. */
+  title: string;
+  /** Texto descritivo curto. Renderizado abaixo do título quando presente. */
+  description?: React.ReactNode;
+  /** Conteúdo da seção. */
+  children: React.ReactNode;
+  /** Identificador acessível — vira `aria-label`. */
+  ariaLabel?: string;
+}
+
+/**
+ * Cabeçalho + caixa padrão das seções de showcase. Padroniza a hierarquia
+ * tipográfica e o respiro entre seções.
+ */
+export const ShowcaseSection: React.FC<ShowcaseSectionProps> = ({
+  eyebrow,
+  title,
+  description,
+  children,
+  ariaLabel,
+}) => (
+  <StyledSection aria-label={ariaLabel ?? title}>
+    <StyledSectionHead>
+      <Caption>{eyebrow}</Caption>
+      <Heading level={3}>{title}</Heading>
+      {description ? <Caption muted>{description}</Caption> : null}
+    </StyledSectionHead>
+    {children}
+  </StyledSection>
+);
+
+/* ─── Token labels (texto informativo) ───────────────────── */
+
+const StyledTokenName = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wide);
+  color: var(--accent-ink);
+  word-break: break-all;
+`;
+
+const StyledTokenValue = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  word-break: break-all;
+`;
+
+interface TokenTextProps {
+  children: React.ReactNode;
+}
+
+/** Nome de token CSS — ex.: `--clr-forest`. */
+export const TokenName: React.FC<TokenTextProps> = ({ children }) => (
+  <StyledTokenName>{children}</StyledTokenName>
+);
+
+/** Valor resolvido — ex.: `#16240F`, `4px`, `0.5rem`. */
+export const TokenValue: React.FC<TokenTextProps> = ({ children }) => (
+  <StyledTokenValue>{children}</StyledTokenValue>
+);
+
+/* ─── Swatch ─────────────────────────────────────────────── */
+
+const SwatchCard = styled.figure`
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-surface);
+`;
+
+/**
+ * Quando o chip é claro demais (ex.: `--bg-surface` branco) ele se
+ * confunde com o card. Inserimos um inset hairline em `--border-subtle`
+ * via `box-shadow: inset` apenas nesse caso, sem alterar o layout.
+ */
+const SwatchChip = styled.div<{ $bordered?: boolean }>`
+  height: 72px;
+  ${({ $bordered }) =>
+    $bordered ? 'box-shadow: inset 0 0 0 var(--border-thin) var(--border-subtle);' : ''}
+`;
+
+const SwatchMeta = styled.figcaption`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  border-top: var(--border-thin) solid var(--border-subtle);
+
+  > strong {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    font-weight: var(--weight-semibold);
+    color: var(--text-primary);
+    letter-spacing: var(--tracking-tight);
+  }
+`;
+
+interface SwatchProps {
+  /** Cor/background aplicado ao chip. Aceita qualquer valor CSS válido. */
+  background: string;
+  /** Nome amigável — ex.: "Forest", "Lime". */
+  name?: string;
+  /** Nome do token CSS — ex.: `--clr-forest`. */
+  token?: string;
+  /** Valor resolvido — ex.: `#16240F`. */
+  value?: string;
+  /** Conteúdo opcional dentro do chip (label, ícone). */
+  children?: React.ReactNode;
+  /**
+   * Quando `true`, força borda inferior no chip — útil para chips muito
+   * claros (ex.: `--bg-surface` branco) que sumiriam sem ela.
+   */
+  borderedChip?: boolean;
+  /** Override do `aria-label` da figura (default: `name` ou `token`). */
+  ariaLabel?: string;
+}
+
+/**
+ * Bloco visual padrão para apresentação de tokens de cor.
+ *
+ * Estrutura: `<figure>` com chip colorido + `<figcaption>` contendo
+ * nome amigável, token CSS e valor resolvido.
+ *
+ * Acessibilidade: o chip é decorativo; o conteúdo informativo está em
+ * `<figcaption>`. `aria-label` cobre leitores de tela.
+ */
+export const Swatch: React.FC<SwatchProps> = ({
+  background,
+  name,
+  token,
+  value,
+  children,
+  borderedChip,
+  ariaLabel,
+}) => {
+  const computedAriaLabel = ariaLabel ?? name ?? token ?? 'color swatch';
+  return (
+    <SwatchCard aria-label={computedAriaLabel}>
+      <SwatchChip
+        style={{ background }}
+        $bordered={borderedChip}
+        role="img"
+        aria-hidden="true"
+      >
+        {children}
+      </SwatchChip>
+      {(name || token || value) && (
+        <SwatchMeta>
+          {name ? <strong>{name}</strong> : null}
+          {token ? <TokenName>{token}</TokenName> : null}
+          {value ? <TokenValue>{value}</TokenValue> : null}
+        </SwatchMeta>
+      )}
+    </SwatchCard>
+  );
+};
+
+/* ─── Layout primitives ───────────────────────────────────── */
+
+/**
+ * Grid responsivo padrão para seções com múltiplos swatches/cards.
+ * A largura mínima do item é configurável via prop `$min` (default 160px).
+ */
+export const SwatchGrid = styled.div<{ $min?: number }>`
+  display: grid;
+  grid-template-columns: ${({ $min = 160 }) =>
+    `repeat(auto-fill, minmax(${$min}px, 1fr))`};
+  gap: var(--space-3);
+`;
+
+/** Subgrupo de conteúdo dentro de uma seção (label + grid de items). */
+export const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+`;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -238,9 +238,20 @@
   --shadow-button-primary: 0 1px 0 rgba(22, 36, 15, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.25);
   --shadow-button-primary-active: inset 0 1px 2px rgba(22, 36, 15, 0.18);
 
-  /* ── Shadows ─────────────────────────────────────────────── */
+  /* ── Shadows ─────────────────────────────────────────────────
+   * Escala completa xs→xl. Os tokens semânticos pré-existentes
+   * `--shadow-card`, `--shadow-modal` e `--shadow-glow` permanecem
+   * para uso por componentes específicos; os tokens xs/sm/md/lg/xl
+   * formam a régua incremental usada quando a elevação do componente
+   * deve crescer com o nível visual (hairline → page-level overlay).
+   */
+  --shadow-xs: 0 1px 1px rgba(22, 36, 15, 0.03), 0 0 0 1px var(--border-subtle);
   --shadow-sm: 0 1px 2px rgba(22, 36, 15, 0.04), 0 0 0 1px var(--border-subtle);
   --shadow-md: 0 4px 14px rgba(22, 36, 15, 0.07), 0 0 0 1px var(--border-subtle);
+  --shadow-lg: 0 12px 28px rgba(22, 36, 15, 0.12), 0 4px 10px rgba(22, 36, 15, 0.06),
+    0 0 0 1px var(--border-subtle);
+  --shadow-xl: 0 24px 48px rgba(22, 36, 15, 0.16), 0 8px 20px rgba(22, 36, 15, 0.08),
+    0 0 0 1px var(--border-base);
   --shadow-card: 0 1px 2px rgba(22, 36, 15, 0.04), 0 2px 12px rgba(22, 36, 15, 0.06),
     0 0 0 1px var(--border-subtle);
   --shadow-modal: 0 24px 48px rgba(22, 36, 15, 0.16), 0 4px 12px rgba(22, 36, 15, 0.06),
@@ -318,8 +329,13 @@
   --shadow-button-primary-active: inset 0 1px 2px rgba(0, 0, 0, 0.45);
 
   /* ── Shadows — pretas puras com alpha maior ──────────────── */
+  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.25), 0 0 0 1px var(--border-subtle);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px var(--border-subtle);
   --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--border-subtle);
+  --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.5), 0 4px 10px rgba(0, 0, 0, 0.35),
+    0 0 0 1px var(--border-subtle);
+  --shadow-xl: 0 24px 48px rgba(0, 0, 0, 0.6), 0 8px 20px rgba(0, 0, 0, 0.4),
+    0 0 0 1px var(--border-base);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 12px rgba(0, 0, 0, 0.35),
     0 0 0 1px var(--border-subtle);
   --shadow-modal: 0 24px 48px rgba(0, 0, 0, 0.55), 0 4px 12px rgba(0, 0, 0, 0.35),


### PR DESCRIPTION
## Summary

PR-A1 do Epic #22 — adiciona 8 seções de tokens visuais ao `ShowcasePage`, espelhando os previews HTML em `identity/preview/`.

- **Cores** (4): Brand, Status, Surfaces & borders, Text — cada token com nome amigável, variável CSS e valor de referência.
- **Tokens dimensionais** (3): Radii, Shadows, Spacing — escalas completas com auto-validação visual.
- **Brand asset**: Logo — variantes em fundos forest/branco + régua de tamanhos mínimos recomendados.

### Tokens novos em `tokens.css`
Escala `--shadow-*` foi expandida para xs→xl (faltavam `--shadow-xs`, `--shadow-lg`, `--shadow-xl`); definidos para ambos os temas, sem alterar tokens semânticos pré-existentes (`--shadow-card/modal/glow`).

### Helpers reutilizáveis
Em `src/pages/showcase/_shared.tsx`: `ShowcaseSection`, `Swatch`, `TokenName`, `TokenValue`, `SwatchGrid`, `Stack`. Específicos do Showcase, fora de `components/ui/`.

### Estratégia de integração
Cada sub-issue virou um sub-componente em `src/pages/showcase/`, plugado em ordem em `ShowcasePage.tsx` logo após o bloco Theme — preserva 100% das seções existentes.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 78/78 passando
- [x] `npm run build` — sucesso
- [x] Validação visual em `http://localhost:3002/showcase`:
  - [x] Tema light — todas as 8 seções renderizam, swatches com contraste correto
  - [x] Tema dark — todas as 8 seções renderizam, surfaces/text inversos corretos
  - [x] Mobile 375px — grids respondem para 2 colunas, sem overflow
  - [x] Mobile 320px — swatches/régua não estouram

## Visual

- Tokens consumidos exclusivamente via `var(--…)` — zero hardcode de cor/spacing/radius/shadow
- Nome amigável + token CSS + valor visíveis em cada item
- Layout responsivo com `grid auto-fill minmax`
- Swatches descritos via `<figure>` + `<figcaption>` (acessibilidade)

## Segurança

Nenhum impacto. Showcase é DEV-only; não introduz dependências, nem renderiza HTML não-sanitizado, nem manipula tokens/credenciais.

## Riscos

Nenhum. Mudança é additiva — sem refatoração das seções pré-existentes ou dos componentes UI.

## Issues relacionadas

Parte do Epic #22.

Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30