### PR TITLE
feat: showcase de tipografia — Display/Scale/Mono (#31-#33)

### DIFF
--- a/src/pages/ShowcasePage.tsx
+++ b/src/pages/ShowcasePage.tsx
@@ -22,6 +22,9 @@ import { Logo } from './showcase/Logo';
 import { Radii } from './showcase/Radii';
 import { Shadows } from './showcase/Shadows';
 import { Spacing } from './showcase/Spacing';
+import { TypeDisplay } from './showcase/TypeDisplay';
+import { TypeMono } from './showcase/TypeMono';
+import { TypeScale } from './showcase/TypeScale';
 
 const Page = styled.div`
   display: flex;
@@ -172,26 +175,10 @@ export const ShowcasePage: React.FC = () => {
       <Spacing />
       <Logo />
 
-      {/* ─── Typography ─────────────────────────────────────────── */}
-      <Section aria-label="Typography">
-        <SectionHead>
-          <Caption>Typography</Caption>
-          <Heading level={3}>Hierarquia tipográfica</Heading>
-        </SectionHead>
-        <Stack>
-          <Heading level={1}>Heading nível 1</Heading>
-          <Heading level={2}>Heading nível 2</Heading>
-          <Heading level={3}>Heading nível 3</Heading>
-          <Heading level={4}>Heading nível 4</Heading>
-          <Body>
-            Body é o estilo padrão para parágrafos. Mantém leitura confortável em
-            blocos longos consumindo a fonte de body e o leading base.
-          </Body>
-          <Body muted>Body muted aplica `--text-muted` para texto secundário.</Body>
-          <Caption>Caption — uso em metadados, descrições compactas e legendas.</Caption>
-          <Label>Label · campos de formulário</Label>
-        </Stack>
-      </Section>
+      {/* ─── Typography (Epic #22 / PR-A2) ──────────────────────── */}
+      <TypeDisplay />
+      <TypeScale />
+      <TypeMono />
 
       {/* ─── Button ─────────────────────────────────────────────── */}
       <Section aria-label="Button">

--- a/src/pages/showcase/TypeDisplay.tsx
+++ b/src/pages/showcase/TypeDisplay.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, Stack, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #31 — Type Display.
+ *
+ * Espelha `identity/preview/type-display.html`. Apresenta os estilos
+ * tipográficos de display usados em hero/marketing — onde a marca fala
+ * em voz alta. Cada amostra mostra:
+ *   - O texto renderizado no tamanho/peso/leading do estilo.
+ *   - As especificações tokenizadas (token de tamanho, peso, leading,
+ *     tracking) para inspeção rápida.
+ *
+ * Usa exclusivamente tokens de `tokens.css`:
+ *   - `--font-display` para a família.
+ *   - `--text-display` (clamp) e `--text-3xl` para os tamanhos.
+ *   - `--weight-bold`, `--leading-tight`, `--tracking-tight` etc.
+ *
+ * Nenhum valor numérico literal é aplicado em `font-size`, `font-weight`,
+ * `line-height` ou `letter-spacing` — o próprio token valida a especificação.
+ */
+
+const SamplesGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+`;
+
+const SampleCard = styled.figure`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  margin: 0;
+  padding: var(--space-6);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  position: relative;
+  overflow: hidden;
+`;
+
+/**
+ * Texto principal da amostra. Cada variante aplica um conjunto coerente
+ * de tokens (tamanho + peso + leading + tracking) tipicamente usado em
+ * blocos de display.
+ */
+const HeroText = styled.span`
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+
+  > em {
+    font-style: normal;
+    color: var(--accent-ink);
+  }
+`;
+
+const SubheroText = styled.span`
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+`;
+
+const SampleMeta = styled.figcaption`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: var(--border-thin) solid var(--border-subtle);
+`;
+
+const MetaItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+`;
+
+const MetaLabel = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--text-muted);
+`;
+
+const Alphabet = styled.p`
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wide);
+`;
+
+interface DisplaySpec {
+  /** Tag/eyebrow exibido acima do texto. */
+  tag: string;
+  /** Identificador acessível do card. */
+  ariaLabel: string;
+  /** Conteúdo renderizado dentro do componente principal. */
+  sample: React.ReactNode;
+  /** Wrapper de texto a usar — Hero (display) ou Subhero (3xl). */
+  variant: 'hero' | 'subhero';
+  /** Tokens aplicados — exibidos no rodapé do card. */
+  tokens: {
+    size: { name: string; value: string };
+    weight: { name: string; value: string };
+    leading: { name: string; value: string };
+    tracking: { name: string; value: string };
+  };
+  /** Linha de amostra de glifos (alfabeto + variantes). */
+  alphabet?: string;
+}
+
+const DISPLAY_SPECS: ReadonlyArray<DisplaySpec> = [
+  {
+    tag: 'Geist · Hero',
+    ariaLabel: 'Hero display',
+    variant: 'hero',
+    sample: (
+      <>
+        Administração <em>segura.</em>
+      </>
+    ),
+    tokens: {
+      size: { name: '--text-display', value: 'clamp(3.75rem, 12vw, 7rem)' },
+      weight: { name: '--weight-bold', value: '700' },
+      leading: { name: '--leading-tight', value: '1.2' },
+      tracking: { name: '--tracking-tight', value: '-0.03em' },
+    },
+    alphabet: 'Aa Bb Cc Dd Ee Ff Gg Hh · Variable 100–900',
+  },
+  {
+    tag: 'Geist · Subhero',
+    ariaLabel: 'Subhero display',
+    variant: 'subhero',
+    sample: 'Identidade visual da plataforma',
+    tokens: {
+      size: { name: '--text-3xl', value: '2.75rem' },
+      weight: { name: '--weight-bold', value: '700' },
+      leading: { name: '--leading-tight', value: '1.2' },
+      tracking: { name: '--tracking-tight', value: '-0.03em' },
+    },
+  },
+];
+
+const renderSample = (spec: DisplaySpec): React.ReactNode =>
+  spec.variant === 'hero' ? (
+    <HeroText>{spec.sample}</HeroText>
+  ) : (
+    <SubheroText>{spec.sample}</SubheroText>
+  );
+
+export const TypeDisplay: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Typography"
+    title="Display"
+    description="Estilos de display usados em hero e marketing. Tamanho fluido (clamp) responde da viewport mobile a desktop largo, mantendo proporção da identidade."
+    ariaLabel="Type Display"
+  >
+    <SamplesGrid>
+      {DISPLAY_SPECS.map(spec => (
+        <SampleCard key={spec.tag} aria-label={spec.ariaLabel}>
+          <Stack>
+            <MetaLabel>{spec.tag}</MetaLabel>
+            {renderSample(spec)}
+            {spec.alphabet ? <Alphabet>{spec.alphabet}</Alphabet> : null}
+          </Stack>
+          <SampleMeta>
+            <MetaItem>
+              <MetaLabel>Size</MetaLabel>
+              <TokenName>{spec.tokens.size.name}</TokenName>
+              <TokenValue>{spec.tokens.size.value}</TokenValue>
+            </MetaItem>
+            <MetaItem>
+              <MetaLabel>Weight</MetaLabel>
+              <TokenName>{spec.tokens.weight.name}</TokenName>
+              <TokenValue>{spec.tokens.weight.value}</TokenValue>
+            </MetaItem>
+            <MetaItem>
+              <MetaLabel>Leading</MetaLabel>
+              <TokenName>{spec.tokens.leading.name}</TokenName>
+              <TokenValue>{spec.tokens.leading.value}</TokenValue>
+            </MetaItem>
+            <MetaItem>
+              <MetaLabel>Tracking</MetaLabel>
+              <TokenName>{spec.tokens.tracking.name}</TokenName>
+              <TokenValue>{spec.tokens.tracking.value}</TokenValue>
+            </MetaItem>
+          </SampleMeta>
+        </SampleCard>
+      ))}
+    </SamplesGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/TypeMono.tsx
+++ b/src/pages/showcase/TypeMono.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, Stack, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #33 — Type Mono.
+ *
+ * Espelha `identity/preview/type-mono.html`. A fonte mono (`--font-mono`,
+ * JetBrains Mono) é usada em:
+ *   - Inline: identificadores, chaves, IDs, hashes dentro de texto.
+ *   - Bloco: snippets de código, payloads, comandos.
+ *
+ * Esta seção apresenta:
+ *   1. Big sample (estilo "label de permissão" — destaque tokenizado).
+ *   2. Inline showcase (tag `<code>` em parágrafo de body).
+ *   3. Bloco (tag `<pre>`) com snippet plausível do domínio.
+ *
+ * Tokens consumidos:
+ *   - `--font-mono`, `--text-xs/sm/base/lg/2xl`, `--weight-*`,
+ *     `--leading-*`, `--tracking-*`.
+ *   - Cores: `--text-primary`, `--text-muted`, `--accent-ink`,
+ *     `--bg-elevated`, `--border-subtle`.
+ */
+
+const SamplesGrid = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+`;
+
+const SampleCard = styled.figure`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+  padding: var(--space-5);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+`;
+
+const CardTag = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--accent-ink);
+`;
+
+/* ─── 1. Big sample ───────────────────────────────────────── */
+
+const MonoBig = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+`;
+
+const MonoEyebrow = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  color: var(--accent-ink);
+`;
+
+const MonoAlphabet = styled.p`
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wide);
+`;
+
+/* ─── 2. Inline ───────────────────────────────────────────── */
+
+/**
+ * Texto de body com `<code>` inline. O parágrafo usa tokens de body
+ * habituais; só o `<code>` aplica `--font-mono` e fundo discreto.
+ */
+const InlineParagraph = styled.p`
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-base);
+  color: var(--text-primary);
+
+  > code {
+    font-family: var(--font-mono);
+    font-size: 0.92em;
+    padding: 0.1em 0.4em;
+    border-radius: var(--radius-sm);
+    background: var(--bg-overlay);
+    color: var(--accent-ink);
+    border: var(--border-thin) solid var(--border-subtle);
+  }
+`;
+
+/* ─── 3. Bloco ────────────────────────────────────────────── */
+
+/**
+ * Bloco `<pre>` para snippets longos. Mantém quebras de linha,
+ * permite scroll horizontal em telas estreitas e aplica cor neutra
+ * para não competir com o conteúdo da página.
+ */
+const CodeBlock = styled.pre`
+  margin: 0;
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: pre;
+
+  /* Realce semântico mínimo para tornar o snippet legível sem depender
+     de uma lib de syntax highlighting. */
+  .key {
+    color: var(--accent-ink);
+    font-weight: var(--weight-semibold);
+  }
+
+  .str {
+    color: var(--text-secondary);
+  }
+
+  .num {
+    color: var(--info);
+  }
+
+  .com {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+`;
+
+const SpecRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: var(--border-thin) solid var(--border-subtle);
+`;
+
+const SpecItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+`;
+
+export const TypeMono: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Typography"
+    title="Mono"
+    description="Fonte monoespaçada (--font-mono / JetBrains Mono) para identificadores, IDs, hashes e blocos de código. Usada inline em texto corrido e em blocos preformatados."
+    ariaLabel="Type Mono"
+  >
+    <SamplesGrid>
+      {/* 1. Big sample — label de permissão / hash em destaque */}
+      <SampleCard aria-label="Mono big sample">
+        <CardTag>JetBrains Mono · Code / Labels</CardTag>
+        <Stack>
+          <MonoBig>perm:Systems.Create</MonoBig>
+          <MonoEyebrow>PERMISSÕES · ROLES · TOKEN</MonoEyebrow>
+          <MonoAlphabet>
+            Aa Bb Cc 0 1 2 3 4 5 6 7 8 9 · {'{ } ( ) < / >'} · 400 500 600
+          </MonoAlphabet>
+        </Stack>
+        <SpecRow>
+          <SpecItem>
+            <TokenName>--font-mono</TokenName>
+            <TokenValue>JetBrains Mono</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--text-2xl</TokenName>
+            <TokenValue>2rem · 32px</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--weight-semibold</TokenName>
+            <TokenValue>600</TokenValue>
+          </SpecItem>
+        </SpecRow>
+      </SampleCard>
+
+      {/* 2. Inline — uso em parágrafo de body */}
+      <SampleCard aria-label="Mono inline sample">
+        <CardTag>Inline · uso em body</CardTag>
+        <InlineParagraph>
+          O endpoint <code>GET /api/v1/systems</code> retorna o catálogo de
+          sistemas; cada item traz o identificador <code>system_id</code> (uuid
+          v4) e o slug <code>perm:Systems.Read</code> usado nas permissões
+          efetivas.
+        </InlineParagraph>
+        <InlineParagraph>
+          Para autenticar use o header <code>Authorization: Bearer &lt;jwt&gt;</code> e
+          observe o claim <code>sub</code> com o hash{' '}
+          <code>9f3a2c1b8d4e5f60</code>.
+        </InlineParagraph>
+        <SpecRow>
+          <SpecItem>
+            <TokenName>--font-mono</TokenName>
+            <TokenValue>inline em body</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--bg-overlay</TokenName>
+            <TokenValue>fundo do chip</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--accent-ink</TokenName>
+            <TokenValue>cor do código</TokenValue>
+          </SpecItem>
+        </SpecRow>
+      </SampleCard>
+
+      {/* 3. Bloco — snippet preformatado */}
+      <SampleCard aria-label="Mono block sample">
+        <CardTag>Block · snippet preformatado</CardTag>
+        <CodeBlock>
+          <span className="com">{'// payload de criação de role'}</span>
+          {'\n'}
+          {'{'}
+          {'\n'}
+          {'  '}
+          <span className="key">&quot;name&quot;</span>:{' '}
+          <span className="str">&quot;catalog_admin&quot;</span>,{'\n'}
+          {'  '}
+          <span className="key">&quot;system_id&quot;</span>:{' '}
+          <span className="str">
+            &quot;9f3a2c1b-8d4e-5f60-a1b2-c3d4e5f60718&quot;
+          </span>
+          ,{'\n'}
+          {'  '}
+          <span className="key">&quot;permissions&quot;</span>: [{'\n'}
+          {'    '}
+          <span className="str">&quot;perm:Systems.Read&quot;</span>,{'\n'}
+          {'    '}
+          <span className="str">&quot;perm:Systems.Create&quot;</span>,{'\n'}
+          {'    '}
+          <span className="str">&quot;perm:Routes.Manage&quot;</span>
+          {'\n'}
+          {'  '}],{'\n'}
+          {'  '}
+          <span className="key">&quot;active&quot;</span>:{' '}
+          <span className="num">true</span>
+          {'\n'}
+          {'}'}
+        </CodeBlock>
+        <SpecRow>
+          <SpecItem>
+            <TokenName>--font-mono</TokenName>
+            <TokenValue>JetBrains Mono</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--text-sm</TokenName>
+            <TokenValue>0.8125rem · 13px</TokenValue>
+          </SpecItem>
+          <SpecItem>
+            <TokenName>--leading-snug</TokenName>
+            <TokenValue>1.4</TokenValue>
+          </SpecItem>
+        </SpecRow>
+      </SampleCard>
+    </SamplesGrid>
+  </ShowcaseSection>
+);

--- a/src/pages/showcase/TypeScale.tsx
+++ b/src/pages/showcase/TypeScale.tsx
@@ -1,0 +1,336 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ShowcaseSection, TokenName, TokenValue } from './_shared';
+
+/**
+ * Issue #32 — Type Scale.
+ *
+ * Espelha `identity/preview/type-scale.html`. Substitui a seção
+ * "Typography" antiga (que apenas listava `Heading/Body/Caption/Label`
+ * sem expor tokens). Aqui cada degrau da escala expõe explicitamente:
+ *   - Token de tamanho (`--text-*`).
+ *   - Papel semântico (H1..H4, Body, Caption, Label).
+ *   - Amostra renderizada.
+ *   - Specs tokenizados (tamanho, peso, leading, tracking).
+ *
+ * O sample de cada linha aplica os mesmos tokens que `Typography.tsx`
+ * usa no componente equivalente — assim a régua valida visualmente a
+ * fonte de verdade do design system.
+ */
+
+const ScaleCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-surface);
+`;
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: minmax(110px, 0.7fr) minmax(0, 2fr) minmax(170px, 1fr);
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  /* Em telas estreitas vira pilha — espelha --bp-md (48em ≈ 768px). */
+  @media (max-width: 48em) {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+`;
+
+const RoleMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+`;
+
+const RoleLabel = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--accent-ink);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+`;
+
+const RoleHint = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wide);
+`;
+
+/**
+ * Wrappers de amostra. Cada um aplica o conjunto coerente de tokens
+ * (size + weight + leading + tracking) usado pelo papel correspondente.
+ *
+ * Não usamos `Heading/Body/Caption/Label` aqui porque queremos demonstrar
+ * a escala isoladamente, sem cores semânticas ou margens dos componentes
+ * — a régua precisa ser puramente tipográfica.
+ */
+const SampleBase = styled.span`
+  font-family: var(--font-body);
+  color: var(--text-primary);
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const SampleH1 = styled(SampleBase)`
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const SampleH2 = styled(SampleBase)`
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const SampleH3 = styled(SampleBase)`
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const SampleH4 = styled(SampleBase)`
+  font-family: var(--font-display);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+`;
+
+const SampleLg = styled(SampleBase)`
+  font-size: var(--text-lg);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+`;
+
+const SampleBody = styled(SampleBase)`
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-base);
+`;
+
+const SampleSm = styled(SampleBase)`
+  font-size: var(--text-sm);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-snug);
+  color: var(--text-secondary);
+`;
+
+const SampleXs = styled(SampleBase)`
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+`;
+
+const SpecMeta = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  align-items: flex-end;
+
+  /* Em mobile o alinhamento volta a ficar à esquerda (vira pilha). */
+  @media (max-width: 48em) {
+    align-items: flex-start;
+  }
+`;
+
+interface ScaleStep {
+  /** Token CSS de tamanho — ex.: `--text-3xl`. */
+  sizeToken: string;
+  /** Valor resolvido — ex.: `2.75rem`. */
+  sizeValue: string;
+  /** Papel semântico — ex.: 'H1', 'Body', 'Label'. */
+  role: string;
+  /** Hint complementar — ex.: 'Heading nível 1'. */
+  hint?: string;
+  /** Conteúdo da amostra. */
+  sample: string;
+  /** Componente de amostra a renderizar. */
+  Component: React.ComponentType<{ children: React.ReactNode }>;
+  /** Token de peso aplicado. */
+  weightToken: string;
+  weightValue: string;
+  /** Token de leading aplicado. */
+  leadingToken: string;
+  leadingValue: string;
+  /** Token de tracking aplicado (opcional — alguns degraus usam o default). */
+  trackingToken?: string;
+  trackingValue?: string;
+}
+
+const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
+  {
+    sizeToken: '--text-3xl',
+    sizeValue: '2.75rem · 44px',
+    role: 'H1',
+    hint: 'Heading nível 1',
+    sample: 'Gerenciamento de Roles',
+    Component: SampleH1,
+    weightToken: '--weight-bold',
+    weightValue: '700',
+    leadingToken: '--leading-tight',
+    leadingValue: '1.2',
+    trackingToken: '--tracking-tight',
+    trackingValue: '-0.03em',
+  },
+  {
+    sizeToken: '--text-2xl',
+    sizeValue: '2rem · 32px',
+    role: 'H2',
+    hint: 'Heading nível 2',
+    sample: 'Sistemas cadastrados',
+    Component: SampleH2,
+    weightToken: '--weight-semibold',
+    weightValue: '600',
+    leadingToken: '--leading-tight',
+    leadingValue: '1.2',
+    trackingToken: '--tracking-tight',
+    trackingValue: '-0.03em',
+  },
+  {
+    sizeToken: '--text-xl',
+    sizeValue: '1.5rem · 24px',
+    role: 'H3',
+    hint: 'Heading nível 3',
+    sample: 'Rotas por sistema',
+    Component: SampleH3,
+    weightToken: '--weight-semibold',
+    weightValue: '600',
+    leadingToken: '--leading-tight',
+    leadingValue: '1.2',
+    trackingToken: '--tracking-tight',
+    trackingValue: '-0.03em',
+  },
+  {
+    sizeToken: '--text-md',
+    sizeValue: '1.0625rem · 17px',
+    role: 'H4',
+    hint: 'Heading nível 4',
+    sample: 'Permissões efetivas',
+    Component: SampleH4,
+    weightToken: '--weight-semibold',
+    weightValue: '600',
+    leadingToken: '--leading-snug',
+    leadingValue: '1.4',
+    trackingToken: '--tracking-normal',
+    trackingValue: '0em',
+  },
+  {
+    sizeToken: '--text-lg',
+    sizeValue: '1.25rem · 20px',
+    role: 'Lead',
+    hint: 'Parágrafo de destaque',
+    sample: 'Atribua permissões granulares por sistema.',
+    Component: SampleLg,
+    weightToken: '--weight-medium',
+    weightValue: '500',
+    leadingToken: '--leading-snug',
+    leadingValue: '1.4',
+    trackingToken: '--tracking-normal',
+    trackingValue: '0em',
+  },
+  {
+    sizeToken: '--text-base',
+    sizeValue: '0.9375rem · 15px',
+    role: 'Body',
+    hint: 'Texto padrão',
+    sample: 'Atribua permissões diretamente ao usuário.',
+    Component: SampleBody,
+    weightToken: '--weight-regular',
+    weightValue: '400',
+    leadingToken: '--leading-base',
+    leadingValue: '1.6',
+    trackingToken: '--tracking-normal',
+    trackingValue: '0em',
+  },
+  {
+    sizeToken: '--text-sm',
+    sizeValue: '0.8125rem · 13px',
+    role: 'Caption',
+    hint: 'Metadados / legendas',
+    sample: 'Última atualização há 3 minutos',
+    Component: SampleSm,
+    weightToken: '--weight-regular',
+    weightValue: '400',
+    leadingToken: '--leading-snug',
+    leadingValue: '1.4',
+    trackingToken: '--tracking-normal',
+    trackingValue: '0em',
+  },
+  {
+    sizeToken: '--text-xs',
+    sizeValue: '0.6875rem · 11px',
+    role: 'Label',
+    hint: 'Form labels / eyebrows',
+    sample: 'NOME DO SISTEMA',
+    Component: SampleXs,
+    weightToken: '--weight-medium',
+    weightValue: '500',
+    leadingToken: '--leading-snug',
+    leadingValue: '1.4',
+    trackingToken: '--tracking-wide',
+    trackingValue: '0.06em',
+  },
+];
+
+export const TypeScale: React.FC = () => (
+  <ShowcaseSection
+    eyebrow="Typography"
+    title="Scale"
+    description="Escala tipográfica completa: H1..H4, Lead, Body, Caption e Label. Cada linha mostra token de tamanho, peso, leading e tracking — espelhando os tokens consumidos por src/components/ui/Typography.tsx."
+    ariaLabel="Type Scale"
+  >
+    <ScaleCard>
+      {SCALE_STEPS.map(step => {
+        const SampleComponent = step.Component;
+        return (
+          <Row key={step.sizeToken}>
+            <RoleMeta>
+              <RoleLabel>{step.role}</RoleLabel>
+              {step.hint ? <RoleHint>{step.hint}</RoleHint> : null}
+            </RoleMeta>
+            <SampleComponent>{step.sample}</SampleComponent>
+            <SpecMeta>
+              <TokenName>{step.sizeToken}</TokenName>
+              <TokenValue>{step.sizeValue}</TokenValue>
+              <TokenValue>
+                {step.weightToken} · {step.weightValue}
+              </TokenValue>
+              <TokenValue>
+                {step.leadingToken} · {step.leadingValue}
+              </TokenValue>
+              {step.trackingToken && step.trackingValue ? (
+                <TokenValue>
+                  {step.trackingToken} · {step.trackingValue}
+                </TokenValue>
+              ) : null}
+            </SpecMeta>
+          </Row>
+        );
+      })}
+    </ScaleCard>
+  </ShowcaseSection>
+);


### PR DESCRIPTION
## Contexto

Epic **#22** — PR-A2 (Tipografia). Sequência ao PR-A1 (#90, mergeado), que adicionou as 8 seções de tokens visuais (Brand/Status/Surfaces/Text/Radii/Shadows/Spacing/Logo).

Este PR cobre **3 sub-issues** da epic:

- **#31 Type — Display**
- **#32 Type — Scale**
- **#33 Type — Mono**

## Objetivo

Adicionar ao `ShowcasePage` três novas seções de tipografia que espelham os previews em `identity/preview/type-*.html`, expondo cada token (`--text-*`, `--weight-*`, `--leading-*`, `--tracking-*`, `--font-mono`, `--font-display`) com nome + valor ao lado da amostra.

## O que foi feito

### `src/pages/showcase/TypeDisplay.tsx` (#31) — novo
- Hero (`--text-display` = `clamp(3.75rem, 12vw, 7rem)` + `--weight-bold` + `--tracking-tight`)
- Subhero (`--text-3xl`)
- Cada card lista `size`, `weight`, `leading`, `tracking` com `<TokenName>` + `<TokenValue>`
- Linha de alfabeto/glifos no estilo do preview

### `src/pages/showcase/TypeScale.tsx` (#32) — novo
- Régua de 8 degraus: H1 (`--text-3xl`) → H2 → H3 → H4 (`--text-md`) → Lead (`--text-lg`) → Body (`--text-base`) → Caption (`--text-sm`) → Label (`--text-xs`)
- Cada linha mostra: papel semântico, amostra renderizada, e specs tokenizados (size + weight + leading + tracking)
- Wrappers de amostra aplicam **os mesmos tokens** que `Typography.tsx` consome no componente equivalente — a régua valida visualmente a fonte de verdade
- **Substitui** a antiga seção `Typography` do ShowcasePage (que listava `Heading/Body/Caption/Label` sem expor tokens)

### `src/pages/showcase/TypeMono.tsx` (#33) — novo
- Big sample (label de permissão `perm:Systems.Create` em `--text-2xl` mono)
- Uso inline (`<code>` em parágrafo de body) com endpoints, IDs e hashes
- Bloco preformatado (`<pre>`) com snippet de payload JSON de criação de role, com classes `.key/.str/.num/.com` para realce semântico mínimo

### `src/pages/ShowcasePage.tsx` — atualizado
- Imports de `TypeDisplay`, `TypeScale`, `TypeMono`
- Antiga seção inline `Typography` removida
- Ordem: tokens visuais → tipografia (Display/Scale/Mono) → componentes (Button/Icon/Spinner)

## Decisão sobre seção Typography antiga

**Substituída.** A seção anterior listava `Heading/Body/Caption/Label` sem expor tokens. `TypeScale` cumpre o mesmo papel com cobertura completa (size + weight + leading + tracking ao lado de cada amostra). Manter ambas seria duplicação visual.

## Tokens novos

Nenhum. `--font-mono` (linha 63 do `tokens.css`) e `--text-display` (linha 75) já existiam.

## Arquivos impactados

- `src/pages/showcase/TypeDisplay.tsx` (novo)
- `src/pages/showcase/TypeScale.tsx` (novo)
- `src/pages/showcase/TypeMono.tsx` (novo)
- `src/pages/ShowcasePage.tsx` (modificado)

## Testes

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test` ✓ (78 passes — sem mudança no número, conforme esperado para alteração visual de Showcase)
- `npm run build` ✓ (321.19 kB JS / 9.12 kB CSS)

Todos via `docker compose exec -T web ...`.

## Visual

- [x] Tokens consumidos exclusivamente de `tokens.css` (nenhum literal de tamanho/peso/leading/tracking)
- [x] Hover/focus N/A (seções são puramente apresentacionais — sem elementos interativos novos)
- [x] Render esperado em ambos temas via tokens semânticos (`--text-primary`, `--text-muted`, `--bg-elevated`, `--bg-surface`, `--border-subtle`, `--accent-ink`)
- [x] Mobile (≤480px): hero responde via `clamp()`; régua de Scale vira pilha em ≤768px

## Segurança

Nenhum impacto. Conteúdo estático apresentacional; nenhum input do usuário, nenhum `dangerouslySetInnerHTML`, nenhum link externo.

## Riscos

Baixos. Alteração isolada à página de showcase. Nenhuma rota produtiva ou componente reusável foi alterado.

## Issues relacionadas

Closes #31
Closes #32
Closes #33

Refs Epic #22