### PR TITLE
feat: fundacao — cliente HTTP centralizado e AuthContext (#43)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,28 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { ToastProvider } from './components/ui';
 import { AppRoutes } from './routes';
+import { AuthProvider } from './shared/auth';
 
+/**
+ * Composição raiz da árvore React.
+ *
+ * Hierarquia:
+ *
+ * - `<BrowserRouter>` — fornece roteamento. Hooks como `useNavigate`
+ *   exigem este ancestral, então fica mais externo.
+ * - `<AuthProvider>` — fica acima do `ToastProvider` para que callbacks
+ *   internos de auth (ex.: handler de 401) possam, no futuro, exibir
+ *   toasts via consumidor que combine `useAuth` + `useToast`.
+ * - `<ToastProvider>` — UI feedback acessível em qualquer página.
+ * - `<AppRoutes />` — componente de roteamento.
+ */
 const App: React.FC = () => (
   <BrowserRouter>
-    <ToastProvider>
-      <AppRoutes />
-    </ToastProvider>
+    <AuthProvider>
+      <ToastProvider>
+        <AppRoutes />
+      </ToastProvider>
+    </AuthProvider>
   </BrowserRouter>
 );
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,0 +1,288 @@
+import type {
+  ApiClient,
+  ApiClientAuthConfig,
+  ApiClientConfig,
+  ApiError,
+  BodyRequestOptions,
+  RequestOptions,
+  SafeRequestOptions,
+} from './types';
+
+/**
+ * Concatena `baseUrl` e `path` de forma idempotente.
+ *
+ * Aceita `baseUrl` com ou sem trailing slash e `path` com ou sem leading
+ * slash — o resultado é estável e consistente, evitando `//` ou
+ * concatenações sem `/` separador.
+ */
+function joinUrl(baseUrl: string, path: string): string {
+  if (!baseUrl) {
+    return path;
+  }
+  const trimmedBase = baseUrl.replace(/\/+$/, '');
+  const trimmedPath = path.replace(/^\/+/, '');
+  return `${trimmedBase}/${trimmedPath}`;
+}
+
+/**
+ * Decide se um valor de body precisa ser serializado em JSON.
+ *
+ * `string`, `FormData`, `URLSearchParams`, `Blob` e `ArrayBuffer` passam
+ * direto para o `fetch` sem transformação — o navegador define o
+ * `Content-Type` correto. Para qualquer outro objeto/array, serializamos
+ * em JSON e marcamos `application/json`.
+ */
+function isRawBody(body: unknown): boolean {
+  if (typeof body === 'string') {
+    return true;
+  }
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    return true;
+  }
+  if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+    return true;
+  }
+  if (typeof Blob !== 'undefined' && body instanceof Blob) {
+    return true;
+  }
+  if (typeof ArrayBuffer !== 'undefined' && body instanceof ArrayBuffer) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Tenta extrair `code` e `message` de um payload de erro arbitrário.
+ *
+ * O `lfc-authenticator` retorna `{code, message, details?}` em erros 4xx;
+ * outros backends/proxies podem responder com formato diferente. Esta
+ * função é tolerante: nunca lança e devolve apenas o que conseguir
+ * inferir.
+ */
+function extractErrorMeta(payload: unknown): {
+  code?: string;
+  message?: string;
+  details?: unknown;
+} {
+  if (!payload || typeof payload !== 'object') {
+    return {};
+  }
+  const record = payload as Record<string, unknown>;
+  const code = typeof record.code === 'string' ? record.code : undefined;
+  const message = typeof record.message === 'string' ? record.message : undefined;
+  return { code, message, details: record.details };
+}
+
+/**
+ * Mensagem padrão por status HTTP.
+ *
+ * Usada quando o backend não envia `message` legível — preserva uma
+ * mensagem amigável em pt-BR para fallback de UI.
+ */
+function defaultMessageForStatus(status: number): string {
+  if (status === 401) return 'Sessão expirada ou credenciais inválidas.';
+  if (status === 403) return 'Você não tem permissão para esta ação.';
+  if (status === 404) return 'Recurso não encontrado.';
+  if (status === 409) return 'Conflito ao processar a requisição.';
+  if (status >= 500) return 'Erro interno do servidor. Tente novamente.';
+  return 'Falha na requisição.';
+}
+
+/**
+ * Lê o corpo da resposta com tolerância:
+ *
+ * - 204/205 ou `Content-Length: 0` → retorna `undefined`.
+ * - `Content-Type: application/json` → tenta `JSON.parse` (lança se inválido).
+ * - Qualquer outro caso → tenta JSON; se falhar, retorna texto cru.
+ *
+ * Em caso de JSON inválido em response 2xx com `Content-Type: application/json`,
+ * lança `ApiError(parse)` para que o caller saiba que a resposta foi
+ * malformada.
+ */
+async function readResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204 || response.status === 205) {
+    return undefined;
+  }
+  const contentLength = response.headers.get('content-length');
+  if (contentLength === '0') {
+    return undefined;
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  const isJson = contentType.toLowerCase().includes('application/json');
+
+  const rawText = await response.text();
+  if (rawText.length === 0) {
+    return undefined;
+  }
+
+  if (isJson) {
+    try {
+      return JSON.parse(rawText) as unknown;
+    } catch (cause) {
+      throw createParseError(cause);
+    }
+  }
+  // Tenta JSON best-effort — se falhar, devolve texto bruto.
+  try {
+    return JSON.parse(rawText) as unknown;
+  } catch {
+    return rawText;
+  }
+}
+
+/**
+ * Constrói um `ApiError` quando o `fetch` rejeita (rede/CORS/abort).
+ *
+ * `AbortError` recebe mensagem dedicada para distinguir cancelamento de
+ * falha de rede real.
+ */
+function createNetworkError(cause: unknown): ApiError {
+  const isAbort =
+    cause instanceof DOMException && cause.name === 'AbortError';
+  return {
+    kind: 'network',
+    message: isAbort
+      ? 'Requisição cancelada.'
+      : 'Falha de conexão com o servidor.',
+    details: cause,
+  };
+}
+
+/**
+ * Constrói um `ApiError` quando o corpo JSON é inválido.
+ */
+function createParseError(cause: unknown): ApiError {
+  return {
+    kind: 'parse',
+    message: 'Resposta inválida do servidor.',
+    details: cause,
+  };
+}
+
+/**
+ * Constrói um `ApiError` para respostas com status HTTP de erro.
+ */
+function createHttpError(status: number, payload: unknown): ApiError {
+  const meta = extractErrorMeta(payload);
+  return {
+    kind: 'http',
+    status,
+    code: meta.code,
+    message: meta.message ?? defaultMessageForStatus(status),
+    details: meta.details ?? payload,
+  };
+}
+
+/**
+ * Cria um cliente HTTP independente baseado em `fetch`.
+ *
+ * O cliente é stateless quanto a cada requisição: lê `getToken()` no
+ * momento de cada chamada (assim o token pode mudar em runtime sem
+ * reconstruir o cliente) e dispara `onUnauthorized()` em respostas 401.
+ *
+ * Note que **não** importamos `useAuth` ou Context aqui — a injeção é
+ * feita via `setAuth` para evitar dependência circular entre
+ * `src/shared/api` e `src/shared/auth`.
+ */
+export function createApiClient(config: ApiClientConfig): ApiClient {
+  const { baseUrl } = config;
+  let getToken = config.getToken;
+  let onUnauthorized = config.onUnauthorized;
+
+  /**
+   * Constrói os headers finais da requisição combinando defaults,
+   * `Authorization` (quando há token) e overrides do consumidor.
+   */
+  function buildHeaders(
+    options: RequestOptions | undefined,
+    hasJsonBody: boolean,
+  ): Headers {
+    const headers = new Headers();
+    headers.set('Accept', 'application/json');
+    if (hasJsonBody) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const token = getToken?.();
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    if (options?.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers.set(key, value);
+      }
+    }
+    return headers;
+  }
+
+  async function request<T>(path: string, options?: RequestOptions): Promise<T> {
+    const method = options?.method ?? 'GET';
+    const rawBody = options?.body;
+    const hasBody = rawBody !== undefined && rawBody !== null;
+    const isJsonBody = hasBody && !isRawBody(rawBody);
+
+    const headers = buildHeaders(options, isJsonBody);
+
+    const init: RequestInit = {
+      method,
+      headers,
+      signal: options?.signal,
+    };
+
+    if (hasBody) {
+      init.body = isJsonBody ? JSON.stringify(rawBody) : (rawBody as BodyInit);
+    }
+
+    const url = joinUrl(baseUrl, path);
+
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (cause) {
+      throw createNetworkError(cause);
+    }
+
+    if (!response.ok) {
+      let payload: unknown = undefined;
+      try {
+        payload = await readResponseBody(response);
+      } catch {
+        // Erro ao ler corpo de resposta de erro — segue com `undefined`
+        // para que o ApiError carregue ao menos `status` e mensagem padrão.
+      }
+
+      if (response.status === 401) {
+        onUnauthorized?.();
+      }
+
+      throw createHttpError(response.status, payload);
+    }
+
+    const body = await readResponseBody(response);
+    return body as T;
+  }
+
+  function setAuth(next: ApiClientAuthConfig): void {
+    getToken = next.getToken;
+    onUnauthorized = next.onUnauthorized;
+  }
+
+  return {
+    request,
+    get<T>(path: string, options?: SafeRequestOptions): Promise<T> {
+      return request<T>(path, { ...options, method: 'GET' });
+    },
+    post<T>(path: string, body?: unknown, options?: BodyRequestOptions): Promise<T> {
+      return request<T>(path, { ...options, method: 'POST', body });
+    },
+    put<T>(path: string, body?: unknown, options?: BodyRequestOptions): Promise<T> {
+      return request<T>(path, { ...options, method: 'PUT', body });
+    },
+    patch<T>(path: string, body?: unknown, options?: BodyRequestOptions): Promise<T> {
+      return request<T>(path, { ...options, method: 'PATCH', body });
+    },
+    delete<T>(path: string, options?: SafeRequestOptions): Promise<T> {
+      return request<T>(path, { ...options, method: 'DELETE' });
+    },
+    setAuth,
+  };
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,34 @@
+import { createApiClient } from './client';
+
+import type { ApiClient } from './types';
+
+/**
+ * Base URL do `lfc-authenticator` resolvida em build-time pelo Vite.
+ *
+ * O fallback `''` é intencional: `joinUrl` aceita base vazia e devolve o
+ * `path` como URL relativa, permitindo cenários de proxy reverso onde o
+ * frontend é servido pelo mesmo host do backend.
+ */
+const baseUrl: string = import.meta.env.VITE_AUTH_API_BASE_URL ?? '';
+
+/**
+ * Singleton consumido pela aplicação.
+ *
+ * `getToken` e `onUnauthorized` são injetados pelo `AuthProvider` via
+ * `apiClient.setAuth(...)` — ver `src/shared/auth/AuthContext.tsx`.
+ */
+export const apiClient: ApiClient = createApiClient({ baseUrl });
+
+export { createApiClient } from './client';
+export { isApiError } from './types';
+export type {
+  ApiClient,
+  ApiClientAuthConfig,
+  ApiClientConfig,
+  ApiError,
+  ApiErrorKind,
+  BodyRequestOptions,
+  HttpMethod,
+  RequestOptions,
+  SafeRequestOptions,
+} from './types';

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Tipos públicos do cliente HTTP compartilhado.
+ *
+ * O cliente abstrai a comunicação com o `lfc-authenticator`, normalizando
+ * falhas heterogêneas (rede, parse, HTTP) em um único contrato `ApiError`
+ * — assim a UI sempre sabe o que lidar, independente do que aconteceu.
+ */
+
+/**
+ * Métodos HTTP suportados pelo cliente.
+ *
+ * Restringimos a este subset para manter o contrato explícito e evitar
+ * uso acidental de verbs incomuns (HEAD/OPTIONS) que o backend não cobre.
+ */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * Origem do erro normalizado.
+ *
+ * - `network`: `fetch` rejeitou (offline, DNS, CORS, etc.).
+ * - `parse`: corpo não pôde ser interpretado como JSON.
+ * - `http`: requisição completou mas retornou status >= 400.
+ */
+export type ApiErrorKind = 'network' | 'parse' | 'http';
+
+/**
+ * Contrato único de erro retornado pelo cliente HTTP.
+ *
+ * Sempre lançado via `throw` — chamadores devem usar `try/catch` ou tratar
+ * a Promise rejeitada. Quando `kind === 'http'`, `status` é garantido.
+ */
+export interface ApiError {
+  /** Origem do erro. Ver `ApiErrorKind`. */
+  kind: ApiErrorKind;
+  /** Status HTTP — presente quando `kind === 'http'`. */
+  status?: number;
+  /** Código do erro retornado pelo backend (ex.: `INVALID_CREDENTIALS`). */
+  code?: string;
+  /** Mensagem amigável, pronta para fallback de UI. */
+  message: string;
+  /** Payload bruto retornado pelo backend, quando aplicável. */
+  details?: unknown;
+}
+
+/**
+ * Type guard que distingue `ApiError` de erros arbitrários.
+ *
+ * Útil para `catch (e)` em call sites que não querem assumir o shape.
+ */
+export function isApiError(value: unknown): value is ApiError {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<ApiError>;
+  return (
+    typeof candidate.message === 'string' &&
+    (candidate.kind === 'network' ||
+      candidate.kind === 'parse' ||
+      candidate.kind === 'http')
+  );
+}
+
+/**
+ * Opções aceitas por uma requisição arbitrária.
+ *
+ * O `body` é serializado automaticamente em JSON quando objeto/array;
+ * `string`/`FormData`/`Blob` passam direto. `signal` permite cancelamento
+ * via `AbortController`.
+ */
+export interface RequestOptions {
+  method?: HttpMethod;
+  body?: unknown;
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+/** Opções de requisição sem `method` e `body` (usadas por `get`/`delete`). */
+export type SafeRequestOptions = Omit<RequestOptions, 'method' | 'body'>;
+
+/** Opções de requisição sem `method` (usadas por `post`/`put`/`patch`). */
+export type BodyRequestOptions = Omit<RequestOptions, 'method'>;
+
+/**
+ * Configuração inicial do cliente.
+ *
+ * `getToken` é uma função para evitar capturar o token em closure
+ * estática — o `AuthProvider` mantém o token em ref e o cliente lê
+ * o valor atual a cada requisição.
+ *
+ * `onUnauthorized` é chamado quando a API responde 401, permitindo
+ * que o consumidor (Provider) limpe sessão e redirecione.
+ */
+export interface ApiClientConfig {
+  baseUrl: string;
+  getToken?: () => string | null;
+  onUnauthorized?: () => void;
+}
+
+/**
+ * Subset de `ApiClientConfig` aceito por `setAuth` — usado pelo
+ * `AuthProvider` para injetar callbacks no singleton sem reconstruí-lo.
+ */
+export interface ApiClientAuthConfig {
+  getToken?: () => string | null;
+  onUnauthorized?: () => void;
+}
+
+/** Contrato exposto pelo cliente HTTP construído por `createApiClient`. */
+export interface ApiClient {
+  /** Executa uma requisição arbitrária e retorna o corpo tipado. */
+  request<T>(path: string, options?: RequestOptions): Promise<T>;
+  /** GET — retorna corpo JSON tipado. */
+  get<T>(path: string, options?: SafeRequestOptions): Promise<T>;
+  /** POST — `body` serializado como JSON quando objeto. */
+  post<T>(path: string, body?: unknown, options?: SafeRequestOptions): Promise<T>;
+  /** PUT — `body` serializado como JSON quando objeto. */
+  put<T>(path: string, body?: unknown, options?: SafeRequestOptions): Promise<T>;
+  /** PATCH — `body` serializado como JSON quando objeto. */
+  patch<T>(path: string, body?: unknown, options?: SafeRequestOptions): Promise<T>;
+  /** DELETE — sem body por padrão. */
+  delete<T>(path: string, options?: SafeRequestOptions): Promise<T>;
+  /** Atualiza callbacks de autenticação sem recriar o cliente. */
+  setAuth(config: ApiClientAuthConfig): void;
+}

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -1,0 +1,154 @@
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { apiClient } from '../api';
+
+import type { AuthContextValue, AuthState, LoginResponse } from './types';
+import type { ApiClient } from '../api';
+
+/**
+ * Estado inicial do Provider antes da hidratação.
+ *
+ * `isLoading: true` evita flicker — guardas de rota observam `isLoading`
+ * para decidir entre splash e redirect-to-login na Epic #44.
+ */
+const INITIAL_STATE: AuthState = {
+  user: null,
+  permissions: [],
+  isAuthenticated: false,
+  isLoading: true,
+};
+
+/**
+ * Contexto interno. `null` antes do Provider montar — o hook `useAuth`
+ * trata o caso e lança erro descritivo.
+ */
+export const AuthContext = createContext<AuthContextValue | null>(null);
+AuthContext.displayName = 'AuthContext';
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+  /**
+   * Cliente HTTP injetável.
+   *
+   * Em produção usamos o singleton `apiClient`. Testes podem injetar
+   * um stub para isolar o Provider da camada de transporte.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Provider que mantém token, usuário e permissões em memória.
+ *
+ * Decisões importantes:
+ *
+ * 1. **Token em ref** — não vai para state porque sua mudança não
+ *    precisa rerenderizar a árvore; o `apiClient` lê via `getToken()`
+ *    a cada requisição.
+ * 2. **Sem `useNavigate`** — Provider pode ser montado fora do
+ *    `<BrowserRouter>` em testes; redirect em 401 é responsabilidade do
+ *    consumidor (componente de guards na Epic #44 #56).
+ * 3. **Sem persistência** — token vive apenas em memória nesta Epic;
+ *    Epic #44 #53 adicionará localStorage com sincronização entre abas.
+ * 4. **Hidratação placeholder** — Epic #44 #54 substituirá pelo
+ *    `verify-token`. Aqui apenas finaliza `isLoading: false`.
+ */
+export const AuthProvider: React.FC<AuthProviderProps> = ({
+  children,
+  client = apiClient,
+}) => {
+  const [state, setState] = useState<AuthState>(INITIAL_STATE);
+  const tokenRef = useRef<string | null>(null);
+
+  /**
+   * Limpa estado e token. Centraliza a transição "autenticado →
+   * deslogado" para que `logout` e o handler de 401 reusem.
+   */
+  const clearSession = useCallback(() => {
+    tokenRef.current = null;
+    setState({
+      user: null,
+      permissions: [],
+      isAuthenticated: false,
+      isLoading: false,
+    });
+  }, []);
+
+  // Injeta callbacks no cliente HTTP. Reexecuta quando o cliente muda
+  // (cenário de teste); em produção, é one-shot.
+  useEffect(() => {
+    client.setAuth({
+      getToken: () => tokenRef.current,
+      onUnauthorized: () => {
+        clearSession();
+      },
+    });
+    return () => {
+      // Em desmontagem (HMR/teste), zera callbacks para evitar que o
+      // singleton mantenha referência a um Provider extinto.
+      client.setAuth({});
+    };
+  }, [client, clearSession]);
+
+  // Hidratação inicial (placeholder).
+  useEffect(() => {
+    // TODO Epic #44 #54: substituir por chamada a `verify-token` quando
+    // houver token persistido em localStorage.
+    setState(prev => ({ ...prev, isLoading: false }));
+  }, []);
+
+  const login = useCallback(
+    async (email: string, password: string): Promise<void> => {
+      setState(prev => ({ ...prev, isLoading: true }));
+      try {
+        const data = await client.post<LoginResponse>('/auth/login', {
+          email,
+          password,
+        });
+        tokenRef.current = data.token;
+        setState({
+          user: data.user,
+          permissions: data.permissions,
+          isAuthenticated: true,
+          isLoading: false,
+        });
+      } catch (error) {
+        setState(prev => ({ ...prev, isLoading: false }));
+        throw error;
+      }
+    },
+    [client],
+  );
+
+  const logout = useCallback(async (): Promise<void> => {
+    // Epic #44 #55: chamar `POST /auth/logout` antes de limpar localmente
+    // (best-effort; falha de rede não impede o clear).
+    clearSession();
+  }, [clearSession]);
+
+  const hasPermission = useCallback(
+    (code: string): boolean => state.permissions.includes(code),
+    [state.permissions],
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user: state.user,
+      permissions: state.permissions,
+      isAuthenticated: state.isAuthenticated,
+      isLoading: state.isLoading,
+      login,
+      logout,
+      hasPermission,
+    }),
+    [state, login, logout, hasPermission],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,0 +1,8 @@
+export { AuthContext, AuthProvider } from './AuthContext';
+export { useAuth } from './useAuth';
+export type {
+  AuthContextValue,
+  AuthState,
+  LoginResponse,
+  User,
+} from './types';

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Tipos públicos do contexto de autenticação.
+ *
+ * Mantemos o shape mínimo nesta Epic — campos adicionais do usuário e
+ * suporte a refresh token serão introduzidos na Epic #44 conforme as
+ * features (Login, persistência, verify-token) forem entrando.
+ */
+
+/**
+ * Representação do usuário autenticado tal como devolvido pelo
+ * `lfc-authenticator` no payload de login.
+ *
+ * Campos opcionais (`avatarUrl`, `roles`) são tolerados para evitar
+ * acoplamento prematuro a um shape exato — a UI sempre deve degradar
+ * quando faltarem.
+ */
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  roles?: ReadonlyArray<string>;
+}
+
+/**
+ * Estado observável do contexto.
+ *
+ * `isLoading` cobre dois momentos:
+ * - hidratação inicial (montagem do Provider) — Epic #44 fará via
+ *   `verify-token`; aqui é resolvido imediatamente como `false`;
+ * - chamadas de `login` em andamento.
+ */
+export interface AuthState {
+  user: User | null;
+  permissions: ReadonlyArray<string>;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Payload retornado pelo endpoint de login.
+ *
+ * Mantido como tipo exportado para que mocks/testes e a futura
+ * integração com `Auth API` compartilhem o mesmo contrato.
+ */
+export interface LoginResponse {
+  token: string;
+  user: User;
+  permissions: ReadonlyArray<string>;
+}
+
+/**
+ * Valor exposto pelo `useAuth()`.
+ *
+ * Combina o estado atual com as ações disponíveis. Todas as ações são
+ * assíncronas — `login` lança `ApiError` em falha, `logout` é tolerante
+ * a erros (sempre limpa estado local).
+ */
+export interface AuthContextValue extends AuthState {
+  /** Autentica via `POST /auth/login` e atualiza o estado. */
+  login(email: string, password: string): Promise<void>;
+  /** Encerra a sessão local (Epic #44 #55 fará a chamada remota). */
+  logout(): Promise<void>;
+  /** Retorna `true` quando `code` está presente em `permissions`. */
+  hasPermission(code: string): boolean;
+}

--- a/src/shared/auth/useAuth.ts
+++ b/src/shared/auth/useAuth.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+
+import { AuthContext } from './AuthContext';
+
+import type { AuthContextValue } from './types';
+
+/**
+ * Acesso ao contexto de autenticação.
+ *
+ * Lança erro descritivo quando usado fora do `<AuthProvider>` — falha
+ * cedo é preferível a fallback silencioso, que esconderia bug de
+ * configuração da árvore React.
+ */
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth deve ser usado dentro de um <AuthProvider>');
+  }
+  return ctx;
+}

--- a/tests/shared/api/client.test.ts
+++ b/tests/shared/api/client.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ApiError } from '@/shared/api';
+
+import { createApiClient, isApiError } from '@/shared/api';
+
+
+
+/**
+ * Constrói uma resposta `fetch` mockada com defaults sensatos.
+ *
+ * Centraliza a configuração para que cada teste expresse só o que é
+ * relevante — status, body, headers — sem reescrever boilerplate.
+ */
+function jsonResponse(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  const status = init.status ?? 200;
+  const payload = body === undefined ? '' : JSON.stringify(body);
+  return new Response(payload, {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+}
+
+/**
+ * Resposta sem corpo (204 No Content) — usada para verificar leitura
+ * tolerante de respostas vazias.
+ */
+function noContentResponse(): Response {
+  return new Response(null, { status: 204 });
+}
+
+describe('createApiClient', () => {
+  // Mock tipado de `fetch`. `unknown[]` no input afrouxa a comparação com a
+  // assinatura sobrecarregada do `fetch` global sem perder o `Response`
+  // como retorno — basta para os asserts feitos pelos testes.
+  let fetchSpy: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<Response>>>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('URL e métodos', () => {
+    test('GET concatena baseUrl e path corretamente', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      const client = createApiClient({ baseUrl: 'https://api.example.com/v1' });
+
+      await client.get('/systems');
+
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe('https://api.example.com/v1/systems');
+      expect((init as RequestInit).method).toBe('GET');
+    });
+
+    test('GET tolera baseUrl com trailing slash e path sem leading slash', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      const client = createApiClient({ baseUrl: 'https://api.example.com/v1/' });
+
+      await client.get('systems');
+
+      expect(fetchSpy.mock.calls[0][0]).toBe('https://api.example.com/v1/systems');
+    });
+
+    test('POST serializa body objeto como JSON e seta Content-Type', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 'abc' }));
+      const client = createApiClient({ baseUrl: 'https://api.example.com' });
+
+      await client.post('/systems', { name: 'Auth' });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const reqInit = init as RequestInit;
+      expect(reqInit.method).toBe('POST');
+      expect(reqInit.body).toBe(JSON.stringify({ name: 'Auth' }));
+      const headers = new Headers(reqInit.headers);
+      expect(headers.get('Content-Type')).toBe('application/json');
+      expect(headers.get('Accept')).toBe('application/json');
+    });
+
+    test('PUT, PATCH e DELETE invocam o método HTTP correspondente', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({}))
+        .mockResolvedValueOnce(jsonResponse({}))
+        .mockResolvedValueOnce(noContentResponse());
+      const client = createApiClient({ baseUrl: '' });
+
+      await client.put('/r/1', { a: 1 });
+      await client.patch('/r/1', { a: 2 });
+      await client.delete('/r/1');
+
+      expect((fetchSpy.mock.calls[0][1] as RequestInit).method).toBe('PUT');
+      expect((fetchSpy.mock.calls[1][1] as RequestInit).method).toBe('PATCH');
+      expect((fetchSpy.mock.calls[2][1] as RequestInit).method).toBe('DELETE');
+    });
+
+    test('204 No Content retorna undefined sem tentar parsear', async () => {
+      fetchSpy.mockResolvedValueOnce(noContentResponse());
+      const client = createApiClient({ baseUrl: '' });
+
+      const result = await client.delete<undefined>('/r/1');
+
+      expect(result).toBeUndefined();
+    });
+
+    test('headers customizados sobrescrevem defaults', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+      const client = createApiClient({ baseUrl: '' });
+
+      await client.get('/x', { headers: { 'X-Trace-Id': 't-123' } });
+
+      const headers = new Headers(
+        (fetchSpy.mock.calls[0][1] as RequestInit).headers,
+      );
+      expect(headers.get('X-Trace-Id')).toBe('t-123');
+    });
+
+    test('signal de AbortController é repassado ao fetch', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+      const client = createApiClient({ baseUrl: '' });
+      const controller = new AbortController();
+
+      await client.get('/x', { signal: controller.signal });
+
+      expect((fetchSpy.mock.calls[0][1] as RequestInit).signal).toBe(
+        controller.signal,
+      );
+    });
+  });
+
+  describe('Authorization', () => {
+    test('injeta Bearer quando getToken retorna token', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+      const client = createApiClient({
+        baseUrl: '',
+        getToken: () => 'jwt-abc',
+      });
+
+      await client.get('/me');
+
+      const headers = new Headers(
+        (fetchSpy.mock.calls[0][1] as RequestInit).headers,
+      );
+      expect(headers.get('Authorization')).toBe('Bearer jwt-abc');
+    });
+
+    test('omite Authorization quando getToken retorna null', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+      const client = createApiClient({ baseUrl: '', getToken: () => null });
+
+      await client.get('/public');
+
+      const headers = new Headers(
+        (fetchSpy.mock.calls[0][1] as RequestInit).headers,
+      );
+      expect(headers.has('Authorization')).toBe(false);
+    });
+
+    test('lê getToken a cada requisição (token rotativo)', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(jsonResponse({}))
+        .mockResolvedValueOnce(jsonResponse({}));
+      let token = 'first';
+      const client = createApiClient({ baseUrl: '', getToken: () => token });
+
+      await client.get('/x');
+      token = 'second';
+      await client.get('/x');
+
+      const first = new Headers(
+        (fetchSpy.mock.calls[0][1] as RequestInit).headers,
+      );
+      const second = new Headers(
+        (fetchSpy.mock.calls[1][1] as RequestInit).headers,
+      );
+      expect(first.get('Authorization')).toBe('Bearer first');
+      expect(second.get('Authorization')).toBe('Bearer second');
+    });
+
+    test('setAuth atualiza callbacks após criação', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+      const client = createApiClient({ baseUrl: '' });
+      client.setAuth({ getToken: () => 'late-token' });
+
+      await client.get('/x');
+
+      const headers = new Headers(
+        (fetchSpy.mock.calls[0][1] as RequestInit).headers,
+      );
+      expect(headers.get('Authorization')).toBe('Bearer late-token');
+    });
+  });
+
+  describe('Tratamento de erros', () => {
+    test('401 chama onUnauthorized e lança ApiError(http, 401)', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ code: 'UNAUTHORIZED', message: 'Token expirado' }, {
+          status: 401,
+        }),
+      );
+      const onUnauthorized = vi.fn();
+      const client = createApiClient({ baseUrl: '', onUnauthorized });
+
+      await expect(client.get('/me')).rejects.toMatchObject({
+        kind: 'http',
+        status: 401,
+        code: 'UNAUTHORIZED',
+        message: 'Token expirado',
+      });
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    test('403 propaga ApiError(http, 403) sem chamar onUnauthorized', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({ code: 'FORBIDDEN', message: 'Sem acesso' }, {
+          status: 403,
+        }),
+      );
+      const onUnauthorized = vi.fn();
+      const client = createApiClient({ baseUrl: '', onUnauthorized });
+
+      await expect(client.get('/admin')).rejects.toMatchObject({
+        kind: 'http',
+        status: 403,
+        code: 'FORBIDDEN',
+      });
+      expect(onUnauthorized).not.toHaveBeenCalled();
+    });
+
+    test('500 retorna ApiError(http) com mensagem padrão quando body vazio', async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(null, { status: 500 }));
+      const client = createApiClient({ baseUrl: '' });
+
+      await expect(client.get('/x')).rejects.toMatchObject({
+        kind: 'http',
+        status: 500,
+      });
+    });
+
+    test('falha de rede vira ApiError(network)', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const client = createApiClient({ baseUrl: '' });
+
+      let captured: unknown;
+      try {
+        await client.get('/x');
+      } catch (e) {
+        captured = e;
+      }
+      expect(isApiError(captured)).toBe(true);
+      expect((captured as ApiError).kind).toBe('network');
+      expect((captured as ApiError).message).toBe('Falha de conexão com o servidor.');
+    });
+
+    test('AbortError vira ApiError(network) com mensagem dedicada', async () => {
+      const abortErr = new DOMException('aborted', 'AbortError');
+      fetchSpy.mockRejectedValueOnce(abortErr);
+      const client = createApiClient({ baseUrl: '' });
+
+      await expect(client.get('/x')).rejects.toMatchObject({
+        kind: 'network',
+        message: 'Requisição cancelada.',
+      });
+    });
+
+    test('JSON inválido em resposta 2xx vira ApiError(parse)', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response('{not json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const client = createApiClient({ baseUrl: '' });
+
+      await expect(client.get('/x')).rejects.toMatchObject({ kind: 'parse' });
+    });
+
+    test('isApiError distingue ApiError de outros valores', () => {
+      expect(isApiError({ kind: 'network', message: 'x' })).toBe(true);
+      expect(isApiError({ kind: 'http', status: 404, message: 'x' })).toBe(true);
+      expect(isApiError(new Error('boom'))).toBe(false);
+      expect(isApiError(null)).toBe(false);
+      expect(isApiError({ kind: 'invalid', message: 'x' })).toBe(false);
+    });
+  });
+
+  describe('Resposta', () => {
+    test('parseia JSON e retorna corpo tipado', async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1, name: 'Auth' }));
+      const client = createApiClient({ baseUrl: '' });
+
+      const result = await client.get<{ id: number; name: string }>('/x');
+
+      expect(result).toEqual({ id: 1, name: 'Auth' });
+    });
+
+    test('retorna texto cru quando Content-Type não é JSON', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response('plain text', {
+          status: 200,
+          headers: { 'Content-Type': 'text/plain' },
+        }),
+      );
+      const client = createApiClient({ baseUrl: '' });
+
+      const result = await client.get<string>('/x');
+      expect(result).toBe('plain text');
+    });
+  });
+});

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -1,0 +1,254 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+
+import type { ApiClient, ApiError } from '@/shared/api';
+import type { LoginResponse } from '@/shared/auth';
+
+import { AuthProvider, useAuth } from '@/shared/auth';
+
+/**
+ * Constrói um stub de `ApiClient` que registra chamadas e devolve
+ * respostas controladas. Cada teste configura o comportamento de `post`
+ * via `mockResolvedValue` / `mockRejectedValue`.
+ */
+function createClientStub(): ApiClient & {
+  post: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+} {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+  } as unknown as ApiClient & {
+    post: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    setAuth: ReturnType<typeof vi.fn>;
+    request: ReturnType<typeof vi.fn>;
+  };
+}
+
+/**
+ * Wrapper de teste que monta o Provider com um cliente injetado.
+ * Usado por `renderHook` para fornecer contexto ao `useAuth`.
+ */
+function makeWrapper(client: ApiClient) {
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <AuthProvider client={client}>{children}</AuthProvider>
+  );
+  Wrapper.displayName = 'AuthProviderTestWrapper';
+  return Wrapper;
+}
+
+/**
+ * Acessa a última chamada registrada por um mock — alternativa a
+ * `Array.prototype.at(-1)`, que exige `lib: ES2022`. Mantém compat com o
+ * `target: ES2020` do projeto.
+ */
+function lastCall<T>(mockCalls: ReadonlyArray<T>): T | undefined {
+  return mockCalls.length > 0 ? mockCalls[mockCalls.length - 1] : undefined;
+}
+
+const SAMPLE_LOGIN: LoginResponse = {
+  token: 'jwt-xyz',
+  user: {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@lfc.com.br',
+  },
+  permissions: ['Systems.Read', 'Systems.Create'],
+};
+
+describe('useAuth fora do Provider', () => {
+  test('lança erro descritivo', () => {
+    // Suprime o `console.error` esperado do React durante teste de erro.
+    const noop = (): void => {
+      // intencionalmente vazio — apenas absorver logs de erro do React.
+    };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    expect(() => renderHook(() => useAuth())).toThrow(
+      /useAuth deve ser usado dentro de um <AuthProvider>/,
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe('AuthProvider — estado inicial', () => {
+  test('expõe estado deslogado e finaliza isLoading após hidratação', async () => {
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.user).toBeNull();
+    expect(result.current.permissions).toEqual([]);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('injeta getToken e onUnauthorized no client via setAuth', () => {
+    const client = createClientStub();
+    renderHook(() => useAuth(), { wrapper: makeWrapper(client) });
+
+    expect(client.setAuth).toHaveBeenCalled();
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(typeof latest?.getToken).toBe('function');
+    expect(typeof latest?.onUnauthorized).toBe('function');
+    // Antes do login, getToken() retorna null.
+    expect(latest?.getToken?.()).toBeNull();
+  });
+});
+
+describe('AuthProvider — login', () => {
+  test('caminho feliz: atualiza estado e dispara POST /auth/login', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/auth/login', {
+      email: 'ada@lfc.com.br',
+      password: 'secret',
+    });
+    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
+    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  test('após login, getToken injetado no client retorna o token recebido', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(latest?.getToken?.()).toBe('jwt-xyz');
+  });
+
+  test('falha de credenciais propaga ApiError e mantém estado deslogado', async () => {
+    const apiError: ApiError = {
+      kind: 'http',
+      status: 401,
+      code: 'INVALID_CREDENTIALS',
+      message: 'Credenciais inválidas.',
+    };
+    const client = createClientStub();
+    client.post.mockRejectedValueOnce(apiError);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(
+      act(async () => {
+        await result.current.login('ada@lfc.com.br', 'wrong');
+      }),
+    ).rejects.toMatchObject({ status: 401, code: 'INVALID_CREDENTIALS' });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe('AuthProvider — logout', () => {
+  test('limpa estado e zera token após logout', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.permissions).toEqual([]);
+    expect(result.current.isAuthenticated).toBe(false);
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(latest?.getToken?.()).toBeNull();
+  });
+});
+
+describe('AuthProvider — hasPermission', () => {
+  test('retorna false enquanto deslogado', async () => {
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.hasPermission('Systems.Read')).toBe(false);
+  });
+
+  test('retorna true para permissões presentes após login', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    expect(result.current.hasPermission('Systems.Read')).toBe(true);
+    expect(result.current.hasPermission('Systems.Create')).toBe(true);
+    expect(result.current.hasPermission('Systems.Delete')).toBe(false);
+  });
+});
+
+describe('AuthProvider — onUnauthorized', () => {
+  test('callback injetado no client limpa sessão quando disparado', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    const onUnauthorized = lastCall(client.setAuth.mock.calls)?.[0]
+      ?.onUnauthorized as () => void;
+    expect(typeof onUnauthorized).toBe('function');
+
+    act(() => {
+      onUnauthorized();
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.permissions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Contexto

Epic [#43](https://github.com/LF-Calegari/lfc-admin-gui/issues/43) — Fundação. Sem essas duas peças nada do backlog (#44, Sistemas, Roles, Permissões, Clientes, Usuários) consegue chamar a API ou aplicar guards.

## Objetivo

Entregar a infraestrutura compartilhada que toda feature do `lfc-admin-gui` consumirá:

- Cliente HTTP único (`src/shared/api/`) apontando para o `lfc-authenticator`.
- `AuthContext` + `useAuth` (`src/shared/auth/`) que mantém token, usuário e permissões em memória.

## O que foi feito

### Cliente HTTP — `src/shared/api/`
- `createApiClient({ baseUrl, getToken?, onUnauthorized? })` baseado em `fetch` nativo (sem axios).
- Base URL via `import.meta.env.VITE_AUTH_API_BASE_URL`.
- Headers `Accept: application/json` por padrão; `Content-Type: application/json` quando body é objeto/array; bodies brutos (`FormData`, `Blob`, `URLSearchParams`, `string`) passam direto.
- Injeção automática de `Authorization: Bearer <token>` via `getToken()` chamado a cada requisição (token rotativo respeitado).
- 401 → dispara `onUnauthorized()` antes de re-lançar; 403 → propaga sem deslogar.
- Erros normalizados em `ApiError { kind: 'network' | 'parse' | 'http', status?, code?, message, details? }`.
- 204/205/`Content-Length: 0` retornam `undefined` sem tentar parsear.
- `setAuth({ getToken, onUnauthorized })` permite injeção tardia (usado pelo Provider) sem ciclo entre `shared/api` e `shared/auth`.
- API: `request<T>`, `get<T>`, `post<T>`, `put<T>`, `patch<T>`, `delete<T>`.
- Type guard público `isApiError(value)`.

### AuthContext — `src/shared/auth/`
- `AuthProvider` mantém estado `{ user, permissions, isAuthenticated, isLoading }` em `useState` e token em `useRef` (memória).
- Métodos: `login(email, password)` → `POST /auth/login`; `logout()`; `hasPermission(code)`.
- No mount, registra `getToken`/`onUnauthorized` no `apiClient.setAuth()`. No unmount, limpa.
- Hidratação inicial é placeholder (`isLoading: false` imediato) — Epic #44 #54 fará via `verify-token`.
- 401 vindo do client → `clearSession()` automático (limpa estado e token).
- `useAuth()` lança erro descritivo se usado fora do Provider.
- `App.tsx` agora envolve a árvore: `<BrowserRouter><AuthProvider><ToastProvider><AppRoutes/></ToastProvider></AuthProvider></BrowserRouter>`.

### Testes — 30 novos (total 161)
- `tests/shared/api/client.test.ts` (20) — URL/headers/Bearer/setAuth, 401 chamando onUnauthorized, 403 sem deslogar, 500 com body vazio, network error, AbortError, JSON inválido (parse), `isApiError`, retorno 204, texto cru, signal repassado, token rotativo.
- `tests/shared/auth/AuthProvider.test.tsx` (10) — `useAuth` fora do Provider, hidratação, injeção via setAuth, login feliz/falha, logout, hasPermission deslogado/logado, callback `onUnauthorized` limpando sessão.

## Arquivos impactados

Novos:
- `src/shared/api/types.ts`
- `src/shared/api/client.ts`
- `src/shared/api/index.ts`
- `src/shared/auth/types.ts`
- `src/shared/auth/AuthContext.tsx`
- `src/shared/auth/useAuth.ts`
- `src/shared/auth/index.ts`
- `tests/shared/api/client.test.ts`
- `tests/shared/auth/AuthProvider.test.tsx`

Alterado:
- `src/App.tsx` — envolve árvore com `<AuthProvider>`.

`.env.example` já continha `VITE_AUTH_API_BASE_URL=https://localhost:8080/api/v1` — não foi alterado.

## Testes

- `npm run lint` — 0 erros, 0 warnings.
- `npm run typecheck` — limpo.
- `npm test` — 161/161 passed (20 testes do client HTTP + 10 do AuthProvider novos).
- `npm run build` — `348.81 KB` (gzip `101.68 KB`).
- Validação manual: app respondendo em `localhost:3002` com status 200, sem regressão funcional.

## Visual

Esta Epic é fundação — sem mudança visual. Componentes existentes não recebem alteração de UI; estados visuais permanecem como antes da Epic #22 PR-A3.

## Segurança

- Token armazenado **apenas em memória** (`useRef` interno do Provider) — sem localStorage nesta Epic. Persistência segura é Epic #44 #53.
- Cliente HTTP nunca loga tokens; `Authorization` não é incluído em `details` de `ApiError`.
- Sem uso de `dangerouslySetInnerHTML` em código novo.
- Ausência total de `any` — apenas `unknown` com type guards.
- Erros HTTP não vazam payload do backend ao usuário final automaticamente: o componente consumidor decide o que renderizar.

## Decisões não óbvias

1. **Hierarquia `<BrowserRouter><AuthProvider><ToastProvider>`** — `BrowserRouter` mais externo para que futuras evoluções (ex.: callback de redirect via `useNavigate`) possam ser adicionadas; `AuthProvider` acima do `ToastProvider` para que consumidores possam combinar `useAuth` + `useToast` em qualquer lugar.
2. **Sem `useNavigate` no Provider** — redirect em 401 fica como callback/responsabilidade do componente de guards (Epic #44 #56). Provider apenas limpa sessão.
3. **`setAuth()` injeção tardia** — evita ciclo de import entre `shared/api` e `shared/auth`. O singleton do client recebe os callbacks no mount do Provider.
4. **Token em ref, não em state** — sua mudança não precisa rerenderizar a árvore; `apiClient` lê via `getToken()` a cada request.
5. **Testes do client com `vi.stubGlobal('fetch', ...)`** — mais portátil que `vi.spyOn(globalThis, 'fetch')` quando o tipo de overload do `fetch` global atrapalha o tipo do mock.

## Riscos

- Hidratação inicial é placeholder e finaliza `isLoading: false` imediatamente. Telas que ainda não foram criadas (login etc.) continuam invisíveis até Epic #44.
- 401 não navega para `/login` ainda — apenas limpa sessão. A Epic #44 #56 acoplará navegação real.
- `apiClient` é singleton; trocar de instância em runtime exigiria recriar o Provider. Isso é aceitável para o escopo atual.

## Issue relacionada

Closes #50
Closes #51
Refs Epic #43