### PR TITLE
feat: tela de login (#52)

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,379 @@
+import { Mail, Lock } from 'lucide-react';
+import React, { useState } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import logoForLightTheme from '../assets/logo-dark.svg';
+import logoForDarkTheme from '../assets/logo-white.svg';
+import { Alert, Button, Input, ThemeToggle } from '../components/ui';
+import { useTheme } from '../hooks/useTheme';
+import { isApiError } from '../shared/api';
+import { useAuth } from '../shared/auth';
+
+import type { ApiError } from '../shared/api';
+
+/**
+ * Destino padrão pós-login quando a `location.state.from` não está
+ * preenchida (acesso direto à rota `/login`).
+ */
+const DEFAULT_REDIRECT = '/systems';
+
+/**
+ * Mensagem genérica exibida quando o erro retornado pelo backend não
+ * carrega texto legível. Em pt-BR para alinhar com o restante da UI.
+ */
+const FALLBACK_ERROR = 'Falha ao entrar. Verifique suas credenciais e tente novamente.';
+
+/**
+ * Mensagem amigável para credenciais inválidas. Mantemos texto
+ * deliberadamente vago ("e-mail ou senha inválidos") para não vazar
+ * existência da conta — boa prática de segurança em telas de login.
+ */
+const INVALID_CREDENTIALS_MESSAGE = 'E-mail ou senha inválidos.';
+
+/**
+ * Validação simples e suficiente para client-side. A validação real
+ * (formato canônico) acontece no backend; aqui só evitamos submits
+ * obviamente inválidos. Regex pragmático: caracteres não-espaço, "@",
+ * caracteres não-espaço, ".", caracteres não-espaço.
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface FormState {
+  email: string;
+  password: string;
+}
+
+interface FieldErrors {
+  email?: string;
+  password?: string;
+}
+
+const PageRoot = styled.div`
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-base);
+  padding: var(--space-6) var(--space-4);
+  position: relative;
+`;
+
+/**
+ * Toggle de tema posicionado no canto superior direito. Mantém o
+ * controle visível antes do login para que o usuário possa ajustar
+ * preferência mesmo sem sessão ativa.
+ */
+const ThemeSlot = styled.div`
+  position: absolute;
+  top: var(--space-4);
+  right: var(--space-4);
+`;
+
+const Container = styled.div`
+  width: 100%;
+  max-width: var(--measure-cta);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+`;
+
+const Brand = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+`;
+
+const Logo = styled.img`
+  width: var(--space-16);
+  height: var(--space-16);
+  display: block;
+`;
+
+const BrandTitle = styled.h1`
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+  text-align: center;
+`;
+
+const BrandSubtitle = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  margin: 0;
+  text-align: center;
+  line-height: var(--leading-snug);
+`;
+
+/**
+ * Card customizado em vez do `Card` compartilhado: o componente padrão
+ * traz hover/transform que é desejável em listas, mas estranho em uma
+ * tela de autenticação onde o foco deve estar 100% no formulário.
+ */
+const FormCard = styled.section`
+  width: 100%;
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  box-shadow: var(--shadow-sm);
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const SubmitButton = styled(Button)`
+  width: 100%;
+`;
+
+const Footer = styled.p`
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  margin: 0;
+  text-align: center;
+  line-height: var(--leading-snug);
+`;
+
+/**
+ * Título acessível (apenas leitor de tela). Mantém a `<section>`
+ * rotulada por um heading sem poluir o layout visual.
+ */
+const VisuallyHidden = styled.h2`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
+/**
+ * Tipa o `state` de `location` para extrair o caminho original que o
+ * usuário tentou acessar antes de ser redirecionado para `/login`.
+ *
+ * O guard de rota (Issue #56) preencherá `location.state.from` com a
+ * rota original; aqui apenas tentamos extrair de forma defensiva — se
+ * o shape não bate, caímos no `DEFAULT_REDIRECT`.
+ */
+function resolveRedirectTarget(state: unknown): string {
+  if (!state || typeof state !== 'object') {
+    return DEFAULT_REDIRECT;
+  }
+  const candidate = (state as { from?: { pathname?: string } }).from;
+  const pathname = candidate?.pathname;
+  return typeof pathname === 'string' && pathname.length > 0 ? pathname : DEFAULT_REDIRECT;
+}
+
+/**
+ * Normaliza um erro arbitrário em mensagem exibível.
+ *
+ * - 401 (credenciais inválidas) → mensagem fixa não-vazante.
+ * - Demais `ApiError` com `message` → reutiliza a mensagem do backend.
+ * - Qualquer outro erro → mensagem genérica.
+ */
+function buildErrorMessage(error: unknown): string {
+  if (isApiError(error)) {
+    const httpError = error as ApiError;
+    if (httpError.status === 401) {
+      return INVALID_CREDENTIALS_MESSAGE;
+    }
+    if (httpError.message) {
+      return httpError.message;
+    }
+  }
+  return FALLBACK_ERROR;
+}
+
+/**
+ * Tela de autenticação do painel administrativo.
+ *
+ * Decisões importantes:
+ *
+ * 1. **Layout dedicado** — fora do `AppLayout` para esconder Sidebar/
+ *    Topbar; o foco visual fica concentrado no Card central.
+ * 2. **Redirect-if-authenticated** — quando `isAuthenticated`, evita
+ *    flash do form retornando `<Navigate />` antes do JSX principal.
+ * 3. **Validação client-side mínima** — o objetivo é evitar requests
+ *    obviamente inválidos. A validação canônica é do backend.
+ * 4. **Mensagem 401 fixa** — "e-mail ou senha inválidos" sem detalhar,
+ *    para não revelar se o e-mail existe (boa prática de segurança).
+ * 5. **Foco automático** — primeiro campo recebe foco no mount; melhora
+ *    UX em desktop sem prejudicar mobile (foco não abre teclado virtual
+ *    automaticamente nos browsers atuais sem interação prévia).
+ * 6. **Token em memória** — esta página apenas dispara `useAuth().login`;
+ *    a persistência (localStorage + sync entre abas) é feita na Issue
+ *    #53.
+ */
+export const LoginPage: React.FC = () => {
+  const { login, isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const { resolvedTheme } = useTheme();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState<FormState>({ email: '', password: '' });
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  // Curto-circuito: se já autenticado (acesso direto a /login com sessão
+  // viva), redireciona imediatamente para o destino preservado ou home.
+  if (isAuthenticated && !isAuthLoading) {
+    return <Navigate to={resolveRedirectTarget(location.state)} replace />;
+  }
+
+  const handleEmailChange = (value: string): void => {
+    setForm(prev => ({ ...prev, email: value }));
+    if (fieldErrors.email) {
+      setFieldErrors(prev => ({ ...prev, email: undefined }));
+    }
+    if (submitError) {
+      setSubmitError(null);
+    }
+  };
+
+  const handlePasswordChange = (value: string): void => {
+    setForm(prev => ({ ...prev, password: value }));
+    if (fieldErrors.password) {
+      setFieldErrors(prev => ({ ...prev, password: undefined }));
+    }
+    if (submitError) {
+      setSubmitError(null);
+    }
+  };
+
+  /**
+   * Valida o formulário e devolve o mapa de erros por campo. Mantida
+   * como função pura para facilitar teste e leitura.
+   */
+  const validate = (values: FormState): FieldErrors => {
+    const errors: FieldErrors = {};
+    const trimmedEmail = values.email.trim();
+    if (!trimmedEmail) {
+      errors.email = 'Informe seu e-mail.';
+    } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+      errors.email = 'E-mail inválido.';
+    }
+    if (!values.password) {
+      errors.password = 'Informe sua senha.';
+    }
+    return errors;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const errors = validate(form);
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      setSubmitError(null);
+      return;
+    }
+
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    try {
+      await login(form.email.trim(), form.password);
+      const target = resolveRedirectTarget(location.state);
+      navigate(target, { replace: true });
+    } catch (error) {
+      setSubmitError(buildErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const logoSrc = resolvedTheme === 'dark' ? logoForDarkTheme : logoForLightTheme;
+
+  return (
+    <PageRoot>
+      <ThemeSlot>
+        <ThemeToggle />
+      </ThemeSlot>
+      <Container>
+        <Brand>
+          <Logo src={logoSrc} alt="LF Calegari Admin" />
+          <div>
+            <BrandTitle>Acesse sua conta</BrandTitle>
+            <BrandSubtitle>Entre para gerenciar o catálogo do autenticador.</BrandSubtitle>
+          </div>
+        </Brand>
+
+        <FormCard aria-labelledby="login-form-title">
+          <VisuallyHidden id="login-form-title">Formulário de login</VisuallyHidden>
+          <Form onSubmit={handleSubmit} noValidate>
+            <Input
+              label="E-mail"
+              type="email"
+              name="email"
+              autoComplete="email"
+              inputMode="email"
+              placeholder="voce@empresa.com.br"
+              value={form.email}
+              onChange={handleEmailChange}
+              error={fieldErrors.email}
+              icon={<Mail size={16} strokeWidth={1.5} />}
+              disabled={isSubmitting}
+              required
+              autoFocus
+              aria-required="true"
+              aria-invalid={fieldErrors.email ? 'true' : undefined}
+            />
+            <Input
+              label="Senha"
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              placeholder="Sua senha"
+              value={form.password}
+              onChange={handlePasswordChange}
+              error={fieldErrors.password}
+              icon={<Lock size={16} strokeWidth={1.5} />}
+              disabled={isSubmitting}
+              required
+              aria-required="true"
+              aria-invalid={fieldErrors.password ? 'true' : undefined}
+            />
+
+            {submitError && (
+              <div role="alert" aria-live="assertive">
+                <Alert variant="danger">{submitError}</Alert>
+              </div>
+            )}
+
+            <SubmitButton
+              type="submit"
+              loading={isSubmitting}
+              disabled={isSubmitting}
+              data-testid="login-submit"
+            >
+              {isSubmitting ? 'Entrando…' : 'Entrar'}
+            </SubmitButton>
+          </Form>
+        </FormCard>
+
+        <Footer>
+          Acesso restrito a administradores autorizados.
+        </Footer>
+      </Container>
+    </PageRoot>
+  );
+};
+
+export default LoginPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { AppLayout } from '../layouts/AppLayout';
 import { ForbiddenPage } from '../pages/ForbiddenPage';
 import { InternalErrorPage } from '../pages/InternalErrorPage';
+import { LoginPage } from '../pages/LoginPage';
 import { NotFoundPage } from '../pages/NotFoundPage';
 import { PermissionsPage } from '../pages/PermissionsPage';
 import { PlaceholderPage } from '../pages/PlaceholderPage';
@@ -39,6 +40,8 @@ const ErrorRouteResolver: React.FC = () => {
  * Estrutura de rotas do painel administrativo.
  *
  * Convenções:
+ * - Rotas públicas (`/login`) vivem em top-level, fora do `<AppLayout>`,
+ *   para que Sidebar/Topbar não apareçam antes da autenticação.
  * - Toda rota autenticada vive sob `<AppLayout>` (Sidebar + Topbar + Outlet).
  * - O índice `/` redireciona para `/systems` para preservar UX legada.
  * - Rotas `/error/:code` mapeiam para as páginas reais de erro
@@ -49,6 +52,8 @@ const ErrorRouteResolver: React.FC = () => {
  */
 export const AppRoutes: React.FC = () => (
   <Routes>
+    <Route path="/login" element={<LoginPage />} />
+
     <Route element={<AppLayout />}>
       <Route index element={<Navigate to="/systems" replace />} />
 

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -1,0 +1,365 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, ApiError } from '@/shared/api';
+import type { LoginResponse } from '@/shared/auth';
+
+import { LoginPage } from '@/pages/LoginPage';
+import { AuthProvider } from '@/shared/auth';
+
+/**
+ * Stub mínimo de `ApiClient` injetado no `AuthProvider` durante os
+ * testes — isola a página de qualquer chamada real ao backend.
+ *
+ * Cada teste configura `post` via `mockResolvedValue` ou
+ * `mockRejectedValue` conforme o cenário sendo coberto.
+ */
+function createClientStub(): ApiClient & {
+  post: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+} {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+  } as unknown as ApiClient & {
+    post: ReturnType<typeof vi.fn>;
+    setAuth: ReturnType<typeof vi.fn>;
+  };
+}
+
+const SAMPLE_LOGIN: LoginResponse = {
+  token: 'jwt-xyz',
+  user: {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@lfc.com.br',
+  },
+  permissions: ['Systems.Read'],
+};
+
+type ClientStub = ReturnType<typeof createClientStub>;
+
+interface RenderOptions {
+  client?: ClientStub;
+  initialEntries?: Array<string | { pathname: string; state?: unknown }>;
+}
+
+/**
+ * Renderiza `LoginPage` dentro de `AuthProvider` + `MemoryRouter` com
+ * uma rota destino (`/systems`) que registra a navegação para validar o
+ * redirect pós-login.
+ */
+function renderLogin(options: RenderOptions = {}): { client: ClientStub } {
+  const client = options.client ?? createClientStub();
+  render(
+    <AuthProvider client={client}>
+      <MemoryRouter initialEntries={options.initialEntries ?? ['/login']}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/systems"
+            element={<div data-testid="systems-page">systems</div>}
+          />
+          <Route
+            path="/permissions"
+            element={<div data-testid="permissions-page">permissions</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+  return { client };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('LoginPage — render inicial', () => {
+  it('renderiza brand, formulário e CTA principal', () => {
+    renderLogin();
+
+    expect(screen.getByRole('img', { name: /LF Calegari Admin/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/E-mail/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Senha/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Entrar/i })).toBeInTheDocument();
+  });
+
+  it('campos começam vazios e botão habilitado', () => {
+    renderLogin();
+    const email = screen.getByLabelText(/E-mail/i) as HTMLInputElement;
+    const password = screen.getByLabelText(/Senha/i) as HTMLInputElement;
+    const submit = screen.getByRole('button', { name: /Entrar/i });
+
+    expect(email.value).toBe('');
+    expect(password.value).toBe('');
+    expect(submit).toBeEnabled();
+  });
+
+  it('aplica foco automático no primeiro campo (e-mail) ao montar', () => {
+    renderLogin();
+    const email = screen.getByLabelText(/E-mail/i);
+    expect(email).toHaveFocus();
+  });
+});
+
+describe('LoginPage — validação client-side', () => {
+  it('exibe erro inline quando email está vazio ao submeter', async () => {
+    const { client } = renderLogin();
+    const submit = screen.getByRole('button', { name: /Entrar/i });
+
+    fireEvent.click(submit);
+
+    expect(await screen.findByText(/Informe seu e-mail\./i)).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('exibe erro inline quando email é inválido', async () => {
+    const { client } = renderLogin();
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'naoeumemail' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    expect(await screen.findByText(/E-mail inválido\./i)).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('exibe erro inline quando senha está vazia', async () => {
+    const { client } = renderLogin();
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    expect(await screen.findByText(/Informe sua senha\./i)).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('limpa erro inline ao digitar novamente no campo', async () => {
+    renderLogin();
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+    expect(await screen.findByText(/Informe seu e-mail\./i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'a' },
+    });
+    expect(screen.queryByText(/Informe seu e-mail\./i)).not.toBeInTheDocument();
+  });
+});
+
+describe('LoginPage — submit feliz', () => {
+  it('chama login com credenciais e redireciona para /systems por padrão', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/auth/login', {
+        email: 'ada@lfc.com.br',
+        password: 'segredo',
+      });
+    });
+
+    expect(await screen.findByTestId('systems-page')).toBeInTheDocument();
+  });
+
+  it('redireciona para a rota original preservada em location.state.from', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    renderLogin({
+      client,
+      initialEntries: [
+        { pathname: '/login', state: { from: { pathname: '/permissions' } } },
+      ],
+    });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    expect(await screen.findByTestId('permissions-page')).toBeInTheDocument();
+  });
+
+  it('faz trim do e-mail antes de submeter', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: '  ada@lfc.com.br  ' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledWith('/auth/login', {
+        email: 'ada@lfc.com.br',
+        password: 'segredo',
+      });
+    });
+  });
+});
+
+describe('LoginPage — submit com erro', () => {
+  it('exibe Alert acessível com mensagem fixa para 401', async () => {
+    const apiError: ApiError = {
+      kind: 'http',
+      status: 401,
+      code: 'INVALID_CREDENTIALS',
+      message: 'Credenciais inválidas.',
+    };
+    const client = createClientStub();
+    client.post.mockRejectedValueOnce(apiError);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'errada' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveTextContent(/E-mail ou senha inválidos\./i);
+  });
+
+  it('exibe mensagem do backend para erros não-401', async () => {
+    const apiError: ApiError = {
+      kind: 'http',
+      status: 503,
+      message: 'Serviço temporariamente indisponível.',
+    };
+    const client = createClientStub();
+    client.post.mockRejectedValueOnce(apiError);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/Serviço temporariamente indisponível\./i);
+  });
+
+  it('exibe mensagem genérica quando o erro não é ApiError', async () => {
+    const client = createClientStub();
+    client.post.mockRejectedValueOnce(new Error('boom'));
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/Falha ao entrar/i);
+  });
+
+  it('limpa o Alert ao digitar novamente em qualquer campo', async () => {
+    const apiError: ApiError = { kind: 'http', status: 401, message: 'x' };
+    const client = createClientStub();
+    client.post.mockRejectedValueOnce(apiError);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'errada' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+    await screen.findByRole('alert');
+
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'errada2' },
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('LoginPage — estado loading', () => {
+  it('marca o botão como aria-busy enquanto a requisição está em andamento', async () => {
+    const noopResolve: (value: LoginResponse) => void = () => {
+      // intencional: substituído pelo resolve real abaixo.
+    };
+    let resolveLogin: (value: LoginResponse) => void = noopResolve;
+    const pending = new Promise<LoginResponse>(resolve => {
+      resolveLogin = resolve;
+    });
+    const client = createClientStub();
+    client.post.mockReturnValueOnce(pending);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByTestId('login-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-submit')).toHaveAttribute('aria-busy', 'true');
+    });
+    expect(screen.getByTestId('login-submit')).toBeDisabled();
+
+    resolveLogin(SAMPLE_LOGIN);
+    await screen.findByTestId('systems-page');
+  });
+});
+
+describe('LoginPage — já autenticado', () => {
+  it('redireciona imediatamente para /systems quando sessão já está ativa', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    renderLogin({ client });
+
+    fireEvent.change(screen.getByLabelText(/E-mail/i), {
+      target: { value: 'ada@lfc.com.br' },
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'segredo' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
+
+    // Após login, mesmo navegando para /login, o efeito é o redirect imediato.
+    expect(await screen.findByTestId('systems-page')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexto

Primeira parte da Epic #44 (Autenticação): a tela `/login` que dispara o `useAuth().login(email, password)` introduzido na Epic #43. Sem ela, o restante da Epic #44 (persistência, verify, logout, guards) fica suspenso.

## Objetivo

Implementar `/login` consumindo `POST /api/v1/auth/login` com validação básica, estados (loading, erro), feedback acessível e redirect pós-login para a rota destino preservada na location ou `/systems`.

## O que foi feito

- **`src/pages/LoginPage.tsx`** — novo componente com layout dedicado (logo + Card central + form), validação client-side (email não-vazio + regex simples; senha não-vazia), integração com `useAuth`, redirect via `useLocation/useNavigate`, redirect-if-authenticated via `<Navigate>`, foco automático no primeiro campo, `ThemeToggle` no canto superior direito, logo trocada por tema.
- **`src/routes/index.tsx`** — rota `/login` registrada em top-level, fora do `<AppLayout>`, para que Sidebar/Topbar não apareçam antes da autenticação. Rotas autenticadas existentes ficam inalteradas sob o layout.
- **`tests/pages/LoginPage.test.tsx`** — 16 testes cobrindo render, validação, submit feliz/erro, loading, redirect when authenticated.

## Decisões

- **Path do endpoint:** `.env` já tem `VITE_AUTH_API_BASE_URL=https://localhost:8080/api/v1` e o `AuthContext` (Epic #43) chama `/auth/login` — resolve para `https://localhost:8080/api/v1/auth/login` por concatenação. Mantido como está; nenhuma mudança no `apiClient` ou `AuthContext`.
- **Mensagem 401 fixa** ("E-mail ou senha inválidos") para não vazar existência de conta — boa prática de segurança em telas de login.
- **Mensagens não-401** vêm do backend (`ApiError.message`) com fallback genérico.
- **Validação mínima:** regex pragmático (`^[^\s@]+@[^\s@]+\.[^\s@]+$`) + senha não-vazia; backend faz validação canônica.
- **Foco automático** via `autoFocus` (em vez de `forwardRef` no `Input`, que exigiria refatoração fora de escopo).
- **Sem nova dependência** — apenas `useState` + `useNavigate` + `useLocation`.

## Arquivos impactados

- `src/pages/LoginPage.tsx` (novo)
- `src/routes/index.tsx` (rota `/login` em top-level)
- `tests/pages/LoginPage.test.tsx` (novo)

## Testes

- Lint: ok
- Typecheck: ok
- Vitest: **177/177 passando** (16 novos)
- Build (vite): ok

## Visual

Validado em `http://localhost:3002/login` (light + dark):

- Form centralizado vertical e horizontalmente, logo no topo, Card com `--bg-surface` e `--shadow-sm`.
- Inputs `Input` com label, placeholder, ícone (Mail/Lock) e mensagem de erro inline.
- Submit `Button` ocupando largura total do form, com `loading` mostrando spinner e `aria-busy="true"`.
- Alert de erro com `role="alert"` + `aria-live="assertive"` (variant `danger`).
- `ThemeToggle` no canto superior direito.
- Mobile (320px+): Card adapta com `max-width: var(--measure-cta)` (~22rem) e padding adequado.
- `:focus-visible` herdado do Button/Input do design system.

## Segurança

- Mensagem 401 propositadamente vaga (não revela se o e-mail existe).
- Sem `dangerouslySetInnerHTML`.
- Sem token persistido (memória apenas; persistência fica na Issue #53).
- Sem `console.log`.

## Riscos

- Nenhum risco funcional identificado. Persistência de token (#53), verify-token (#54), logout remoto (#55) e guards de rota (#56) seguem como issues separadas da Epic #44.

## Issue relacionada

Closes #52
Refs Epic #44