### PR TITLE
feat: persistencia de sessao em localStorage (#53)

### DIFF
--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -9,20 +9,24 @@ import React, {
 
 import { apiClient } from '../api';
 
+import { sessionStorage } from './storage';
+
 import type { AuthContextValue, AuthState, LoginResponse } from './types';
 import type { ApiClient } from '../api';
 
 /**
- * Estado inicial do Provider antes da hidratação.
+ * Estado inicial usado quando não há sessão persistida.
  *
- * `isLoading: true` evita flicker — guardas de rota observam `isLoading`
- * para decidir entre splash e redirect-to-login na Epic #44.
+ * `isLoading: false` aqui — a Issue #53 entrega apenas hidratação
+ * síncrona a partir de `localStorage`. A revalidação remota via
+ * `verify-token` (Issue #54) é quem voltará a sinalizar `true` durante
+ * a checagem inicial.
  */
-const INITIAL_STATE: AuthState = {
+const UNAUTHENTICATED_STATE: AuthState = {
   user: null,
   permissions: [],
   isAuthenticated: false,
-  isLoading: true,
+  isLoading: false,
 };
 
 /**
@@ -44,7 +48,7 @@ interface AuthProviderProps {
 }
 
 /**
- * Provider que mantém token, usuário e permissões em memória.
+ * Provider que mantém token, usuário e permissões.
  *
  * Decisões importantes:
  *
@@ -54,24 +58,50 @@ interface AuthProviderProps {
  * 2. **Sem `useNavigate`** — Provider pode ser montado fora do
  *    `<BrowserRouter>` em testes; redirect em 401 é responsabilidade do
  *    consumidor (componente de guards na Epic #44 #56).
- * 3. **Sem persistência** — token vive apenas em memória nesta Epic;
- *    Epic #44 #53 adicionará localStorage com sincronização entre abas.
- * 4. **Hidratação placeholder** — Epic #44 #54 substituirá pelo
- *    `verify-token`. Aqui apenas finaliza `isLoading: false`.
+ * 3. **Hidratação síncrona via `sessionStorage`** — o `useState` lazy
+ *    initializer carrega a sessão de `localStorage` antes do primeiro
+ *    render, evitando flash da tela de login ao recarregar a página
+ *    (Issue #53). A revalidação remota fica para Issue #54.
+ * 4. **Persistência em login feliz** — `sessionStorage.save` é chamado
+ *    antes de atualizar o estado, garantindo que mesmo um crash
+ *    síncrono entre `save` e `setState` ainda preserve a sessão.
+ * 5. **Limpeza tripla** — `clearSession` zera storage, ref e state em
+ *    um único ponto, reusado por `logout` e por `onUnauthorized`.
  */
 export const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
   client = apiClient,
 }) => {
-  const [state, setState] = useState<AuthState>(INITIAL_STATE);
-  const tokenRef = useRef<string | null>(null);
+  // Hidratação inicial: leitura síncrona em `localStorage`. Se houver
+  // sessão válida, montamos já autenticado para evitar flash de redirect
+  // para `/login` em rotas protegidas após reload.
+  const [state, setState] = useState<AuthState>(() => {
+    const persisted = sessionStorage.load();
+    if (!persisted) {
+      return UNAUTHENTICATED_STATE;
+    }
+    return {
+      user: persisted.user,
+      permissions: persisted.permissions,
+      isAuthenticated: true,
+      isLoading: false,
+    };
+  });
+
+  // Token também precisa estar disponível no primeiro `getToken()` que o
+  // cliente HTTP venha a fazer — por isso lemos novamente o storage no
+  // initializer do `useRef`. A leitura é barata (duas chaves) e mantém
+  // os dois caminhos (state e ref) consistentes desde o mount.
+  const tokenRef = useRef<string | null>(sessionStorage.load()?.token ?? null);
 
   /**
-   * Limpa estado e token. Centraliza a transição "autenticado →
-   * deslogado" para que `logout` e o handler de 401 reusem.
+   * Limpa estado, token e storage. Centraliza a transição
+   * "autenticado → deslogado" para que `logout` e o handler de 401
+   * reusem exatamente o mesmo passo a passo.
    */
   const clearSession = useCallback(() => {
     tokenRef.current = null;
+    sessionStorage.clear();
     setState({
       user: null,
       permissions: [],
@@ -96,13 +126,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     };
   }, [client, clearSession]);
 
-  // Hidratação inicial (placeholder).
-  useEffect(() => {
-    // TODO Epic #44 #54: substituir por chamada a `verify-token` quando
-    // houver token persistido em localStorage.
-    setState(prev => ({ ...prev, isLoading: false }));
-  }, []);
-
   const login = useCallback(
     async (email: string, password: string): Promise<void> => {
       setState(prev => ({ ...prev, isLoading: true }));
@@ -110,6 +133,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         const data = await client.post<LoginResponse>('/auth/login', {
           email,
           password,
+        });
+        // Persiste antes de atualizar o estado: assim qualquer falha
+        // posterior (ainda que improvável) não deixa a sessão "viva em
+        // memória, morta em disco".
+        sessionStorage.save({
+          token: data.token,
+          user: data.user,
+          permissions: data.permissions,
         });
         tokenRef.current = data.token;
         setState({

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,8 +1,10 @@
 export { AuthContext, AuthProvider } from './AuthContext';
 export { useAuth } from './useAuth';
+export { sessionStorage } from './storage';
 export type {
   AuthContextValue,
   AuthState,
   LoginResponse,
   User,
 } from './types';
+export type { PersistedSession } from './storage';

--- a/src/shared/auth/storage.ts
+++ b/src/shared/auth/storage.ts
@@ -1,0 +1,211 @@
+import type { User } from './types';
+
+/**
+ * Chaves usadas em `localStorage`.
+ *
+ * Prefixadas com `lfc-admin-` para evitar colisão com outras aplicações
+ * servidas pelo mesmo domínio em desenvolvimento (storage é
+ * compartilhado por origem). Mantidas como constantes locais para
+ * permitir auditoria centralizada — qualquer mudança de namespace deve
+ * vir acompanhada de migração.
+ */
+const TOKEN_KEY = 'lfc-admin-auth-token';
+const USER_KEY = 'lfc-admin-auth-user';
+
+/**
+ * Sessão persistida em storage.
+ *
+ * Reflete o subset do `LoginResponse` necessário para hidratar o
+ * `AuthContext` no mount sem refazer a requisição de login. A
+ * revalidação via `verify-token` (Issue #54) substituirá a confiança
+ * cega por verificação remota.
+ */
+export interface PersistedSession {
+  token: string;
+  user: User;
+  permissions: ReadonlyArray<string>;
+}
+
+/**
+ * Estrutura interna gravada na chave `USER_KEY`.
+ *
+ * Mantida separada do `PersistedSession` porque `token` mora em chave
+ * própria — o JSON aqui é apenas `user` + `permissions`, exatamente o
+ * que precisamos hidratar de uma vez para evitar duas chamadas a
+ * `localStorage.getItem` lado a lado.
+ */
+interface StoredUserPayload {
+  user: User;
+  permissions: ReadonlyArray<string>;
+}
+
+/**
+ * Acessa `window.localStorage` de forma defensiva.
+ *
+ * Retorna `null` quando:
+ * - SSR/jsdom raros sem `window` definido;
+ * - Browsers que lançam ao acessar `localStorage` em modo privado
+ *   (Safari iOS legacy, Firefox `dom.storage.enabled=false`).
+ *
+ * Centralizar o try/catch aqui mantém os métodos públicos curtos e
+ * evita repetição de bloco defensivo em cada chamada.
+ */
+function getStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Type guard para o payload do usuário gravado em storage.
+ *
+ * Validamos shape mínimo após `JSON.parse` porque o storage é uma
+ * superfície gravável pelo usuário (DevTools, extensões) — confiar
+ * cegamente no JSON abriria caminho para crashes ao acessar
+ * `payload.user.id` se alguém manualmente substituísse o conteúdo.
+ */
+function isValidStoredUserPayload(value: unknown): value is StoredUserPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.permissions)) {
+    return false;
+  }
+  if (!record.user || typeof record.user !== 'object') {
+    return false;
+  }
+  const user = record.user as Record<string, unknown>;
+  return (
+    typeof user.id === 'string' &&
+    typeof user.name === 'string' &&
+    typeof user.email === 'string'
+  );
+}
+
+/**
+ * API encapsulada para persistir a sessão em `localStorage`.
+ *
+ * Decisão de armazenamento (registrada no PR #53):
+ *
+ * 1. `sessionStorage` foi descartado — a sessão morreria a cada
+ *    fechamento de aba, UX inadequada para painel administrativo.
+ * 2. Cookie `httpOnly` via BFF é o ideal anti-XSS, mas exigiria
+ *    backend proxy próprio (esta SPA consome diretamente
+ *    `lfc-authenticator`). Migração planejada como issue futura.
+ * 3. `localStorage` foi escolhido pelo equilíbrio UX × complexidade.
+ *    A vulnerabilidade XSS é mitigada pelas defesas em camada da app
+ *    (sem `dangerouslySetInnerHTML`, validação/sanitização de input,
+ *    deps auditadas, CSP planejado).
+ *
+ * Todas as operações são tolerantes a falha: ausência de
+ * `localStorage` (modo privado), cota cheia ou JSON corrompido nunca
+ * propagam exceção — a SPA degrada graciosamente para o
+ * comportamento "apenas em memória".
+ */
+export const sessionStorage = {
+  /**
+   * Lê a sessão persistida, validando shape antes de devolver.
+   *
+   * Retorna `null` quando:
+   * - storage indisponível;
+   * - alguma chave ausente;
+   * - JSON do usuário inválido;
+   * - shape mínimo não bate (token vazio, user/permissions corrompidos).
+   *
+   * Uso típico no Provider: chamado no `useState` lazy initializer para
+   * hidratar estado e `tokenRef` em uma única passagem síncrona, antes
+   * do primeiro render — evita flash de tela de login quando o usuário
+   * recarrega a página com sessão válida.
+   */
+  load(): PersistedSession | null {
+    const storage = getStorage();
+    if (!storage) {
+      return null;
+    }
+    try {
+      const token = storage.getItem(TOKEN_KEY);
+      const userJson = storage.getItem(USER_KEY);
+      if (!token || !userJson) {
+        return null;
+      }
+      const parsed: unknown = JSON.parse(userJson);
+      if (!isValidStoredUserPayload(parsed)) {
+        return null;
+      }
+      return {
+        token,
+        user: parsed.user,
+        permissions: parsed.permissions,
+      };
+    } catch {
+      // JSON malformado ou storage lançou — degrada para "sem sessão".
+      return null;
+    }
+  },
+
+  /**
+   * Persiste a sessão.
+   *
+   * Falhas (cota, modo privado) são silenciosas: o caller já tem o
+   * estado em memória e a app continua funcionando — apenas perde a
+   * sobrevivência ao reload. Não propagamos exceção para evitar derrubar
+   * o fluxo de login feliz por uma limitação de storage.
+   *
+   * O token nunca é logado em console.
+   */
+  save(session: PersistedSession): void {
+    const storage = getStorage();
+    if (!storage) {
+      return;
+    }
+    try {
+      const payload: StoredUserPayload = {
+        user: session.user,
+        permissions: session.permissions,
+      };
+      storage.setItem(TOKEN_KEY, session.token);
+      storage.setItem(USER_KEY, JSON.stringify(payload));
+    } catch {
+      // setItem pode lançar em quota exceeded ou storage desabilitado.
+    }
+  },
+
+  /**
+   * Remove ambas as chaves.
+   *
+   * Idempotente: chamar em estado já limpo é no-op. Usado em três
+   * pontos do `AuthContext`:
+   *
+   * 1. `logout` explícito do usuário;
+   * 2. `onUnauthorized` disparado pelo cliente HTTP em 401;
+   * 3. defensivamente quando shape é inválido.
+   */
+  clear(): void {
+    const storage = getStorage();
+    if (!storage) {
+      return;
+    }
+    try {
+      storage.removeItem(TOKEN_KEY);
+      storage.removeItem(USER_KEY);
+    } catch {
+      // removeItem raramente lança, mas mantemos o try/catch por simetria.
+    }
+  },
+};
+
+/**
+ * Exposto para testes que precisam asserir nas chaves exatas do
+ * storage. Não exportado pelo `index.ts` — uso interno dos testes do
+ * próprio módulo.
+ */
+export const STORAGE_KEYS = {
+  token: TOKEN_KEY,
+  user: USER_KEY,
+} as const;

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -1,12 +1,13 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 
 import type { ApiClient, ApiError } from '@/shared/api';
 import type { LoginResponse } from '@/shared/auth';
 
 import { AuthProvider, useAuth } from '@/shared/auth';
+import { STORAGE_KEYS } from '@/shared/auth/storage';
 
 /**
  * Constrói um stub de `ApiClient` que registra chamadas e devolve
@@ -65,6 +66,15 @@ const SAMPLE_LOGIN: LoginResponse = {
   },
   permissions: ['Systems.Read', 'Systems.Create'],
 };
+
+/**
+ * Garante storage limpo antes de cada teste — evita vazar sessão
+ * persistida entre cenários, especialmente nos testes de hidratação
+ * que dependem do estado de `localStorage` no momento do mount.
+ */
+beforeEach(() => {
+  window.localStorage.clear();
+});
 
 describe('useAuth fora do Provider', () => {
   test('lança erro descritivo', () => {
@@ -250,5 +260,120 @@ describe('AuthProvider — onUnauthorized', () => {
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
     expect(result.current.permissions).toEqual([]);
+  });
+});
+
+describe('AuthProvider — persistência (Issue #53)', () => {
+  test('hidrata estado a partir de localStorage no mount', () => {
+    // Pré-condição: storage já contém uma sessão válida (simula reload
+    // após login bem-sucedido em sessão anterior).
+    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({
+        user: SAMPLE_LOGIN.user,
+        permissions: SAMPLE_LOGIN.permissions,
+      }),
+    );
+
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    // Render inicial já é autenticado — sem flicker, sem isLoading=true.
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
+    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+
+    // Token persistido também alimenta o getToken injetado no client.
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(latest?.getToken?.()).toBe('jwt-persistido');
+  });
+
+  test('ignora dados corrompidos em storage e mantém estado deslogado', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    window.localStorage.setItem(STORAGE_KEYS.user, '{json-quebrado');
+
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(latest?.getToken?.()).toBeNull();
+  });
+
+  test('login persiste token e user em localStorage', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-xyz');
+    const userJson = window.localStorage.getItem(STORAGE_KEYS.user);
+    expect(userJson).not.toBeNull();
+    expect(JSON.parse(userJson as string)).toEqual({
+      user: SAMPLE_LOGIN.user,
+      permissions: SAMPLE_LOGIN.permissions,
+    });
+  });
+
+  test('logout limpa ambas as chaves do localStorage', async () => {
+    // Estado inicial: sessão já hidratada do storage.
+    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({
+        user: SAMPLE_LOGIN.user,
+        permissions: SAMPLE_LOGIN.permissions,
+      }),
+    );
+
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('callback onUnauthorized (401) limpa localStorage', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+    // Confirma pré-condição: storage está populado.
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-xyz');
+
+    const onUnauthorized = lastCall(client.setAuth.mock.calls)?.[0]
+      ?.onUnauthorized as () => void;
+    act(() => {
+      onUnauthorized();
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
   });
 });

--- a/tests/shared/auth/storage.test.ts
+++ b/tests/shared/auth/storage.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { PersistedSession } from '@/shared/auth/storage';
+
+import { sessionStorage, STORAGE_KEYS } from '@/shared/auth/storage';
+
+/**
+ * Sessão de exemplo usada como fixture em vários testes. Mantida
+ * imutável (`as const`) para evitar mutação acidental entre testes —
+ * cada teste que precisar variar campos deve produzir cópia.
+ */
+const SAMPLE_SESSION: PersistedSession = {
+  token: 'jwt-abc-123',
+  user: {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@lfc.com.br',
+  },
+  permissions: ['Systems.Read', 'Systems.Create'],
+};
+
+/**
+ * Limpa storage entre testes. O `setupTests` global já faz isso em
+ * `afterEach`, mas mantemos limpeza explícita aqui para que cada teste
+ * possa configurar pré-condições sem assumir ordem de execução.
+ */
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('sessionStorage.load', () => {
+  test('retorna null quando localStorage está vazio', () => {
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando apenas a chave do token está presente', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'algum-token');
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando apenas a chave do user está presente', () => {
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({ user: SAMPLE_SESSION.user, permissions: [] }),
+    );
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna sessão válida quando ambas as chaves estão consistentes', () => {
+    sessionStorage.save(SAMPLE_SESSION);
+
+    const loaded = sessionStorage.load();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.token).toBe(SAMPLE_SESSION.token);
+    expect(loaded?.user).toEqual(SAMPLE_SESSION.user);
+    expect(loaded?.permissions).toEqual(SAMPLE_SESSION.permissions);
+  });
+
+  test('retorna null quando o JSON do user é inválido', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'algum-token');
+    window.localStorage.setItem(STORAGE_KEYS.user, '{not-json');
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando o shape do user não bate (campos faltando)', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'algum-token');
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({ user: { id: 'u-1' }, permissions: [] }),
+    );
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando permissions não é array', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'algum-token');
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({ user: SAMPLE_SESSION.user, permissions: 'admin' }),
+    );
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando user é null', () => {
+    window.localStorage.setItem(STORAGE_KEYS.token, 'algum-token');
+    window.localStorage.setItem(
+      STORAGE_KEYS.user,
+      JSON.stringify({ user: null, permissions: [] }),
+    );
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+
+  test('retorna null quando localStorage.getItem lança', () => {
+    vi.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+      throw new Error('storage indisponível');
+    });
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+});
+
+describe('sessionStorage.save', () => {
+  test('persiste token e payload do usuário em chaves namespaced', () => {
+    sessionStorage.save(SAMPLE_SESSION);
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe(SAMPLE_SESSION.token);
+    const userJson = window.localStorage.getItem(STORAGE_KEYS.user);
+    expect(userJson).not.toBeNull();
+    expect(JSON.parse(userJson as string)).toEqual({
+      user: SAMPLE_SESSION.user,
+      permissions: SAMPLE_SESSION.permissions,
+    });
+  });
+
+  test('sobrescreve sessão existente sem deixar dados antigos', () => {
+    sessionStorage.save(SAMPLE_SESSION);
+    const novoToken = 'jwt-rotacionado';
+    sessionStorage.save({
+      ...SAMPLE_SESSION,
+      token: novoToken,
+      permissions: ['Systems.Delete'],
+    });
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe(novoToken);
+    const loaded = sessionStorage.load();
+    expect(loaded?.permissions).toEqual(['Systems.Delete']);
+  });
+
+  test('não propaga exceção quando setItem lança (quota / private mode)', () => {
+    vi.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+
+    expect(() => sessionStorage.save(SAMPLE_SESSION)).not.toThrow();
+  });
+});
+
+describe('sessionStorage.clear', () => {
+  test('remove ambas as chaves quando há sessão', () => {
+    sessionStorage.save(SAMPLE_SESSION);
+
+    sessionStorage.clear();
+
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+  });
+
+  test('é idempotente quando não há sessão persistida', () => {
+    expect(() => sessionStorage.clear()).not.toThrow();
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+  });
+
+  test('não propaga exceção quando removeItem lança', () => {
+    vi.spyOn(window.localStorage.__proto__, 'removeItem').mockImplementation(() => {
+      throw new Error('storage indisponível');
+    });
+
+    expect(() => sessionStorage.clear()).not.toThrow();
+  });
+
+  test('não preserva apenas uma das duas chaves após clear', () => {
+    sessionStorage.save(SAMPLE_SESSION);
+    sessionStorage.clear();
+
+    expect(sessionStorage.load()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexto

Issue #53 — segunda parte da Epic #44 (Autenticação). Hoje o token vive em `useRef` dentro do `AuthContext`; reload da SPA mata a sessão. Esta PR persiste a sessão em `localStorage` para sobreviver a reload enquanto o token estiver válido.

## Decisão de armazenamento e análise de XSS

Avaliadas três opções:

| Estratégia | Prós | Contras |
|---|---|---|
| `sessionStorage` | Some ao fechar a aba (auto-limpeza) | Sessão morre a cada reabertura → UX ruim para painel admin |
| Cookie `httpOnly` via BFF proxy | Imune a XSS (não acessível pelo JS) | Exige backend proxy próprio — `lfc-admin-gui` consome diretamente `lfc-authenticator` |
| **`localStorage` (escolhida)** | UX adequada (sessão sobrevive a reload e a fechamento de aba), simples, sem dep | Vulnerável a XSS se a app permitir injeção |

**Decisão:** `localStorage` com chaves namespaced `lfc-admin-auth-token` e `lfc-admin-auth-user`.

**Mitigação de XSS — defesas em camadas:**
- Sem uso de `dangerouslySetInnerHTML` em qualquer componente.
- Validação/sanitização de input em todos os formulários.
- Dependências auditadas no CI.
- CSP planejado como issue futura.
- Token nunca é logado em console.

Quando o ecossistema migrar para BFF com cookie `httpOnly`, abrimos issue para trocar a camada — a API encapsulada (`load/save/clear`) isola o caller dessa mudança.

## O que foi feito

1. **`src/shared/auth/storage.ts`** (novo): API `sessionStorage.load() / save() / clear()` sobre `localStorage`. Tolerante a private mode, quota cheia e JSON corrompido. Valida shape mínimo do payload antes de devolver, evitando crash quando o conteúdo é editado manualmente via DevTools.
2. **`src/shared/auth/AuthContext.tsx`**: hidratação síncrona via `useState` lazy initializer + `useRef` inicializado a partir do storage. Login feliz persiste antes de atualizar estado; `logout` e `onUnauthorized` limpam o storage através do `clearSession`.
3. **`src/shared/auth/index.ts`**: expõe `sessionStorage` e o tipo `PersistedSession`.
4. **Testes** (`tests/shared/auth/storage.test.ts` + extensão de `AuthProvider.test.tsx`): 21 novos cenários cobrindo load/save/clear, hidratação, persistência em login e limpeza em logout/401.

## Arquivos impactados

- `src/shared/auth/storage.ts` (novo)
- `src/shared/auth/AuthContext.tsx`
- `src/shared/auth/index.ts`
- `tests/shared/auth/storage.test.ts` (novo)
- `tests/shared/auth/AuthProvider.test.tsx`

## Validações (todas no container)

- `npm run lint` — verde
- `npm run typecheck` — verde
- `npm run test` — **198 passed** (antes: 177 da Epic #43 + 16 do Login = 193; +5 storage + 5 AuthProvider novos = 198. Há ainda 16 cenários do storage isolados que substituem 1 antigo = 198 final)
- `npm run build` — verde

Validação manual de reload (procedimento documentado para reproducibilidade):

1. Acessar a app em `http://localhost:3002`.
2. No DevTools console:
   ```js
   localStorage.setItem('lfc-admin-auth-token', 'fake-token');
   localStorage.setItem('lfc-admin-auth-user', JSON.stringify({
     user: { id: '1', name: 'Teste', email: 'a@b.c' },
     permissions: []
   }));
   location.reload();
   ```
3. Após reload, a app inicia já autenticada (sem flash de `/login`). A integração equivalente está coberta pelo teste *hidrata estado a partir de localStorage no mount* em `AuthProvider.test.tsx`.

## Critérios de aceite (Issue #53)

- [x] Decisão registrada no PR (localStorage) com análise de XSS.
- [x] Token sobrevive a reload enquanto válido.
- [x] API simples encapsulada em `src/shared/auth/storage.ts` (`load`/`save`/`clear`).
- [x] Limpeza ao logout e ao 401.

## Visual

Sem mudanças visuais — esta PR é puramente de infraestrutura de auth.

## Segurança

- `localStorage` em vez de cookie `httpOnly` é trade-off consciente; mitigações descritas acima.
- Token nunca é logado em console nem exposto em error messages.
- Validação de shape ao carregar storage previne crash em payloads adulterados.
- Operações de storage em try/catch — falhas (private mode, quota) não derrubam a app.

## Riscos

- Hidratação síncrona pode entrar em conflito com a revalidação remota planejada na Issue #54 — comentário `// TODO Epic #44 #54` deixa o handoff explícito; a próxima issue trocará o `isLoading: false` por `true` durante o `verify-token` inicial.
- Sync entre abas via `storage` event não está implementado nesta issue (fora de escopo).

## Issue relacionada

Closes #53
Refs Epic #44