### PR TITLE
feat: hidratacao via verify-token + revalidacao (#54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 VITE_AUTH_API_BASE_URL=https://localhost:8080/api/v1
 VITE_APP_NAME=Auth Admin
 VITE_SESSION_IDLE_MINUTES=15
+# Intervalo entre revalidações automáticas via GET /auth/verify-token (ms).
+# Default 300000 (5 min). Use 0 para desativar a revalidação periódica.
+VITE_AUTH_VERIFY_INTERVAL_MS=300000
 PORT=3002

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -6,21 +6,28 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useNavigate } from 'react-router-dom';
 
-import { apiClient } from '../api';
+import { apiClient, isApiError } from '../api';
 
+import { AuthSplash } from './AuthSplash';
 import { sessionStorage } from './storage';
 
-import type { AuthContextValue, AuthState, LoginResponse } from './types';
-import type { ApiClient } from '../api';
+import type { ApiClient, ApiError } from '../api';
+import type {
+  AuthContextValue,
+  AuthState,
+  LoginResponse,
+  VerifyTokenResponse,
+} from './types';
 
 /**
  * Estado inicial usado quando não há sessão persistida.
  *
- * `isLoading: false` aqui — a Issue #53 entrega apenas hidratação
- * síncrona a partir de `localStorage`. A revalidação remota via
- * `verify-token` (Issue #54) é quem voltará a sinalizar `true` durante
- * a checagem inicial.
+ * `isLoading: false` aqui — sem sessão para revalidar, o app já pode
+ * renderizar a tela de login imediatamente. Quando há sessão, o lazy
+ * initializer marca `isLoading: true` para sinalizar a revalidação
+ * remota em andamento (Issue #54).
  */
 const UNAUTHENTICATED_STATE: AuthState = {
   user: null,
@@ -28,6 +35,82 @@ const UNAUTHENTICATED_STATE: AuthState = {
   isAuthenticated: false,
   isLoading: false,
 };
+
+/**
+ * Default do intervalo de revalidação periódica em milissegundos.
+ *
+ * Resolvido a partir de `VITE_AUTH_VERIFY_INTERVAL_MS`; quando ausente,
+ * inválido ou não-numérico, cai em 5 minutos — equilíbrio entre detectar
+ * revogações server-side rapidamente e não saturar o backend.
+ */
+const DEFAULT_VERIFY_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Resolve o intervalo de revalidação a partir de variável de ambiente.
+ *
+ * - `0` (string ou número) → desativa a revalidação periódica;
+ * - valores não numéricos / negativos → cai no default;
+ * - valores muito pequenos (< 1000 ms) → cai no default para evitar
+ *   loops abusivos por configuração equivocada.
+ */
+function resolveVerifyInterval(): number {
+  const raw: unknown = import.meta.env.VITE_AUTH_VERIFY_INTERVAL_MS;
+  if (raw === undefined || raw === null || raw === '') {
+    return DEFAULT_VERIFY_INTERVAL_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_VERIFY_INTERVAL_MS;
+  }
+  if (parsed === 0) {
+    return 0;
+  }
+  if (parsed < 1000) {
+    return DEFAULT_VERIFY_INTERVAL_MS;
+  }
+  return parsed;
+}
+
+/**
+ * Type guard mínimo para o payload do endpoint `verify-token`.
+ *
+ * Garante que `user.id/name/email` e `permissions[]` existem antes de
+ * confiar em `data.user` no Provider — defesa contra contrato divergente
+ * ou resposta corrompida em proxies intermediários.
+ */
+function isValidVerifyTokenResponse(value: unknown): value is VerifyTokenResponse {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.permissions)) {
+    return false;
+  }
+  if (!record.user || typeof record.user !== 'object') {
+    return false;
+  }
+  const user = record.user as Record<string, unknown>;
+  return (
+    typeof user.id === 'string' &&
+    typeof user.name === 'string' &&
+    typeof user.email === 'string'
+  );
+}
+
+/**
+ * Distingue erro 401 (token inválido/expirado) de qualquer outra falha.
+ *
+ * Em 401 o cliente HTTP já dispara `onUnauthorized` (limpa sessão); o
+ * Provider apenas precisa saber se deve manter a sessão local em pé
+ * (qualquer outro erro, especialmente `network`).
+ */
+function isUnauthorizedError(error: unknown): boolean {
+  if (!isApiError(error)) {
+    return false;
+  }
+  const httpError = error as ApiError;
+  return httpError.kind === 'http' && httpError.status === 401;
+}
 
 /**
  * Contexto interno. `null` antes do Provider montar — o hook `useAuth`
@@ -45,6 +128,29 @@ interface AuthProviderProps {
    * um stub para isolar o Provider da camada de transporte.
    */
   client?: ApiClient;
+  /**
+   * Override do intervalo (ms) entre revalidações periódicas.
+   *
+   * Útil em testes que precisam acionar o tick manualmente via fake
+   * timers. Em produção o valor vem de `VITE_AUTH_VERIFY_INTERVAL_MS`.
+   *
+   * Passar `0` desativa a revalidação periódica (a hidratação inicial
+   * continua acontecendo).
+   */
+  verifyIntervalMs?: number;
+  /**
+   * Override do componente de splash. Default: `<AuthSplash />`. Testes
+   * podem injetar um placeholder para asserir o estado de carregamento
+   * sem montar o componente visual completo.
+   */
+  splash?: React.ReactNode;
+  /**
+   * Quando `true`, renderiza `children` mesmo durante a hidratação
+   * inicial (splash desativada). Útil para testes que precisam observar
+   * o `useAuth()` enquanto `isLoading` ainda é `true` — em produção fica
+   * sempre `false`.
+   */
+  disableSplash?: boolean;
 }
 
 /**
@@ -55,26 +161,46 @@ interface AuthProviderProps {
  * 1. **Token em ref** — não vai para state porque sua mudança não
  *    precisa rerenderizar a árvore; o `apiClient` lê via `getToken()`
  *    a cada requisição.
- * 2. **Sem `useNavigate`** — Provider pode ser montado fora do
- *    `<BrowserRouter>` em testes; redirect em 401 é responsabilidade do
- *    consumidor (componente de guards na Epic #44 #56).
- * 3. **Hidratação síncrona via `sessionStorage`** — o `useState` lazy
- *    initializer carrega a sessão de `localStorage` antes do primeiro
- *    render, evitando flash da tela de login ao recarregar a página
- *    (Issue #53). A revalidação remota fica para Issue #54.
- * 4. **Persistência em login feliz** — `sessionStorage.save` é chamado
+ * 2. **Hidratação otimista + revalidação remota** — Issue #54: o
+ *    `useState` lazy initializer carrega a sessão de `localStorage` e
+ *    marca `isLoading: true` quando há sessão (vai revalidar). O
+ *    `useEffect` chama `GET /auth/verify-token` e atualiza `user` +
+ *    `permissions` com o snapshot atual do backend, capturando mudanças
+ *    server-side (role removida, permissão revogada) sem novo login.
+ * 3. **Splash durante hidratação inicial** — `isLoading: true` faz o
+ *    Provider renderizar `<AuthSplash />` em vez de `children`, evitando
+ *    flicker de UI semi-autenticada antes da revalidação.
+ * 4. **Tolerância a falha de rede** — quando o `verify-token` falha por
+ *    `network`/`parse`, mantemos a sessão local; o próximo tick tentará
+ *    novamente. Apenas 401 desautentica (via `onUnauthorized` do client).
+ * 5. **Revalidação periódica configurável** — `setInterval` com
+ *    intervalo de `VITE_AUTH_VERIFY_INTERVAL_MS` (default 5 min). O
+ *    cleanup do `useEffect` cancela o timer no unmount; um
+ *    `AbortController` cancela a requisição em voo se o Provider
+ *    desmontar antes da resposta.
+ * 6. **Redirect em 401 via `useNavigate`** — quando a sessão é limpa
+ *    pelo handler de 401, navegamos para `/login` preservando a rota
+ *    de origem. Curto-circuito em `/login` evita loop.
+ * 7. **Persistência em login feliz** — `sessionStorage.save` é chamado
  *    antes de atualizar o estado, garantindo que mesmo um crash
  *    síncrono entre `save` e `setState` ainda preserve a sessão.
- * 5. **Limpeza tripla** — `clearSession` zera storage, ref e state em
+ * 8. **Limpeza tripla** — `clearSession` zera storage, ref e state em
  *    um único ponto, reusado por `logout` e por `onUnauthorized`.
  */
 export const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
   client = apiClient,
+  verifyIntervalMs,
+  splash,
+  disableSplash = false,
 }) => {
+  const navigate = useNavigate();
+
   // Hidratação inicial: leitura síncrona em `localStorage`. Se houver
   // sessão válida, montamos já autenticado para evitar flash de redirect
-  // para `/login` em rotas protegidas após reload.
+  // para `/login` em rotas protegidas após reload — porém com
+  // `isLoading: true` para sinalizar que uma revalidação remota está
+  // em curso (Issue #54).
   const [state, setState] = useState<AuthState>(() => {
     const persisted = sessionStorage.load();
     if (!persisted) {
@@ -84,7 +210,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       user: persisted.user,
       permissions: persisted.permissions,
       isAuthenticated: true,
-      isLoading: false,
+      isLoading: true,
     };
   });
 
@@ -93,6 +219,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   // initializer do `useRef`. A leitura é barata (duas chaves) e mantém
   // os dois caminhos (state e ref) consistentes desde o mount.
   const tokenRef = useRef<string | null>(sessionStorage.load()?.token ?? null);
+
+  // `wasAuthenticated` permite ao callback `onUnauthorized` decidir se
+  // deve disparar a navegação para `/login`. Sem isso, um 401 "limpando
+  // estado já vazio" navegaria desnecessariamente.
+  const wasAuthenticatedRef = useRef<boolean>(state.isAuthenticated);
+  useEffect(() => {
+    wasAuthenticatedRef.current = state.isAuthenticated;
+  }, [state.isAuthenticated]);
 
   /**
    * Limpa estado, token e storage. Centraliza a transição
@@ -110,13 +244,36 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     });
   }, []);
 
+  /**
+   * Redireciona para `/login` quando o usuário está em rota privada e
+   * acaba de perder a sessão. Curto-circuito em `/login` evita loop.
+   *
+   * Tolerante a `useNavigate` ausente (cenários onde o Provider é usado
+   * em ambiente sem Router — futuro, hoje sempre dentro de BrowserRouter).
+   */
+  const redirectToLogin = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (window.location.pathname === '/login') return;
+    try {
+      navigate('/login', { replace: true });
+    } catch {
+      // Em ambientes sem Router context, `navigate` lança — degradamos
+      // graciosamente para `window.location` como fallback.
+      window.location.assign('/login');
+    }
+  }, [navigate]);
+
   // Injeta callbacks no cliente HTTP. Reexecuta quando o cliente muda
   // (cenário de teste); em produção, é one-shot.
   useEffect(() => {
     client.setAuth({
       getToken: () => tokenRef.current,
       onUnauthorized: () => {
+        const wasAuthenticated = wasAuthenticatedRef.current;
         clearSession();
+        if (wasAuthenticated) {
+          redirectToLogin();
+        }
       },
     });
     return () => {
@@ -124,7 +281,122 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       // singleton mantenha referência a um Provider extinto.
       client.setAuth({});
     };
-  }, [client, clearSession]);
+  }, [client, clearSession, redirectToLogin]);
+
+  /**
+   * Hidratação remota + revalidação periódica.
+   *
+   * Disparada uma vez no mount; quando há sessão local, chama
+   * `verify-token`. Em sucesso, sincroniza `user` + `permissions` com
+   * o snapshot atual do backend e marca `isLoading: false`. Em erro
+   * 401, o handler do cliente já limpou a sessão; em outros erros
+   * (rede/parse), mantemos a sessão local e seguimos.
+   *
+   * O `setInterval` aqui executa o mesmo `verify-token` periodicamente
+   * para refletir mudanças server-side (role atualizada, permissões
+   * revogadas) sem novo login. O intervalo é configurável via prop
+   * `verifyIntervalMs` (testes) ou env `VITE_AUTH_VERIFY_INTERVAL_MS`
+   * (produção). Passar `0` desativa o intervalo, mas a hidratação
+   * inicial sempre acontece.
+   */
+  useEffect(() => {
+    let cancelled = false;
+    const controllers = new Set<AbortController>();
+
+    const performVerify = async (): Promise<void> => {
+      if (!tokenRef.current) {
+        return;
+      }
+      const controller = new AbortController();
+      controllers.add(controller);
+      try {
+        const data = await client.get<VerifyTokenResponse>(
+          '/auth/verify-token',
+          { signal: controller.signal },
+        );
+        if (cancelled) return;
+        if (!isValidVerifyTokenResponse(data)) {
+          // Resposta com shape inesperado: não desautenticamos por
+          // segurança — mantemos a sessão local para o tick seguinte
+          // tentar novamente. Apenas saímos de `isLoading` para a UI
+          // não ficar travada na splash.
+          setState(prev =>
+            prev.isLoading ? { ...prev, isLoading: false } : prev,
+          );
+          return;
+        }
+        // Persiste antes de setState pelos mesmos motivos do `login`.
+        sessionStorage.save({
+          token: tokenRef.current,
+          user: data.user,
+          permissions: data.permissions,
+        });
+        setState({
+          user: data.user,
+          permissions: data.permissions,
+          isAuthenticated: true,
+          isLoading: false,
+        });
+      } catch (error) {
+        if (cancelled) return;
+        if (isUnauthorizedError(error)) {
+          // O cliente HTTP já chamou `onUnauthorized` → sessão limpa.
+          // Aqui só precisamos garantir que `isLoading` saia de `true`.
+          // (O `clearSession` já fez isso, mas reforçamos contra
+          // ordens de set-state diferentes em corner cases de teste.)
+          return;
+        }
+        // Falha de rede / parse / 5xx: mantém sessão local. Logamos
+        // um warning para diagnóstico, sem expor detalhes sensíveis.
+        // eslint-disable-next-line no-console
+        console.warn('[auth] verify-token falhou; mantendo sessão local até próxima revalidação.');
+        setState(prev =>
+          prev.isLoading ? { ...prev, isLoading: false } : prev,
+        );
+      } finally {
+        controllers.delete(controller);
+      }
+    };
+
+    // Hidratação inicial: dispara imediatamente quando há token.
+    if (tokenRef.current) {
+      void performVerify();
+    } else {
+      // Sem sessão local: garante isLoading=false (já é o padrão, mas
+      // protege contra mudanças futuras no initializer).
+      setState(prev =>
+        prev.isLoading ? { ...prev, isLoading: false } : prev,
+      );
+    }
+
+    // Revalidação periódica.
+    const interval =
+      typeof verifyIntervalMs === 'number'
+        ? verifyIntervalMs
+        : resolveVerifyInterval();
+    let timer: ReturnType<typeof setInterval> | null = null;
+    if (interval > 0) {
+      timer = setInterval(() => {
+        if (tokenRef.current) {
+          void performVerify();
+        }
+      }, interval);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) {
+        clearInterval(timer);
+      }
+      // Cancela requisições em voo para não chamar setState após unmount.
+      controllers.forEach(controller => controller.abort());
+      controllers.clear();
+    };
+    // `client` e `verifyIntervalMs` são as dependências reais; demais
+    // setters/refs são estáveis. Não incluímos `clearSession` porque o
+    // path 401 é gerenciado pelo `onUnauthorized` do cliente HTTP.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, verifyIntervalMs]);
 
   const login = useCallback(
     async (email: string, password: string): Promise<void> => {
@@ -181,5 +453,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
     [state, login, logout, hasPermission],
   );
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  // Splash apenas durante a hidratação inicial (sessão local +
+  // revalidação remota em curso). Em revalidações periódicas
+  // posteriores, `isLoading` permanece `false` para não esconder a UI.
+  const showSplash = state.isLoading && state.isAuthenticated && !disableSplash;
+
+  return (
+    <AuthContext.Provider value={value}>
+      {showSplash ? (splash ?? <AuthSplash />) : children}
+    </AuthContext.Provider>
+  );
 };

--- a/src/shared/auth/AuthSplash.tsx
+++ b/src/shared/auth/AuthSplash.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import logoForLightTheme from '../../assets/logo-dark.svg';
+import logoForDarkTheme from '../../assets/logo-white.svg';
+import { Spinner } from '../../components/ui';
+import { useTheme } from '../../hooks/useTheme';
+
+/**
+ * Mensagem padrão exibida ao usuário enquanto a sessão é validada com o
+ * backend. Mantida em pt-BR para coerência com o restante da UI.
+ */
+const DEFAULT_MESSAGE = 'Validando sua sessão...';
+
+interface AuthSplashProps {
+  /**
+   * Mensagem exibida abaixo do spinner. Permite que cenários distintos
+   * (revalidação periódica, retorno de offline) reaproveitem o
+   * componente com texto contextual.
+   */
+  message?: string;
+}
+
+const SplashRoot = styled.div`
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-base);
+  padding: var(--space-6) var(--space-4);
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-5);
+  text-align: center;
+`;
+
+const Logo = styled.img`
+  width: var(--space-16);
+  height: var(--space-16);
+  display: block;
+`;
+
+const Message = styled.p`
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+  margin: 0;
+`;
+
+/**
+ * Tela de carregamento exibida enquanto o `AuthProvider` valida a
+ * sessão remota via `verify-token` no mount.
+ *
+ * Decisões importantes:
+ *
+ * 1. **Sem hardcode de cor** — todas as superfícies consomem tokens do
+ *    design system (`--bg-base`, `--fg2`), o que garante coerência
+ *    automática entre `light` e `dark`.
+ * 2. **Logo trocado por tema** — usa o mesmo critério da `LoginPage`:
+ *    `useTheme().resolvedTheme` decide entre `logo-dark.svg` (light) e
+ *    `logo-white.svg` (dark) para preservar contraste WCAG AA contra
+ *    `--bg-base` em ambos os temas.
+ * 3. **Acessibilidade** — `role="status"` + `aria-live="polite"` no
+ *    container raiz. O `Spinner` já expõe `role="status"` próprio; ao
+ *    envolvê-lo neste live region, garantimos que leitores de tela
+ *    anunciem "Validando sua sessão..." sem repetir o nome do spinner.
+ * 4. **Sem interativos** — não há foco a tratar. Caso futuras versões
+ *    incluam botão "tentar novamente", revisar `:focus-visible`.
+ */
+export const AuthSplash: React.FC<AuthSplashProps> = ({
+  message = DEFAULT_MESSAGE,
+}) => {
+  const { resolvedTheme } = useTheme();
+  const logoSrc = resolvedTheme === 'dark' ? logoForDarkTheme : logoForLightTheme;
+
+  return (
+    <SplashRoot role="status" aria-live="polite" data-testid="auth-splash">
+      <Container>
+        <Logo src={logoSrc} alt="LF Calegari Admin" />
+        <Spinner size="lg" tone="accent" label={message} />
+        <Message>{message}</Message>
+      </Container>
+    </SplashRoot>
+  );
+};
+
+export default AuthSplash;

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,4 +1,5 @@
 export { AuthContext, AuthProvider } from './AuthContext';
+export { AuthSplash } from './AuthSplash';
 export { useAuth } from './useAuth';
 export { sessionStorage } from './storage';
 export type {
@@ -6,5 +7,6 @@ export type {
   AuthState,
   LoginResponse,
   User,
+  VerifyTokenResponse,
 } from './types';
 export type { PersistedSession } from './storage';

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -50,6 +50,23 @@ export interface LoginResponse {
 }
 
 /**
+ * Payload retornado pelo endpoint `GET /auth/verify-token`.
+ *
+ * O token continua sendo o mesmo já enviado em `Authorization`; o backend
+ * apenas confirma sua validade e devolve o snapshot atual de `user` e
+ * `permissions` — permitindo que o frontend reaja a mudanças server-side
+ * (role atualizada, permissões revogadas) sem exigir novo login.
+ *
+ * O contrato é deliberadamente um subset de `LoginResponse`: caso o
+ * backend evolua para incluir `token` (rotacionado), bastará trocar o
+ * tipo abaixo sem impactar a forma como o Provider consome.
+ */
+export interface VerifyTokenResponse {
+  user: User;
+  permissions: ReadonlyArray<string>;
+}
+
+/**
  * Valor exposto pelo `useAuth()`.
  *
  * Combina o estado atual com as ações disponíveis. Todas as ações são

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -59,8 +59,8 @@ interface RenderOptions {
 function renderLogin(options: RenderOptions = {}): { client: ClientStub } {
   const client = options.client ?? createClientStub();
   render(
-    <AuthProvider client={client}>
-      <MemoryRouter initialEntries={options.initialEntries ?? ['/login']}>
+    <MemoryRouter initialEntries={options.initialEntries ?? ['/login']}>
+      <AuthProvider client={client} verifyIntervalMs={0}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route
@@ -72,8 +72,8 @@ function renderLogin(options: RenderOptions = {}): { client: ClientStub } {
             element={<div data-testid="permissions-page">permissions</div>}
           />
         </Routes>
-      </MemoryRouter>
-    </AuthProvider>,
+      </AuthProvider>
+    </MemoryRouter>,
   );
   return { client };
 }

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -1,10 +1,11 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 
 import type { ApiClient, ApiError } from '@/shared/api';
-import type { LoginResponse } from '@/shared/auth';
+import type { LoginResponse, VerifyTokenResponse } from '@/shared/auth';
 
 import { AuthProvider, useAuth } from '@/shared/auth';
 import { STORAGE_KEYS } from '@/shared/auth/storage';
@@ -36,13 +37,45 @@ function createClientStub(): ApiClient & {
   };
 }
 
+interface WrapperOptions {
+  initialEntries?: ReadonlyArray<string>;
+  verifyIntervalMs?: number;
+  /**
+   * `false` por padrão nos testes de hook (`renderHook` precisa que o
+   * children renderize sempre, senão `result.current` fica `null`
+   * enquanto a splash está visível). O teste dedicado de splash UI
+   * passa `false` aqui e renderiza com `render` em vez de `renderHook`.
+   */
+  disableSplash?: boolean;
+}
+
 /**
- * Wrapper de teste que monta o Provider com um cliente injetado.
- * Usado por `renderHook` para fornecer contexto ao `useAuth`.
+ * Wrapper de teste que monta o Provider com um cliente injetado e
+ * `MemoryRouter` para satisfazer o `useNavigate` interno.
  */
-function makeWrapper(client: ApiClient) {
+function makeWrapper(client: ApiClient, options: WrapperOptions = {}) {
+  const {
+    initialEntries = ['/'],
+    verifyIntervalMs = 0,
+    disableSplash = true,
+  } = options;
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <AuthProvider client={client}>{children}</AuthProvider>
+    <MemoryRouter initialEntries={[...initialEntries]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <AuthProvider
+              client={client}
+              verifyIntervalMs={verifyIntervalMs}
+              disableSplash={disableSplash}
+            >
+              {children}
+            </AuthProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
   );
   Wrapper.displayName = 'AuthProviderTestWrapper';
   return Wrapper;
@@ -67,6 +100,42 @@ const SAMPLE_LOGIN: LoginResponse = {
   permissions: ['Systems.Read', 'Systems.Create'],
 };
 
+const VERIFY_RESPONSE: VerifyTokenResponse = {
+  user: {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@lfc.com.br',
+  },
+  permissions: ['Systems.Read', 'Systems.Create', 'Systems.Update'],
+};
+
+const UNAUTHORIZED_ERROR: ApiError = {
+  kind: 'http',
+  status: 401,
+  code: 'TOKEN_INVALID',
+  message: 'Sessão expirada.',
+};
+
+const NETWORK_ERROR: ApiError = {
+  kind: 'network',
+  message: 'Falha de conexão com o servidor.',
+};
+
+/**
+ * Pré-popula `localStorage` para simular sessão persistida — usado nos
+ * testes de hidratação remota.
+ */
+function seedPersistedSession(): void {
+  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+  window.localStorage.setItem(
+    STORAGE_KEYS.user,
+    JSON.stringify({
+      user: SAMPLE_LOGIN.user,
+      permissions: SAMPLE_LOGIN.permissions,
+    }),
+  );
+}
+
 /**
  * Garante storage limpo antes de cada teste — evita vazar sessão
  * persistida entre cenários, especialmente nos testes de hidratação
@@ -74,6 +143,10 @@ const SAMPLE_LOGIN: LoginResponse = {
  */
 beforeEach(() => {
   window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('useAuth fora do Provider', () => {
@@ -103,6 +176,8 @@ describe('AuthProvider — estado inicial', () => {
     expect(result.current.user).toBeNull();
     expect(result.current.permissions).toEqual([]);
     expect(result.current.isAuthenticated).toBe(false);
+    // Sem sessão local, verify-token NÃO deve ser chamado.
+    expect(client.get).not.toHaveBeenCalled();
   });
 
   test('injeta getToken e onUnauthorized no client via setAuth', () => {
@@ -264,32 +339,26 @@ describe('AuthProvider — onUnauthorized', () => {
 });
 
 describe('AuthProvider — persistência (Issue #53)', () => {
-  test('hidrata estado a partir de localStorage no mount', () => {
+  test('hidrata estado a partir de localStorage no mount', async () => {
     // Pré-condição: storage já contém uma sessão válida (simula reload
     // após login bem-sucedido em sessão anterior).
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
-    window.localStorage.setItem(
-      STORAGE_KEYS.user,
-      JSON.stringify({
-        user: SAMPLE_LOGIN.user,
-        permissions: SAMPLE_LOGIN.permissions,
-      }),
-    );
-
+    seedPersistedSession();
     const client = createClientStub();
+    // Verify-token bem-sucedido para destravar isLoading.
+    client.get.mockResolvedValueOnce(VERIFY_RESPONSE);
+
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
 
-    // Render inicial já é autenticado — sem flicker, sem isLoading=true.
+    // Render inicial já é autenticado.
     expect(result.current.isAuthenticated).toBe(true);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
-    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
 
     // Token persistido também alimenta o getToken injetado no client.
     const latest = lastCall(client.setAuth.mock.calls)?.[0];
     expect(latest?.getToken?.()).toBe('jwt-persistido');
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 
   test('ignora dados corrompidos em storage e mantém estado deslogado', () => {
@@ -330,20 +399,15 @@ describe('AuthProvider — persistência (Issue #53)', () => {
 
   test('logout limpa ambas as chaves do localStorage', async () => {
     // Estado inicial: sessão já hidratada do storage.
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
-    window.localStorage.setItem(
-      STORAGE_KEYS.user,
-      JSON.stringify({
-        user: SAMPLE_LOGIN.user,
-        permissions: SAMPLE_LOGIN.permissions,
-      }),
-    );
+    seedPersistedSession();
 
     const client = createClientStub();
+    client.get.mockResolvedValueOnce(VERIFY_RESPONSE);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
     expect(result.current.isAuthenticated).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     await act(async () => {
       await result.current.logout();
@@ -375,5 +439,217 @@ describe('AuthProvider — persistência (Issue #53)', () => {
 
     expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
     expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+  });
+});
+
+describe('AuthProvider — verify-token (Issue #54)', () => {
+  test('com sessão local, hidrata via GET /auth/verify-token e atualiza permissions', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(VERIFY_RESPONSE);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    // Mount inicial já está autenticado (otimista) com permissões antigas
+    // e isLoading=true sinalizando revalidação em curso.
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+
+    // Após o verify-token resolver, permissões são atualizadas.
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(client.get).toHaveBeenCalledWith(
+      '/auth/verify-token',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(result.current.permissions).toEqual(VERIFY_RESPONSE.permissions);
+    expect(result.current.user).toEqual(VERIFY_RESPONSE.user);
+  });
+
+  test('sem sessão local, NÃO chama verify-token no mount', async () => {
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  test('verify-token com 401 limpa sessão e redireciona para /login', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    // Simula o comportamento real do client HTTP: em 401, dispara
+    // `onUnauthorized` antes de rejeitar a Promise.
+    client.get.mockImplementationOnce(async () => {
+      const config = lastCall(client.setAuth.mock.calls)?.[0];
+      config?.onUnauthorized?.();
+      throw UNAUTHORIZED_ERROR;
+    });
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client, { initialEntries: ['/systems'] }),
+    });
+
+    // O verify-token resolve assincronamente; aguardamos a transição
+    // para `isAuthenticated: false` em vez de afirmar o estado inicial
+    // (que pode ou não ter sido capturado antes do `useEffect` rodar).
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(result.current.permissions).toEqual([]);
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+  });
+
+  test('verify-token com falha de rede mantém sessão local intacta', async () => {
+    seedPersistedSession();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const client = createClientStub();
+    client.get.mockRejectedValueOnce(NETWORK_ERROR);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // Sessão local preservada — usuário continua autenticado com último
+    // snapshot conhecido.
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
+    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-persistido');
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test('verify-token com payload inválido mantém sessão local', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    // Resposta sem `user` válido — Provider deve descartar silenciosamente.
+    client.get.mockResolvedValueOnce({ permissions: [] } as unknown);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
+    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+  });
+
+  test('revalidação periódica chama verify-token a cada tick', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    client.get.mockResolvedValue(VERIFY_RESPONSE);
+
+    const { unmount } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client, { verifyIntervalMs: 50 }),
+    });
+
+    // A hidratação inicial dispara a chamada #1; cada tick subsequente
+    // adiciona mais uma. Asserimos apenas a transição de "1 → ≥3" para
+    // evitar corrida com intervalo de 50ms vs. agendamento do React.
+    await waitFor(
+      () => expect(client.get.mock.calls.length).toBeGreaterThanOrEqual(3),
+      { timeout: 1500 },
+    );
+    // Desmonta explicitamente para liberar `setInterval` antes de o
+    // próximo teste começar — `renderHook` faz auto-cleanup, mas sob
+    // intervalo de 50ms o timer pode disparar entre tests vizinhos.
+    unmount();
+  });
+
+  test('verifyIntervalMs=0 desativa revalidação periódica mas mantém hidratação inicial', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    client.get.mockResolvedValue(VERIFY_RESPONSE);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client, { verifyIntervalMs: 0 }),
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Aguarda um pouco para garantir que nenhum tick adicional chegou.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    expect(client.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('renderiza splash enquanto verify-token está em curso (sessão local)', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    // Promise pendente para manter `isLoading: true` enquanto asserimos
+    // a presença da splash.
+    let resolveVerify: ((value: VerifyTokenResponse) => void) | null = null;
+    client.get.mockImplementationOnce(
+      () =>
+        new Promise<VerifyTokenResponse>(resolve => {
+          resolveVerify = resolve;
+        }),
+    );
+
+    render(
+      <MemoryRouter>
+        <AuthProvider client={client} verifyIntervalMs={0}>
+          <div data-testid="protected-content">conteúdo protegido</div>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    // Splash visível, conteúdo protegido oculto.
+    expect(screen.getByTestId('auth-splash')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+
+    // Resolve o verify-token: splash desaparece, conteúdo aparece.
+    await act(async () => {
+      resolveVerify?.(VERIFY_RESPONSE);
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('auth-splash')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+  });
+
+  test('sem sessão local, NÃO exibe splash e renderiza children imediatamente', () => {
+    const client = createClientStub();
+    render(
+      <MemoryRouter>
+        <AuthProvider client={client} verifyIntervalMs={0}>
+          <div data-testid="public-content">conteúdo público</div>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('auth-splash')).not.toBeInTheDocument();
+    expect(screen.getByTestId('public-content')).toBeInTheDocument();
+  });
+
+  test('unmount cancela revalidação pendente via AbortController', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    let abortSignal: AbortSignal | undefined;
+    client.get.mockImplementationOnce((_path: string, options?: { signal?: AbortSignal }) => {
+      abortSignal = options?.signal;
+      // Promise pendente — nunca resolve — para asserir o abort.
+      return new Promise(() => undefined);
+    });
+
+    const { unmount } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+
+    // O `useEffect` que dispara o verify-token roda após o primeiro
+    // commit; aguardamos até que o mock receba o signal antes de
+    // desmontar.
+    await waitFor(() => expect(abortSignal).toBeDefined());
+    expect(abortSignal?.aborted).toBe(false);
+
+    unmount();
+    expect(abortSignal?.aborted).toBe(true);
   });
 });

--- a/tests/shared/auth/AuthSplash.test.tsx
+++ b/tests/shared/auth/AuthSplash.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { AuthSplash } from '@/shared/auth';
+
+describe('AuthSplash', () => {
+  test('renderiza logo com alt acessível', () => {
+    render(<AuthSplash />);
+    const logo = screen.getByAltText('LF Calegari Admin');
+    expect(logo).toBeInTheDocument();
+    expect(logo.tagName).toBe('IMG');
+  });
+
+  test('expõe role="status" e aria-live="polite" no container raiz', () => {
+    render(<AuthSplash />);
+    const root = screen.getByTestId('auth-splash');
+    expect(root).toHaveAttribute('role', 'status');
+    expect(root).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('exibe mensagem padrão quando nenhuma é informada', () => {
+    render(<AuthSplash />);
+    expect(screen.getByText('Validando sua sessão...')).toBeInTheDocument();
+  });
+
+  test('aceita mensagem customizada via prop', () => {
+    render(<AuthSplash message="Reconectando ao servidor..." />);
+    expect(screen.getByText('Reconectando ao servidor...')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexto

Terceira parte da Epic #44 (Autenticação). PR #93 entregou login, PR #95 entregou storage + hidratação síncrona; este PR fecha o ciclo da hidratação remota:

- Ao iniciar o app com sessão local, valida o token via `GET /api/v1/auth/verify-token` antes de liberar a UI.
- Splash dedicado durante a primeira validação para evitar flicker.
- Revalidação periódica configurável reflete mudanças server-side (role atualizada, permissão revogada) sem novo login.
- 401 limpa sessão e redireciona para `/login` (curto-circuito quando já está em `/login`).

## Endpoint

`GET /api/v1/auth/verify-token` (path completo resolvido pelo `VITE_AUTH_API_BASE_URL`).

Contrato assumido (alinhado ao padrão do `lfc-authenticator`):

\`\`\`json
{
  "user": { "id": "u-1", "name": "...", "email": "..." },
  "permissions": ["Systems.Read", "Systems.Create"]
}
\`\`\`

Header: \`Authorization: Bearer <jwt>\` (injetado pelo `apiClient` via `getToken()`).

## O que foi feito

- `src/shared/auth/AuthContext.tsx`
  - Hidratação otimista no `useState` initializer agora marca `isLoading: true` quando há sessão local — sinaliza revalidação em curso.
  - `useEffect` dispara `client.get('/auth/verify-token', { signal })` no mount; em sucesso, sincroniza `user`/`permissions` com o snapshot atual e persiste.
  - 401 → `onUnauthorized` do client já limpa storage/state; o Provider adiciona redirect para `/login` via `useNavigate` (com curto-circuito quando já estiver em `/login`).
  - Falha de rede → mantém sessão local (logging via `console.warn`); próximo tick tenta novamente.
  - Payload inválido → mantém sessão; só destrava `isLoading`.
  - Revalidação periódica via `setInterval` configurável; cleanup cancela timer e `AbortController`'s pendentes no unmount.
- `src/shared/auth/AuthSplash.tsx` (novo) — logo + spinner + mensagem; respeita tema (light/dark) via `useTheme().resolvedTheme`; expõe `role="status"` e `aria-live="polite"`.
- `src/shared/auth/types.ts` — adicionado `VerifyTokenResponse`.
- `src/shared/auth/index.ts` — re-exporta `AuthSplash` e o novo tipo.
- `.env.example` — `VITE_AUTH_VERIFY_INTERVAL_MS=300000` (default 5 min; `0` desativa).

## Decisões importantes

1. **Hidratação otimista + splash**: já mostramos UI \"montada\" mentalmente para evitar flash de `/login` em reload, mas o splash garante que ações privadas só aconteçam após o verify confirmar a sessão.
2. **Falha de rede mantém sessão local**: backend offline não deve forçar logout — mantém último snapshot conhecido até o próximo tick (ou 401 explícito).
3. **`useNavigate` no Provider**: o `App.tsx` já monta `<AuthProvider>` dentro de `<BrowserRouter>`, então o hook funciona; em ambientes sem Router, há fallback para `window.location.assign('/login')`.
4. **Token nunca é trocado pelo verify**: o backend retorna apenas `user` + `permissions`; o token persistido continua válido. Caso o backend evolua para rotacionar token, basta estender `VerifyTokenResponse`.
5. **`disableSplash` prop**: existente apenas para testes que usam `renderHook` (precisa observar estado durante `isLoading: true`); produção sempre exibe a splash.

## Arquivos impactados

**Modificados**
- \`src/shared/auth/AuthContext.tsx\`
- \`src/shared/auth/types.ts\`
- \`src/shared/auth/index.ts\`
- \`tests/pages/LoginPage.test.tsx\` (ordem de wrapping `MemoryRouter > AuthProvider`)
- \`tests/shared/auth/AuthProvider.test.tsx\` (nova suíte verify-token + adapt para Router)
- \`.env.example\`

**Novos**
- \`src/shared/auth/AuthSplash.tsx\`
- \`tests/shared/auth/AuthSplash.test.tsx\`

## Testes

- Lint: ok
- Typecheck: ok
- Vitest: **212 passed** (era 198; +14 novos cobrindo verify-token, splash, abort, interval, payload inválido)
- Build: ok (357 KB JS, 9 KB CSS)

Cenários cobertos:
- Sessão local + verify 200 → atualiza permissões; isLoading desce
- Sessão local + verify 401 → limpa sessão; storage zerado
- Sessão local + verify falha de rede → mantém sessão local; warning logado
- Sessão local + payload inválido → mantém sessão; isLoading desce
- Sem sessão local → não chama verify; renderiza children imediatamente
- Splash visível durante isLoading; some quando verify resolve
- Revalidação periódica chama verify a cada tick
- `verifyIntervalMs=0` desativa revalidação (mantém hidratação inicial)
- Unmount cancela `AbortController` pendente

## Visual

- AuthSplash usa exclusivamente tokens (`--bg-base`, `--fg2`, `--space-*`); nenhum hardcode de cor.
- Logo trocado por tema (mesma estratégia do `LoginPage`) garante contraste WCAG AA contra `--bg-base` em light/dark.
- Spinner `lg` com tom `accent` consistente com o sistema.
- `role=\"status\"` + `aria-live=\"polite\"` no container raiz; `Spinner` interno tem `aria-label` próprio.
- Sem elementos interativos no splash (sem `:focus-visible` a tratar).

## Segurança

- Token nunca é logado em console (apenas a label genérica do warning de rede).
- Resposta do verify passa por `isValidVerifyTokenResponse` antes de ser confiada (defesa contra contrato divergente / proxy malicioso).
- Falha de rede mantém sessão local: aceitável porque o token continua sendo o JWT já validado anteriormente; o backend, ao voltar, eventualmente rejeitará 401.
- `AbortController` cancela requisições em voo no unmount, evitando setState após desmontagem.

## Riscos

- Caso o backend `lfc-authenticator` exija método diferente de GET ou body no verify, o path precisa ser ajustado — contrato assumido é GET sem body com `Authorization: Bearer`.
- O fallback em \"backend offline + sessão local\" permite uso da SPA com último snapshot conhecido; é UX positiva, mas significa que permissões revogadas server-side só serão aplicadas no próximo verify de sucesso (ou em 401 retornado pelo próprio backend em outra rota).

## Issue relacionada

Closes #54
Ref Epic #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)