### PR TITLE
feat: logout local + remoto (#55)

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Outlet, useLocation, matchPath } from 'react-router-dom';
 import styled, { createGlobalStyle } from 'styled-components';
 
 import { Sidebar } from '../components/layout/Sidebar';
 import { Topbar } from '../components/layout/Topbar';
+import { useAuth } from '../shared/auth';
 
 interface AuthUser {
   name: string;
@@ -118,12 +119,29 @@ export const AppLayout: React.FC = () => {
   const location = useLocation();
   const title = resolveTitle(location.pathname);
 
-  // Sessão estática enquanto não há integração com lfc-authenticator.
-  const [user] = useState<AuthUser>({
-    name: 'admin@lfc.com.br',
-    role: 'root',
-    permCount: 12,
-  });
+  const auth = useAuth();
+
+  /**
+   * Sessão exposta para a Topbar. Derivada do `useAuth()` quando há
+   * usuário autenticado; cai em fallback genérico até o Provider terminar
+   * de hidratar (apenas se a rota privada for pintada antes da splash, o
+   * que não acontece em fluxo normal — defesa contra corner case).
+   */
+  const user = useMemo<AuthUser>(() => {
+    if (auth.user) {
+      const roleLabel = auth.user.roles?.[0] ?? 'user';
+      return {
+        name: auth.user.email,
+        role: roleLabel,
+        permCount: auth.permissions.length,
+      };
+    }
+    return {
+      name: 'admin@lfc.com.br',
+      role: 'root',
+      permCount: 12,
+    };
+  }, [auth.user, auth.permissions]);
 
   // Drawer mobile da Sidebar — fechado por padrão.
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -137,10 +155,17 @@ export const AppLayout: React.FC = () => {
   const handleOpenDrawer = useCallback(() => setDrawerOpen(true), []);
   const handleCloseDrawer = useCallback(() => setDrawerOpen(false), []);
 
-  const handleLogout = () => {
-    // Sessão invalidada — placeholder para integração com lfc-authenticator.
-    globalThis.location.reload();
-  };
+  /**
+   * Encerra a sessão via `useAuth().logout()`. O Provider já cuida de:
+   * (1) chamar `GET /auth/logout` para invalidar `tokenVersion` no
+   * backend; (2) limpar storage/estado; (3) redirecionar para `/login`.
+   *
+   * `void` é intencional: o handler do botão não precisa aguardar a
+   * Promise — a navegação é disparada de dentro do `logout`.
+   */
+  const handleLogout = useCallback(() => {
+    void auth.logout();
+  }, [auth]);
 
   return (
     <>

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -430,10 +430,35 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   );
 
   const logout = useCallback(async (): Promise<void> => {
-    // Epic #44 #55: chamar `POST /auth/logout` antes de limpar localmente
-    // (best-effort; falha de rede não impede o clear).
+    // Issue #55: notifica o backend para incrementar `tokenVersion`,
+    // invalidando todos os JWTs emitidos antes — o `auth-service` expõe
+    // `GET /api/v1/auth/logout` (com `Authorization: Bearer`).
+    //
+    // A chamada é best-effort: falha de rede ou 401 (já deslogado de
+    // qualquer forma) não impede a limpeza local. O usuário pediu
+    // logout; o estado local sempre cai. Errar no remoto e manter sessão
+    // local presa é UX inaceitável.
+    //
+    // O `clearSession` zera ref, storage e state em uma única passagem,
+    // e o `redirectToLogin` cobre o critério "em qualquer caso,
+    // redireciona para /login" (Issue #55). Curto-circuitamos em
+    // `/login` lá dentro para não fazer push redundante.
+    if (tokenRef.current) {
+      try {
+        await client.get('/auth/logout');
+      } catch (error) {
+        if (!isUnauthorizedError(error)) {
+          // Falha de rede ou 5xx — apenas logamos um warning para
+          // diagnóstico. Não expomos `error` em console para evitar
+          // vazar metadados de request em logs do navegador.
+          // eslint-disable-next-line no-console
+          console.warn('[auth] logout remoto falhou; sessão local foi encerrada.');
+        }
+      }
+    }
     clearSession();
-  }, [clearSession]);
+    redirectToLogin();
+  }, [client, clearSession, redirectToLogin]);
 
   const hasPermission = useCallback(
     (code: string): boolean => state.permissions.includes(code),

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -76,7 +76,14 @@ export interface VerifyTokenResponse {
 export interface AuthContextValue extends AuthState {
   /** Autentica via `POST /auth/login` e atualiza o estado. */
   login(email: string, password: string): Promise<void>;
-  /** Encerra a sessão local (Epic #44 #55 fará a chamada remota). */
+  /**
+   * Encerra a sessão.
+   *
+   * Best-effort: chama `GET /auth/logout` para incrementar
+   * `tokenVersion` no backend (invalidando JWTs emitidos antes); falha
+   * remota não bloqueia a limpeza local. Sempre limpa storage/estado e
+   * redireciona para `/login`.
+   */
   logout(): Promise<void>;
   /** Retorna `true` quando `code` está presente em `permissions`. */
   hasPermission(code: string): boolean;

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,12 +1,37 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import type { ApiClient } from '@/shared/api';
 
 import { AppRoutes } from '@/routes';
+import { AuthProvider } from '@/shared/auth';
+
+/**
+ * Cliente HTTP stub para os testes de árvore: o `AppLayout` agora consome
+ * `useAuth()`, e o `AuthProvider` injeta callbacks no client. Como os
+ * cenários daqui não exercitam autenticação, devolvemos um stub inerte —
+ * sem sessão local, o `verify-token` nem chega a ser chamado.
+ */
+function makeInertClient(): ApiClient {
+  const stub = {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+  };
+  return stub as unknown as ApiClient;
+}
 
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
+      <AuthProvider client={makeInertClient()} verifyIntervalMs={0} disableSplash>
+        <AppRoutes />
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 
@@ -262,6 +262,7 @@ describe('AuthProvider — logout', () => {
   test('limpa estado e zera token após logout', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce({ message: 'Sessão encerrada.' });
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -280,6 +281,234 @@ describe('AuthProvider — logout', () => {
     expect(result.current.isAuthenticated).toBe(false);
     const latest = lastCall(client.setAuth.mock.calls)?.[0];
     expect(latest?.getToken?.()).toBeNull();
+  });
+
+  test('chama GET /auth/logout para invalidar tokenVersion remoto (Issue #55)', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce({ message: 'Sessão encerrada.' });
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/auth/logout');
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('logout sem sessão ativa NÃO chama o endpoint remoto', async () => {
+    const client = createClientStub();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  test('falha de rede no logout remoto ainda limpa estado e storage', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockRejectedValueOnce(NETWORK_ERROR);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/auth/logout');
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test('logout em 401 (já deslogado no backend) limpa local sem warning', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    // Simula o comportamento real do client HTTP em 401: dispara
+    // `onUnauthorized` (que limpa sessão) e rejeita com ApiError.
+    client.get.mockImplementationOnce(async () => {
+      const config = lastCall(client.setAuth.mock.calls)?.[0];
+      config?.onUnauthorized?.();
+      throw UNAUTHORIZED_ERROR;
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/auth/logout');
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    // 401 é silencioso: o usuário já estava deslogado de qualquer forma.
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test('logout redireciona para /login após sucesso remoto', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    // Primeira chamada: hidratação verify-token; Segunda: logout remoto.
+    client.get
+      .mockResolvedValueOnce(VERIFY_RESPONSE)
+      .mockResolvedValueOnce({ message: 'Sessão encerrada.' });
+
+    let capturedPath = '';
+    const PathProbe: React.FC = () => {
+      const location = useLocation();
+      capturedPath = location.pathname;
+      return null;
+    };
+
+    const TriggerScreen: React.FC = () => {
+      const authValue = useAuth();
+      return (
+        <>
+          <PathProbe />
+          <button
+            type="button"
+            data-testid="trigger-logout"
+            onClick={() => {
+              void authValue.logout();
+            }}
+          >
+            sair
+          </button>
+        </>
+      );
+    };
+
+    const LoginScreen: React.FC = () => (
+      <>
+        <PathProbe />
+        <div data-testid="login-screen">login</div>
+      </>
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/systems']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route path="/login" element={<LoginScreen />} />
+            <Route path="/systems" element={<TriggerScreen />} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+    expect(capturedPath).toBe('/systems');
+
+    await act(async () => {
+      screen.getByTestId('trigger-logout').click();
+    });
+
+    await waitFor(() => expect(capturedPath).toBe('/login'));
+    expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+  });
+
+  test('logout redireciona para /login mesmo após falha remota', async () => {
+    seedPersistedSession();
+    const client = createClientStub();
+    // Hidratação OK, depois logout falha por rede.
+    client.get
+      .mockResolvedValueOnce(VERIFY_RESPONSE)
+      .mockRejectedValueOnce(NETWORK_ERROR);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    let capturedPath = '';
+    const PathProbe: React.FC = () => {
+      const location = useLocation();
+      capturedPath = location.pathname;
+      return null;
+    };
+
+    const TriggerScreen: React.FC = () => {
+      const authValue = useAuth();
+      return (
+        <>
+          <PathProbe />
+          <button
+            type="button"
+            data-testid="trigger-logout"
+            onClick={() => {
+              void authValue.logout();
+            }}
+          >
+            sair
+          </button>
+        </>
+      );
+    };
+
+    const LoginScreen: React.FC = () => (
+      <>
+        <PathProbe />
+        <div data-testid="login-screen">login</div>
+      </>
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/systems']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route path="/login" element={<LoginScreen />} />
+            <Route path="/systems" element={<TriggerScreen />} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+    expect(capturedPath).toBe('/systems');
+
+    await act(async () => {
+      screen.getByTestId('trigger-logout').click();
+    });
+
+    await waitFor(() => expect(capturedPath).toBe('/login'));
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,12 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['tests/setupTests.ts'],
       include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+      // Default 5s do Vitest fica apertado para a primeira renderização
+      // da árvore real (Routes + AppLayout + AuthProvider + styled-components)
+      // sob jsdom, especialmente em CI quando a JIT ainda está fria.
+      // 10s mantém latência confortável sem deixar testes presos
+      // verdadeiramente quebrados rodando indefinidamente.
+      testTimeout: 10000,
     },
   };
 });


### PR DESCRIPTION
## Contexto

Quarta parte da Epic [#44](https://github.com/LF-Calegari/lfc-admin-gui/issues/44) — Autenticação completa.

Antes deste PR o `useAuth().logout()` era um placeholder que limpava apenas o estado local; o `handleLogout` do `AppLayout` apenas chamava `globalThis.location.reload()`. Esta PR liga o logout ao backend e ao novo fluxo de redirect para `/login`.

## Objetivo

Atender os critérios da Issue #55:
- Limpa token no storage e estado.
- Chama endpoint do auth-service para invalidar `tokenVersion` quando disponível.
- Em qualquer caso, redireciona para `/login`.
- Botão de logout disponível na Topbar.

## O que foi feito

- `useAuth().logout()` agora dispara `GET /auth/logout` (best-effort) antes de limpar storage/estado e redirecionar para `/login` via `useNavigate`.
- Falha de rede / 5xx emite warning curto sem expor `error` ao console; 401 é silenciado (usuário já está deslogado de qualquer forma); o limpo local sempre acontece — usuário pediu logout, fail-safe.
- `AppLayout` consome `useAuth()` para derivar o usuário exibido na Topbar (email, role, contagem de permissões) com fallback estático até hidratação concluir.
- O botão de logout no `Topbar` continua visível em todas as larguras (mobile mantém o ícone Sair; apenas o `UserMeta` permanece oculto).
- 5 novos testes em `AuthProvider.test.tsx` cobrindo: chamada remota feliz, ausência de sessão, falha de rede, 401, redirect pós-falha.
- `App.test.tsx` envelopa `AppRoutes` com `AuthProvider` stub agora que `AppLayout` consome `useAuth()`.
- `vite.config.ts` ganha `testTimeout: 10000` para acomodar primeira renderização da árvore real sob jsdom (Routes + AppLayout + AuthProvider + styled-components).

## Decisões

- **Verb HTTP**: o briefing sugeriu `POST /auth/logout`, mas o backend `lfc-authenticator` expõe `GET /api/v1/auth/logout` (verificado em `AuthService/Controllers/Auth/AuthController.cs`). Sigo o backend real.
- **Sem toast pós-logout**: o redirect para `/login` é feedback claro; toast disparado durante navegação aparece numa tela diferente, com UX questionável. Decisão preservada.
- **Mobile mantém logout via ícone existente**: o `IconButton` Sair já é renderizado em mobile (apenas `UserMeta` é ocultado). Não adicionei drawer item nem segundo ícone.

## Arquivos impactados

- `src/shared/auth/AuthContext.tsx` — `logout` chama `client.get('/auth/logout')` e redireciona para `/login`.
- `src/shared/auth/types.ts` — JSDoc do contrato `logout` atualizado.
- `src/layouts/AppLayout.tsx` — consome `useAuth()`, deriva `user` real e dispara `logout` real.
- `tests/shared/auth/AuthProvider.test.tsx` — 5 novos casos cobrindo endpoint, falha de rede, 401, redirect.
- `tests/App.test.tsx` — wrap com `AuthProvider` stub.
- `vite.config.ts` — `testTimeout: 10000`.

## Testes

- `docker compose exec -T web npm run lint` — OK.
- `docker compose exec -T web npm run typecheck` — OK.
- `docker compose exec -T web npm run test` — 218/218 passando (212 anteriores + 6 novos).
- `docker compose exec -T web npm run build` — OK.

## Visual

Sem alterações visuais. Botão de logout pré-existente continua coerente com tokens de design (`var(--touch-min)`, `var(--accent)`, `var(--border-thick)`); estados hover/focus-visible/disabled já cobertos no `IconButton`.

## Segurança

- Token nunca aparece em console (warning de logout omite `error` para não vazar metadados).
- Logout sempre limpa local mesmo com remoto inacessível — não há cenário em que sessão local fique presa enquanto backend incrementa `tokenVersion`.
- Sem novas dependências externas.

## Riscos

- Se proxy/intermediário reescrever 200 do backend para 502 transiente, o usuário verá `[auth] logout remoto falhou; sessão local foi encerrada.` no console — comportamento aceitável: usuário já foi para `/login`.
- `tokenVersion` é incrementado pelo backend; sessões abertas em outras abas só serão derrubadas no próximo `verify-token` (já implementado na Issue #54). Janela de 5 min default — aceitável para esta Epic.

## Issue relacionada

Closes #55
Ref Epic #44