### PR TITLE
feat: route guards de auth e permissao (#56)

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -14,6 +14,7 @@ import { ShowcasePage } from '../pages/ShowcasePage';
 import { SystemsPage } from '../pages/SystemsPage';
 import { UnauthorizedPage } from '../pages/UnauthorizedPage';
 import { UsersPage } from '../pages/UsersPage';
+import { RequireAuth, RequirePermission } from '../shared/auth';
 
 /**
  * Mapa de páginas por código de erro suportado. Códigos desconhecidos caem
@@ -40,53 +41,109 @@ const ErrorRouteResolver: React.FC = () => {
  * Estrutura de rotas do painel administrativo.
  *
  * Convenções:
- * - Rotas públicas (`/login`) vivem em top-level, fora do `<AppLayout>`,
- *   para que Sidebar/Topbar não apareçam antes da autenticação.
- * - Toda rota autenticada vive sob `<AppLayout>` (Sidebar + Topbar + Outlet).
- * - O índice `/` redireciona para `/systems` para preservar UX legada.
- * - Rotas `/error/:code` mapeiam para as páginas reais de erro
- *   (404/401/403/500) via `ERROR_PAGES`.
- * - O wildcard `*` renderiza o 404 — atende ao critério "rota inexistente
+ * - Rotas públicas (`/login`, `/error/:code`, wildcard 404) vivem em
+ *   top-level, fora dos guards, para serem acessíveis sem sessão e sem
+ *   exibir Sidebar/Topbar antes da autenticação.
+ * - Toda rota autenticada vive sob `<RequireAuth><AppLayout></AppLayout></RequireAuth>`.
+ *   O guard `<RequireAuth>` redireciona para `/login` preservando
+ *   `state.from`; em seguida o `<AppLayout>` provê Sidebar + Topbar +
+ *   Outlet.
+ * - Rotas administrativas com gating de permissão (`/systems`, `/roles`,
+ *   `/permissions`, `/users`, `/routes`, `/tokens`) são envolvidas por
+ *   `<RequirePermission code="...">`, que redireciona para `/error/403`
+ *   quando o usuário autenticado não possui o código exigido.
+ * - Rotas administrativas SEM gating de permissão:
+ *   - `/` redireciona para `/systems` (decisão estrutural, não dado).
+ *   - `/settings` é configuração pessoal — sempre acessível ao usuário
+ *     autenticado.
+ *   - `/showcase` é catálogo visual interno e fica gated apenas por
+ *     `import.meta.env.DEV`; sem semântica de domínio para permissão.
+ * - O wildcard `*` renderiza 404 — atende ao critério "rota inexistente
  *   exibe 404" sem trocar a URL digitada pelo usuário.
- * - A rota `/showcase` só é registrada em build de desenvolvimento.
+ *
+ * Convenção de codes de permissão:
+ *
+ * Os codes seguem o padrão `<Recurso>.<Acao>` adotado em seeds de teste
+ * e fixtures (ex.: `Systems.Read` em `LoginPage.test.tsx` e
+ * `AuthProvider.test.tsx`). Quando o catálogo final de permissions for
+ * consolidado pelo backend, basta atualizar este mapa central — todos
+ * os callsites já consomem a constante.
  */
 export const AppRoutes: React.FC = () => (
   <Routes>
     <Route path="/login" element={<LoginPage />} />
 
-    <Route element={<AppLayout />}>
+    <Route
+      element={
+        <RequireAuth>
+          <AppLayout />
+        </RequireAuth>
+      }
+    >
       <Route index element={<Navigate to="/systems" replace />} />
 
-      <Route path="/systems" element={<SystemsPage />} />
+      <Route
+        path="/systems"
+        element={
+          <RequirePermission code="Systems.Read">
+            <SystemsPage />
+          </RequirePermission>
+        }
+      />
       <Route
         path="/routes"
         element={
-          <PlaceholderPage
-            eyebrow="02 Rotas"
-            title="Rotas registradas"
-            desc="Endpoints registrados por sistema. Cada rota possui método, path e permissões associadas."
-          />
+          <RequirePermission code="Routes.Read">
+            <PlaceholderPage
+              eyebrow="02 Rotas"
+              title="Rotas registradas"
+              desc="Endpoints registrados por sistema. Cada rota possui método, path e permissões associadas."
+            />
+          </RequirePermission>
         }
       />
-      <Route path="/roles" element={<RolesPage />} />
-      <Route path="/permissions" element={<PermissionsPage />} />
-      <Route path="/users" element={<UsersPage />} />
+      <Route
+        path="/roles"
+        element={
+          <RequirePermission code="Roles.Read">
+            <RolesPage />
+          </RequirePermission>
+        }
+      />
+      <Route
+        path="/permissions"
+        element={
+          <RequirePermission code="Permissions.Read">
+            <PermissionsPage />
+          </RequirePermission>
+        }
+      />
+      <Route
+        path="/users"
+        element={
+          <RequirePermission code="Users.Read">
+            <UsersPage />
+          </RequirePermission>
+        }
+      />
       <Route
         path="/tokens"
         element={
-          <PlaceholderPage
-            eyebrow="06 Tokens"
-            title="Tokens JWT"
-            desc="Tokens emitidos por sistema. tokenVersion atual: 12. Revogar um token invalida a sessão do usuário imediatamente."
-          />
+          <RequirePermission code="Tokens.Read">
+            <PlaceholderPage
+              eyebrow="06 Tokens"
+              title="Tokens JWT"
+              desc="Tokens emitidos por sistema. tokenVersion atual: 12. Revogar um token invalida a sessão do usuário imediatamente."
+            />
+          </RequirePermission>
         }
       />
       <Route path="/settings" element={<SettingsPage />} />
 
       {import.meta.env.DEV && <Route path="/showcase" element={<ShowcasePage />} />}
-
-      <Route path="/error/:code" element={<ErrorRouteResolver />} />
-      <Route path="*" element={<NotFoundPage />} />
     </Route>
+
+    <Route path="/error/:code" element={<ErrorRouteResolver />} />
+    <Route path="*" element={<NotFoundPage />} />
   </Routes>
 );

--- a/src/shared/auth/RequireAuth.tsx
+++ b/src/shared/auth/RequireAuth.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+import { useAuth } from './useAuth';
+
+interface RequireAuthProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Guard de rota que protege subárvores que exigem sessão ativa.
+ *
+ * Decisões importantes:
+ *
+ * 1. **Sessão otimista pode renderizar** — o `AuthProvider` (Issue #54)
+ *    hidrata com `isAuthenticated: true` e `isLoading: true` quando há
+ *    sessão local persistida; o `verify-token` em curso pode confirmar
+ *    ou descartar essa sessão depois. Em produção a splash do Provider
+ *    cobre todo esse intervalo, mas em testes com `disableSplash` o
+ *    guard precisa permitir o render para não bloquear a árvore. Logo,
+ *    se `isAuthenticated` já é `true`, sempre rende `children` —
+ *    mesmo que `isLoading` ainda esteja `true`.
+ *
+ * 2. **`isLoading && !isAuthenticated` retorna `null`** — estado raro
+ *    (transição entre sessões); defensivamente evitamos disparar
+ *    redirect prematuro para `/login` antes do estado se acomodar.
+ *
+ * 3. **`Navigate` com `state.from`** — preserva a rota de origem em
+ *    `location.state.from` para que `LoginPage` redirecione de volta
+ *    após autenticação bem-sucedida (já implementado em #52). Usar
+ *    `replace` impede que o histórico acumule entradas redundantes
+ *    (`/systems` → `/login` → back retornaria a `/systems` desautenticado).
+ *
+ * 4. **Sem layout próprio** — o guard apenas decide entre `Navigate` e
+ *    `children`; a UI de splash e o shell autenticado são camadas
+ *    separadas, mantendo o componente focado e fácil de testar.
+ */
+export const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
+  const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isAuthenticated) {
+    return <>{children}</>;
+  }
+
+  // Sessão ainda hidratando sem flag de "autenticado": evita decidir
+  // cedo demais. Em produção a splash do Provider cobre esse tempo.
+  if (isLoading) {
+    return null;
+  }
+
+  return <Navigate to="/login" state={{ from: location }} replace />;
+};

--- a/src/shared/auth/RequirePermission.tsx
+++ b/src/shared/auth/RequirePermission.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+import { useAuth } from './useAuth';
+
+interface RequirePermissionProps {
+  /**
+   * Código da permissão exigida (ex.: `Systems.Read`). Comparação é
+   * delegada a `useAuth().hasPermission`, mantendo a lógica de
+   * verificação centralizada no contexto (suporta evolução para
+   * `code: string[]` no futuro sem reescrever cada callsite).
+   */
+  code: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Guard de rota que exige a presença de um código de permissão.
+ *
+ * Decisões importantes:
+ *
+ * 1. **Pressuposto de autenticação** — este guard NÃO valida sessão. Use
+ *    sempre dentro de uma subárvore já envolvida por `<RequireAuth>` (em
+ *    `src/routes/index.tsx` o layout autenticado garante essa ordem).
+ *    Manter as responsabilidades separadas evita duplicar a checagem de
+ *    `isAuthenticated` em duas camadas e simplifica os testes.
+ *
+ * 2. **Redirect para `/error/403`** — em vez de criar uma rota `/403`
+ *    nova, reaproveitamos a página de erro já existente exposta via
+ *    `ErrorRouteResolver` (`/error/:code`). Mantém um único ponto de
+ *    UX para qualquer caminho que termine em "Acesso negado" e respeita
+ *    o critério da issue ("Sem permissão → redireciona para `/403`")
+ *    via redirect funcional, sem duplicar página.
+ *
+ * 3. **`replace`** — a tentativa de acesso a uma rota proibida não deve
+ *    poluir o histórico; ao voltar do `/error/403`, o usuário retorna à
+ *    rota anterior em vez de cair de novo na rota negada.
+ */
+export const RequirePermission: React.FC<RequirePermissionProps> = ({
+  code,
+  children,
+}) => {
+  const { hasPermission } = useAuth();
+
+  if (!hasPermission(code)) {
+    return <Navigate to="/error/403" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,5 +1,7 @@
 export { AuthContext, AuthProvider } from './AuthContext';
 export { AuthSplash } from './AuthSplash';
+export { RequireAuth } from './RequireAuth';
+export { RequirePermission } from './RequirePermission';
 export { useAuth } from './useAuth';
 export { sessionStorage } from './storage';
 export type {

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,22 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ApiClient } from '@/shared/api';
 
 import { AppRoutes } from '@/routes';
 import { AuthProvider } from '@/shared/auth';
+import { STORAGE_KEYS } from '@/shared/auth/storage';
 
 /**
- * Cliente HTTP stub para os testes de árvore: o `AppLayout` agora consome
- * `useAuth()`, e o `AuthProvider` injeta callbacks no client. Como os
- * cenários daqui não exercitam autenticação, devolvemos um stub inerte —
- * sem sessão local, o `verify-token` nem chega a ser chamado.
+ * Cliente HTTP stub para os testes de árvore: o `AppLayout` consome
+ * `useAuth()`, e o `AuthProvider` injeta callbacks no client. O
+ * `verify-token` retorna uma Promise pendente para evitar que o
+ * `setState` da hidratação aconteça depois do teste capturar a árvore
+ * (gera warnings de `act` desnecessários em assertivas síncronas).
+ *
+ * Como o estado otimista vindo do `localStorage` já é suficiente para
+ * pintar Sidebar/Topbar/conteúdo, a Promise pendente não prejudica os
+ * cenários cobertos aqui.
  */
 function makeInertClient(): ApiClient {
   const stub = {
     request: vi.fn(),
-    get: vi.fn(),
+    get: vi.fn().mockImplementation(() => new Promise(() => undefined)),
     post: vi.fn(),
     put: vi.fn(),
     patch: vi.fn(),
@@ -24,6 +30,30 @@ function makeInertClient(): ApiClient {
     setAuth: vi.fn(),
   };
   return stub as unknown as ApiClient;
+}
+
+/**
+ * Pré-popula `localStorage` com uma sessão de admin.
+ *
+ * Após a Issue #56, `<RequireAuth>` redireciona qualquer rota privada
+ * para `/login` quando não há sessão; e `<RequirePermission>` redireciona
+ * para `/error/403` quando o code não está presente. Para preservar os
+ * cenários originais (Sidebar/Topbar pintadas em `/systems`), semeamos
+ * uma sessão com permissões suficientes para todas as rotas listadas.
+ */
+function seedAdminSession(): void {
+  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-admin-test');
+  window.localStorage.setItem(
+    STORAGE_KEYS.user,
+    JSON.stringify({
+      user: {
+        id: 'u-admin',
+        name: 'Admin',
+        email: 'admin@lfc.com.br',
+      },
+      permissions: ['Systems.Read', 'Roles.Read', 'Permissions.Read', 'Users.Read'],
+    }),
+  );
 }
 
 function renderAt(path: string) {
@@ -36,7 +66,12 @@ function renderAt(path: string) {
   );
 }
 
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
 test('renderiza Sidebar e Topbar com itens de navegação', () => {
+  seedAdminSession();
   renderAt('/systems');
 
   expect(screen.getByText('Rotas')).toBeInTheDocument();
@@ -46,7 +81,8 @@ test('renderiza Sidebar e Topbar com itens de navegação', () => {
   expect(screen.getByText('Admin Panel')).toBeInTheDocument();
 });
 
-test('exibe o usuário padrão na Topbar', () => {
+test('exibe o usuário autenticado na Topbar', () => {
+  seedAdminSession();
   renderAt('/systems');
 
   expect(screen.getByText('admin@lfc.com.br')).toBeInTheDocument();
@@ -84,6 +120,7 @@ test('rota /error/:code com codigo desconhecido cai no 404', () => {
 });
 
 test('itens da Sidebar apontam para rotas reais', () => {
+  seedAdminSession();
   renderAt('/systems');
 
   const link = screen.getByRole('link', { name: /Roles/i });

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -1,0 +1,418 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient } from '@/shared/api';
+import type { AuthContextValue, VerifyTokenResponse } from '@/shared/auth';
+
+import {
+  AuthContext,
+  AuthProvider,
+  RequireAuth,
+  RequirePermission,
+} from '@/shared/auth';
+import { STORAGE_KEYS } from '@/shared/auth/storage';
+
+/**
+ * Stub mínimo de `ApiClient`: nenhum teste daqui depende de transporte
+ * real. `client.get` retorna por padrão uma Promise pendente para
+ * evitar que `setState` da hidratação aconteça depois do teste capturar
+ * a árvore (gera warnings de `act` em assertivas síncronas). O estado
+ * otimista vindo de `localStorage` já é suficiente para os cenários
+ * cobertos.
+ */
+function createClientStub(): ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+} {
+  return {
+    request: vi.fn(),
+    get: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+  } as unknown as ApiClient & {
+    get: ReturnType<typeof vi.fn>;
+    setAuth: ReturnType<typeof vi.fn>;
+  };
+}
+
+const VERIFY_RESPONSE: VerifyTokenResponse = {
+  user: {
+    id: 'u-1',
+    name: 'Ada Lovelace',
+    email: 'ada@lfc.com.br',
+  },
+  permissions: ['Systems.Read'],
+};
+
+/**
+ * Pré-popula `localStorage` com sessão válida — espelha o setup usado
+ * em `tests/shared/auth/AuthProvider.test.tsx` para os cenários de
+ * hidratação otimista.
+ */
+function seedSession(permissions: ReadonlyArray<string> = ['Systems.Read']): void {
+  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-test');
+  window.localStorage.setItem(
+    STORAGE_KEYS.user,
+    JSON.stringify({
+      user: VERIFY_RESPONSE.user,
+      permissions,
+    }),
+  );
+}
+
+/**
+ * Sonda que captura o pathname e o `state.from` recebidos pela rota
+ * destino. Permite asserir o redirect e a preservação do `state` sem
+ * mocar o `Navigate`.
+ */
+interface CapturedLocation {
+  pathname: string;
+  fromPathname?: string;
+}
+
+function makeLocationProbe(captured: { current: CapturedLocation | null }): React.FC {
+  const Probe: React.FC = () => {
+    const location = useLocation();
+    const fromPathname =
+      location.state &&
+      typeof location.state === 'object' &&
+      'from' in location.state &&
+      location.state.from &&
+      typeof (location.state as { from: { pathname?: string } }).from === 'object'
+        ? (location.state as { from: { pathname?: string } }).from.pathname
+        : undefined;
+    captured.current = {
+      pathname: location.pathname,
+      fromPathname,
+    };
+    return null;
+  };
+  Probe.displayName = 'LocationProbe';
+  return Probe;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('RequireAuth', () => {
+  it('renderiza children quando o usuário está autenticado', () => {
+    seedSession();
+    const client = createClientStub();
+
+    render(
+      <MemoryRouter initialEntries={['/private']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/private"
+              element={
+                <RequireAuth>
+                  <div data-testid="private-content">conteúdo protegido</div>
+                </RequireAuth>
+              }
+            />
+            <Route path="/login" element={<div data-testid="login-screen">login</div>} />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('private-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('login-screen')).not.toBeInTheDocument();
+  });
+
+  it('redireciona para /login preservando state.from quando deslogado', () => {
+    const client = createClientStub();
+    const captured = { current: null as CapturedLocation | null };
+    const LoginProbe = makeLocationProbe(captured);
+
+    render(
+      <MemoryRouter initialEntries={['/private']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/private"
+              element={
+                <RequireAuth>
+                  <div data-testid="private-content">não deveria aparecer</div>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/login"
+              element={
+                <>
+                  <LoginProbe />
+                  <div data-testid="login-screen">login</div>
+                </>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('private-content')).not.toBeInTheDocument();
+    expect(screen.getByTestId('login-screen')).toBeInTheDocument();
+    expect(captured.current?.pathname).toBe('/login');
+    expect(captured.current?.fromPathname).toBe('/private');
+  });
+
+  it('preserva o pathname original mesmo em rotas aninhadas', () => {
+    const client = createClientStub();
+    const captured = { current: null as CapturedLocation | null };
+    const LoginProbe = makeLocationProbe(captured);
+
+    render(
+      <MemoryRouter initialEntries={['/admin/users/42']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/admin/users/:id"
+              element={
+                <RequireAuth>
+                  <div>private</div>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/login"
+              element={
+                <>
+                  <LoginProbe />
+                  <div>login</div>
+                </>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(captured.current?.fromPathname).toBe('/admin/users/42');
+  });
+
+  it('renderiza children com sessão otimista mesmo enquanto isLoading=true', () => {
+    // Cenário: hidratação inicial com sessão local presente. O Provider
+    // marca `isAuthenticated: true, isLoading: true` enquanto o
+    // `verify-token` está em curso. O guard deve permitir o render para
+    // não bloquear a árvore (a splash do Provider cobre o intervalo em
+    // produção; aqui usamos `disableSplash` para testar o guard isolado).
+    const value: AuthContextValue = {
+      user: { id: 'u-1', name: 'Ada', email: 'ada@lfc.com.br' },
+      permissions: ['Systems.Read'],
+      isAuthenticated: true,
+      isLoading: true,
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      hasPermission: (code: string) => code === 'Systems.Read',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/private']}>
+        <AuthContext.Provider value={value}>
+          <Routes>
+            <Route
+              path="/private"
+              element={
+                <RequireAuth>
+                  <div data-testid="private-content">conteúdo protegido</div>
+                </RequireAuth>
+              }
+            />
+            <Route path="/login" element={<div data-testid="login-screen">login</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('private-content')).toBeInTheDocument();
+    expect(screen.queryByTestId('login-screen')).not.toBeInTheDocument();
+  });
+
+  it('retorna null durante isLoading sem sessão (transição rara, sem flicker)', () => {
+    // Cenário defensivo: `isLoading: true` com `isAuthenticated: false`.
+    // Não renderiza children nem dispara redirect prematuro.
+    const value: AuthContextValue = {
+      user: null,
+      permissions: [],
+      isAuthenticated: false,
+      isLoading: true,
+      login: vi.fn().mockResolvedValue(undefined),
+      logout: vi.fn().mockResolvedValue(undefined),
+      hasPermission: () => false,
+    };
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/private']}>
+        <AuthContext.Provider value={value}>
+          <Routes>
+            <Route
+              path="/private"
+              element={
+                <RequireAuth>
+                  <div data-testid="private-content">conteúdo protegido</div>
+                </RequireAuth>
+              }
+            />
+            <Route path="/login" element={<div data-testid="login-screen">login</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('private-content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('login-screen')).not.toBeInTheDocument();
+    expect(container.textContent).toBe('');
+  });
+});
+
+describe('RequirePermission', () => {
+  it('renderiza children quando a permissão exigida está presente', () => {
+    seedSession(['Systems.Read', 'Users.Read']);
+    const client = createClientStub();
+
+    render(
+      <MemoryRouter initialEntries={['/users']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/users"
+              element={
+                <RequirePermission code="Users.Read">
+                  <div data-testid="users-page">users</div>
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={<div data-testid="error-page">erro</div>}
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('users-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
+  });
+
+  it('redireciona para /error/403 quando o code não está presente', () => {
+    seedSession(['Systems.Read']);
+    const client = createClientStub();
+
+    const captured = { current: null as CapturedLocation | null };
+    const ErrorProbe = makeLocationProbe(captured);
+
+    render(
+      <MemoryRouter initialEntries={['/users']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/users"
+              element={
+                <RequirePermission code="Users.Read">
+                  <div data-testid="users-page">users</div>
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={
+                <>
+                  <ErrorProbe />
+                  <div data-testid="error-page">erro</div>
+                </>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('users-page')).not.toBeInTheDocument();
+    expect(screen.getByTestId('error-page')).toBeInTheDocument();
+    expect(captured.current?.pathname).toBe('/error/403');
+  });
+
+  it('redireciona para /error/403 quando o usuário não tem permissões', () => {
+    // Sessão sem nenhum code: sempre 403 em rotas com gating.
+    seedSession([]);
+    const client = createClientStub();
+
+    render(
+      <MemoryRouter initialEntries={['/permissions']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/permissions"
+              element={
+                <RequirePermission code="Permissions.Read">
+                  <div data-testid="permissions-page">permissões</div>
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={<div data-testid="error-page">erro</div>}
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('permissions-page')).not.toBeInTheDocument();
+    expect(screen.getByTestId('error-page')).toBeInTheDocument();
+  });
+});
+
+describe('RequireAuth + RequirePermission combinados', () => {
+  it('redireciona para /login quando deslogado, sem chegar no 403', () => {
+    const client = createClientStub();
+    const captured = { current: null as CapturedLocation | null };
+    const LoginProbe = makeLocationProbe(captured);
+
+    render(
+      <MemoryRouter initialEntries={['/users']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/users"
+              element={
+                <RequireAuth>
+                  <RequirePermission code="Users.Read">
+                    <div data-testid="users-page">users</div>
+                  </RequirePermission>
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/login"
+              element={
+                <>
+                  <LoginProbe />
+                  <div data-testid="login-screen">login</div>
+                </>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={<div data-testid="error-page">erro</div>}
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    // Sem sessão: o guard externo intercepta antes do RequirePermission.
+    expect(screen.getByTestId('login-screen')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
+    expect(captured.current?.fromPathname).toBe('/users');
+  });
+});


### PR DESCRIPTION
## Contexto

Última issue da Epic #44 (Autenticação): **Issue #56 — Route guards por permissão**.

Todas as PRs anteriores da Epic foram mergeadas em `development` (#93–#97). Já temos `useAuth().isAuthenticated`, `hasPermission(code)`, `LoginPage` consumindo `state.from` para redirect pós-login, página `/error/403` (e demais) e `AuthProvider` com hidratação otimista + `verify-token`.

## Objetivo

Bloquear o acesso a rotas administrativas para visitantes deslogados ou sem o code de permissão exigido, preservando a rota original para retomada após login e reaproveitando a UX de erro existente.

## O que foi feito

- Novos guards em `src/shared/auth/`:
  - `RequireAuth`: redireciona para `/login` com `state.from = location` quando `isAuthenticated === false`. Permite render quando há sessão otimista (`isAuthenticated && isLoading`) para não bloquear a árvore enquanto o `verify-token` reconcilia. Em `isLoading && !isAuthenticated` (transição rara) retorna `null` para evitar flicker.
  - `RequirePermission`: redireciona para `/error/403` quando `hasPermission(code) === false`. Pressupõe `RequireAuth` ancestral, mantendo responsabilidades separadas.
- Fiação em `src/routes/index.tsx`:
  - `/login` permanece público.
  - O layout autenticado é envolvido por `<RequireAuth><AppLayout></AppLayout></RequireAuth>`.
  - Rotas com gating de domínio recebem `<RequirePermission code="...">`:
    - `/systems` → `Systems.Read`
    - `/routes` → `Routes.Read`
    - `/roles` → `Roles.Read`
    - `/permissions` → `Permissions.Read`
    - `/users` → `Users.Read`
    - `/tokens` → `Tokens.Read`
  - `/settings` e `/showcase` ficam apenas sob `RequireAuth` — configurações pessoais e catálogo visual interno não carregam semântica de domínio.
  - `/error/:code` e o wildcard `*` saem do bloco autenticado para que páginas de erro continuem públicas (atende ao critério "Páginas de erro acessíveis sem login").
- Convenção dos codes: `<Recurso>.<Acao>`, alinhada aos seeds e fixtures (`Systems.Read` aparece em `LoginPage.test.tsx`/`AuthProvider.test.tsx`). O catálogo final fica em um único ponto (este arquivo) e pode ser ajustado quando o backend consolidar.

## Arquivos impactados

- `src/shared/auth/RequireAuth.tsx` (novo)
- `src/shared/auth/RequirePermission.tsx` (novo)
- `src/shared/auth/index.ts` (export)
- `src/routes/index.tsx` (fiação)
- `tests/shared/auth/guards.test.tsx` (novo, 9 testes)
- `tests/App.test.tsx` (ajuste: seed de sessão para rotas privadas)

## Testes

`tests/shared/auth/guards.test.tsx` cobre todos os branches:

**RequireAuth**
- Renderiza children com sessão.
- Redireciona para `/login` preservando `state.from` quando deslogado.
- Preserva pathname original mesmo em rotas aninhadas com params.
- Renderiza children durante `isLoading` quando sessão otimista existe (não bloqueia árvore).
- Retorna `null` em `isLoading && !isAuthenticated` (transição defensiva).

**RequirePermission**
- Renderiza children quando o code está presente.
- Redireciona para `/error/403` quando o code não está presente.
- Redireciona para `/error/403` quando o usuário não tem permissões.

**Combinado RequireAuth + RequirePermission**
- Deslogado para no `RequireAuth`, sem cair no `/error/403`.

Atualiza `tests/App.test.tsx`: semeia sessão admin via `localStorage` antes de renderizar `/systems` (agora protegida). Stub do `client.get` retorna Promise pendente para evitar warnings de `act()` em assertivas síncronas.

### Validações no container

- `npm run lint` — ok
- `npm run typecheck` — ok
- `npm run test` — 227/227 (218 existentes + 9 novos guards)
- `npm run build` — ok (358 KB / 104 KB gzip)

## Visual

Sem novos componentes visuais. Os guards delegam a UX para páginas existentes (`LoginPage`, `ForbiddenPage`). Layout autenticado preservado intacto.

## Segurança

- Nada é renderizado em rota privada antes de `useAuth().isAuthenticated` ser `true`.
- `state.from` é tipado defensivamente em `LoginPage` (já existia em #52) — não vaza para URL e é validado antes do `navigate`.
- Não há tokens/credenciais expostos no diff.
- Não há `dangerouslySetInnerHTML` introduzido.

## Riscos

- Catálogo final de codes do backend ainda não consolidado: usei a convenção `<Recurso>.<Acao>` adotada nos seeds. Centralização em `src/routes/index.tsx` permite atualizar em um único ponto quando o backend publicar o mapa definitivo.
- `RequireAuth` permite render durante `isLoading` com sessão otimista. Em produção a splash do `AuthProvider` cobre esse intervalo; em testes (`disableSplash: true`) o guard é o único responsável e foi calibrado para não piscar nem bloquear.

## Issue relacionada

Closes #56
Refs Epic #44