### PR TITLE
fix: ajustar AuthContext ao contrato real do auth-service (#100)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_AUTH_API_BASE_URL=https://localhost:8080/api/v1
+VITE_AUTH_API_BASE_URL=http://localhost:8080/api/v1
 VITE_APP_NAME=Auth Admin
 VITE_SESSION_IDLE_MINUTES=15
 # Intervalo entre revalidações automáticas via GET /auth/verify-token (ms).

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -18,6 +18,7 @@ import type {
   AuthContextValue,
   AuthState,
   LoginResponse,
+  User,
   VerifyTokenResponse,
 } from './types';
 
@@ -74,9 +75,16 @@ function resolveVerifyInterval(): number {
 /**
  * Type guard mínimo para o payload do endpoint `verify-token`.
  *
- * Garante que `user.id/name/email` e `permissions[]` existem antes de
- * confiar em `data.user` no Provider — defesa contra contrato divergente
- * ou resposta corrompida em proxies intermediários.
+ * O contrato real do `auth-service` é achatado: `{ id, name, email,
+ * identity, permissions: Guid[], routeCodes: string[] }`. Validamos os
+ * campos essenciais (`id`, `name`, `email` strings; `identity` numérico;
+ * `routeCodes` array) antes de o Provider confiar no payload — defesa
+ * contra resposta corrompida em proxies intermediários ou divergência
+ * silenciosa de versão entre frontend/backend.
+ *
+ * `permissions` (GUIDs) também é exigido como array para manter simetria
+ * com o backend, mas o Provider nunca consome diretamente — o catálogo
+ * que alimenta `hasPermission()` é `routeCodes`.
  */
 function isValidVerifyTokenResponse(value: unknown): value is VerifyTokenResponse {
   if (!value || typeof value !== 'object') {
@@ -86,15 +94,32 @@ function isValidVerifyTokenResponse(value: unknown): value is VerifyTokenRespons
   if (!Array.isArray(record.permissions)) {
     return false;
   }
-  if (!record.user || typeof record.user !== 'object') {
+  if (!Array.isArray(record.routeCodes)) {
     return false;
   }
-  const user = record.user as Record<string, unknown>;
   return (
-    typeof user.id === 'string' &&
-    typeof user.name === 'string' &&
-    typeof user.email === 'string'
+    typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.email === 'string' &&
+    typeof record.identity === 'number'
   );
+}
+
+/**
+ * Extrai o subset de campos do `VerifyTokenResponse` que compõem o
+ * `User` exposto pela aplicação.
+ *
+ * Centralizar a projeção evita divergência entre os call sites (login e
+ * hidratação remota): qualquer mudança no contrato de `User` fica em um
+ * único lugar.
+ */
+function toUser(payload: VerifyTokenResponse): User {
+  return {
+    id: payload.id,
+    name: payload.name,
+    email: payload.email,
+    identity: payload.identity,
+  };
 }
 
 /**
@@ -185,7 +210,14 @@ interface AuthProviderProps {
  *    antes de atualizar o estado, garantindo que mesmo um crash
  *    síncrono entre `save` e `setState` ainda preserve a sessão.
  * 8. **Limpeza tripla** — `clearSession` zera storage, ref e state em
- *    um único ponto, reusado por `logout` e por `onUnauthorized`.
+ *    um único ponto, reusado por `logout`, `onUnauthorized` e por
+ *    falhas pós-login (`verify-token` rejeitou após token aceito).
+ * 9. **Login encadeado (POST /auth/login → GET /auth/verify-token)** —
+ *    o backend retorna apenas `{ token }` no login; o perfil e o
+ *    catálogo `routeCodes` vêm em `verify-token`. Setamos `tokenRef`
+ *    entre as duas chamadas porque o cliente HTTP precisa do header
+ *    `Authorization` para a segunda. Falha entre as duas (rede, 401,
+ *    payload inválido) limpa a sessão parcial via `clearSession`.
  */
 export const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
@@ -325,15 +357,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           );
           return;
         }
-        // Persiste antes de setState pelos mesmos motivos do `login`.
+        // Projeta o payload achatado em `User` e usa `routeCodes` (e
+        // não `permissions`/GUIDs) como catálogo consumido por
+        // `hasPermission()`. Persiste antes de setState pelos mesmos
+        // motivos do `login`.
+        const user = toUser(data);
+        const permissions = data.routeCodes;
         sessionStorage.save({
           token: tokenRef.current,
-          user: data.user,
-          permissions: data.permissions,
+          user,
+          permissions,
         });
         setState({
-          user: data.user,
-          permissions: data.permissions,
+          user,
+          permissions,
           isAuthenticated: true,
           isLoading: false,
         });
@@ -401,32 +438,72 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   const login = useCallback(
     async (email: string, password: string): Promise<void> => {
       setState(prev => ({ ...prev, isLoading: true }));
+      // `tokenAcquired` distingue falhas pré-token (login) de falhas
+      // pós-token (verify-token): o cleanup do segundo caso precisa
+      // limpar `tokenRef`/storage para não deixar a aplicação com
+      // token "vivo em memória" sem perfil correspondente.
+      let tokenAcquired = false;
       try {
-        const data = await client.post<LoginResponse>('/auth/login', {
+        const loginData = await client.post<LoginResponse>('/auth/login', {
           email,
           password,
         });
+        // Setar `tokenRef` ANTES do verify é crítico: o cliente HTTP
+        // injeta `Authorization: Bearer ${getToken()}` lendo a ref a
+        // cada requisição. Sem isso, o `verify-token` sai sem header
+        // de autenticação e o backend responde 401.
+        tokenRef.current = loginData.token;
+        tokenAcquired = true;
+
+        const verifyData = await client.get<VerifyTokenResponse>(
+          '/auth/verify-token',
+        );
+        if (!isValidVerifyTokenResponse(verifyData)) {
+          // Backend respondeu 200 mas com payload inesperado. Tratamos
+          // como falha pós-login: zera token e propaga erro tipado para
+          // a UI exibir mensagem genérica.
+          throw {
+            kind: 'parse',
+            message: 'Resposta inválida do servidor.',
+          } satisfies ApiError;
+        }
+
+        const user = toUser(verifyData);
+        const permissions = verifyData.routeCodes;
+
         // Persiste antes de atualizar o estado: assim qualquer falha
         // posterior (ainda que improvável) não deixa a sessão "viva em
         // memória, morta em disco".
         sessionStorage.save({
-          token: data.token,
-          user: data.user,
-          permissions: data.permissions,
+          token: loginData.token,
+          user,
+          permissions,
         });
-        tokenRef.current = data.token;
         setState({
-          user: data.user,
-          permissions: data.permissions,
+          user,
+          permissions,
           isAuthenticated: true,
           isLoading: false,
         });
       } catch (error) {
-        setState(prev => ({ ...prev, isLoading: false }));
+        // Falha pós-login (verify-token rejeitou ou payload inválido):
+        // o token já foi setado em `tokenRef`, então precisamos limpar
+        // tudo via `clearSession` para não deixar header `Authorization`
+        // pendurado em chamadas seguintes.
+        //
+        // Falha pré-login (credenciais inválidas, rede): `tokenRef`
+        // ainda é `null`/o valor anterior, basta sair de `isLoading`.
+        // Em ambos os casos, o erro é re-lançado para o caller decidir
+        // a apresentação.
+        if (tokenAcquired) {
+          clearSession();
+        } else {
+          setState(prev => ({ ...prev, isLoading: false }));
+        }
         throw error;
       }
     },
-    [client],
+    [client, clearSession],
   );
 
   const logout = useCallback(async (): Promise<void> => {

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -8,7 +8,12 @@
 
 /**
  * Representação do usuário autenticado tal como devolvido pelo
- * `lfc-authenticator` no payload de login.
+ * `lfc-authenticator` no payload de `verify-token`.
+ *
+ * `identity` é o discriminador numérico do registro do usuário no
+ * backend — necessário para chamadas que referenciam o usuário por
+ * número (ex.: auditoria/admin) e mantido como `number` por simetria
+ * com o contrato real do `auth-service`.
  *
  * Campos opcionais (`avatarUrl`, `roles`) são tolerados para evitar
  * acoplamento prematuro a um shape exato — a UI sempre deve degradar
@@ -18,6 +23,7 @@ export interface User {
   id: string;
   name: string;
   email: string;
+  identity: number;
   avatarUrl?: string;
   roles?: ReadonlyArray<string>;
 }
@@ -38,32 +44,44 @@ export interface AuthState {
 }
 
 /**
- * Payload retornado pelo endpoint de login.
+ * Payload retornado pelo endpoint `POST /auth/login`.
  *
- * Mantido como tipo exportado para que mocks/testes e a futura
- * integração com `Auth API` compartilhem o mesmo contrato.
+ * O `lfc-authenticator` retorna apenas `{ token }`; o perfil do usuário
+ * e o catálogo de permissões vêm em uma chamada subsequente a
+ * `GET /auth/verify-token`. Manter este tipo enxuto evita que call sites
+ * passem a depender de campos que o backend nunca enviou.
  */
 export interface LoginResponse {
   token: string;
-  user: User;
-  permissions: ReadonlyArray<string>;
 }
 
 /**
  * Payload retornado pelo endpoint `GET /auth/verify-token`.
  *
- * O token continua sendo o mesmo já enviado em `Authorization`; o backend
- * apenas confirma sua validade e devolve o snapshot atual de `user` e
- * `permissions` — permitindo que o frontend reaja a mudanças server-side
- * (role atualizada, permissões revogadas) sem exigir novo login.
+ * Shape achatado, espelhando exatamente o contrato real do
+ * `auth-service`:
  *
- * O contrato é deliberadamente um subset de `LoginResponse`: caso o
- * backend evolua para incluir `token` (rotacionado), bastará trocar o
- * tipo abaixo sem impactar a forma como o Provider consome.
+ * - `id`, `name`, `email`, `identity` formam o perfil completo do
+ *   usuário autenticado (mapeados para `User` antes de armazenar);
+ * - `permissions` é uma lista de **GUIDs** internos do backend —
+ *   carregamos no tipo por simetria e diagnóstico, mas o frontend
+ *   nunca os usa diretamente em `hasPermission`;
+ * - `routeCodes` é a lista de códigos semânticos usados por
+ *   `hasPermission()` (ex.: `Systems.Read`). É essa lista que o
+ *   Provider persiste como `permissions` no estado/storage.
+ *
+ * O token continua sendo o mesmo já enviado em `Authorization`; o
+ * backend apenas confirma sua validade e devolve o snapshot atual do
+ * usuário — permitindo que o frontend reaja a mudanças server-side
+ * (role atualizada, permissões revogadas) sem exigir novo login.
  */
 export interface VerifyTokenResponse {
-  user: User;
+  id: string;
+  name: string;
+  email: string;
+  identity: number;
   permissions: ReadonlyArray<string>;
+  routeCodes: ReadonlyArray<string>;
 }
 
 /**

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ApiClient, ApiError } from '@/shared/api';
-import type { LoginResponse } from '@/shared/auth';
+import type { LoginResponse, VerifyTokenResponse } from '@/shared/auth';
 
 import { LoginPage } from '@/pages/LoginPage';
 import { AuthProvider } from '@/shared/auth';
@@ -18,6 +18,7 @@ import { AuthProvider } from '@/shared/auth';
  */
 function createClientStub(): ApiClient & {
   post: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
   setAuth: ReturnType<typeof vi.fn>;
 } {
   return {
@@ -30,18 +31,27 @@ function createClientStub(): ApiClient & {
     setAuth: vi.fn(),
   } as unknown as ApiClient & {
     post: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
     setAuth: ReturnType<typeof vi.fn>;
   };
 }
 
 const SAMPLE_LOGIN: LoginResponse = {
   token: 'jwt-xyz',
-  user: {
-    id: 'u-1',
-    name: 'Ada Lovelace',
-    email: 'ada@lfc.com.br',
-  },
-  permissions: ['Systems.Read'],
+};
+
+/**
+ * Resposta de `verify-token` usada nos cenários de submit feliz —
+ * espelha o contrato real do `auth-service` (achatado, com `routeCodes`
+ * separado de `permissions`/Guid[]).
+ */
+const SAMPLE_VERIFY: VerifyTokenResponse = {
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  email: 'ada@lfc.com.br',
+  identity: 42,
+  permissions: ['11111111-1111-1111-1111-111111111111'],
+  routeCodes: ['Systems.Read'],
 };
 
 type ClientStub = ReturnType<typeof createClientStub>;
@@ -164,7 +174,10 @@ describe('LoginPage — validação client-side', () => {
 describe('LoginPage — submit feliz', () => {
   it('chama login com credenciais e redireciona para /systems por padrão', async () => {
     const client = createClientStub();
+    // Login encadeia POST /auth/login + GET /auth/verify-token; ambos
+    // precisam estar mockados para o submit feliz completar.
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     renderLogin({ client });
 
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
@@ -188,6 +201,7 @@ describe('LoginPage — submit feliz', () => {
   it('redireciona para a rota original preservada em location.state.from', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     renderLogin({
       client,
       initialEntries: [
@@ -209,6 +223,7 @@ describe('LoginPage — submit feliz', () => {
   it('faz trim do e-mail antes de submeter', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     renderLogin({ client });
 
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
@@ -325,6 +340,9 @@ describe('LoginPage — estado loading', () => {
     });
     const client = createClientStub();
     client.post.mockReturnValueOnce(pending);
+    // `verify-token` resolve imediatamente assim que for chamado (após
+    // `resolveLogin` liberar a 1ª etapa).
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     renderLogin({ client });
 
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
@@ -349,6 +367,7 @@ describe('LoginPage — já autenticado', () => {
   it('redireciona imediatamente para /systems quando sessão já está ativa', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     renderLogin({ client });
 
     fireEvent.change(screen.getByLabelText(/E-mail/i), {

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -92,22 +92,60 @@ function lastCall<T>(mockCalls: ReadonlyArray<T>): T | undefined {
 
 const SAMPLE_LOGIN: LoginResponse = {
   token: 'jwt-xyz',
-  user: {
-    id: 'u-1',
-    name: 'Ada Lovelace',
-    email: 'ada@lfc.com.br',
-  },
-  permissions: ['Systems.Read', 'Systems.Create'],
 };
 
-const VERIFY_RESPONSE: VerifyTokenResponse = {
-  user: {
-    id: 'u-1',
-    name: 'Ada Lovelace',
-    email: 'ada@lfc.com.br',
-  },
-  permissions: ['Systems.Read', 'Systems.Create', 'Systems.Update'],
+/**
+ * Perfil retornado por `verify-token` logo após o login feliz —
+ * espelha o contrato real do `auth-service` (id/name/email/identity +
+ * permissions/Guid[] + routeCodes/string[]).
+ *
+ * Usado também em testes de hidratação otimista após reload.
+ */
+const SAMPLE_VERIFY: VerifyTokenResponse = {
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  email: 'ada@lfc.com.br',
+  identity: 42,
+  permissions: ['11111111-1111-1111-1111-111111111111'],
+  routeCodes: ['Systems.Read', 'Systems.Create'],
 };
+
+/**
+ * Espelho do `User` projetado pelo Provider a partir de `SAMPLE_VERIFY`.
+ * Centraliza o shape esperado pela maioria dos asserts.
+ */
+const SAMPLE_USER = {
+  id: SAMPLE_VERIFY.id,
+  name: SAMPLE_VERIFY.name,
+  email: SAMPLE_VERIFY.email,
+  identity: SAMPLE_VERIFY.identity,
+};
+
+const SAMPLE_PERMISSIONS = SAMPLE_VERIFY.routeCodes;
+
+/**
+ * Resposta de `verify-token` para a revalidação periódica — simula o
+ * cenário em que o backend acrescentou um `routeCode` (por exemplo, uma
+ * permissão recém-concedida) e o Provider precisa refletir o snapshot
+ * atualizado.
+ */
+const VERIFY_RESPONSE: VerifyTokenResponse = {
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  email: 'ada@lfc.com.br',
+  identity: 42,
+  permissions: ['11111111-1111-1111-1111-111111111111'],
+  routeCodes: ['Systems.Read', 'Systems.Create', 'Systems.Update'],
+};
+
+const VERIFY_USER = {
+  id: VERIFY_RESPONSE.id,
+  name: VERIFY_RESPONSE.name,
+  email: VERIFY_RESPONSE.email,
+  identity: VERIFY_RESPONSE.identity,
+};
+
+const VERIFY_PERMISSIONS = VERIFY_RESPONSE.routeCodes;
 
 const UNAUTHORIZED_ERROR: ApiError = {
   kind: 'http',
@@ -124,14 +162,18 @@ const NETWORK_ERROR: ApiError = {
 /**
  * Pré-popula `localStorage` para simular sessão persistida — usado nos
  * testes de hidratação remota.
+ *
+ * O shape gravado espelha o `PersistedSession` real (User com `identity`
+ * + permissions = routeCodes), de modo que os testes leiam exatamente
+ * o que o Provider gravou em sessões anteriores.
  */
 function seedPersistedSession(): void {
   window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
   window.localStorage.setItem(
     STORAGE_KEYS.user,
     JSON.stringify({
-      user: SAMPLE_LOGIN.user,
-      permissions: SAMPLE_LOGIN.permissions,
+      user: SAMPLE_USER,
+      permissions: SAMPLE_PERMISSIONS,
     }),
   );
 }
@@ -194,9 +236,10 @@ describe('AuthProvider — estado inicial', () => {
 });
 
 describe('AuthProvider — login', () => {
-  test('caminho feliz: atualiza estado e dispara POST /auth/login', async () => {
+  test('caminho feliz: encadeia POST /auth/login + GET /auth/verify-token e popula estado', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -210,8 +253,11 @@ describe('AuthProvider — login', () => {
       email: 'ada@lfc.com.br',
       password: 'secret',
     });
-    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
-    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(client.get).toHaveBeenCalledWith('/auth/verify-token');
+    // `permissions` no estado é o catálogo de `routeCodes`, não os GUIDs
+    // brutos retornados em `verify-token.permissions`.
+    expect(result.current.user).toEqual(SAMPLE_USER);
+    expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.isLoading).toBe(false);
   });
@@ -219,6 +265,7 @@ describe('AuthProvider — login', () => {
   test('após login, getToken injetado no client retorna o token recebido', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -230,6 +277,32 @@ describe('AuthProvider — login', () => {
 
     const latest = lastCall(client.setAuth.mock.calls)?.[0];
     expect(latest?.getToken?.()).toBe('jwt-xyz');
+  });
+
+  test('tokenRef é setado ANTES do verify-token (header Authorization presente)', async () => {
+    // Asserção crítica do contrato: o `verify-token` precisa ler o token
+    // recém-recebido via `getToken()` para que o cliente HTTP injete
+    // `Authorization: Bearer ...`. Capturamos o valor de `getToken()` no
+    // momento exato da chamada `client.get`.
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+
+    let tokenAtVerify: string | null | undefined;
+    client.get.mockImplementationOnce(async () => {
+      tokenAtVerify = lastCall(client.setAuth.mock.calls)?.[0]?.getToken?.();
+      return SAMPLE_VERIFY;
+    });
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login('ada@lfc.com.br', 'secret');
+    });
+
+    expect(tokenAtVerify).toBe('jwt-xyz');
   });
 
   test('falha de credenciais propaga ApiError e mantém estado deslogado', async () => {
@@ -255,6 +328,78 @@ describe('AuthProvider — login', () => {
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
     expect(result.current.isLoading).toBe(false);
+    // `verify-token` nunca chega a ser chamado quando o login rejeita.
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  test('falha no verify-token pós-login limpa sessão parcial e propaga erro', async () => {
+    // Cenário: backend aceitou as credenciais mas a chamada subsequente
+    // a `verify-token` falhou (ex.: rede caiu, 5xx, payload corrompido).
+    // O Provider já tinha aceitado o token em `tokenRef`; precisa
+    // limpar tudo (storage + ref + state) para não deixar um header
+    // `Authorization` pendurado em chamadas seguintes.
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockRejectedValueOnce(apiError);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Capturamos a rejection diretamente — `await expect(act(..)).rejects`
+    // pode liberar antes do bloco `finally` interno do Provider rodar
+    // sob certas timings, gerando race com asserts subsequentes em
+    // `tokenRef`.
+    let captured: unknown;
+    await act(async () => {
+      try {
+        await result.current.login('ada@lfc.com.br', 'secret');
+      } catch (e) {
+        captured = e;
+      }
+    });
+
+    expect(captured).toMatchObject({ kind: 'network' });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.permissions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+
+    // Storage limpo — a sessão parcial (token sem perfil) foi descartada.
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEYS.user)).toBeNull();
+
+    // Token injetado no client também foi zerado.
+    const latest = lastCall(client.setAuth.mock.calls)?.[0];
+    expect(latest?.getToken?.()).toBeNull();
+  });
+
+  test('verify-token com payload inválido pós-login limpa sessão e propaga ApiError(parse)', async () => {
+    const client = createClientStub();
+    client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    // Resposta sem campos obrigatórios — o type guard deve rejeitar.
+    client.get.mockResolvedValueOnce({ permissions: [] } as unknown);
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let captured: unknown;
+    await act(async () => {
+      try {
+        await result.current.login('ada@lfc.com.br', 'secret');
+      } catch (e) {
+        captured = e;
+      }
+    });
+
+    expect(captured).toMatchObject({ kind: 'parse' });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 });
 
@@ -262,7 +407,10 @@ describe('AuthProvider — logout', () => {
   test('limpa estado e zera token após logout', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
-    client.get.mockResolvedValueOnce({ message: 'Sessão encerrada.' });
+    // 1ª chamada: verify-token do login encadeado; 2ª: logout remoto.
+    client.get
+      .mockResolvedValueOnce(SAMPLE_VERIFY)
+      .mockResolvedValueOnce({ message: 'Sessão encerrada.' });
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -286,7 +434,9 @@ describe('AuthProvider — logout', () => {
   test('chama GET /auth/logout para invalidar tokenVersion remoto (Issue #55)', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
-    client.get.mockResolvedValueOnce({ message: 'Sessão encerrada.' });
+    client.get
+      .mockResolvedValueOnce(SAMPLE_VERIFY)
+      .mockResolvedValueOnce({ message: 'Sessão encerrada.' });
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -323,7 +473,10 @@ describe('AuthProvider — logout', () => {
   test('falha de rede no logout remoto ainda limpa estado e storage', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
-    client.get.mockRejectedValueOnce(NETWORK_ERROR);
+    // 1ª chamada: verify-token (login feliz); 2ª: logout falha por rede.
+    client.get
+      .mockResolvedValueOnce(SAMPLE_VERIFY)
+      .mockRejectedValueOnce(NETWORK_ERROR);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     const { result } = renderHook(() => useAuth(), {
@@ -339,7 +492,7 @@ describe('AuthProvider — logout', () => {
       await result.current.logout();
     });
 
-    expect(client.get).toHaveBeenCalledWith('/auth/logout');
+    expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
     expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
@@ -352,13 +505,16 @@ describe('AuthProvider — logout', () => {
   test('logout em 401 (já deslogado no backend) limpa local sem warning', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
-    // Simula o comportamento real do client HTTP em 401: dispara
-    // `onUnauthorized` (que limpa sessão) e rejeita com ApiError.
-    client.get.mockImplementationOnce(async () => {
-      const config = lastCall(client.setAuth.mock.calls)?.[0];
-      config?.onUnauthorized?.();
-      throw UNAUTHORIZED_ERROR;
-    });
+    // 1ª chamada: verify-token do login feliz; 2ª: logout em 401.
+    client.get
+      .mockResolvedValueOnce(SAMPLE_VERIFY)
+      .mockImplementationOnce(async () => {
+        // Simula o comportamento real do client HTTP em 401: dispara
+        // `onUnauthorized` (que limpa sessão) e rejeita com ApiError.
+        const config = lastCall(client.setAuth.mock.calls)?.[0];
+        config?.onUnauthorized?.();
+        throw UNAUTHORIZED_ERROR;
+      });
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     const { result } = renderHook(() => useAuth(), {
@@ -373,7 +529,7 @@ describe('AuthProvider — logout', () => {
       await result.current.logout();
     });
 
-    expect(client.get).toHaveBeenCalledWith('/auth/logout');
+    expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
     expect(result.current.isAuthenticated).toBe(false);
     expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
     // 401 é silencioso: o usuário já estava deslogado de qualquer forma.
@@ -526,6 +682,7 @@ describe('AuthProvider — hasPermission', () => {
   test('retorna true para permissões presentes após login', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -544,6 +701,7 @@ describe('AuthProvider — onUnauthorized', () => {
   test('callback injetado no client limpa sessão quando disparado', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -608,6 +766,7 @@ describe('AuthProvider — persistência (Issue #53)', () => {
   test('login persiste token e user em localStorage', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -620,18 +779,23 @@ describe('AuthProvider — persistência (Issue #53)', () => {
     expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-xyz');
     const userJson = window.localStorage.getItem(STORAGE_KEYS.user);
     expect(userJson).not.toBeNull();
+    // Storage espelha a projeção que o Provider faz: User com `identity`
+    // e permissions = routeCodes (nunca os GUIDs brutos).
     expect(JSON.parse(userJson as string)).toEqual({
-      user: SAMPLE_LOGIN.user,
-      permissions: SAMPLE_LOGIN.permissions,
+      user: SAMPLE_USER,
+      permissions: SAMPLE_PERMISSIONS,
     });
   });
 
   test('logout limpa ambas as chaves do localStorage', async () => {
-    // Estado inicial: sessão já hidratada do storage.
+    // Estado inicial: sessão já hidratada do storage. A 1ª chamada
+    // a `client.get` é a hidratação otimista; a 2ª, o logout remoto.
     seedPersistedSession();
 
     const client = createClientStub();
-    client.get.mockResolvedValueOnce(VERIFY_RESPONSE);
+    client.get
+      .mockResolvedValueOnce(VERIFY_RESPONSE)
+      .mockResolvedValueOnce({ message: 'Sessão encerrada.' });
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -650,6 +814,7 @@ describe('AuthProvider — persistência (Issue #53)', () => {
   test('callback onUnauthorized (401) limpa localStorage', async () => {
     const client = createClientStub();
     client.post.mockResolvedValueOnce(SAMPLE_LOGIN);
+    client.get.mockResolvedValueOnce(SAMPLE_VERIFY);
     const { result } = renderHook(() => useAuth(), {
       wrapper: makeWrapper(client),
     });
@@ -685,16 +850,18 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
     // e isLoading=true sinalizando revalidação em curso.
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.isLoading).toBe(true);
-    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
 
-    // Após o verify-token resolver, permissões são atualizadas.
+    // Após o verify-token resolver, permissões são atualizadas com o
+    // snapshot fresco — `routeCodes` é a fonte da verdade para o que
+    // o frontend chama de `permissions`.
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(client.get).toHaveBeenCalledWith(
       '/auth/verify-token',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
-    expect(result.current.permissions).toEqual(VERIFY_RESPONSE.permissions);
-    expect(result.current.user).toEqual(VERIFY_RESPONSE.user);
+    expect(result.current.permissions).toEqual(VERIFY_PERMISSIONS);
+    expect(result.current.user).toEqual(VERIFY_USER);
   });
 
   test('sem sessão local, NÃO chama verify-token no mount', async () => {
@@ -745,8 +912,8 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
     // Sessão local preservada — usuário continua autenticado com último
     // snapshot conhecido.
     expect(result.current.isAuthenticated).toBe(true);
-    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
-    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(result.current.user).toEqual(SAMPLE_USER);
+    expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
     expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-persistido');
     expect(warnSpy).toHaveBeenCalled();
 
@@ -756,7 +923,8 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
   test('verify-token com payload inválido mantém sessão local', async () => {
     seedPersistedSession();
     const client = createClientStub();
-    // Resposta sem `user` válido — Provider deve descartar silenciosamente.
+    // Resposta sem `id`/`name`/`email`/`identity`/`routeCodes` válidos —
+    // Provider deve descartar silenciosamente e manter sessão local.
     client.get.mockResolvedValueOnce({ permissions: [] } as unknown);
 
     const { result } = renderHook(() => useAuth(), {
@@ -765,8 +933,8 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isAuthenticated).toBe(true);
-    expect(result.current.user).toEqual(SAMPLE_LOGIN.user);
-    expect(result.current.permissions).toEqual(SAMPLE_LOGIN.permissions);
+    expect(result.current.user).toEqual(SAMPLE_USER);
+    expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
   });
 
   test('revalidação periódica chama verify-token a cada tick', async () => {

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -40,13 +40,32 @@ function createClientStub(): ApiClient & {
   };
 }
 
+/**
+ * Espelha o contrato real do `auth-service`: payload achatado com
+ * `id/name/email/identity` + `permissions: Guid[]` + `routeCodes: string[]`.
+ * Mantemos o tipo aqui apenas para documentar o shape; nenhum teste
+ * deste arquivo dispara o verify-token de fato (o stub de `client.get`
+ * devolve Promise pendente por padrão para evitar setState pós-assert).
+ */
 const VERIFY_RESPONSE: VerifyTokenResponse = {
-  user: {
-    id: 'u-1',
-    name: 'Ada Lovelace',
-    email: 'ada@lfc.com.br',
-  },
-  permissions: ['Systems.Read'],
+  id: 'u-1',
+  name: 'Ada Lovelace',
+  email: 'ada@lfc.com.br',
+  identity: 42,
+  permissions: ['11111111-1111-1111-1111-111111111111'],
+  routeCodes: ['Systems.Read'],
+};
+
+/**
+ * Projeção de `User` derivada do verify (id/name/email/identity) — usada
+ * nos asserts e no seed do `localStorage` para garantir que o shape
+ * gravado bate com o que o Provider espera ler na hidratação.
+ */
+const VERIFY_USER = {
+  id: VERIFY_RESPONSE.id,
+  name: VERIFY_RESPONSE.name,
+  email: VERIFY_RESPONSE.email,
+  identity: VERIFY_RESPONSE.identity,
 };
 
 /**
@@ -59,7 +78,7 @@ function seedSession(permissions: ReadonlyArray<string> = ['Systems.Read']): voi
   window.localStorage.setItem(
     STORAGE_KEYS.user,
     JSON.stringify({
-      user: VERIFY_RESPONSE.user,
+      user: VERIFY_USER,
       permissions,
     }),
   );
@@ -205,7 +224,7 @@ describe('RequireAuth', () => {
     // não bloquear a árvore (a splash do Provider cobre o intervalo em
     // produção; aqui usamos `disableSplash` para testar o guard isolado).
     const value: AuthContextValue = {
-      user: { id: 'u-1', name: 'Ada', email: 'ada@lfc.com.br' },
+      user: { id: 'u-1', name: 'Ada', email: 'ada@lfc.com.br', identity: 42 },
       permissions: ['Systems.Read'],
       isAuthenticated: true,
       isLoading: true,

--- a/tests/shared/auth/storage.test.ts
+++ b/tests/shared/auth/storage.test.ts
@@ -15,6 +15,7 @@ const SAMPLE_SESSION: PersistedSession = {
     id: 'u-1',
     name: 'Ada Lovelace',
     email: 'ada@lfc.com.br',
+    identity: 42,
   },
   permissions: ['Systems.Read', 'Systems.Create'],
 };


### PR DESCRIPTION
## Contexto

Durante a integração com o `lfc-authenticator` (rodando local em `http://localhost:8080/api/v1`) com o usuário seedado `root@email.com.br`, identificamos divergência entre o que o `AuthContext` esperava e o que o backend de fato retorna.

| Endpoint | Resposta real |
|---|---|
| `POST /auth/login` | `{ token: string }` |
| `GET /auth/verify-token` | `{ id, name, email, identity, permissions: Guid[], routeCodes: string[] }` |
| `GET /auth/logout` | `{ message: string }` |

`login()` assumia receber `{token, user, permissions}` em uma única chamada — gap reportado na Issue #100.

## Objetivo

Adaptar o `AuthContext` ao contrato real do `auth-service`, encadeando duas chamadas no login, distinguindo `permissions: Guid[]` de `routeCodes: string[]` (o frontend usa apenas o segundo) e adicionando o campo `identity: number` ao `User`.

## O que foi feito

### `src/shared/auth/types.ts`
- `User` ganhou `identity: number`.
- `LoginResponse` reduzido a `{ token: string }`.
- `VerifyTokenResponse` agora reflete o payload achatado real (`id`, `name`, `email`, `identity`, `permissions: ReadonlyArray<string>`, `routeCodes: ReadonlyArray<string>`).

### `src/shared/auth/AuthContext.tsx`
- `login(email, password)` encadeia:
  1. `POST /auth/login` → recebe `{ token }`.
  2. `tokenRef.current = token` **antes** do verify (pré-condição para o cliente HTTP injetar `Authorization: Bearer`).
  3. `GET /auth/verify-token` → projeta o payload em `User` (com `identity`) e usa `routeCodes` como catálogo de `permissions`.
  4. Persiste em `localStorage` antes de `setState` (evita sessão "viva em memória, morta em disco").
- Falha pós-login (rede, 401, payload inválido) chama `clearSession()` para zerar `tokenRef` + storage + state, e re-lança o erro tipado.
- A hidratação remota (Issue #54) e a revalidação periódica também passaram a popular `permissions` com `routeCodes` (não com os GUIDs brutos).
- `isValidVerifyTokenResponse` reescrito para o novo shape achatado; helper `toUser()` centraliza a projeção.

### `.env.example`
- `VITE_AUTH_API_BASE_URL` corrigido de `https://localhost:8080/api/v1` para `http://localhost:8080/api/v1` (backend local não tem TLS).

### Testes
- `tests/shared/auth/AuthProvider.test.tsx`: fixtures atualizadas (`SAMPLE_LOGIN = { token }`, `SAMPLE_VERIFY` com shape real); cada cenário de login feliz mocka `client.post` + `client.get`; cenários de logout/onUnauthorized/persistência seguem o mesmo padrão.
  - **Novos testes:**
    - `tokenRef` setado ANTES do verify-token (prova o ordering crítico do header `Authorization`).
    - Falha de rede no verify-token pós-login limpa sessão parcial e propaga `ApiError`.
    - Payload inválido pós-login propaga `ApiError(parse)` e limpa storage/ref/state.
- `tests/pages/LoginPage.test.tsx`: cada cenário de submit feliz mocka ambas as chamadas; o teste de `aria-busy` também adiciona mock de verify-token para o login completar após `resolveLogin`.
- `tests/shared/auth/guards.test.tsx` e `tests/shared/auth/storage.test.ts`: fixtures atualizadas para `User` com `identity`.

## Decisões não óbvias

1. **`isValidVerifyTokenResponse` exige `permissions` como array, mesmo sem usá-lo.** É simetria com o backend e blindagem contra divergência silenciosa de versão; o catálogo consumido por `hasPermission()` continua sendo `routeCodes`.
2. **Falha pós-login → `clearSession()` total, não apenas `setState`.** Sem isso, `tokenRef` permaneceria "vivo" e a próxima chamada arbitrária ao backend sairia com `Authorization` inválido, levando a 401s espúrios e ciclo de redirect.
3. **Pattern `try/catch` interno do `act` nos novos testes.** O combo `await expect(act(async)).rejects` em Vitest pode resolver antes do `setState` interno do Provider terminar de propagar, causando race nos asserts subsequentes que leem `tokenRef`. O padrão `let captured; await act(async () => { try { ... } catch (e) { captured = e; } })` força o flush completo antes do assert.

## Arquivos impactados

- `.env.example`
- `src/shared/auth/types.ts`
- `src/shared/auth/AuthContext.tsx`
- `tests/shared/auth/AuthProvider.test.tsx`
- `tests/shared/auth/guards.test.tsx`
- `tests/shared/auth/storage.test.ts`
- `tests/pages/LoginPage.test.tsx`

## Test plan

- [x] `docker compose exec -T web npm run lint` — clean
- [x] `docker compose exec -T web npm run typecheck` — clean
- [x] `docker compose exec -T web npm run test` — **230/230 passing** (24 arquivos)
- [x] `docker compose exec -T web npm run build` — `✓ built in 5.18s`
- [ ] Validação manual contra `localhost:8080` com `root@email.com.br` / `toor` (recomendada após merge; container precisa de `docker compose restart web` para o Vite recarregar `.env`).

## Visual

Nenhuma alteração visual — escopo puramente de contrato/lógica de auth.

## Segurança

- Token nunca logado em console (debug logs removidos antes do commit).
- `try/catch` defensivo em todas as transições de sessão.
- Falha pós-login limpa estado antes de propagar erro (não vaza header `Authorization` para chamadas subsequentes).
- Sem `any`; sem `as any` para silenciar tipos.

## Riscos

- Frontend agora exige que o backend retorne **exatamente** `{ id, name, email, identity, routeCodes }` em verify-token. Divergência → o type guard rejeita e o Provider mantém a sessão local sem atualizar (com warning) ou propaga `ApiError(parse)` no login. Comportamento intencional.

## Issue relacionada

Closes #100