### PR TITLE
feat: logo authenticator com proporcao balanceada (#104)

### DIFF
--- a/src/assets/logo-dark.svg
+++ b/src/assets/logo-dark.svg
@@ -1,11 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 48" fill="none">
-  
-  <rect x="1" y="1" width="46" height="46" rx="10" stroke="#16240F" stroke-width="1.5"></rect>
-  
-  <circle cx="24" cy="24" r="2.5" fill="#16240F"></circle>
-  <path d="M17.5 24 C17.5 20 20.5 17 24 17 C27.5 17 30.5 20 30.5 24 C30.5 27 28.5 29.5 26 30.5" stroke="#16240F" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  <path d="M14 24 C14 16.8 18.3 12 24 12 C29.7 12 34 16.8 34 24 C34 28.5 31.5 32.5 27.5 34.5" stroke="#16240F" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  <path d="M10.5 24 C10.5 13.5 16.5 8 24 8 C31.5 8 37.5 13.5 37.5 24 C37.5 30 34 36 28.5 38.5" stroke="#16240F" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  
-  <text x="58" y="30" font-family="Inter, sans-serif" font-size="16" font-weight="400" letter-spacing="-0.02em" fill="#16240F">authenticator</text>
+  <rect x="6" y="6" width="36" height="36" rx="8" stroke="#16240F" stroke-width="1.5"></rect>
+  <circle cx="24" cy="24" r="2" fill="#16240F"></circle>
+  <path d="M19 24 C19 21 21.5 18.7 24 18.7 C26.5 18.7 29 21 29 24 C29 26.3 27.5 28.2 25.5 29" stroke="#16240F" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <path d="M16.3 24 C16.3 18.5 19.7 14.7 24 14.7 C28.3 14.7 31.7 18.5 31.7 24 C31.7 27.5 29.7 30.6 26.7 32.2" stroke="#16240F" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <path d="M13.6 24 C13.6 15.7 18.2 11.5 24 11.5 C29.8 11.5 34.4 15.7 34.4 24 C34.4 28.7 31.7 33.4 27.5 35.4" stroke="#16240F" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <text x="52" y="32" font-family="Inter, sans-serif" font-size="22" font-weight="600" letter-spacing="-0.02em" fill="#16240F">authenticator</text>
 </svg>

--- a/src/assets/logo-white.svg
+++ b/src/assets/logo-white.svg
@@ -1,11 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 48" fill="none">
-  
-  <rect x="1" y="1" width="46" height="46" rx="10" stroke="#AECA59" stroke-width="1.5"></rect>
-  
-  <circle cx="24" cy="24" r="2.5" fill="#AECA59"></circle>
-  <path d="M17.5 24 C17.5 20 20.5 17 24 17 C27.5 17 30.5 20 30.5 24 C30.5 27 28.5 29.5 26 30.5" stroke="#AECA59" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  <path d="M14 24 C14 16.8 18.3 12 24 12 C29.7 12 34 16.8 34 24 C34 28.5 31.5 32.5 27.5 34.5" stroke="#AECA59" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  <path d="M10.5 24 C10.5 13.5 16.5 8 24 8 C31.5 8 37.5 13.5 37.5 24 C37.5 30.5 34 36 28.5 38.5" stroke="#AECA59" stroke-width="1.3" stroke-linecap="round" fill="none"></path>
-  
-  <text x="58" y="30" font-family="Inter, sans-serif" font-size="16" font-weight="400" letter-spacing="-0.02em" fill="#E2EDD0">authenticator</text>
+  <rect x="6" y="6" width="36" height="36" rx="8" stroke="#AECA59" stroke-width="1.5"></rect>
+  <circle cx="24" cy="24" r="2" fill="#AECA59"></circle>
+  <path d="M19 24 C19 21 21.5 18.7 24 18.7 C26.5 18.7 29 21 29 24 C29 26.3 27.5 28.2 25.5 29" stroke="#AECA59" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <path d="M16.3 24 C16.3 18.5 19.7 14.7 24 14.7 C28.3 14.7 31.7 18.5 31.7 24 C31.7 27.5 29.7 30.6 26.7 32.2" stroke="#AECA59" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <path d="M13.6 24 C13.6 15.7 18.2 11.5 24 11.5 C29.8 11.5 34.4 15.7 34.4 24 C34.4 28.7 31.7 33.4 27.5 35.4" stroke="#AECA59" stroke-width="1.2" stroke-linecap="round" fill="none"></path>
+  <text x="52" y="32" font-family="Inter, sans-serif" font-size="22" font-weight="600" letter-spacing="-0.02em" fill="#E2EDD0">authenticator</text>
 </svg>


### PR DESCRIPTION
## Contexto

A logo SVG (`logo-dark.svg` / `logo-white.svg`) usada na Sidebar, na LoginPage e no Showcase apresentava desproporção visual: o ícone (rect 46x46) dominava enquanto o texto `authenticator` (font-size 16) ficava pequeno e secundário.

## Objetivo

Reequilibrar o ícone e o texto preservando viewBox, paleta de cores e contratos de altura usados pelos consumidores.

## O que foi feito

- **Ícone reduzido** de 46x46 para 36x36 dentro do viewBox `0 0 200 48` (`x=6, y=6, rx=8`), mantendo o centro em (24, 24).
- **Ondas concêntricas e ponto central** reescaladas proporcionalmente (~78% do raio original); ponto central com `r=2` e ondas com `stroke-width=1.2`.
- **Texto** `authenticator` aumentado para `font-size: 22` com `font-weight: 600` (semibold), preservando `letter-spacing: -0.02em`.
- **Gap** entre ícone e texto ajustado para `x=52` (de 11px para ~10px de respiro a partir da borda do rect, agora mais limpo com o ícone menor).
- **Cores preservadas**: `#16240F` (forest, dark) e `#AECA59` + `#E2EDD0` (lime + cream, white).
- **viewBox preservado** (`0 0 200 48`) — contratos `height={28|38|56}` no Sidebar/LoginPage/Showcase continuam válidos.

### Antes / Depois

| Atributo | Antes | Depois |
|---|---|---|
| `rect` ícone | 46x46 (`x=1, y=1, rx=10`) | 36x36 (`x=6, y=6, rx=8`) |
| Texto `font-size` | 16 | 22 |
| Texto `font-weight` | 400 | 600 |
| Texto `x` | 58 | 52 |
| Stroke das ondas | 1.3 | 1.2 |
| Raio do ponto | 2.5 | 2 |

## Arquivos impactados

- `src/assets/logo-dark.svg`
- `src/assets/logo-white.svg`

## Testes

- `docker compose exec -T web npm run lint` — verde
- `docker compose exec -T web npm run typecheck` — verde
- `docker compose exec -T web npm run test` — 230 passed (24 suites)
- `docker compose exec -T web npm run build` — verde

Os testes existentes que verificam fill (`#16240F` em `logo-dark`, `#AECA59` em `logo-white`) continuam válidos: as cores foram preservadas, apenas a geometria mudou.

## Visual

- Ícone passou de ~96% da altura do viewBox para ~75%, deixando o conjunto visualmente equilibrado.
- Texto `authenticator` agora tem peso e tamanho compatíveis com a presença do ícone, sem disputa hierárquica.
- Ambos os assets continuam respeitando os fundos canônicos: `logo-dark.svg` sobre claro, `logo-white.svg` sobre escuro (Sidebar troca em runtime via `useTheme().resolvedTheme`).

## Segurança

Sem impacto. Apenas alteração geométrica em assets estáticos (sem mudança de fonte de dados, sem mudança de import, sem novos consumidores).

## Riscos

- Baixos. Mantida a estrutura do SVG (mesmo viewBox, mesmas cores, mesma estrutura de elementos), o que preserva todos os contratos atuais (`height` em px nos consumidores e asserts de fill nos testes).

## Issue relacionada

Closes #104