### PR TITLE
feat: repaginar login com gradientes, eyebrow e footer (#105)

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import logoForLightTheme from '../assets/logo-dark.svg';
 import logoForDarkTheme from '../assets/logo-white.svg';
-import { Alert, Button, Input, ThemeToggle } from '../components/ui';
+import { Alert, Button, Input, ThemeToggle, useToast } from '../components/ui';
 import { useTheme } from '../hooks/useTheme';
 import { isApiError } from '../shared/api';
 import { useAuth } from '../shared/auth';
@@ -39,6 +39,21 @@ const INVALID_CREDENTIALS_MESSAGE = 'E-mail ou senha inválidos.';
  */
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * Eyebrow exibido acima do título principal — espelha o padrão do
+ * identity kit (`identity/ui_kits/admin-spa/screens.jsx:20`). Mantemos
+ * a string como constante para facilitar evolução futura (ex.: trocar
+ * versão ao subir release).
+ */
+const EYEBROW_TEXT = 'Authenticator · v1.0';
+
+/**
+ * Mensagem do toast disparado pelo botão "Esqueci a senha". Por agora
+ * o fluxo real não está implementado (fora do escopo da #105); o toast
+ * informa o usuário e direciona para o canal humano.
+ */
+const FORGOT_PASSWORD_TOAST = 'Funcionalidade em breve. Contate o administrador.';
+
 interface FormState {
   email: string;
   password: string;
@@ -49,6 +64,11 @@ interface FieldErrors {
   password?: string;
 }
 
+/**
+ * Container raiz — `position: relative` para servir de âncora para a
+ * camada de glow absoluta. `overflow: hidden` corta os gradientes que
+ * vazam fora do viewport.
+ */
 const PageRoot = styled.div`
   min-height: 100vh;
   width: 100%;
@@ -57,24 +77,51 @@ const PageRoot = styled.div`
   align-items: center;
   justify-content: center;
   background: var(--bg-base);
-  padding: var(--space-6) var(--space-4);
+  padding: var(--space-8) var(--space-4);
   position: relative;
+  overflow: hidden;
+`;
+
+/**
+ * Camada decorativa com os dois gradientes radiais. Fica em `inset:
+ * -10%` para que os gradientes "sangrem" para fora do viewport visível
+ * (espelha a referência `.lfc-login__grid` do identity kit).
+ *
+ * `pointer-events: none` é crítico — esta camada é puramente
+ * decorativa e não pode interceptar cliques no card central.
+ */
+const GlowLayer = styled.div`
+  position: absolute;
+  inset: -10%;
+  pointer-events: none;
+  background: var(--login-glow-1), var(--login-glow-2);
+  z-index: var(--z-base);
 `;
 
 /**
  * Toggle de tema posicionado no canto superior direito. Mantém o
  * controle visível antes do login para que o usuário possa ajustar
  * preferência mesmo sem sessão ativa.
+ *
+ * `z-index: var(--z-raised)` garante que fica acima da `GlowLayer`.
  */
 const ThemeSlot = styled.div`
   position: absolute;
   top: var(--space-4);
   right: var(--space-4);
+  z-index: var(--z-raised);
 `;
 
+/**
+ * Wrapper do conteúdo principal. `z-index: var(--z-raised)` mantém o
+ * card e a marca acima da `GlowLayer`. `width: 440px` espelha o kit;
+ * `max-width: 100%` mantém responsividade em telas estreitas.
+ */
 const Container = styled.div`
+  position: relative;
+  z-index: var(--z-raised);
   width: 100%;
-  max-width: var(--measure-cta);
+  max-width: 440px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -85,7 +132,7 @@ const Brand = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
 `;
 
 const Logo = styled.img`
@@ -94,37 +141,80 @@ const Logo = styled.img`
   display: block;
 `;
 
-const BrandTitle = styled.h1`
-  font-family: var(--font-display);
-  font-size: var(--text-lg);
-  font-weight: var(--weight-semibold);
-  color: var(--fg1);
-  letter-spacing: var(--tracking-tight);
-  line-height: var(--leading-tight);
-  margin: 0;
-  text-align: center;
-`;
-
-const BrandSubtitle = styled.p`
-  font-size: var(--text-sm);
-  color: var(--fg2);
-  margin: 0;
-  text-align: center;
-  line-height: var(--leading-snug);
-`;
-
 /**
  * Card customizado em vez do `Card` compartilhado: o componente padrão
  * traz hover/transform que é desejável em listas, mas estranho em uma
  * tela de autenticação onde o foco deve estar 100% no formulário.
+ *
+ * `box-shadow: var(--shadow-modal)` confere a profundidade pedida pela
+ * issue — espelha exatamente o `.lfc-login__card` do identity kit.
  */
 const FormCard = styled.section`
   width: 100%;
   background: var(--bg-surface);
   border: var(--border-thin) solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-6);
-  box-shadow: var(--shadow-sm);
+  padding: var(--space-8);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+
+  /* Em mobile estreito reduz padding interno para não comprimir o
+     conteudo. Threshold espelha --bp-sm (30em, ~480px). */
+  @media (max-width: 30em) {
+    padding: var(--space-6);
+  }
+`;
+
+/**
+ * Eyebrow mono-uppercase tracking-wide acima do `<h1>`. Replica o
+ * `.lfc-eyebrow--accent` do kit (`identity/ui_kits/admin-spa/kit.css:115`).
+ */
+const Eyebrow = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--accent-ink);
+`;
+
+/**
+ * Título principal — semântica `<h1>` (preserva o critério "h1 único").
+ * Tipografia segue o kit: `--text-3xl`, peso 700, tracking-tight.
+ */
+const BrandTitle = styled.h1`
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  color: var(--fg1);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0;
+
+  /* Em telas pequenas reduz para --text-2xl para evitar quebra
+     desconfortavel de linha. */
+  @media (max-width: 30em) {
+    font-size: var(--text-2xl);
+  }
+`;
+
+const BrandSubtitle = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  margin: 0;
+  line-height: var(--leading-snug);
+`;
+
+/**
+ * Bloco de cabeçalho dentro do card — agrupa eyebrow, título e
+ * subtítulo com hierarquia visual coerente.
+ */
+const CardHeader = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 `;
 
 const Form = styled.form`
@@ -133,16 +223,52 @@ const Form = styled.form`
   gap: var(--space-4);
 `;
 
-const SubmitButton = styled(Button)`
-  width: 100%;
+/**
+ * Linha de ações com os dois botões lado a lado. Em mobile estreito
+ * (< `--bp-sm`) os botões empilham para preservar touch target ≥ 44px.
+ */
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+
+  @media (max-width: 30em) {
+    flex-direction: column;
+    align-items: stretch;
+  }
 `;
 
-const Footer = styled.p`
+const PrimaryButton = styled(Button)`
+  flex: 1;
+  min-width: 0;
+`;
+
+const SecondaryButton = styled(Button)`
+  flex-shrink: 0;
+`;
+
+/**
+ * Footer mono que espelha `.lfc-login__meta`. Linha divisória sutil no
+ * topo, fonte mono uppercase tracking-wide, dois itens em
+ * `space-between`. Em mobile empilha para evitar truncamento.
+ */
+const MetaFooter = styled.div`
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: var(--border-thin) solid var(--border-subtle);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--fg3);
-  margin: 0;
-  text-align: center;
-  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+
+  @media (max-width: 30em) {
+    flex-direction: column;
+    gap: var(--space-1);
+  }
 `;
 
 /**
@@ -199,28 +325,41 @@ function buildErrorMessage(error: unknown): string {
 }
 
 /**
+ * Retorna a data corrente em ISO `YYYY-MM-DD`. Mantida como função
+ * separada para ser substituível em testes (vi.spyOn) sem precisar
+ * forçar `vi.useFakeTimers` no caller.
+ */
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
  * Tela de autenticação do painel administrativo.
  *
  * Decisões importantes:
  *
  * 1. **Layout dedicado** — fora do `AppLayout` para esconder Sidebar/
  *    Topbar; o foco visual fica concentrado no Card central.
- * 2. **Redirect-if-authenticated** — quando `isAuthenticated`, evita
+ * 2. **Atmosfera por gradientes radiais** — `GlowLayer` cobre o
+ *    viewport com os tokens `--login-glow-*` (definidos por tema);
+ *    o card flutua sobre essa cena com `--shadow-modal`.
+ * 3. **Redirect-if-authenticated** — quando `isAuthenticated`, evita
  *    flash do form retornando `<Navigate />` antes do JSX principal.
- * 3. **Validação client-side mínima** — o objetivo é evitar requests
+ * 4. **Validação client-side mínima** — o objetivo é evitar requests
  *    obviamente inválidos. A validação canônica é do backend.
- * 4. **Mensagem 401 fixa** — "e-mail ou senha inválidos" sem detalhar,
+ * 5. **Mensagem 401 fixa** — "e-mail ou senha inválidos" sem detalhar,
  *    para não revelar se o e-mail existe (boa prática de segurança).
- * 5. **Foco automático** — primeiro campo recebe foco no mount; melhora
+ * 6. **Foco automático** — primeiro campo recebe foco no mount; melhora
  *    UX em desktop sem prejudicar mobile (foco não abre teclado virtual
  *    automaticamente nos browsers atuais sem interação prévia).
- * 6. **Token em memória** — esta página apenas dispara `useAuth().login`;
- *    a persistência (localStorage + sync entre abas) é feita na Issue
- *    #53.
+ * 7. **"Esqueci a senha"** — placeholder com toast informativo. O
+ *    fluxo real está fora do escopo da #105; o toast direciona para
+ *    contato humano até a feature ser implementada.
  */
 export const LoginPage: React.FC = () => {
   const { login, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { resolvedTheme } = useTheme();
+  const { show: showToast } = useToast();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -299,24 +438,33 @@ export const LoginPage: React.FC = () => {
     }
   };
 
+  const handleForgotPassword = (): void => {
+    showToast(FORGOT_PASSWORD_TOAST, { variant: 'info' });
+  };
+
   const logoSrc = resolvedTheme === 'dark' ? logoForDarkTheme : logoForLightTheme;
 
   return (
     <PageRoot>
+      <GlowLayer aria-hidden="true" />
       <ThemeSlot>
         <ThemeToggle />
       </ThemeSlot>
       <Container>
         <Brand>
           <Logo src={logoSrc} alt="LF Calegari Admin" />
-          <div>
-            <BrandTitle>Acesse sua conta</BrandTitle>
-            <BrandSubtitle>Entre para gerenciar o catálogo do autenticador.</BrandSubtitle>
-          </div>
         </Brand>
 
         <FormCard aria-labelledby="login-form-title">
           <VisuallyHidden id="login-form-title">Formulário de login</VisuallyHidden>
+          <CardHeader>
+            <Eyebrow data-testid="login-eyebrow">{EYEBROW_TEXT}</Eyebrow>
+            <BrandTitle>Entrar no painel</BrandTitle>
+            <BrandSubtitle>
+              Acesso restrito a administradores do ecossistema LFC.
+            </BrandSubtitle>
+          </CardHeader>
+
           <Form onSubmit={handleSubmit} noValidate>
             <Input
               label="E-mail"
@@ -357,20 +505,32 @@ export const LoginPage: React.FC = () => {
               </div>
             )}
 
-            <SubmitButton
-              type="submit"
-              loading={isSubmitting}
-              disabled={isSubmitting}
-              data-testid="login-submit"
-            >
-              {isSubmitting ? 'Entrando…' : 'Entrar'}
-            </SubmitButton>
+            <Actions>
+              <PrimaryButton
+                type="submit"
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                data-testid="login-submit"
+              >
+                {isSubmitting ? 'Entrando…' : 'Entrar'}
+              </PrimaryButton>
+              <SecondaryButton
+                type="button"
+                variant="ghost"
+                onClick={handleForgotPassword}
+                disabled={isSubmitting}
+                data-testid="login-forgot"
+              >
+                Esqueci a senha
+              </SecondaryButton>
+            </Actions>
           </Form>
-        </FormCard>
 
-        <Footer>
-          Acesso restrito a administradores autorizados.
-        </Footer>
+          <MetaFooter data-testid="login-meta">
+            <span>JWT · tokenVersion assinado</span>
+            <span>v1.0 · {todayIso()}</span>
+          </MetaFooter>
+        </FormCard>
       </Container>
     </PageRoot>
   );

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -257,6 +257,27 @@
   --shadow-modal: 0 24px 48px rgba(22, 36, 15, 0.16), 0 4px 12px rgba(22, 36, 15, 0.06),
     0 0 0 1px var(--border-base);
   --shadow-glow: 0 0 24px rgba(174, 202, 89, 0.3), 0 0 48px rgba(174, 202, 89, 0.12);
+
+  /* ── Login glows ─────────────────────────────────────────────
+   * Camadas de gradiente radial usadas como atmosfera de fundo na
+   * tela de autenticação. Espelham o padrão `.lfc-login__grid` do
+   * identity kit. No light, o lime predomina (glow-1) com forest
+   * sutil em diagonal oposta (glow-2); o conjunto produz uma
+   * superfície leve e arejada sem competir com o card central.
+   *
+   * As funções `radial-gradient(...)` ficam embutidas no token
+   * porque o consumidor (`LoginPage`) usa-as diretamente em
+   * `background: var(--login-glow-1), var(--login-glow-2);`. */
+  --login-glow-1: radial-gradient(
+    circle at 70% 30%,
+    rgba(174, 202, 89, 0.14),
+    transparent 55%
+  );
+  --login-glow-2: radial-gradient(
+    circle at 20% 80%,
+    rgba(91, 125, 71, 0.1),
+    transparent 55%
+  );
 }
 
 /* ── Dark theme ─────────────────────────────────────────────
@@ -341,4 +362,21 @@
   --shadow-modal: 0 24px 48px rgba(0, 0, 0, 0.55), 0 4px 12px rgba(0, 0, 0, 0.35),
     0 0 0 1px var(--border-base);
   --shadow-glow: 0 0 24px rgba(174, 202, 89, 0.4), 0 0 48px rgba(174, 202, 89, 0.18);
+
+  /* ── Login glows (dark) ──────────────────────────────────────
+   * No dark, o glow lime fica mais sutil para não competir com a
+   * superfície escura do card; em compensação, o glow forest é
+   * amplificado (alpha 0.20) para criar uma "halo" verde-profundo
+   * em diagonal oposta — a leitura final é de um card flutuando
+   * sobre uma cena com profundidade, não sobre um plano achatado. */
+  --login-glow-1: radial-gradient(
+    circle at 70% 30%,
+    rgba(174, 202, 89, 0.1),
+    transparent 55%
+  );
+  --login-glow-2: radial-gradient(
+    circle at 20% 80%,
+    rgba(91, 125, 71, 0.2),
+    transparent 55%
+  );
 }

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiClient, ApiError } from '@/shared/api';
 import type { LoginResponse, VerifyTokenResponse } from '@/shared/auth';
 
+import { ToastProvider } from '@/components/ui';
 import { LoginPage } from '@/pages/LoginPage';
 import { AuthProvider } from '@/shared/auth';
 
@@ -71,17 +72,19 @@ function renderLogin(options: RenderOptions = {}): { client: ClientStub } {
   render(
     <MemoryRouter initialEntries={options.initialEntries ?? ['/login']}>
       <AuthProvider client={client} verifyIntervalMs={0}>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route
-            path="/systems"
-            element={<div data-testid="systems-page">systems</div>}
-          />
-          <Route
-            path="/permissions"
-            element={<div data-testid="permissions-page">permissions</div>}
-          />
-        </Routes>
+        <ToastProvider>
+          <Routes>
+            <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/systems"
+              element={<div data-testid="systems-page">systems</div>}
+            />
+            <Route
+              path="/permissions"
+              element={<div data-testid="permissions-page">permissions</div>}
+            />
+          </Routes>
+        </ToastProvider>
       </AuthProvider>
     </MemoryRouter>,
   );
@@ -100,14 +103,14 @@ describe('LoginPage — render inicial', () => {
     expect(screen.getByRole('img', { name: /LF Calegari Admin/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/E-mail/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Senha/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Entrar/i })).toBeInTheDocument();
+    expect(screen.getByTestId('login-submit')).toBeInTheDocument();
   });
 
   it('campos começam vazios e botão habilitado', () => {
     renderLogin();
     const email = screen.getByLabelText(/E-mail/i) as HTMLInputElement;
     const password = screen.getByLabelText(/Senha/i) as HTMLInputElement;
-    const submit = screen.getByRole('button', { name: /Entrar/i });
+    const submit = screen.getByTestId('login-submit');
 
     expect(email.value).toBe('');
     expect(password.value).toBe('');
@@ -118,6 +121,57 @@ describe('LoginPage — render inicial', () => {
     renderLogin();
     const email = screen.getByLabelText(/E-mail/i);
     expect(email).toHaveFocus();
+  });
+
+  it('renderiza heading principal "Entrar no painel" como h1 único', () => {
+    renderLogin();
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent(/Entrar no painel/i);
+  });
+
+  it('exibe eyebrow "Authenticator · v1.0" acima do título', () => {
+    renderLogin();
+    const eyebrow = screen.getByTestId('login-eyebrow');
+    expect(eyebrow).toBeInTheDocument();
+    expect(eyebrow).toHaveTextContent(/Authenticator/i);
+    expect(eyebrow).toHaveTextContent(/v1\.0/i);
+  });
+
+  it('exibe footer mono com metadados de JWT e data ISO', () => {
+    renderLogin();
+    const meta = screen.getByTestId('login-meta');
+    expect(meta).toBeInTheDocument();
+    expect(meta).toHaveTextContent(/JWT/i);
+    expect(meta).toHaveTextContent(/tokenVersion assinado/i);
+    // Data corrente em formato YYYY-MM-DD
+    expect(meta).toHaveTextContent(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it('exibe botão "Esqueci a senha" como secundário (variant ghost)', () => {
+    renderLogin();
+    expect(screen.getByTestId('login-forgot')).toBeInTheDocument();
+    expect(screen.getByTestId('login-forgot')).toHaveTextContent(/Esqueci a senha/i);
+  });
+});
+
+describe('LoginPage — esqueci a senha', () => {
+  it('dispara toast informativo ao clicar em "Esqueci a senha"', async () => {
+    renderLogin();
+
+    fireEvent.click(screen.getByTestId('login-forgot'));
+
+    expect(
+      await screen.findByText(/Funcionalidade em breve\. Contate o administrador\./i),
+    ).toBeInTheDocument();
+  });
+
+  it('não submete o formulário ao clicar em "Esqueci a senha"', () => {
+    const { client } = renderLogin();
+
+    fireEvent.click(screen.getByTestId('login-forgot'));
+
+    expect(client.post).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Contexto

A `LoginPage` atual era funcionalmente correta (PR #100/#101 integraram com o `auth-service` real), mas visualmente austera. No tema dark especialmente, o card "achatava" no fundo plano (`var(--bg-base)`), perdendo a profundidade. O identity kit (`identity/ui_kits/admin-spa/screens.jsx:5-38` + `kit.css:288-302`) traz um padrão com:

- Background composto por dois gradientes radiais (lime + forest);
- Card 440px com `--shadow-modal` flutuando sobre o glow;
- Eyebrow mono uppercase acima do `<h1>`;
- Footer mono com metadados (versão, data).

Esta PR adota esse padrão.

## Objetivo

Espelhar o `LoginScreen` do identity kit no `lfc-admin-gui`, com tratamento dedicado para o tema dark (gradientes amplificados em forest para criar halo verde-profundo).

## O que foi feito

**Tokens (`src/styles/tokens.css`)**
- Novos `--login-glow-1` e `--login-glow-2` definidos por tema. Cada token guarda uma função `radial-gradient(...)` completa, pronta para ser composta em `background: var(--login-glow-1), var(--login-glow-2);`.
- Light: lime `rgba(174,202,89,0.14)` em 70/30 + forest `rgba(91,125,71,0.10)` em 20/80.
- Dark: lime mais sutil `rgba(174,202,89,0.10)` + forest amplificado `rgba(91,125,71,0.20)`.

**LoginPage (`src/pages/LoginPage.tsx`)**
- `GlowLayer` decorativa absoluta (`inset: -10%`, `pointer-events: none`, `aria-hidden`) compõe os tokens e cria a atmosfera.
- `Container` em `z-index: var(--z-raised)` mantém card e marca acima do glow.
- `FormCard` 440px com `var(--shadow-modal)`, `var(--radius-lg)`, `border-thin solid border-subtle`. Padding `--space-8` em desktop, `--space-6` em <30em.
- Eyebrow `Authenticator · v1.0` em mono uppercase tracking-wider, cor `--accent-ink`.
- `<h1>` `Entrar no painel` em `--text-3xl` peso 700, encolhe para `--text-2xl` em mobile.
- Botões "Entrar" (primary) + "Esqueci a senha" (ghost) lado a lado; em <30em empilham.
- "Esqueci a senha" dispara toast `info` "Funcionalidade em breve. Contate o administrador." (fluxo real fora do escopo da #105).
- Footer mono com "JWT · tokenVersion assinado" + data ISO `YYYY-MM-DD`.
- ThemeToggle preservado no canto superior direito, agora `z-index: var(--z-raised)` para ficar acima da `GlowLayer`.

**Testes (`tests/pages/LoginPage.test.tsx`)**
- `renderLogin` envolvido em `ToastProvider` (necessário porque `LoginPage` agora consome `useToast`).
- Novos testes: heading h1 único com texto correto; eyebrow presente; footer mono com texto e data ISO; botão "Esqueci a senha" presente; clique dispara toast e não submete o formulário.
- Substituído `getByRole('button', { name: /Entrar/i })` por `getByTestId('login-submit')` para desambiguar entre os dois botões.

### Decisão sobre `Input.leadingIcon`

A API atual do `Input` (`src/components/ui/Input.tsx`) já expõe a prop `icon` (`React.ReactNode`) que é renderizada antes do `<input>` via `IconSlot` posicionado absolutamente. O `LoginPage` original já usava essa prop. **Não foi necessário adicionar `leadingIcon`** — a API existente cobre o caso de uso. Mantive o uso de `icon={<Mail .../>}` e `icon={<Lock .../>}`, evitando expansão de superfície de API sem benefício.

## Comparação textual

**Antes**
- Background: `var(--bg-base)` plano.
- Card: `border-radius: --radius-lg`, `box-shadow: --shadow-sm`, padding `--space-6`, sem largura fixa.
- Brand: logo + h1 `--text-lg` com "Acesse sua conta".
- Form: 2 inputs + 1 botão.
- Footer: `<p>` com texto único "Acesso restrito a administradores autorizados.".

**Depois**
- Background: glow-layer com gradientes radiais (lime + forest, alpha por tema).
- Card: 440px, `--shadow-modal`, padding `--space-8` (`--space-6` em mobile).
- Brand: logo isolado; eyebrow mono dentro do card; h1 `--text-3xl` "Entrar no painel".
- Form: 2 inputs + linha de ações com 2 botões (primary + ghost).
- Footer mono dentro do card com 2 colunas (`space-between`).

## Arquivos impactados

- `src/styles/tokens.css` (+38)
- `src/pages/LoginPage.tsx` (+207, -47)
- `tests/pages/LoginPage.test.tsx` (+67, -13)

## Testes

- `npm run lint` — verde
- `npm run typecheck` — verde
- `npm run test` — 236 passes (24 arquivos de teste)
- `npm run build` — verde

## Visual

Validação manual a fazer pelo reviewer em `http://localhost:3002/login`:

- **Light:** background com gradientes lime+forest sutis; card flutua com sombra `--shadow-modal`; eyebrow visível em `--accent-ink`; h1 destacado; ícones nos inputs; botões "Entrar" + "Esqueci a senha" lado a lado; footer mono no rodapé.
- **Dark:** background mais escuro com glow forest amplificado; card destaca-se claramente do fundo; mesma estrutura.
- **Mobile (320px):** card responde bem; padding reduzido; botões empilham; footer mono empilha em duas linhas.
- **Toggle tema:** funciona sem reload, gradientes mudam ao trocar `data-theme`.
- **Click "Esqueci a senha":** toast `info` "Funcionalidade em breve. Contate o administrador.".

## Segurança

Sem impacto. Nenhum `dangerouslySetInnerHTML`, nenhum `console.*`, nenhum input sem sanitização. Lógica de submit/auth preservada exatamente como estava.

## Riscos

- Eyebrow + footer adicionam densidade visual ao card; em viewports muito baixos pode haver scroll. O viewport de 568px (iPhone SE landscape) acomoda confortavelmente; em <500px de altura entra scroll, comportamento aceitável para tela de login.
- O toast "Esqueci a senha" deixa explícito que o fluxo não está implementado — nenhum risco de UX, mas reviewer deve confirmar que essa estratégia (placeholder + toast) atende ao que se quer expor para usuários reais antes de produção.

## Issue relacionada

Closes #105