### PR TITLE
fix: logo do login e splash com aspect-ratio preservado (#111)

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -462,7 +462,7 @@ export const LoginPage: React.FC = () => {
           <Logo src={logoSrc} alt="LF Calegari Admin" />
           <CardHeader>
             <Eyebrow data-testid="login-eyebrow">{EYEBROW_TEXT}</Eyebrow>
-            <BrandTitle>Acessar no painel</BrandTitle>
+            <BrandTitle>Entrar no painel</BrandTitle>
             <BrandSubtitle>
               Acesso restrito a administradores do ecossistema LFC.
             </BrandSubtitle>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -128,17 +128,23 @@ const Container = styled.div`
   gap: var(--space-6);
 `;
 
-const Brand = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
-`;
-
+/**
+ * Logo da marca exibida no topo do `FormCard`. Dimensão definida por
+ * `height` literal (`36px`) com `width: auto` para preservar o
+ * aspect-ratio original do SVG (viewBox 200×48 ≈ 4.16:1) e manter o
+ * texto "authenticator" legível. Espelha o padrão do identity kit
+ * (`identity/ui_kits/admin-spa/screens.jsx:19` — `<img height="36">`).
+ *
+ * Decisão sobre o literal `36px`: é dimensão visual de imagem, não
+ * spacing/font/color — tokens semânticos `--space-*` representam outra
+ * coisa. Aceitável literal aqui (consistente com o atributo HTML
+ * `<img height="36">` da referência).
+ */
 const Logo = styled.img`
-  width: var(--space-16);
-  height: var(--space-16);
+  height: 36px;
+  width: auto;
   display: block;
+  margin-bottom: var(--space-4);
 `;
 
 /**
@@ -451,15 +457,12 @@ export const LoginPage: React.FC = () => {
         <ThemeToggle />
       </ThemeSlot>
       <Container>
-        <Brand>
-          <Logo src={logoSrc} alt="LF Calegari Admin" />
-        </Brand>
-
         <FormCard aria-labelledby="login-form-title">
           <VisuallyHidden id="login-form-title">Formulário de login</VisuallyHidden>
+          <Logo src={logoSrc} alt="LF Calegari Admin" />
           <CardHeader>
             <Eyebrow data-testid="login-eyebrow">{EYEBROW_TEXT}</Eyebrow>
-            <BrandTitle>Entrar no painel</BrandTitle>
+            <BrandTitle>Acessar no painel</BrandTitle>
             <BrandSubtitle>
               Acesso restrito a administradores do ecossistema LFC.
             </BrandSubtitle>

--- a/src/shared/auth/AuthSplash.tsx
+++ b/src/shared/auth/AuthSplash.tsx
@@ -39,9 +39,17 @@ const Container = styled.div`
   text-align: center;
 `;
 
+/**
+ * Logo da marca exibida no splash. Dimensão definida por `height`
+ * literal (`36px`) com `width: auto` para preservar o aspect-ratio
+ * original do SVG (viewBox 200×48 ≈ 4.16:1) — mesma decisão da
+ * `LoginPage`. Sem o `width: auto` o container quadrado de
+ * `--space-16` causava letterboxing e tornava o texto "authenticator"
+ * ilegível (Issue #111).
+ */
 const Logo = styled.img`
-  width: var(--space-16);
-  height: var(--space-16);
+  height: 36px;
+  width: auto;
   display: block;
 `;
 


### PR DESCRIPTION
## Contexto

O SVG de logo (`logo-dark.svg` / `logo-white.svg`) tem `viewBox="0 0 200 48"` (ratio ~4.16:1, 25:6). Tanto a `LoginPage` quanto o `AuthSplash` estavam renderizando a imagem em um container quadrado (`width: var(--space-16); height: var(--space-16)` = 64×64), forçando o conteúdo a ocupar apenas ~64×15.4 — resultando em letterboxing vertical e tornando o texto "authenticator" ilegível.

## Objetivo

Preservar o aspect-ratio original do SVG nas duas telas, espelhando o padrão do identity kit (`identity/ui_kits/admin-spa/screens.jsx:19` — `<img height="36">`).

## O que foi feito

### `src/pages/LoginPage.tsx`
- Logo movida para **dentro** do `FormCard`, antes do `CardHeader` (espelha a referência do identity kit em que a logo está dentro do card e não no `Brand` externo).
- Removido o wrapper `<Brand>` que ficou vazio.
- Restyle do `Logo`:
  ```css
  height: 36px;
  width: auto;
  display: block;
  margin-bottom: var(--space-4);
  ```

### `src/shared/auth/AuthSplash.tsx`
- Mesmo fix análogo no estilo do `Logo`:
  ```css
  height: 36px;
  width: auto;
  display: block;
  ```

### Decisão sobre token vs literal

`36px` foi mantido como **literal** porque é dimensão visual de imagem, não spacing/font/color. Tokens semânticos `--space-*` representam espaçamento, não tamanho de logo — usar `--space-9` (36px) seria semanticamente confuso. O literal é consistente com o atributo HTML `<img height="36">` do identity kit. Comentário no código documenta a decisão.

### Antes / depois

- **Antes**: container 64×64, logo letterboxada para ~64×15.4, texto ilegível.
- **Depois**: container `36px` × auto (~150×36), aspect-ratio preservado, texto legível.

## Arquivos impactados

- `src/pages/LoginPage.tsx`
- `src/shared/auth/AuthSplash.tsx`

## Testes

- `docker compose exec -T web npm run lint` — 0 warnings
- `docker compose exec -T web npm run typecheck` — 0 erros
- `docker compose exec -T web npm test` — **236/236 passing** (sem ajuste em testes existentes; nenhum ancorava na hierarquia `Brand > Logo` ou na localização da logo)
- `docker compose exec -T web npm run build` — verde, 1821 módulos transformados

## Visual

- [x] Logo agora dentro do card, com aspect-ratio preservado e texto "authenticator" legível
- [x] Sem hardcode de cor (literal de dimensão pixel para imagem é aceitável)
- [x] Logo continua trocando por tema via `useTheme().resolvedTheme` (intacto)
- [x] Card centralizado verticalmente sem espaço morto
- [x] `:focus-visible` dos interativos do form preservado
- [x] Sem regressão dark/light
- [x] Mobile (< 30em / ~480px): `width: auto` mantém logo dentro do card

## Segurança

Nenhum impacto. Apenas estilização visual — sem mudança de dependências, autenticação ou superfície exposta.

## Riscos

Nenhum. Mudança isolada em dois componentes apresentacionais. Testes existentes (236) permanecem verdes sem ajuste.

## Issue relacionada

Closes #111