### PR TITLE
feat: grid overlay engineering-tool no background global (#114)

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -36,20 +36,6 @@ const ROUTE_TITLES: RouteTitleEntry[] = [
 
 const FALLBACK_TITLE = 'Admin';
 
-const GridOverlay = createGlobalStyle`
-  body::before {
-    content: '';
-    position: fixed;
-    inset: 0;
-    background-image:
-      linear-gradient(var(--grid-line) 1px, transparent 1px),
-      linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
-    background-size: var(--grid-cell) var(--grid-cell);
-    pointer-events: none;
-    z-index: 0;
-  }
-`;
-
 /**
  * Trava de scroll body enquanto o drawer está aberto. Aplica via styled
  * `createGlobalStyle` para evitar manipulação imperativa de `document`.
@@ -169,7 +155,6 @@ export const AppLayout: React.FC = () => {
 
   return (
     <>
-      <GridOverlay />
       {drawerOpen && <BodyScrollLock />}
       <Shell>
         <Sidebar open={drawerOpen} onClose={handleCloseDrawer} />

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -68,6 +68,12 @@ interface FieldErrors {
  * Container raiz — `position: relative` para servir de âncora para a
  * camada de glow absoluta. `overflow: hidden` corta os gradientes que
  * vazam fora do viewport.
+ *
+ * Background transparente: o `<body>` global (em `globals.css`) já
+ * pinta `--bg-base` + grid overlay "engineering tool"
+ * (`identity/README.md:75`); manter o `PageRoot` opaco esconderia o
+ * grid também na tela de login. A `GlowLayer` continua por cima como
+ * camada decorativa absoluta.
  */
 const PageRoot = styled.div`
   min-height: 100vh;
@@ -76,7 +82,7 @@ const PageRoot = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: var(--bg-base);
+  background: transparent;
   padding: var(--space-8) var(--space-4);
   position: relative;
   overflow: hidden;

--- a/src/shared/auth/AuthSplash.tsx
+++ b/src/shared/auth/AuthSplash.tsx
@@ -21,13 +21,19 @@ interface AuthSplashProps {
   message?: string;
 }
 
+/**
+ * Background transparente: o `<body>` global já pinta `--bg-base` e o
+ * grid overlay "engineering tool" (`identity/README.md:75`); manter o
+ * `SplashRoot` opaco esconderia o grid também durante a validação
+ * inicial da sessão.
+ */
 const SplashRoot = styled.div`
   min-height: 100vh;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-base);
+  background: transparent;
   padding: var(--space-6) var(--space-4);
 `;
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -15,12 +15,36 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/*
+ * Grid overlay "engineering tool" descrito em `identity/README.md:75`.
+ * Duas camadas de `linear-gradient` (horizontal + vertical) desenham
+ * linhas de 1px em `--grid-overlay-color`; o restante das células fica
+ * transparente, deixando aparecer `--bg-base` por baixo. As células
+ * começam em 24px (mobile) e crescem para 40px a partir de `--bp-md`.
+ *
+ * Nota sobre breakpoint: CSS custom properties não funcionam dentro da
+ * condição de `@media (...)` — o token `--bp-md` é mantido em
+ * `tokens.css` apenas como referência documental; aqui usamos o literal
+ * `48em` correspondente.
+ */
 body {
   font-family: var(--font-body);
   font-size: var(--text-base);
   line-height: var(--leading-base);
   color: var(--text-primary);
   background-color: var(--bg-base);
+  background-image:
+    linear-gradient(var(--grid-overlay-color) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-overlay-color) 1px, transparent 1px);
+  background-size: var(--grid-overlay-size-mobile) var(--grid-overlay-size-mobile);
+  background-attachment: fixed;
+}
+
+/* Espelha `--bp-md` (48em ≈ 768px). */
+@media (min-width: 48em) {
+  body {
+    background-size: var(--grid-overlay-size-desktop) var(--grid-overlay-size-desktop);
+  }
 }
 
 button,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -138,6 +138,16 @@
   --grid-cell: 24px;
   --pad-inline: clamp(1.25rem, 5vw, 5rem);
 
+  /* ── Background grid overlay ─────────────────────────────────
+   * Textura "engineering tool" descrita em `identity/README.md:75`.
+   * Linhas de 1px desenhadas em `<body>` via duplo `linear-gradient`
+   * com células de 24px em mobile, alargando para 40px a partir de
+   * `--bp-md` (48em ≈ 768px). A cor é definida por tema em
+   * `--grid-overlay-color` (forest 4% no light, lime 4% no dark).
+   * Estes tamanhos são invariantes — não mudam entre temas. */
+  --grid-overlay-size-mobile: 24px;
+  --grid-overlay-size-desktop: 40px;
+
   /* Larguras semânticas — usadas por blocos de conteúdo centralizado */
   --measure-narrow: 48ch;
   --measure-base: 56ch;
@@ -221,6 +231,10 @@
 
   /* ── UI state colors/shadows ─────────────────────────────── */
   --grid-line: rgba(22, 36, 15, 0.04);
+  /* Cor do grid overlay global aplicado em `<body>`. No light é
+     forest 4% sobre o cream — sutil mas presente, conforme
+     `identity/README.md:75`. */
+  --grid-overlay-color: rgba(22, 36, 15, 0.04);
   --bg-ghost-hover: rgba(22, 36, 15, 0.05);
   --bg-ghost-active: rgba(22, 36, 15, 0.1);
   --bg-danger-soft: rgba(217, 95, 95, 0.1);
@@ -331,6 +345,11 @@
 
   /* ── UI state colors ─────────────────────────────────────── */
   --grid-line: rgba(174, 202, 89, 0.04);
+  /* Cor do grid overlay global no dark — lime sobre fundo profundo.
+     Mantemos alpha 0.04 (mesmo do light) porque nos pretos o lime
+     já tem contraste suficiente: subir o alpha torna o grid ruidoso
+     e quebra o "never noisy" pedido em `identity/README.md:75`. */
+  --grid-overlay-color: rgba(174, 202, 89, 0.04);
   --bg-ghost-hover: rgba(174, 202, 89, 0.08);
   --bg-ghost-active: rgba(174, 202, 89, 0.14);
   --bg-danger-soft: rgba(232, 117, 117, 0.12);


### PR DESCRIPTION
## Contexto

A `identity/README.md:75` define como assinatura visual da identidade uma textura sutil de grid (linhas 1px @ 4% de opacidade, células 24px em mobile / 40px em desktop) presente em todo o ecossistema. Hoje o `lfc-admin-gui` pintava apenas `--bg-base` solido no `<body>`; o grid existia somente dentro do `AppLayout` via `createGlobalStyle`, deixando `LoginPage` e `AuthSplash` sem a textura.

## Objetivo

Promover o grid overlay para o `<body>` global, garantindo que a textura "engineering tool" apareca em todas as paginas, com responsividade entre mobile (24px) e desktop (40px) a partir de `--bp-md` (48em ≈ 768px) e adaptado por tema (forest 4% no light, lime 4% no dark).

## O que foi feito

### Tokens (`src/styles/tokens.css`)
- Adicionados invariantes em `:root`:
  - `--grid-overlay-size-mobile: 24px`
  - `--grid-overlay-size-desktop: 40px`
- Adicionado `--grid-overlay-color` por tema:
  - light: `rgba(22, 36, 15, 0.04)` (forest)
  - dark: `rgba(174, 202, 89, 0.04)` (lime)

> **Decisao sobre alpha do dark:** mantido em `0.04` (igual ao light). Sobre o `#0d1410` o lime ja tem contraste suficiente; subir para `0.06`/`0.08` torna o grid ruidoso e quebra o "never noisy" pedido em `identity/README.md:75`.

### `src/styles/globals.css`
- `body` recebe duplo `linear-gradient` (horizontal + vertical) sobre `--bg-base`.
- `background-size` acompanha `--grid-overlay-size-mobile` em mobile e `--grid-overlay-size-desktop` a partir de `48em` (literal espelhando o token `--bp-md`, com comentario explicando por que CSS custom properties nao funcionam na condicao de `@media`).
- `background-attachment: fixed` mantem a malha estavel durante o scroll.

### `src/layouts/AppLayout.tsx`
- Removido o `createGlobalStyle` `GridOverlay` (`body::before` com `--grid-line` / `--grid-cell`). Agora o body global cobre o caso, eliminando duplicacao.

### `src/pages/LoginPage.tsx` e `src/shared/auth/AuthSplash.tsx`
- `PageRoot` e `SplashRoot` trocaram `background: var(--bg-base)` por `background: transparent`. O body global ja pinta `--bg-base`; o efeito de cor nao muda, mas o grid passa a aparecer atras do `GlowLayer` (login) e do conteudo do splash.

## Decisoes

- **Manter `--grid-line` / `--grid-cell` legados:** preservados em `tokens.css` para evitar mexer fora de escopo. Eles deixam de ser referenciados pelo `AppLayout`, mas a remocao final pode acontecer em uma issue separada de cleanup.
- **`background-attachment: fixed`** alinha o comportamento ao identity kit (`identity/ui_kits/admin-spa/kit.css:13-22` usava `position: fixed` num pseudo-elemento).
- **Sem alteracoes de copy/layout** — atendendo a licao do PR #112.

## Arquivos impactados

- `src/styles/tokens.css`
- `src/styles/globals.css`
- `src/layouts/AppLayout.tsx`
- `src/pages/LoginPage.tsx`
- `src/shared/auth/AuthSplash.tsx`

## Testes

Tudo executado em container (`docker compose exec -T web ...`):

- `npm run lint` — OK (zero warnings).
- `npm run typecheck` — OK.
- `npm run test` — 236/236 passando (24 arquivos).
- `npm run build` — OK (`360 kB JS`, `10 kB CSS` gzip).

## Visual

Antes/depois textual:

- **Antes:** body solido em `--bg-base`. Grid presente apenas dentro do `AppLayout`. `LoginPage` e `AuthSplash` sem a textura.
- **Depois:** body com malha 1px a 4% de opacidade, celulas 24px mobile / 40px desktop. Visivel em todas as paginas (login, splash, sistemas) e nos dois temas.

Checklist visual:
- [x] Cores via `--grid-overlay-color` (sem hardcode em componente)
- [x] Tokens de tamanho via `--grid-overlay-size-*`
- [x] Espacamentos consistentes
- [x] Hover/focus/disabled inalterados (sem regressao em interativos)
- [x] Loading/empty/error inalterados (mudanca puramente visual de fundo)
- [x] Layout validado nas larguras alvo (24px ate 48em, 40px a partir de 48em)
- [x] `identity/` usado apenas como referencia local

## Seguranca

Nenhum impacto. Mudanca puramente cosmetica (CSS background-image). Sem novas deps, sem novas APIs, sem inputs/outputs.

## Riscos

- Pequeno custo adicional de pintura do background no scroll (`background-attachment: fixed`). Em testes manuais nao houve impacto perceptivel; o linear-gradient e GPU-friendly.
- O `LoginPage` agora deixa o grid passar atras do `GlowLayer`. Os gradientes radiais continuam dominantes; o grid funciona como camada de "pano de fundo" da cena.

## Issue relacionada

Closes #114