### PR TITLE
feat: consumir permissionCodes do verify-token (#116)

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -63,11 +63,13 @@ const ErrorRouteResolver: React.FC = () => {
  *
  * Convenção de codes de permissão:
  *
- * Os codes seguem o padrão `<Recurso>.<Acao>` adotado em seeds de teste
- * e fixtures (ex.: `Systems.Read` em `LoginPage.test.tsx` e
- * `AuthProvider.test.tsx`). Quando o catálogo final de permissions for
- * consolidado pelo backend, basta atualizar este mapa central — todos
- * os callsites já consomem a constante.
+ * Os codes seguem o padrão real do backend `perm:<Recurso>.<Acao>`,
+ * espelhando exatamente as constantes definidas em
+ * `auth-service/AuthService/Auth/PermissionPolicies.cs`. Atenção a
+ * nomes não óbvios: rotas de sistemas são `SystemsRoutes` (não
+ * `Routes`) e tokens são `SystemTokensTypes` (não `Tokens`). O
+ * catálogo consumido é `permissionCodes` no `verify-token`, populado
+ * em `state.permissions` pelo Provider.
  */
 export const AppRoutes: React.FC = () => (
   <Routes>
@@ -85,7 +87,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/systems"
         element={
-          <RequirePermission code="Systems.Read">
+          <RequirePermission code="perm:Systems.Read">
             <SystemsPage />
           </RequirePermission>
         }
@@ -93,7 +95,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/routes"
         element={
-          <RequirePermission code="Routes.Read">
+          <RequirePermission code="perm:SystemsRoutes.Read">
             <PlaceholderPage
               eyebrow="02 Rotas"
               title="Rotas registradas"
@@ -105,7 +107,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/roles"
         element={
-          <RequirePermission code="Roles.Read">
+          <RequirePermission code="perm:Roles.Read">
             <RolesPage />
           </RequirePermission>
         }
@@ -113,7 +115,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/permissions"
         element={
-          <RequirePermission code="Permissions.Read">
+          <RequirePermission code="perm:Permissions.Read">
             <PermissionsPage />
           </RequirePermission>
         }
@@ -121,7 +123,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/users"
         element={
-          <RequirePermission code="Users.Read">
+          <RequirePermission code="perm:Users.Read">
             <UsersPage />
           </RequirePermission>
         }
@@ -129,7 +131,7 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/tokens"
         element={
-          <RequirePermission code="Tokens.Read">
+          <RequirePermission code="perm:SystemTokensTypes.Read">
             <PlaceholderPage
               eyebrow="06 Tokens"
               title="Tokens JWT"

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -76,15 +76,18 @@ function resolveVerifyInterval(): number {
  * Type guard mínimo para o payload do endpoint `verify-token`.
  *
  * O contrato real do `auth-service` é achatado: `{ id, name, email,
- * identity, permissions: Guid[], routeCodes: string[] }`. Validamos os
- * campos essenciais (`id`, `name`, `email` strings; `identity` numérico;
- * `routeCodes` array) antes de o Provider confiar no payload — defesa
+ * identity, permissions: Guid[], permissionCodes: string[],
+ * routeCodes: string[] }`. Validamos os campos essenciais (`id`,
+ * `name`, `email` strings; `identity` numérico; `permissionCodes` e
+ * `routeCodes` arrays) antes de o Provider confiar no payload — defesa
  * contra resposta corrompida em proxies intermediários ou divergência
  * silenciosa de versão entre frontend/backend.
  *
  * `permissions` (GUIDs) também é exigido como array para manter simetria
  * com o backend, mas o Provider nunca consome diretamente — o catálogo
- * que alimenta `hasPermission()` é `routeCodes`.
+ * que alimenta `hasPermission()` é `permissionCodes` (ex.:
+ * `perm:Systems.Read`). Cada item de `permissionCodes` deve ser string
+ * para evitar que entradas corrompidas escapem para `state.permissions`.
  */
 function isValidVerifyTokenResponse(value: unknown): value is VerifyTokenResponse {
   if (!value || typeof value !== 'object') {
@@ -92,6 +95,12 @@ function isValidVerifyTokenResponse(value: unknown): value is VerifyTokenRespons
   }
   const record = value as Record<string, unknown>;
   if (!Array.isArray(record.permissions)) {
+    return false;
+  }
+  if (!Array.isArray(record.permissionCodes)) {
+    return false;
+  }
+  if (!record.permissionCodes.every(item => typeof item === 'string')) {
     return false;
   }
   if (!Array.isArray(record.routeCodes)) {
@@ -214,10 +223,11 @@ interface AuthProviderProps {
  *    falhas pós-login (`verify-token` rejeitou após token aceito).
  * 9. **Login encadeado (POST /auth/login → GET /auth/verify-token)** —
  *    o backend retorna apenas `{ token }` no login; o perfil e o
- *    catálogo `routeCodes` vêm em `verify-token`. Setamos `tokenRef`
- *    entre as duas chamadas porque o cliente HTTP precisa do header
- *    `Authorization` para a segunda. Falha entre as duas (rede, 401,
- *    payload inválido) limpa a sessão parcial via `clearSession`.
+ *    catálogo `permissionCodes` vêm em `verify-token`. Setamos
+ *    `tokenRef` entre as duas chamadas porque o cliente HTTP precisa
+ *    do header `Authorization` para a segunda. Falha entre as duas
+ *    (rede, 401, payload inválido) limpa a sessão parcial via
+ *    `clearSession`.
  */
 export const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
@@ -357,12 +367,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           );
           return;
         }
-        // Projeta o payload achatado em `User` e usa `routeCodes` (e
-        // não `permissions`/GUIDs) como catálogo consumido por
-        // `hasPermission()`. Persiste antes de setState pelos mesmos
-        // motivos do `login`.
+        // Projeta o payload achatado em `User` e usa `permissionCodes`
+        // (e não `permissions`/GUIDs nem `routeCodes`) como catálogo
+        // consumido por `hasPermission()`. Persiste antes de setState
+        // pelos mesmos motivos do `login`.
         const user = toUser(data);
-        const permissions = data.routeCodes;
+        const permissions = data.permissionCodes;
         sessionStorage.save({
           token: tokenRef.current,
           user,
@@ -469,7 +479,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         }
 
         const user = toUser(verifyData);
-        const permissions = verifyData.routeCodes;
+        const permissions = verifyData.permissionCodes;
 
         // Persiste antes de atualizar o estado: assim qualquer falha
         // posterior (ainda que improvável) não deixa a sessão "viva em

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -66,9 +66,12 @@ export interface LoginResponse {
  * - `permissions` é uma lista de **GUIDs** internos do backend —
  *   carregamos no tipo por simetria e diagnóstico, mas o frontend
  *   nunca os usa diretamente em `hasPermission`;
- * - `routeCodes` é a lista de códigos semânticos usados por
- *   `hasPermission()` (ex.: `Systems.Read`). É essa lista que o
- *   Provider persiste como `permissions` no estado/storage.
+ * - `permissionCodes` é a lista de códigos semânticos das permissões
+ *   reais do usuário no `lfc-admin-gui` (ex.: `perm:Systems.Read`).
+ *   É essa lista que o Provider persiste como `permissions` no
+ *   estado/storage e que `hasPermission()` consulta;
+ * - `routeCodes` é a lista de códigos de rota filtrada para o sistema
+ *   kurtto (mantida no contrato por simetria; não consumida aqui).
  *
  * O token continua sendo o mesmo já enviado em `Authorization`; o
  * backend apenas confirma sua validade e devolve o snapshot atual do
@@ -81,6 +84,7 @@ export interface VerifyTokenResponse {
   email: string;
   identity: number;
   permissions: ReadonlyArray<string>;
+  permissionCodes: ReadonlyArray<string>;
   routeCodes: ReadonlyArray<string>;
 }
 

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -51,7 +51,12 @@ function seedAdminSession(): void {
         name: 'Admin',
         email: 'admin@lfc.com.br',
       },
-      permissions: ['Systems.Read', 'Roles.Read', 'Permissions.Read', 'Users.Read'],
+      permissions: [
+        'perm:Systems.Read',
+        'perm:Roles.Read',
+        'perm:Permissions.Read',
+        'perm:Users.Read',
+      ],
     }),
   );
 }

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -43,8 +43,9 @@ const SAMPLE_LOGIN: LoginResponse = {
 
 /**
  * Resposta de `verify-token` usada nos cenários de submit feliz —
- * espelha o contrato real do `auth-service` (achatado, com `routeCodes`
- * separado de `permissions`/Guid[]).
+ * espelha o contrato real do `auth-service` (achatado, com
+ * `permissionCodes` consumido por `hasPermission()` e `routeCodes`
+ * separado, ambos paralelos a `permissions`/Guid[]).
  */
 const SAMPLE_VERIFY: VerifyTokenResponse = {
   id: 'u-1',
@@ -52,7 +53,8 @@ const SAMPLE_VERIFY: VerifyTokenResponse = {
   email: 'ada@lfc.com.br',
   identity: 42,
   permissions: ['11111111-1111-1111-1111-111111111111'],
-  routeCodes: ['Systems.Read'],
+  permissionCodes: ['perm:Systems.Read'],
+  routeCodes: ['KURTTO_V1_URLS_HOME'],
 };
 
 type ClientStub = ReturnType<typeof createClientStub>;

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -97,7 +97,7 @@ const SAMPLE_LOGIN: LoginResponse = {
 /**
  * Perfil retornado por `verify-token` logo após o login feliz —
  * espelha o contrato real do `auth-service` (id/name/email/identity +
- * permissions/Guid[] + routeCodes/string[]).
+ * permissions/Guid[] + permissionCodes/string[] + routeCodes/string[]).
  *
  * Usado também em testes de hidratação otimista após reload.
  */
@@ -107,7 +107,8 @@ const SAMPLE_VERIFY: VerifyTokenResponse = {
   email: 'ada@lfc.com.br',
   identity: 42,
   permissions: ['11111111-1111-1111-1111-111111111111'],
-  routeCodes: ['Systems.Read', 'Systems.Create'],
+  permissionCodes: ['perm:Systems.Read', 'perm:Systems.Create'],
+  routeCodes: ['KURTTO_V1_URLS_HOME'],
 };
 
 /**
@@ -121,13 +122,13 @@ const SAMPLE_USER = {
   identity: SAMPLE_VERIFY.identity,
 };
 
-const SAMPLE_PERMISSIONS = SAMPLE_VERIFY.routeCodes;
+const SAMPLE_PERMISSIONS = SAMPLE_VERIFY.permissionCodes;
 
 /**
  * Resposta de `verify-token` para a revalidação periódica — simula o
- * cenário em que o backend acrescentou um `routeCode` (por exemplo, uma
- * permissão recém-concedida) e o Provider precisa refletir o snapshot
- * atualizado.
+ * cenário em que o backend acrescentou um `permissionCode` (por exemplo,
+ * uma permissão recém-concedida) e o Provider precisa refletir o
+ * snapshot atualizado.
  */
 const VERIFY_RESPONSE: VerifyTokenResponse = {
   id: 'u-1',
@@ -135,7 +136,8 @@ const VERIFY_RESPONSE: VerifyTokenResponse = {
   email: 'ada@lfc.com.br',
   identity: 42,
   permissions: ['11111111-1111-1111-1111-111111111111'],
-  routeCodes: ['Systems.Read', 'Systems.Create', 'Systems.Update'],
+  permissionCodes: ['perm:Systems.Read', 'perm:Systems.Create', 'perm:Systems.Update'],
+  routeCodes: ['KURTTO_V1_URLS_HOME'],
 };
 
 const VERIFY_USER = {
@@ -145,7 +147,7 @@ const VERIFY_USER = {
   identity: VERIFY_RESPONSE.identity,
 };
 
-const VERIFY_PERMISSIONS = VERIFY_RESPONSE.routeCodes;
+const VERIFY_PERMISSIONS = VERIFY_RESPONSE.permissionCodes;
 
 const UNAUTHORIZED_ERROR: ApiError = {
   kind: 'http',
@@ -164,8 +166,8 @@ const NETWORK_ERROR: ApiError = {
  * testes de hidratação remota.
  *
  * O shape gravado espelha o `PersistedSession` real (User com `identity`
- * + permissions = routeCodes), de modo que os testes leiam exatamente
- * o que o Provider gravou em sessões anteriores.
+ * + permissions = permissionCodes), de modo que os testes leiam
+ * exatamente o que o Provider gravou em sessões anteriores.
  */
 function seedPersistedSession(): void {
   window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
@@ -254,8 +256,9 @@ describe('AuthProvider — login', () => {
       password: 'secret',
     });
     expect(client.get).toHaveBeenCalledWith('/auth/verify-token');
-    // `permissions` no estado é o catálogo de `routeCodes`, não os GUIDs
-    // brutos retornados em `verify-token.permissions`.
+    // `permissions` no estado é o catálogo de `permissionCodes`, não os
+    // GUIDs brutos em `verify-token.permissions` nem os `routeCodes`
+    // (filtrados para kurtto).
     expect(result.current.user).toEqual(SAMPLE_USER);
     expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
     expect(result.current.isAuthenticated).toBe(true);
@@ -676,7 +679,7 @@ describe('AuthProvider — hasPermission', () => {
     });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.hasPermission('Systems.Read')).toBe(false);
+    expect(result.current.hasPermission('perm:Systems.Read')).toBe(false);
   });
 
   test('retorna true para permissões presentes após login', async () => {
@@ -691,9 +694,9 @@ describe('AuthProvider — hasPermission', () => {
       await result.current.login('ada@lfc.com.br', 'secret');
     });
 
-    expect(result.current.hasPermission('Systems.Read')).toBe(true);
-    expect(result.current.hasPermission('Systems.Create')).toBe(true);
-    expect(result.current.hasPermission('Systems.Delete')).toBe(false);
+    expect(result.current.hasPermission('perm:Systems.Read')).toBe(true);
+    expect(result.current.hasPermission('perm:Systems.Create')).toBe(true);
+    expect(result.current.hasPermission('perm:Systems.Delete')).toBe(false);
   });
 });
 
@@ -780,7 +783,7 @@ describe('AuthProvider — persistência (Issue #53)', () => {
     const userJson = window.localStorage.getItem(STORAGE_KEYS.user);
     expect(userJson).not.toBeNull();
     // Storage espelha a projeção que o Provider faz: User com `identity`
-    // e permissions = routeCodes (nunca os GUIDs brutos).
+    // e permissions = permissionCodes (nunca os GUIDs brutos).
     expect(JSON.parse(userJson as string)).toEqual({
       user: SAMPLE_USER,
       permissions: SAMPLE_PERMISSIONS,
@@ -853,8 +856,8 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
     expect(result.current.permissions).toEqual(SAMPLE_PERMISSIONS);
 
     // Após o verify-token resolver, permissões são atualizadas com o
-    // snapshot fresco — `routeCodes` é a fonte da verdade para o que
-    // o frontend chama de `permissions`.
+    // snapshot fresco — `permissionCodes` é a fonte da verdade para o
+    // que o frontend chama de `permissions`.
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(client.get).toHaveBeenCalledWith(
       '/auth/verify-token',
@@ -923,8 +926,8 @@ describe('AuthProvider — verify-token (Issue #54)', () => {
   test('verify-token com payload inválido mantém sessão local', async () => {
     seedPersistedSession();
     const client = createClientStub();
-    // Resposta sem `id`/`name`/`email`/`identity`/`routeCodes` válidos —
-    // Provider deve descartar silenciosamente e manter sessão local.
+    // Resposta sem `id`/`name`/`email`/`identity`/`permissionCodes`/`routeCodes`
+    // válidos — Provider deve descartar silenciosamente e manter sessão local.
     client.get.mockResolvedValueOnce({ permissions: [] } as unknown);
 
     const { result } = renderHook(() => useAuth(), {

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -375,82 +375,115 @@ function renderRequirePermissionScenario(
   return { captured };
 }
 
-describe('RequirePermission', () => {
-  it('renderiza children quando a permissão exigida está presente', () => {
-    renderRequirePermissionScenario({
+/**
+ * Tabela de cenários do `RequirePermission`. Cada caso é um teste
+ * independente, mas o esqueleto (chamada do helper + asserts de
+ * presença/ausência + assert opcional do redirect) é idêntico, então
+ * usamos `it.each` para colapsar a repetição estrutural — preservando
+ * a granularidade dos testes (1 caso = 1 `it`) sem mudar o que cada
+ * cenário valida.
+ *
+ * - `expectsContent: true` → permissão satisfeita; conteúdo protegido
+ *   aparece e a `error-page` não aparece.
+ * - `expectsContent: false` → permissão ausente; `error-page` aparece
+ *   e o conteúdo protegido não. Quando `expectedRedirectPath` é
+ *   informado, asserimos também o pathname capturado pela sonda (e o
+ *   helper é instruído a anexá-la via `withProbe`).
+ */
+interface RequirePermissionCase {
+  name: string;
+  options: RenderRequirePermissionOptions;
+  expectsContent: boolean;
+  expectedRedirectPath?: string;
+}
+
+const REQUIRE_PERMISSION_CASES: ReadonlyArray<RequirePermissionCase> = [
+  {
+    name: 'renderiza children quando a permissão exigida está presente',
+    options: {
       protectedRoute: '/users',
       code: 'perm:Users.Read',
       sessionPermissions: ['perm:Systems.Read', 'perm:Users.Read'],
       protectedTestId: 'users-page',
       protectedLabel: 'users',
-    });
-
-    expect(screen.getByTestId('users-page')).toBeInTheDocument();
-    expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
-  });
-
-  it('redireciona para /error/403 quando o code não está presente', () => {
-    const { captured } = renderRequirePermissionScenario({
+    },
+    expectsContent: true,
+  },
+  {
+    name: 'redireciona para /error/403 quando o code não está presente',
+    options: {
       protectedRoute: '/users',
       code: 'perm:Users.Read',
       sessionPermissions: ['perm:Systems.Read'],
       protectedTestId: 'users-page',
       protectedLabel: 'users',
       withProbe: true,
-    });
-
-    expect(screen.queryByTestId('users-page')).not.toBeInTheDocument();
-    expect(screen.getByTestId('error-page')).toBeInTheDocument();
-    expect(captured.current?.pathname).toBe('/error/403');
-  });
-
-  it('redireciona para /error/403 quando o usuário não tem permissões', () => {
+    },
+    expectsContent: false,
+    expectedRedirectPath: '/error/403',
+  },
+  {
     // Sessão sem nenhum code: sempre 403 em rotas com gating.
-    renderRequirePermissionScenario({
+    name: 'redireciona para /error/403 quando o usuário não tem permissões',
+    options: {
       protectedRoute: '/permissions',
       code: 'perm:Permissions.Read',
       sessionPermissions: [],
       protectedTestId: 'permissions-page',
       protectedLabel: 'permissões',
-    });
-
-    expect(screen.queryByTestId('permissions-page')).not.toBeInTheDocument();
-    expect(screen.getByTestId('error-page')).toBeInTheDocument();
-  });
-
-  it('renderiza children com o code exato presente em permissionCodes', () => {
+    },
+    expectsContent: false,
+  },
+  {
     // Caso explícito do contrato pós-#116: o code precisa bater
     // exatamente com o item em `permissions` (alimentado por
     // `permissionCodes` do verify-token). Usar o nome `SystemsRoutes`
     // do backend valida que os codes não-óbvios também são respeitados.
-    renderRequirePermissionScenario({
+    name: 'renderiza children com o code exato presente em permissionCodes',
+    options: {
       protectedRoute: '/routes',
       code: 'perm:SystemsRoutes.Read',
       sessionPermissions: ['perm:SystemsRoutes.Read', 'perm:Systems.Read'],
       protectedTestId: 'routes-page',
       protectedLabel: 'rotas',
-    });
-
-    expect(screen.getByTestId('routes-page')).toBeInTheDocument();
-    expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
-  });
-
-  it('redireciona para /error/403 quando o code com prefixo perm: não existe em permissionCodes', () => {
+    },
+    expectsContent: true,
+  },
+  {
     // Cenário do bug original (#116): se o catálogo `permissions` no
     // estado vier sem o code exato esperado pelo guard, o usuário cai
     // em 403 — confirmando que o match continua estritamente por igualdade.
-    const { captured } = renderRequirePermissionScenario({
+    name: 'redireciona para /error/403 quando o code com prefixo perm: não existe em permissionCodes',
+    options: {
       protectedRoute: '/tokens',
       code: 'perm:SystemTokensTypes.Read',
       sessionPermissions: ['perm:Systems.Read'],
       protectedTestId: 'tokens-page',
       protectedLabel: 'tokens',
       withProbe: true,
-    });
+    },
+    expectsContent: false,
+    expectedRedirectPath: '/error/403',
+  },
+];
 
-    expect(screen.queryByTestId('tokens-page')).not.toBeInTheDocument();
-    expect(screen.getByTestId('error-page')).toBeInTheDocument();
-    expect(captured.current?.pathname).toBe('/error/403');
+describe('RequirePermission', () => {
+  it.each(REQUIRE_PERMISSION_CASES)('$name', ({ options, expectsContent, expectedRedirectPath }) => {
+    const { captured } = renderRequirePermissionScenario(options);
+    const protectedQuery = screen.queryByTestId(options.protectedTestId);
+    const errorQuery = screen.queryByTestId(options.errorTestId ?? 'error-page');
+
+    if (expectsContent) {
+      expect(protectedQuery).toBeInTheDocument();
+      expect(errorQuery).not.toBeInTheDocument();
+    } else {
+      expect(protectedQuery).not.toBeInTheDocument();
+      expect(errorQuery).toBeInTheDocument();
+    }
+
+    if (expectedRedirectPath !== undefined) {
+      expect(captured.current?.pathname).toBe(expectedRedirectPath);
+    }
   });
 });
 

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -42,10 +42,11 @@ function createClientStub(): ApiClient & {
 
 /**
  * Espelha o contrato real do `auth-service`: payload achatado com
- * `id/name/email/identity` + `permissions: Guid[]` + `routeCodes: string[]`.
- * Mantemos o tipo aqui apenas para documentar o shape; nenhum teste
- * deste arquivo dispara o verify-token de fato (o stub de `client.get`
- * devolve Promise pendente por padrão para evitar setState pós-assert).
+ * `id/name/email/identity` + `permissions: Guid[]` +
+ * `permissionCodes: string[]` + `routeCodes: string[]`. Mantemos o tipo
+ * aqui apenas para documentar o shape; nenhum teste deste arquivo
+ * dispara o verify-token de fato (o stub de `client.get` devolve
+ * Promise pendente por padrão para evitar setState pós-assert).
  */
 const VERIFY_RESPONSE: VerifyTokenResponse = {
   id: 'u-1',
@@ -53,7 +54,8 @@ const VERIFY_RESPONSE: VerifyTokenResponse = {
   email: 'ada@lfc.com.br',
   identity: 42,
   permissions: ['11111111-1111-1111-1111-111111111111'],
-  routeCodes: ['Systems.Read'],
+  permissionCodes: ['perm:Systems.Read'],
+  routeCodes: ['KURTTO_V1_URLS_HOME'],
 };
 
 /**
@@ -73,7 +75,7 @@ const VERIFY_USER = {
  * em `tests/shared/auth/AuthProvider.test.tsx` para os cenários de
  * hidratação otimista.
  */
-function seedSession(permissions: ReadonlyArray<string> = ['Systems.Read']): void {
+function seedSession(permissions: ReadonlyArray<string> = ['perm:Systems.Read']): void {
   window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-test');
   window.localStorage.setItem(
     STORAGE_KEYS.user,
@@ -225,12 +227,12 @@ describe('RequireAuth', () => {
     // produção; aqui usamos `disableSplash` para testar o guard isolado).
     const value: AuthContextValue = {
       user: { id: 'u-1', name: 'Ada', email: 'ada@lfc.com.br', identity: 42 },
-      permissions: ['Systems.Read'],
+      permissions: ['perm:Systems.Read'],
       isAuthenticated: true,
       isLoading: true,
       login: vi.fn().mockResolvedValue(undefined),
       logout: vi.fn().mockResolvedValue(undefined),
-      hasPermission: (code: string) => code === 'Systems.Read',
+      hasPermission: (code: string) => code === 'perm:Systems.Read',
     };
 
     render(
@@ -294,7 +296,7 @@ describe('RequireAuth', () => {
 
 describe('RequirePermission', () => {
   it('renderiza children quando a permissão exigida está presente', () => {
-    seedSession(['Systems.Read', 'Users.Read']);
+    seedSession(['perm:Systems.Read', 'perm:Users.Read']);
     const client = createClientStub();
 
     render(
@@ -304,7 +306,7 @@ describe('RequirePermission', () => {
             <Route
               path="/users"
               element={
-                <RequirePermission code="Users.Read">
+                <RequirePermission code="perm:Users.Read">
                   <div data-testid="users-page">users</div>
                 </RequirePermission>
               }
@@ -323,7 +325,7 @@ describe('RequirePermission', () => {
   });
 
   it('redireciona para /error/403 quando o code não está presente', () => {
-    seedSession(['Systems.Read']);
+    seedSession(['perm:Systems.Read']);
     const client = createClientStub();
 
     const captured = { current: null as CapturedLocation | null };
@@ -336,7 +338,7 @@ describe('RequirePermission', () => {
             <Route
               path="/users"
               element={
-                <RequirePermission code="Users.Read">
+                <RequirePermission code="perm:Users.Read">
                   <div data-testid="users-page">users</div>
                 </RequirePermission>
               }
@@ -372,7 +374,7 @@ describe('RequirePermission', () => {
             <Route
               path="/permissions"
               element={
-                <RequirePermission code="Permissions.Read">
+                <RequirePermission code="perm:Permissions.Read">
                   <div data-testid="permissions-page">permissões</div>
                 </RequirePermission>
               }
@@ -388,6 +390,80 @@ describe('RequirePermission', () => {
 
     expect(screen.queryByTestId('permissions-page')).not.toBeInTheDocument();
     expect(screen.getByTestId('error-page')).toBeInTheDocument();
+  });
+
+  it('renderiza children com o code exato presente em permissionCodes', () => {
+    // Caso explícito do contrato pós-#116: o code precisa bater
+    // exatamente com o item em `permissions` (alimentado por
+    // `permissionCodes` do verify-token). Usar o nome `SystemsRoutes`
+    // do backend valida que os codes não-óbvios também são respeitados.
+    seedSession(['perm:SystemsRoutes.Read', 'perm:Systems.Read']);
+    const client = createClientStub();
+
+    render(
+      <MemoryRouter initialEntries={['/routes']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/routes"
+              element={
+                <RequirePermission code="perm:SystemsRoutes.Read">
+                  <div data-testid="routes-page">rotas</div>
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={<div data-testid="error-page">erro</div>}
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('routes-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
+  });
+
+  it('redireciona para /error/403 quando o code com prefixo perm: não existe em permissionCodes', () => {
+    // Cenário do bug original (#116): se o catálogo `permissions` no
+    // estado vier sem o code exato esperado pelo guard, o usuário cai
+    // em 403 — confirmando que o match continua estritamente por igualdade.
+    seedSession(['perm:Systems.Read']);
+    const client = createClientStub();
+
+    const captured = { current: null as CapturedLocation | null };
+    const ErrorProbe = makeLocationProbe(captured);
+
+    render(
+      <MemoryRouter initialEntries={['/tokens']}>
+        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+          <Routes>
+            <Route
+              path="/tokens"
+              element={
+                <RequirePermission code="perm:SystemTokensTypes.Read">
+                  <div data-testid="tokens-page">tokens</div>
+                </RequirePermission>
+              }
+            />
+            <Route
+              path="/error/:code"
+              element={
+                <>
+                  <ErrorProbe />
+                  <div data-testid="error-page">erro</div>
+                </>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('tokens-page')).not.toBeInTheDocument();
+    expect(screen.getByTestId('error-page')).toBeInTheDocument();
+    expect(captured.current?.pathname).toBe('/error/403');
   });
 });
 
@@ -405,7 +481,7 @@ describe('RequireAuth + RequirePermission combinados', () => {
               path="/users"
               element={
                 <RequireAuth>
-                  <RequirePermission code="Users.Read">
+                  <RequirePermission code="perm:Users.Read">
                     <div data-testid="users-page">users</div>
                   </RequirePermission>
                 </RequireAuth>

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -294,68 +294,110 @@ describe('RequireAuth', () => {
   });
 });
 
+/**
+ * Helper local para reduzir duplicação dos cenários de `RequirePermission`.
+ * Concentra o boilerplate `MemoryRouter` + `AuthProvider` + `Routes` +
+ * `Route` + `RequirePermission` + `Route /error/:code` em um único lugar.
+ *
+ * Pontos de variação cobertos:
+ * - `protectedRoute` / `initialEntries` para roteamento.
+ * - `code` exigido pelo guard.
+ * - `sessionPermissions` para o `seedSession` (ou seed vazio com `[]`).
+ * - `protectedTestId` / `protectedLabel` para o conteúdo protegido.
+ * - `errorTestId` para o conteúdo de fallback.
+ * - `withProbe` para anexar a sonda de location na rota `/error/:code`
+ *   quando o teste asserir o redirect (`captured.current?.pathname`).
+ */
+interface RenderRequirePermissionOptions {
+  protectedRoute: string;
+  initialEntries?: string[];
+  code: string;
+  sessionPermissions: ReadonlyArray<string>;
+  protectedTestId: string;
+  protectedLabel: string;
+  errorTestId?: string;
+  withProbe?: boolean;
+}
+
+interface RenderRequirePermissionResult {
+  captured: { current: CapturedLocation | null };
+}
+
+function renderRequirePermissionScenario(
+  options: RenderRequirePermissionOptions,
+): RenderRequirePermissionResult {
+  const {
+    protectedRoute,
+    initialEntries = [protectedRoute],
+    code,
+    sessionPermissions,
+    protectedTestId,
+    protectedLabel,
+    errorTestId = 'error-page',
+    withProbe = false,
+  } = options;
+
+  seedSession(sessionPermissions);
+  const client = createClientStub();
+  const captured = { current: null as CapturedLocation | null };
+  const ErrorProbe = makeLocationProbe(captured);
+
+  render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
+        <Routes>
+          <Route
+            path={protectedRoute}
+            element={
+              <RequirePermission code={code}>
+                <div data-testid={protectedTestId}>{protectedLabel}</div>
+              </RequirePermission>
+            }
+          />
+          <Route
+            path="/error/:code"
+            element={
+              withProbe ? (
+                <>
+                  <ErrorProbe />
+                  <div data-testid={errorTestId}>erro</div>
+                </>
+              ) : (
+                <div data-testid={errorTestId}>erro</div>
+              )
+            }
+          />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+
+  return { captured };
+}
+
 describe('RequirePermission', () => {
   it('renderiza children quando a permissão exigida está presente', () => {
-    seedSession(['perm:Systems.Read', 'perm:Users.Read']);
-    const client = createClientStub();
-
-    render(
-      <MemoryRouter initialEntries={['/users']}>
-        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
-          <Routes>
-            <Route
-              path="/users"
-              element={
-                <RequirePermission code="perm:Users.Read">
-                  <div data-testid="users-page">users</div>
-                </RequirePermission>
-              }
-            />
-            <Route
-              path="/error/:code"
-              element={<div data-testid="error-page">erro</div>}
-            />
-          </Routes>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    renderRequirePermissionScenario({
+      protectedRoute: '/users',
+      code: 'perm:Users.Read',
+      sessionPermissions: ['perm:Systems.Read', 'perm:Users.Read'],
+      protectedTestId: 'users-page',
+      protectedLabel: 'users',
+    });
 
     expect(screen.getByTestId('users-page')).toBeInTheDocument();
     expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
   });
 
   it('redireciona para /error/403 quando o code não está presente', () => {
-    seedSession(['perm:Systems.Read']);
-    const client = createClientStub();
-
-    const captured = { current: null as CapturedLocation | null };
-    const ErrorProbe = makeLocationProbe(captured);
-
-    render(
-      <MemoryRouter initialEntries={['/users']}>
-        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
-          <Routes>
-            <Route
-              path="/users"
-              element={
-                <RequirePermission code="perm:Users.Read">
-                  <div data-testid="users-page">users</div>
-                </RequirePermission>
-              }
-            />
-            <Route
-              path="/error/:code"
-              element={
-                <>
-                  <ErrorProbe />
-                  <div data-testid="error-page">erro</div>
-                </>
-              }
-            />
-          </Routes>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    const { captured } = renderRequirePermissionScenario({
+      protectedRoute: '/users',
+      code: 'perm:Users.Read',
+      sessionPermissions: ['perm:Systems.Read'],
+      protectedTestId: 'users-page',
+      protectedLabel: 'users',
+      withProbe: true,
+    });
 
     expect(screen.queryByTestId('users-page')).not.toBeInTheDocument();
     expect(screen.getByTestId('error-page')).toBeInTheDocument();
@@ -364,29 +406,13 @@ describe('RequirePermission', () => {
 
   it('redireciona para /error/403 quando o usuário não tem permissões', () => {
     // Sessão sem nenhum code: sempre 403 em rotas com gating.
-    seedSession([]);
-    const client = createClientStub();
-
-    render(
-      <MemoryRouter initialEntries={['/permissions']}>
-        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
-          <Routes>
-            <Route
-              path="/permissions"
-              element={
-                <RequirePermission code="perm:Permissions.Read">
-                  <div data-testid="permissions-page">permissões</div>
-                </RequirePermission>
-              }
-            />
-            <Route
-              path="/error/:code"
-              element={<div data-testid="error-page">erro</div>}
-            />
-          </Routes>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    renderRequirePermissionScenario({
+      protectedRoute: '/permissions',
+      code: 'perm:Permissions.Read',
+      sessionPermissions: [],
+      protectedTestId: 'permissions-page',
+      protectedLabel: 'permissões',
+    });
 
     expect(screen.queryByTestId('permissions-page')).not.toBeInTheDocument();
     expect(screen.getByTestId('error-page')).toBeInTheDocument();
@@ -397,29 +423,13 @@ describe('RequirePermission', () => {
     // exatamente com o item em `permissions` (alimentado por
     // `permissionCodes` do verify-token). Usar o nome `SystemsRoutes`
     // do backend valida que os codes não-óbvios também são respeitados.
-    seedSession(['perm:SystemsRoutes.Read', 'perm:Systems.Read']);
-    const client = createClientStub();
-
-    render(
-      <MemoryRouter initialEntries={['/routes']}>
-        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
-          <Routes>
-            <Route
-              path="/routes"
-              element={
-                <RequirePermission code="perm:SystemsRoutes.Read">
-                  <div data-testid="routes-page">rotas</div>
-                </RequirePermission>
-              }
-            />
-            <Route
-              path="/error/:code"
-              element={<div data-testid="error-page">erro</div>}
-            />
-          </Routes>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    renderRequirePermissionScenario({
+      protectedRoute: '/routes',
+      code: 'perm:SystemsRoutes.Read',
+      sessionPermissions: ['perm:SystemsRoutes.Read', 'perm:Systems.Read'],
+      protectedTestId: 'routes-page',
+      protectedLabel: 'rotas',
+    });
 
     expect(screen.getByTestId('routes-page')).toBeInTheDocument();
     expect(screen.queryByTestId('error-page')).not.toBeInTheDocument();
@@ -429,37 +439,14 @@ describe('RequirePermission', () => {
     // Cenário do bug original (#116): se o catálogo `permissions` no
     // estado vier sem o code exato esperado pelo guard, o usuário cai
     // em 403 — confirmando que o match continua estritamente por igualdade.
-    seedSession(['perm:Systems.Read']);
-    const client = createClientStub();
-
-    const captured = { current: null as CapturedLocation | null };
-    const ErrorProbe = makeLocationProbe(captured);
-
-    render(
-      <MemoryRouter initialEntries={['/tokens']}>
-        <AuthProvider client={client} verifyIntervalMs={0} disableSplash>
-          <Routes>
-            <Route
-              path="/tokens"
-              element={
-                <RequirePermission code="perm:SystemTokensTypes.Read">
-                  <div data-testid="tokens-page">tokens</div>
-                </RequirePermission>
-              }
-            />
-            <Route
-              path="/error/:code"
-              element={
-                <>
-                  <ErrorProbe />
-                  <div data-testid="error-page">erro</div>
-                </>
-              }
-            />
-          </Routes>
-        </AuthProvider>
-      </MemoryRouter>,
-    );
+    const { captured } = renderRequirePermissionScenario({
+      protectedRoute: '/tokens',
+      code: 'perm:SystemTokensTypes.Read',
+      sessionPermissions: ['perm:Systems.Read'],
+      protectedTestId: 'tokens-page',
+      protectedLabel: 'tokens',
+      withProbe: true,
+    });
 
     expect(screen.queryByTestId('tokens-page')).not.toBeInTheDocument();
     expect(screen.getByTestId('error-page')).toBeInTheDocument();


### PR DESCRIPTION
## Contexto

O `AuthContext` populava `state.permissions` com `routeCodes`, que retornam apenas codes filtrados para o sistema **kurtto** — nada das permissões reais do `lfc-admin-gui`. Resultado: todos os `<RequirePermission>` redirecionavam para `/error/403`, deixando Systems/Roles/Users/Permissions/Tokens/Routes inacessíveis mesmo para o usuário `root`.

A issue depende de `lfc-authenticator#138`, já mergeada — o `verify-token` agora retorna `permissionCodes: string[]` com strings legíveis (`perm:<Recurso>.<Acao>`).

## Objetivo

Consumir o novo campo `permissionCodes` e ajustar os guards para usarem os codes reais do backend.

## O que foi feito

- `VerifyTokenResponse` recebe `permissionCodes: ReadonlyArray<string>` (campo novo); `permissions` (GUIDs) e `routeCodes` permanecem.
- `isValidVerifyTokenResponse` valida o novo campo como array de strings.
- `AuthContext.login()` e a hidratação remota populam `state.permissions` (e o storage) com `permissionCodes` em vez de `routeCodes`.
- `routes/index.tsx` adota os 6 codes com prefixo `perm:` e os nomes corretos do backend:
  - `/systems` → `perm:Systems.Read`
  - `/routes` → `perm:SystemsRoutes.Read`
  - `/roles` → `perm:Roles.Read`
  - `/permissions` → `perm:Permissions.Read`
  - `/users` → `perm:Users.Read`
  - `/tokens` → `perm:SystemTokensTypes.Read`
- Fixtures dos 4 testes afetados (`AuthProvider.test.tsx`, `guards.test.tsx`, `LoginPage.test.tsx`, `App.test.tsx`) atualizadas para o novo shape.
- 2 testes novos em `guards.test.tsx`: render permitido com code de recurso não óbvio (`SystemsRoutes`) presente em `permissionCodes` e redirect para `/error/403` quando o code com prefixo `perm:` não está presente.

## Arquivos impactados

- `src/shared/auth/types.ts`
- `src/shared/auth/AuthContext.tsx`
- `src/routes/index.tsx`
- `tests/shared/auth/AuthProvider.test.tsx`
- `tests/shared/auth/guards.test.tsx`
- `tests/pages/LoginPage.test.tsx`
- `tests/App.test.tsx`

## Testes

- `docker compose exec -T web npm run lint` — verde
- `docker compose exec -T web npm run typecheck` — verde
- `docker compose exec -T web npm run test` — 238/238 verdes (236 anteriores + 2 novos cenários de guard)
- `docker compose exec -T web npm run build` — verde

## Validação manual

- `POST /api/v1/auth/login` em `localhost:8080` com `root@email.com.br` / `toor` retorna token.
- `GET /api/v1/auth/verify-token` com o token confirma que `permissionCodes` inclui os 6 codes consumidos pelos guards: `perm:Systems.Read`, `perm:SystemsRoutes.Read`, `perm:Roles.Read`, `perm:Permissions.Read`, `perm:Users.Read`, `perm:SystemTokensTypes.Read`.
- Build pronta para servir em `localhost:3002`; o fluxo de login real popula `state.permissions` com strings `perm:*` e libera as rotas administrativas sem redirecionar para 403.

## Visual

Sem mudança visual.

## Segurança

Sem impacto. O type guard exige array de strings em `permissionCodes`, evitando que entradas corrompidas caiam em `state.permissions`.

## Riscos

- O catálogo `routeCodes` deixa de ser fonte de `permissions`; nenhum callsite remanescente o consumia para `hasPermission`. Caso outra feature dependa de `routeCodes`, ele continua disponível em `VerifyTokenResponse`.

## Issue relacionada

Closes #116
Ref `lfc-authenticator#138`