### PR TITLE
feat(systems): listagem com busca e paginação server-side (#57)

### DIFF
--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Espelha `value` em um estado interno com atraso de `delayMs`.
+ *
+ * Útil em campos de busca: o `value` reflete o input em tempo real (UI
+ * responsiva) e o `debouncedValue` só dispara depois que o usuário para
+ * de digitar pelo intervalo configurado — evita uma request por tecla.
+ *
+ * Cada mudança em `value` reseta o timer; o cleanup garante que apenas
+ * o último valor pendente é aplicado quando o componente desmonta ou o
+ * `value` muda novamente antes do timeout disparar.
+ *
+ * `delayMs <= 0` aplica o valor imediatamente — útil em testes que
+ * preferem desabilitar o debounce.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setDebounced(value);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setDebounced(value);
+    }, delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -1,175 +1,561 @@
-import { Filter, Plus, Shuffle, Activity } from 'lucide-react';
-import React from 'react';
+import { ChevronLeft, ChevronRight, RotateCcw, Search } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { PageHeader } from '../components/layout/PageHeader';
-import { Button, Badge, PermChip, Card } from '../components/ui';
+import {
+  Alert,
+  Badge,
+  Button,
+  Input,
+  Spinner,
+  Switch,
+  Table,
+} from '../components/ui';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import {
+  DEFAULT_INCLUDE_DELETED,
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  isApiError,
+  listSystems,
+} from '../shared/api';
 
-import type { BadgeVariant } from '../components/ui';
-
-interface SystemItem {
-  id: string;
-  name: string;
-  stack: string;
-  status: 'active' | 'inactive' | 'verifying' | 'pending';
-  routes: number;
-  tokens: number;
-}
-
-const INITIAL_SYSTEMS: SystemItem[] = [
-  { id: 'sys_a1b2c3', name: 'lfc-authenticator',  stack: 'ASP.NET Core 10 · PostgreSQL',        status: 'active',    routes: 42, tokens: 128 },
-  { id: 'sys_d4e5f6', name: 'lfc-kurtto',         stack: 'Node.js · TypeScript · PostgreSQL',   status: 'verifying', routes: 14, tokens: 22  },
-  { id: 'sys_g7h8i9', name: 'lfc-reportd',        stack: 'Go 1.22 · ClickHouse',               status: 'active',    routes: 8,  tokens: 41  },
-  { id: 'sys_j0k1l2', name: 'lfc-legacy-bridge',  stack: 'Python 3.12 · MySQL',                status: 'inactive',  routes: 3,  tokens: 0   },
-];
-
-const STATUS_MAP: Record<SystemItem['status'], { variant: BadgeVariant; label: string }> = {
-  active:    { variant: 'success', label: 'Ativo' },
-  inactive:  { variant: 'danger',  label: 'Inativo' },
-  verifying: { variant: 'info',    label: 'Verificando' },
-  pending:   { variant: 'warning', label: 'Pendente' },
-};
+import type { TableColumn } from '../components/ui';
+import type { ApiClient, PagedResponse, SystemDto } from '../shared/api';
 
 /**
- * StatRow — em mobile (< --bp-md, 48em) duas colunas para evitar números
- * espremidos; a partir de `--bp-md` recupera o layout 4×1 característico.
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
+ * o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 request por caractere.
  */
-const StatRow = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface SystemsPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido — a
+   * página usa o singleton `apiClient` por trás de `listSystems`. Em
+   * testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+interface PageData {
+  /** Itens da página corrente devolvidos pelo backend. */
+  rows: ReadonlyArray<SystemDto>;
+  /** Tamanho de página efetivamente aplicado. */
+  pageSize: number;
+  /** Total filtrado (antes do skip/take). */
+  total: number;
+}
+
+const INITIAL_PAGE_DATA: PageData = {
+  rows: [],
+  pageSize: DEFAULT_PAGE_SIZE,
+  total: 0,
+};
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+const Toolbar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
   margin-bottom: var(--space-5);
 
   @media (min-width: 48em) {
-    grid-template-columns: repeat(4, 1fr);
-    gap: 14px;
-    margin-bottom: 26px;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-6);
   }
 `;
 
-const StatCard = styled.div`
-  background: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: 14px 16px;
+const SearchSlot = styled.div`
+  width: 100%;
 
   @media (min-width: 48em) {
-    padding: 16px 18px;
+    max-width: 360px;
+    flex: 1;
   }
 `;
 
-const StatNumber = styled.div`
-  font-size: 24px;
-  font-weight: var(--weight-bold);
-  letter-spacing: -0.03em;
-  color: var(--fg1);
-
-  @media (min-width: 48em) {
-    font-size: 28px;
-  }
+const ToggleSlot = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
-const StatLabel = styled.div`
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--fg3);
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  margin-top: 4px;
+const TableShell = styled.div`
+  position: relative;
 `;
 
 /**
- * Grid de cards de sistemas. Em mobile (< --bp-md) cada card ocupa a
- * largura inteira; a partir de `--bp-md` (48em) volta a duas colunas.
+ * Overlay leve aplicado em cima da tabela durante refetches subsequentes
+ * (busca/paginação/toggle). Mantém os dados anteriores visíveis para
+ * evitar flicker enquanto sinaliza atividade — o spinner ancorado ao
+ * topo deixa claro que algo está em curso sem mover a tabela.
  */
-const Grid2 = styled.div`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
+const TableOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: var(--space-6);
+  background: color-mix(in srgb, var(--bg-base) 55%, transparent);
+  border-radius: var(--radius-lg);
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const InitialLoading = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-12) 0;
+`;
+
+const ErrorBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+`;
+
+const FootBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: stretch;
+  margin-top: var(--space-5);
 
   @media (min-width: 48em) {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 16px;
-  }
-`;
-
-const CardMeta = styled.div`
-  font-size: 12.5px;
-  color: var(--fg3);
-  margin-bottom: 12px;
-`;
-
-const PermRow = styled.div`
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-bottom: 12px;
-`;
-
-const CardStats = styled.div`
-  display: flex;
-  gap: 14px;
-  flex-wrap: wrap;
-  font-size: 12px;
-  color: var(--fg2);
-  padding-top: 12px;
-  border-top: 1px solid var(--border-subtle);
-  align-items: center;
-
-  > span {
-    display: inline-flex;
+    flex-direction: row;
     align-items: center;
-    gap: 5px;
+    justify-content: space-between;
   }
 `;
 
-const MonoMuted = styled.span`
+const PageInfo = styled.span`
   font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--fg3);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
 `;
 
-export const SystemsPage: React.FC = () => (
-  <>
-    <PageHeader
-      eyebrow="01 Sistemas"
-      title="Sistemas cadastrados"
-      desc="Serviços registrados no ecossistema de autenticação. Cada sistema possui suas próprias rotas, roles e permissões."
-      actions={
-        <>
-          <Button variant="secondary" icon={<Filter size={14} strokeWidth={1.5} />}>Filtrar</Button>
-          <Button variant="primary" icon={<Plus size={14} strokeWidth={1.5} />}>Novo sistema</Button>
-        </>
-      }
-    />
-    <StatRow>
-      <StatCard><StatNumber>4</StatNumber><StatLabel>Sistemas</StatLabel></StatCard>
-      <StatCard><StatNumber>67</StatNumber><StatLabel>Rotas totais</StatLabel></StatCard>
-      <StatCard><StatNumber>191</StatNumber><StatLabel>Tokens ativos</StatLabel></StatCard>
-      <StatCard><StatNumber>1</StatNumber><StatLabel>Inativo</StatLabel></StatCard>
-    </StatRow>
-    <Grid2>
-      {INITIAL_SYSTEMS.map(s => {
-        const { variant, label } = STATUS_MAP[s.status];
-        return (
-          <Card
-            key={s.id}
-            title={s.name}
-            right={<Badge variant={variant} dot>{label}</Badge>}
+const PageNav = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+`;
+
+const EmptyMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+`;
+
+const EmptyTitle = styled.span`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+`;
+
+const EmptyHint = styled.span`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg2);
+`;
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Calcula a quantidade total de páginas a partir do `total` filtrado e
+ * do `pageSize` aplicado. Com `total === 0`, devolve `1` para que os
+ * controles de paginação sigam exibindo "página 1 de 1" (e ambos prev/
+ * next apareçam desabilitados) — preserva consistência visual no estado
+ * vazio.
+ */
+function computeTotalPages(total: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  if (total <= 0) return 1;
+  return Math.ceil(total / pageSize);
+}
+
+/**
+ * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
+ *
+ * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
+ * resolveu fallbacks por status). Para erros arbitrários, usamos uma
+ * mensagem genérica em pt-BR — preserva privacidade da arquitetura
+ * (não vaza stack/objeto cru) sem mascarar a origem do problema.
+ */
+function extractErrorMessage(error: unknown): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  return 'Falha ao carregar a lista de sistemas. Tente novamente.';
+}
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_PAGE);
+
+  const [data, setData] = useState<PageData>(INITIAL_PAGE_DATA);
+  const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Controller da request mais recente — usado para cancelar a anterior
+  // em mudanças rápidas de busca/paginação/toggle.
+  const lastControllerRef = useRef<AbortController | null>(null);
+  // Sinaliza se a primeira request já completou (sucesso OU erro). O
+  // estado `isInitialLoading` deve cair na primeira resposta para que o
+  // próximo refetch use o overlay leve em vez do spinner cheio.
+  const hasCompletedFirstRequestRef = useRef<boolean>(false);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
+   * 3 itens, mas continuo na página 5 vazia". `page` é setado direto
+   * pelos callbacks dos controles para manter o efeito previsível.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_PAGE);
+  }, []);
+
+  // Bumper monotônico para forçar refetch via "Tentar novamente" sem
+  // mexer em filtros — dependência sintética do useEffect.
+  const [retryNonce, setRetryNonce] = useState<number>(0);
+  const handleRetry = useCallback(() => {
+    setRetryNonce(n => n + 1);
+  }, []);
+
+  /**
+   * Dispara `listSystems` sempre que mudam: termo debounced, página,
+   * filtro de inativos ou bumper de retry. Cancela qualquer request em
+   * voo antes de disparar a nova — ignorando `AbortError` no catch.
+   */
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    if (hasCompletedFirstRequestRef.current) {
+      setIsFetching(true);
+    }
+
+    const trimmed = debouncedSearch.trim();
+    const params = {
+      q: trimmed.length > 0 ? trimmed : undefined,
+      page,
+      pageSize: DEFAULT_PAGE_SIZE,
+      includeDeleted,
+    };
+
+    listSystems(params, { signal: controller.signal }, client)
+      .then((response: PagedResponse<SystemDto>) => {
+        if (cancelled) return;
+        setData({
+          rows: response.data,
+          pageSize: response.pageSize,
+          total: response.total,
+        });
+        setErrorMessage(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        // Cancelamento explícito (fetch abortado) é fluxo normal —
+        // não vira erro de UI.
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        if (
+          isApiError(error) &&
+          error.kind === 'network' &&
+          error.message === 'Requisição cancelada.'
+        ) {
+          return;
+        }
+        setErrorMessage(extractErrorMessage(error));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        hasCompletedFirstRequestRef.current = true;
+        setIsInitialLoading(false);
+        setIsFetching(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, debouncedSearch, includeDeleted, page, retryNonce]);
+
+  const totalPages = useMemo(
+    () => computeTotalPages(data.total, data.pageSize),
+    [data.total, data.pageSize],
+  );
+
+  const isFirstPage = page <= 1;
+  const isLastPage = page >= totalPages;
+
+  const handlePrevPage = useCallback(() => {
+    setPage(prev => (prev > 1 ? prev - 1 : prev));
+  }, []);
+
+  const handleNextPage = useCallback(() => {
+    setPage(prev => (prev < totalPages ? prev + 1 : prev));
+  }, [totalPages]);
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `data.rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio com toggle "incluir inativos" mas sem busca → mensagem
+   *   neutra (não há nem sistemas vivos nem soft-deleted).
+   * - Vazio sem busca → "nenhum sistema cadastrado" (default puro).
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhum sistema encontrado para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="systems-empty-clear"
           >
-            <CardMeta>{s.stack}</CardMeta>
-            <PermRow>
-              <PermChip>perm:Systems.Read</PermChip>
-              <PermChip>perm:Routes.List</PermChip>
-            </PermRow>
-            <CardStats>
-              <span><Shuffle size={12} strokeWidth={1.5} /> {s.routes} rotas</span>
-              <span><Activity size={12} strokeWidth={1.5} /> {s.tokens} tokens</span>
-              <MonoMuted>{s.id}</MonoMuted>
-            </CardStats>
-          </Card>
-        );
-      })}
-    </Grid2>
-  </>
-);
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhum sistema cadastrado.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Sistemas removidos podem ser visualizados ativando &quot;Mostrar inativos&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  const columns = useMemo<ReadonlyArray<TableColumn<SystemDto>>>(
+    () => [
+      {
+        key: 'name',
+        label: 'Nome',
+        render: row => row.name,
+      },
+      {
+        key: 'code',
+        label: 'Código',
+        render: row => <Mono>{row.code}</Mono>,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '140px',
+        render: row =>
+          row.deletedAt ? (
+            <Badge variant="danger" dot>
+              Inativo
+            </Badge>
+          ) : (
+            <Badge variant="success" dot>
+              Ativo
+            </Badge>
+          ),
+      },
+    ],
+    [],
+  );
+
+  const showOverlay = isFetching && !isInitialLoading;
+
+  // ARIA-live: anuncia o estado da tabela quando muda. Em loading
+  // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
+  // o total. Em erro, o `<Alert role="alert">` já cobre.
+  const liveMessage = useMemo<string>(() => {
+    if (isInitialLoading) return 'Carregando lista de sistemas.';
+    if (isFetching) return 'Atualizando lista de sistemas.';
+    if (errorMessage) return '';
+    if (data.total === 0) {
+      return hasActiveSearch
+        ? `Nenhum sistema encontrado para ${trimmedSearch}.`
+        : 'Nenhum sistema cadastrado.';
+    }
+    return `${data.total} sistema(s) encontrado(s). Página ${page} de ${totalPages}.`;
+  }, [
+    data.total,
+    errorMessage,
+    hasActiveSearch,
+    isFetching,
+    isInitialLoading,
+    page,
+    totalPages,
+    trimmedSearch,
+  ]);
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="01 Sistemas"
+        title="Sistemas cadastrados"
+        desc="Serviços registrados no ecossistema de autenticação. Cada sistema possui suas próprias rotas, roles e permissões."
+      />
+
+      <Toolbar>
+        <SearchSlot>
+          <Input
+            label="Buscar"
+            type="search"
+            placeholder="Nome ou código do sistema"
+            icon={<Search size={14} strokeWidth={1.5} />}
+            value={searchTerm}
+            onChange={handleSearchChange}
+            aria-label="Buscar sistemas por nome ou código"
+            data-testid="systems-search"
+          />
+        </SearchSlot>
+        <ToggleSlot>
+          <Switch
+            label="Mostrar inativos"
+            helperText="Inclui sistemas com remoção lógica."
+            checked={includeDeleted}
+            onChange={handleIncludeDeletedChange}
+            data-testid="systems-include-deleted"
+          />
+        </ToggleSlot>
+      </Toolbar>
+
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+        data-testid="systems-live"
+      >
+        {liveMessage}
+      </span>
+
+      {isInitialLoading && (
+        <InitialLoading data-testid="systems-loading">
+          <Spinner size="lg" label="Carregando sistemas" />
+        </InitialLoading>
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorBlock>
+          <Alert variant="danger">{errorMessage}</Alert>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<RotateCcw size={14} strokeWidth={1.5} />}
+            onClick={handleRetry}
+            data-testid="systems-retry"
+          >
+            Tentar novamente
+          </Button>
+        </ErrorBlock>
+      )}
+
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          <Table<SystemDto>
+            caption="Lista de sistemas cadastrados no auth-service."
+            columns={columns}
+            data={data.rows}
+            getRowKey={row => row.id}
+            emptyState={emptyContent}
+          />
+          {showOverlay && (
+            <TableOverlay aria-hidden="true" data-testid="systems-overlay">
+              <Spinner size="md" label="Atualizando" />
+            </TableOverlay>
+          )}
+        </TableShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && data.total > 0 && (
+        <FootBar>
+          <PageInfo data-testid="systems-page-info">
+            Página {page} de {totalPages} · {data.total} resultado(s)
+          </PageInfo>
+          <PageNav>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ChevronLeft size={14} strokeWidth={1.5} />}
+              disabled={isFirstPage}
+              onClick={handlePrevPage}
+              aria-label="Ir para a página anterior"
+              data-testid="systems-prev"
+            >
+              Anterior
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ChevronRight size={14} strokeWidth={1.5} />}
+              disabled={isLastPage}
+              onClick={handleNextPage}
+              aria-label="Ir para a próxima página"
+              data-testid="systems-next"
+            >
+              Próxima
+            </Button>
+          </PageNav>
+        </FootBar>
+      )}
+    </>
+  );
+};

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -67,3 +67,15 @@ export type {
   RequestOptions,
   SafeRequestOptions,
 } from './types';
+export {
+  DEFAULT_INCLUDE_DELETED,
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  isPagedSystemsResponse,
+  listSystems,
+} from './systems';
+export type {
+  ListSystemsParams,
+  PagedResponse,
+  SystemDto,
+} from './systems';

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -1,0 +1,188 @@
+import { apiClient } from './index';
+
+import type { ApiClient, SafeRequestOptions } from './types';
+
+/**
+ * Envelope genérico de resposta paginada do `lfc-authenticator`
+ * (`PagedResponse<T>` em `AuthService.Controllers.Common`).
+ *
+ * O backend devolve este formato sempre que um endpoint de listagem
+ * suporta `page`/`pageSize`/filtros — `total` é o count após filtros e
+ * antes do `Skip`/`Take`. Tipo genérico para que outros recursos da
+ * EPIC #45 (rotas, roles, permissões, clientes, usuários) reutilizem o
+ * mesmo contrato sem duplicação.
+ */
+export interface PagedResponse<T> {
+  /** Itens da página corrente (após filtros + skip/take). */
+  data: ReadonlyArray<T>;
+  /** Página retornada (1-based) após defaults/validação no backend. */
+  page: number;
+  /** Tamanho de página efetivamente aplicado. */
+  pageSize: number;
+  /** Total de registros que casam com os filtros aplicados. */
+  total: number;
+}
+
+/**
+ * Espelho do `SystemResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Systems.SystemsController.SystemResponse`).
+ *
+ * O backend serializa as datas em ISO 8601 (UTC) — mantemos como `string`
+ * porque a UI consome via `Intl.DateTimeFormat`/`new Date()` quando
+ * precisar exibir; converter no boundary do cliente HTTP traria custo
+ * sem benefício. `deletedAt !== null` indica soft-delete.
+ */
+export interface SystemDto {
+  id: string;
+  name: string;
+  code: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `SystemDto`. Tolera `description`/`deletedAt` ausentes
+ * (tratados como `null`) — outros campos são obrigatórios e checados em
+ * runtime.
+ */
+function isSystemDto(value: unknown): value is SystemDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.code === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.description === null ||
+      record.description === undefined ||
+      typeof record.description === 'string') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<SystemDto>`. Valida o envelope antes de
+ * confiar no payload — protege contra divergência silenciosa de versão
+ * entre frontend e backend (proxy intermediário cortando campos, deploy
+ * desalinhado).
+ */
+export function isPagedSystemsResponse(
+  value: unknown,
+): value is PagedResponse<SystemDto> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isSystemDto);
+}
+
+/**
+ * Defaults usados pela `listSystems` para omitir parâmetros que coincidem
+ * com o backend — preserva a URL "limpa" no caminho default
+ * (`GET /systems` em vez de `GET /systems?q=&page=1&pageSize=20&includeDeleted=false`).
+ *
+ * Exportados para que a UI compartilhe a mesma fonte de verdade ao
+ * inicializar o estado dos controles de busca/paginação/filtro.
+ */
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 20;
+export const DEFAULT_INCLUDE_DELETED = false;
+
+/**
+ * Parâmetros aceitos por `listSystems`. Todos opcionais — quando omitidos
+ * (ou iguais aos defaults), são removidos da querystring.
+ */
+export interface ListSystemsParams {
+  /** Termo de busca (case-insensitive em `Name` e `Code`). */
+  q?: string;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
+  pageSize?: number;
+  /** Quando `true`, inclui sistemas com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de proxy.
+ *
+ * `q` é trimado e omitido quando vazio para evitar `?q=` literal (que o
+ * backend trataria como busca por string vazia, mas a UI sinalizaria
+ * estado de "busca ativa" no `q`).
+ */
+function buildQueryString(params: ListSystemsParams): string {
+  const search = new URLSearchParams();
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set('q', q);
+  }
+
+  if (typeof params.page === 'number' && params.page !== DEFAULT_PAGE) {
+    search.set('page', String(params.page));
+  }
+
+  if (
+    typeof params.pageSize === 'number' &&
+    params.pageSize !== DEFAULT_PAGE_SIZE
+  ) {
+    search.set('pageSize', String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === 'boolean' &&
+    params.includeDeleted !== DEFAULT_INCLUDE_DELETED
+  ) {
+    search.set('includeDeleted', String(params.includeDeleted));
+  }
+
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : '';
+}
+
+/**
+ * Lista sistemas via `GET /systems` com busca, paginação e filtro de
+ * soft-deleted.
+ *
+ * Retorna o envelope tipado `PagedResponse<SystemDto>`. Lança `ApiError`
+ * em falhas (rede, parse, HTTP); o caller deve tratar com try/catch.
+ *
+ * Cancelamento: aceita `signal` em `options` (via AbortController) — em
+ * navegações rápidas, o caller cancela a request anterior antes de
+ * disparar a nova, evitando race em `setState`.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); o default usa o singleton `apiClient`
+ * configurado com `baseUrl` + `systemId` reais.
+ */
+export async function listSystems(
+  params: ListSystemsParams = {},
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<SystemDto>> {
+  const path = `/systems${buildQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedSystemsResponse(data)) {
+    throw {
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    };
+  }
+  return data;
+}

--- a/tests/pages/SystemsPage.test.tsx
+++ b/tests/pages/SystemsPage.test.tsx
@@ -1,0 +1,585 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, ApiError, PagedResponse, SystemDto } from '@/shared/api';
+
+import { SystemsPage } from '@/pages/SystemsPage';
+
+/**
+ * Atraso de debounce esperado pela página (300 ms). Espelha o valor
+ * interno da `SystemsPage` — alterar em ambos os lados quando ajustar
+ * a UX, ou (idealmente) extrair em constante exportada de um módulo
+ * compartilhado quando outras páginas reusarem o mesmo padrão.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * UUID de um sistema arbitrário fixado para que asserts comparem strings
+ * estáveis em vez de gerar GUIDs aleatórios a cada execução.
+ */
+const ID_SYS_AUTH = '11111111-1111-1111-1111-111111111111';
+const ID_SYS_KURTTO = '22222222-2222-2222-2222-222222222222';
+const ID_SYS_LEGACY = '33333333-3333-3333-3333-333333333333';
+
+/**
+ * Stub de `ApiClient` injetado em `<SystemsPage client={stub} />` —
+ * mesmo padrão de injeção usado nos testes de auth (PR #122/#123).
+ */
+type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+function createClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `SystemDto` com defaults — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos do contrato.
+ */
+function makeSystem(overrides: Partial<SystemDto> = {}): SystemDto {
+  return {
+    id: ID_SYS_AUTH,
+    name: 'lfc-authenticator',
+    code: 'AUTH',
+    description: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend — `total` reflete o
+ * `data.length` por default; testes que cobrem paginação sobrescrevem.
+ */
+function makePagedResponse(
+  data: ReadonlyArray<SystemDto>,
+  overrides: Partial<PagedResponse<SystemDto>> = {},
+): PagedResponse<SystemDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+const SAMPLE_ROWS: ReadonlyArray<SystemDto> = [
+  makeSystem({
+    id: ID_SYS_AUTH,
+    name: 'lfc-authenticator',
+    code: 'AUTH',
+  }),
+  makeSystem({
+    id: ID_SYS_KURTTO,
+    name: 'lfc-kurtto',
+    code: 'KURTTO',
+  }),
+  makeSystem({
+    id: ID_SYS_LEGACY,
+    name: 'lfc-legacy-bridge',
+    code: 'LEGACY',
+    deletedAt: '2026-02-01T00:00:00Z',
+  }),
+];
+
+/**
+ * Helper para extrair o `query` do path passado a `client.get`. Usado em
+ * asserts que verificam a serialização da querystring.
+ */
+function lastGetPath(client: ApiClientStub): string {
+  const calls = client.get.mock.calls;
+  if (calls.length === 0) return '';
+  const path = calls[calls.length - 1][0];
+  return typeof path === 'string' ? path : '';
+}
+
+beforeEach(() => {
+  // `shouldAdvanceTime: true` permite que `setTimeout` interno do
+  // testing-library (`waitFor`/`findBy*`) avance com o relógio real
+  // enquanto `vi.advanceTimersByTime(...)` ainda controla manualmente o
+  // debounce da busca. Sem isso, o tempo virtual congela e `waitFor`
+  // espera por timeouts que nunca disparam — fonte do bloqueio inicial
+  // da implementação. Padrão recomendado pelo Vitest para tests de
+  // componentes com debounce + RTL.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('SystemsPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e depois popula a tabela', async () => {
+    const client = createClientStub();
+    let resolveFn: (value: PagedResponse<SystemDto>) => void = () => undefined;
+    const pending = new Promise<PagedResponse<SystemDto>>(resolve => {
+      resolveFn = resolve;
+    });
+    client.get.mockReturnValueOnce(pending);
+
+    render(<SystemsPage client={client} />);
+
+    expect(screen.getByTestId('systems-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(makePagedResponse(SAMPLE_ROWS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('lfc-authenticator')).toBeInTheDocument();
+    expect(screen.getByText('lfc-kurtto')).toBeInTheDocument();
+    expect(screen.getByText('lfc-legacy-bridge')).toBeInTheDocument();
+  });
+
+  it('renderiza header com título e descrição da página', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('heading', { name: /Sistemas cadastrados/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend com defaults e sem querystring no primeiro render', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(lastGetPath(client)).toBe('/systems');
+  });
+
+  it('renderiza badge "Inativo" para sistemas com deletedAt e "Ativo" para os demais', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedResponse([
+        makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
+        makeSystem({
+          id: ID_SYS_LEGACY,
+          name: 'lfc-legacy-bridge',
+          code: 'LEGACY',
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    // rows[0] é o header.
+    const authRow = rows[1];
+    const legacyRow = rows[2];
+    expect(within(authRow).getByText('Ativo')).toBeInTheDocument();
+    expect(within(legacyRow).getByText('Inativo')).toBeInTheDocument();
+  });
+});
+
+describe('SystemsPage — busca debounced', () => {
+  it('digitar não dispara request imediato; após 300ms dispara com q=auth', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('systems-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'auth' } });
+
+    // Antes de avançar o timer, ainda só há a request inicial.
+    expect(client.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/systems?q=auth');
+  });
+
+  it('cliques de teclado em sequência só disparam a última busca', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('systems-search') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'au' } });
+    fireEvent.change(input, { target: { value: 'aut' } });
+    fireEvent.change(input, { target: { value: 'auth' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/systems?q=auth');
+  });
+
+  it('busca limpa volta para o caminho default (sem querystring)', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('systems-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'auth' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/systems?q=auth');
+
+    fireEvent.change(input, { target: { value: '' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe('/systems');
+  });
+});
+
+describe('SystemsPage — paginação', () => {
+  it('clicar "próxima" chama com page=2; "anterior" volta para page default', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValue(
+      makePagedResponse(SAMPLE_ROWS, { page: 1, total: 50 }),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('systems-next'));
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/systems?page=2');
+
+    fireEvent.click(screen.getByTestId('systems-prev'));
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe('/systems');
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedResponse(SAMPLE_ROWS, { page: 1, total: 50 }),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('systems-prev')).toBeDisabled();
+    expect(screen.getByTestId('systems-next')).toBeEnabled();
+  });
+
+  it('botão "próxima" desabilita na última página', async () => {
+    const client = createClientStub();
+    // total=15, pageSize=20 → totalPages=1 → ambos desabilitados.
+    client.get.mockResolvedValueOnce(
+      makePagedResponse(SAMPLE_ROWS, { page: 1, total: 15, pageSize: 20 }),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('systems-prev')).toBeDisabled();
+    expect(screen.getByTestId('systems-next')).toBeDisabled();
+  });
+
+  it('exibe indicador "página X de Y" com total filtrado', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedResponse(SAMPLE_ROWS, { page: 1, total: 42 }),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    const info = screen.getByTestId('systems-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('SystemsPage — filtro de inativos', () => {
+  it('liga toggle dispara request com includeDeleted=true', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const toggle = screen.getByTestId('systems-include-deleted') as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/systems?includeDeleted=true');
+  });
+
+  it('badge "Inativo" aparece quando deletedAt está presente', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedResponse([
+        makeSystem({
+          id: ID_SYS_LEGACY,
+          name: 'lfc-legacy-bridge',
+          code: 'LEGACY',
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Inativo')).toBeInTheDocument();
+  });
+});
+
+describe('SystemsPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createClientStub();
+    // Primeiro carregamento: lista normal.
+    client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
+    // Após busca debounced: backend devolve vazio.
+    client.get.mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+
+    render(<SystemsPage client={client} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('systems-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    // `getAllByText` em vez de `getByText`: o texto aparece tanto no
+    // aria-live span (acessibilidade) quanto na EmptyMessage visual —
+    // a duplicação é proposital. Asserir presença sem exigir unicidade.
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhum sistema encontrado para/i).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.getByTestId('systems-empty-clear')).toBeInTheDocument();
+  });
+
+  it('vazio sem busca: mensagem dedicada de "nenhum cadastrado"', async () => {
+    const client = createClientStub();
+    client.get.mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+
+    render(<SystemsPage client={client} />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
+    });
+
+    // Idem: aria-live + EmptyMessage repetem o texto.
+    expect(
+      screen.getAllByText(/Nenhum sistema cadastrado\./i).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByTestId('systems-empty-clear')).not.toBeInTheDocument();
+  });
+
+  it('clicar em "limpar busca" reseta termo e dispara nova request', async () => {
+    const client = createClientStub();
+    client.get
+      .mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS))
+      .mockResolvedValueOnce(makePagedResponse([], { total: 0 }))
+      .mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('systems-search'), {
+      target: { value: 'naoexiste' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(await screen.findByTestId('systems-empty-clear'));
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe('/systems');
+  });
+});
+
+describe('SystemsPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createClientStub();
+    client.get
+      .mockRejectedValueOnce(apiError)
+      .mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
+
+    render(<SystemsPage client={client} />);
+
+    expect(
+      await screen.findByText(/Falha de conexão com o servidor\./i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('systems-retry'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('lfc-authenticator')).toBeInTheDocument();
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createClientStub();
+    client.get.mockRejectedValueOnce(new Error('boom'));
+
+    render(<SystemsPage client={client} />);
+
+    expect(
+      await screen.findByText(
+        /Falha ao carregar a lista de sistemas\. Tente novamente\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('SystemsPage — cancelamento de request', () => {
+  it('navegação rápida (busca + paginação) cancela a request anterior via AbortController', async () => {
+    const client = createClientStub();
+    // Capturar os signals para asserir abort.
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (
+        _path: string,
+        options?: { signal?: AbortSignal },
+      ): Promise<PagedResponse<SystemDto>> => {
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        return Promise.resolve(makePagedResponse(SAMPLE_ROWS));
+      },
+    );
+
+    render(<SystemsPage client={client} />);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    // Dispara duas buscas rapidamente — sem debounce, segunda mudança
+    // imediata cancelaria a primeira; com debounce, fazemos uma busca
+    // e depois um clique de paginação.
+    fireEvent.change(screen.getByTestId('systems-search'), {
+      target: { value: 'auth' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    // Imediatamente paginar — deve abortar a request da busca
+    // (que aqui já resolveu, mas o signal anterior continua observável
+    // pelo cleanup do useEffect anterior).
+    fireEvent.change(screen.getByTestId('systems-search'), {
+      target: { value: 'auths' },
+    });
+
+    // Antes do debounce, a segunda mudança ainda não disparou request.
+    expect(client.get).toHaveBeenCalledTimes(2);
+
+    // Quando o useEffect anterior é desmontado pelo cleanup (a
+    // dependência `debouncedSearch` muda apenas após o timer), o
+    // controller anterior é abortado. Aqui validamos que o signal mais
+    // recente disponível é o que segue ativo.
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    // O penúltimo signal foi abortado pelo cleanup do effect que
+    // disparou a request "auth" — quando o efeito recompila o run-time
+    // dispara novo controller.
+    // Aqui, com fake timers, ainda não houve novo run; mas o effect
+    // anterior já foi limpo na próxima execução do timer:
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+
+    // Agora o signal #2 (da busca "auth") deve estar abortado: o
+    // cleanup do useEffect que rodou para "auth" foi chamado quando
+    // `debouncedSearch` mudou para "auths".
+    expect(signals[1].aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa a listagem de sistemas em `/systems` consumindo o endpoint paginado do `lfc-authenticator` (estendido em `lfc-authenticator#151` / PR #152, mergeado em `development`).

Resolve #57. Parte da EPIC #45.

## O que entra

### Tipos compartilhados (`src/shared/api/systems.ts`)
- `PagedResponse<T>` genérico — reutilizável pelas próximas issues da EPIC (#58/#59/#60/#61) e por outros recursos paginados.
- `SystemDto` espelhando o `SystemResponse` do backend.
- Type guards (`isSystemDto`, `isPagedSystemsResponse`) que validam shape antes de confiar no payload.
- `listSystems(params, options, client)` com cliente injetável, querystring que **omite parâmetros default** (mantém URL canônica em GET sem filtros).
- Constantes `DEFAULT_PAGE`, `DEFAULT_PAGE_SIZE`, `DEFAULT_INCLUDE_DELETED` exportadas e reusadas pela UI (única fonte de verdade dos defaults).

### Hook `useDebouncedValue` (`src/hooks/useDebouncedValue.ts`)
- Genérico, com cleanup correto (sem leak em unmount).
- `delayMs <= 0` aplica imediatamente — útil para testes que preferem desabilitar o debounce.

### `SystemsPage` (`src/pages/SystemsPage.tsx`)
- **Toolbar**: input de busca debounced (300ms) + toggle "Mostrar inativos".
- **Tabela**: Nome / Código (mono) / Status (`Badge` Ativo verde, Inativo vermelho).
- **Paginação**: prev/next desabilitados nos limites + indicador "Página X de Y · N resultado(s)".
- **Estados**:
  - Loading inicial (Spinner centralizado).
  - Refetch subsequente (overlay leve sobre a tabela — mantém dados anteriores visíveis pra evitar flicker).
  - Erro (Alert + botão "Tentar novamente").
  - Vazio com busca → "Nenhum sistema encontrado para `q`" + botão limpar.
  - Vazio sem busca → "Nenhum sistema cadastrado." + dica de ativar "Mostrar inativos".
- **Cancelamento**: `AbortController` cancela request anterior em mudanças rápidas (busca/paginação/toggle).
- **Acessibilidade**: `aria-live` polite anuncia mudanças do estado (carregando, atualizando, total, vazio); botões de paginação com `aria-label`.

### Cobertura de testes (19 testes em `tests/pages/SystemsPage.test.tsx`)
- Render inicial (loading → tabela populada).
- Defaults: GET `/systems` sem querystring quando params estão nos defaults.
- Badge Ativo/Inativo conforme `deletedAt`.
- Busca debounced: digitação não dispara request imediato; 300ms depois, dispara `?q=auth`.
- Cliques de teclado em sequência: só a última busca dispara.
- Limpar busca volta para o caminho default.
- Paginação: prev/next disparam com `?page=N` correto; botões desabilitam nos limites.
- Indicador "página X de Y" com total filtrado.
- Toggle inativos: dispara `?includeDeleted=true`.
- Vazio com busca vs. vazio sem busca: mensagens distintas.
- Erro de rede: Alert + retry funciona; erro desconhecido cai no fallback genérico.
- AbortController: navegações rápidas cancelam request anterior (asserting `signal.aborted === true`).

## Decisões e ressalvas

- **Path mantido em `/systems`** (issue menciona `/sistemas`, mas a convenção do projeto é em inglês — alinhado com `/users`, `/roles`, etc.).
- **Cliente HTTP via injeção** (`client?: ApiClient` prop) seguindo o padrão dos testes de auth (PR #122/#123) — singleton em produção, stub em testes.
- **`buildQueryString` omite params iguais ao default** (URL canônica `GET /systems` em vez de `?q=&page=1&pageSize=20&includeDeleted=false`).
- **Debounce 300ms** seguindo o ponto de equilíbrio observado em UIs administrativas. Reset de página em mudança de filtro/busca pra UX previsível.
- **Texto duplicado em `aria-live` + EmptyMessage** é proposital — screen reader precisa anunciar quando o visual muda.

## Out of scope (próximas issues da EPIC #45)

- #58 Criar novo sistema
- #59 Editar sistema
- #60 Desativar (soft delete)
- #61 Restaurar sistema desativado

Apenas a listagem (4 critérios da #57) entra nesta PR. Lição do PR #112: mudança fora do escopo declarado é BLOCKER.

## Test plan

- [x] `npm run typecheck` ✅
- [x] `npm run lint` ✅ (zero warnings, `--max-warnings 0`)
- [x] `npm test -- --run` ✅ (300 passed / 27 files)
- [ ] Validação manual no browser (`docker compose up -d`, `localhost:3002`):
  - [ ] Login com root + ir em `/systems` → tabela carrega
  - [ ] Busca filtra resultados após 300ms
  - [ ] Paginação navega + indicador atualiza
  - [ ] Toggle "Mostrar inativos" mostra registros soft-deleted com badge "Inativo"
  - [ ] Erro de rede mostra Alert + retry funciona
  - [ ] Light/dark + mobile (responsividade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
