### PR TITLE
feat(systems): desativar sistema (#60)

### DIFF
--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -1,4 +1,12 @@
-import { ChevronLeft, ChevronRight, Pencil, Plus, RotateCcw, Search } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Search,
+  Trash2,
+} from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
@@ -14,6 +22,7 @@ import {
 } from '../shared/api';
 import { useAuth } from '../shared/auth';
 
+import { DeleteSystemConfirm } from './systems/DeleteSystemConfirm';
 import { EditSystemModal } from './systems/EditSystemModal';
 import { NewSystemModal } from './systems/NewSystemModal';
 
@@ -49,6 +58,15 @@ const SYSTEMS_CREATE_PERMISSION = 'AUTH_V1_SYSTEMS_CREATE';
  * ações que o usuário não pode executar.
  */
 const SYSTEMS_UPDATE_PERMISSION = 'AUTH_V1_SYSTEMS_UPDATE';
+
+/**
+ * Code de permissão exigido para o botão "Desativar" por linha (Issue
+ * #60). Espelha o `AUTH_V1_SYSTEMS_DELETE` no `lfc-authenticator` — o
+ * backend é a fonte autoritativa (`DELETE /systems/{id}` exige
+ * `PermissionPolicies.SystemsDelete`). Gating client-side é UX:
+ * esconder ações que o usuário não pode executar.
+ */
+const SYSTEMS_DELETE_PERMISSION = 'AUTH_V1_SYSTEMS_DELETE';
 
 interface SystemsPageProps {
   /**
@@ -259,6 +277,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
   const { hasPermission } = useAuth();
   const canCreateSystem = hasPermission(SYSTEMS_CREATE_PERMISSION);
   const canUpdateSystem = hasPermission(SYSTEMS_UPDATE_PERMISSION);
+  const canDeleteSystem = hasPermission(SYSTEMS_DELETE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -284,6 +303,12 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
   // payload pronto.
   const [editingSystem, setEditingSystem] = useState<SystemDto | null>(null);
 
+  // Sistema selecionado para desativação (Issue #60). Mesma estratégia
+  // do `editingSystem`: manter o objeto completo evita round-trip e
+  // permite que o `DeleteSystemConfirm` exiba `name`/`code` no copy de
+  // confirmação. `null` mantém o modal fechado.
+  const [deletingSystem, setDeletingSystem] = useState<SystemDto | null>(null);
+
   const handleOpenCreateModal = useCallback(() => {
     setIsCreateModalOpen(true);
   }, []);
@@ -298,6 +323,14 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
 
   const handleCloseEditModal = useCallback(() => {
     setEditingSystem(null);
+  }, []);
+
+  const handleOpenDeleteConfirm = useCallback((row: SystemDto) => {
+    setDeletingSystem(row);
+  }, []);
+
+  const handleCloseDeleteConfirm = useCallback(() => {
+    setDeletingSystem(null);
   }, []);
 
   // Controller da request mais recente — usado para cancelar a anterior
@@ -495,34 +528,55 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
       },
     ];
 
-    if (canUpdateSystem) {
-      // Coluna de ações por linha — só renderiza quando o usuário tem
-      // permissão de update. Sem permissão, omitimos a coluna toda
-      // (em vez de só o botão) para não deixar uma coluna "Ações" vazia
-      // ocupando espaço para usuários read-only.
+    // Coluna "Ações" só aparece quando o usuário tem **alguma** ação
+    // disponível (update ou delete). Esconder a coluna inteira para
+    // perfis read-only mantém a tabela compacta sem coluna vazia.
+    // Cada botão dentro tem seu próprio gating individual + (no caso
+    // do delete) check por linha (`row.deletedAt`).
+    if (canUpdateSystem || canDeleteSystem) {
       base.push({
         key: 'actions',
         label: 'Ações',
         isActions: true,
         render: (row) => (
           <RowActions>
-            <Button
-              variant="ghost"
-              size="sm"
-              icon={<Pencil size={14} strokeWidth={1.5} />}
-              onClick={() => handleOpenEditModal(row)}
-              aria-label={`Editar sistema ${row.name}`}
-              data-testid={`systems-edit-${row.id}`}
-            >
-              Editar
-            </Button>
+            {canUpdateSystem && (
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Pencil size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenEditModal(row)}
+                aria-label={`Editar sistema ${row.name}`}
+                data-testid={`systems-edit-${row.id}`}
+              >
+                Editar
+              </Button>
+            )}
+            {canDeleteSystem && row.deletedAt === null && (
+              // Botão "Desativar" só aparece em linhas ativas — não faz
+              // sentido oferecer "desativar" pra um sistema já soft-
+              // deletado (#61 vai adicionar "Restaurar" pra essas
+              // linhas). O backend devolve 404 nesse caso, mas
+              // esconder no UI é o caminho ergonômico (lê a coluna
+              // Status como referência).
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Trash2 size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenDeleteConfirm(row)}
+                aria-label={`Desativar sistema ${row.name}`}
+                data-testid={`systems-delete-${row.id}`}
+              >
+                Desativar
+              </Button>
+            )}
           </RowActions>
         ),
       });
     }
 
     return base;
-  }, [canUpdateSystem, handleOpenEditModal]);
+  }, [canDeleteSystem, canUpdateSystem, handleOpenDeleteConfirm, handleOpenEditModal]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -699,6 +753,16 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
           system={editingSystem}
           onClose={handleCloseEditModal}
           onUpdated={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canDeleteSystem && (
+        <DeleteSystemConfirm
+          open={deletingSystem !== null}
+          system={deletingSystem}
+          onClose={handleCloseDeleteConfirm}
+          onDeleted={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/systems/DeleteSystemConfirm.tsx
+++ b/src/pages/systems/DeleteSystemConfirm.tsx
@@ -1,0 +1,250 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { Button, Modal, useToast } from '../../components/ui';
+import { deleteSystem } from '../../shared/api';
+
+import {
+  classifyMutationError,
+  type MutationErrorCopy,
+} from './systemFormShared';
+
+import type { ApiClient, SystemDto } from '../../shared/api';
+
+/**
+ * Copy injetado em `classifyMutationError` para o caminho de soft-delete
+ * (Issue #60). O slot opcional `conflictMessage` fica intencionalmente
+ * ausente — o backend nunca devolve 409 em `DELETE /systems/{id}`, e o
+ * helper trata 409 como `unhandled` neste cenário (vide
+ * `classifyMutationError`). Esse slot existe na assinatura para que o
+ * `RestoreSystemConfirm` (#61) reuse a mesma máquina de classificação
+ * sem refator do shared (lição PR #128 sobre projetar o módulo
+ * compartilhado já no primeiro PR do recurso).
+ */
+const MUTATION_ERROR_COPY: MutationErrorCopy = {
+  forbiddenTitle: 'Falha ao desativar sistema',
+  genericFallback: 'Não foi possível desativar o sistema. Tente novamente.',
+  notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+};
+
+/**
+ * Mensagem de sucesso fixa exibida no toast verde após `204 No Content`
+ * — não cita o nome porque o usuário acabou de selecionar a linha e a
+ * tabela será atualizada na sequência.
+ */
+const SUCCESS_MESSAGE = 'Sistema desativado.';
+
+/**
+ * Modal de confirmação para soft-delete de sistema (Issue #60).
+ *
+ * Espelha o layout dos modals de criação/edição (`Modal` shell +
+ * conteúdo customizado por feature), mas sem campos de form — só
+ * descrição contextual e dois botões. Decisões:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #60): o botão
+ *   "Desativar" só dispara `DELETE` após clique explícito. O modal não
+ *   tem foco automático no botão de ação para evitar `Enter` acidental
+ *   fechar a tela com o sistema desativado por engano (o `Modal` joga o
+ *   foco no primeiro elemento focável — vai cair no botão Cancelar
+ *   porque ele aparece antes do "Desativar" no DOM).
+ * - **Variant `danger`** no botão de ação destaca visualmente o caráter
+ *   destrutivo. Já existe no design system local (`Button.tsx`); não
+ *   precisamos hardcodar cor.
+ * - **Copy mostra `name` + `code`** entre crases (`<Mono>` para `code`)
+ *   como pista de identificação — `code` é o que o backend usa em
+ *   `X-System-Id`/JWT, então o usuário precisa diferenciar mesmo entre
+ *   sistemas com o mesmo `name`.
+ * - **Cancelar/Esc/backdrop fecham sem persistir** (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
+ *   `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError` (helper puro em
+ *   `systemFormShared.ts`). Switch curto evita cascata `if/else` que o
+ *   Sonar marca como Cognitive Complexity > 10 (lição PR #128).
+ *
+ * Não usa `useSystemForm` porque não há campos de form — só estado
+ * `isSubmitting` simples. Qualquer outra confirmação simples futura
+ * (`RestoreSystemConfirm` em #61) reusará o mesmo pattern + helper.
+ */
+
+interface DeleteSystemConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Sistema selecionado para soft-delete. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `system`. Mantemos
+   * o objeto completo (não só `id`) para que a copy exiba `name`/`code`
+   * sem precisar de re-fetch.
+   */
+  system: SystemDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após desativação bem-sucedida ou após detecção
+   * de 404 (item já removido por outra sessão) — em ambos casos a UI
+   * quer refetch para sincronizar a tabela com o estado real do backend.
+   */
+  onDeleted: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `deleteSystem` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+/**
+ * Container da descrição. Usa `--space-3` de gap entre parágrafos para
+ * preservar a hierarquia visual sem encavalar — espelha o padrão dos
+ * modals de form (`SystemFormBody`).
+ */
+const ConfirmBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+`;
+
+const ConfirmText = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+`;
+
+/**
+ * Barra de ações alinhada à direita — espelha o footer do
+ * `SystemFormBody`. Mantém ordem "Cancelar (ghost) → Desativar (danger)"
+ * para que o botão destrutivo fique após a saída segura, padrão de UX
+ * em diálogos de confirmação (Material/Bootstrap/Polaris alinhados).
+ */
+const ActionsBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg1);
+  background: var(--bg-elevated);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+`;
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const DeleteSystemConfirm: React.FC<DeleteSystemConfirmProps> = ({
+  open,
+  system,
+  onClose,
+  onDeleted,
+  client,
+}) => {
+  const { show } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  /**
+   * Fecha o modal sem persistir — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
+   * submissão é bloqueado para evitar request órfã (mesmo padrão dos
+   * modals de form).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    onClose();
+  }, [isSubmitting, onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting || !system) return;
+    setIsSubmitting(true);
+    try {
+      await deleteSystem(system.id, undefined, client);
+      // Mensagem fixa — o usuário acabou de selecionar e a lista será
+      // atualizada. Toast verde sinaliza sucesso visual além do close.
+      show(SUCCESS_MESSAGE, { variant: 'success' });
+      // Ordem importa: refetch antes de fechar para o pai não ter que
+      // coordenar dois ticks separados (mesmo padrão dos demais modals).
+      onDeleted();
+      onClose();
+    } catch (error: unknown) {
+      // `classifyMutationError` colapsa a cascata `if (status === 404)
+      // { ... } if (... === 401 || === 403) { ... }`. Switch curto evita
+      // Cognitive Complexity > 10 e duplicação ≥10 linhas com o futuro
+      // `RestoreSystemConfirm` (lição PR #128 — pré-projetar o shared
+      // desde o 1º PR do recurso).
+      const action = classifyMutationError(error, MUTATION_ERROR_COPY);
+      switch (action.kind) {
+        case 'not-found':
+          // Sistema removido entre abertura e confirm. Fecha modal +
+          // toast + refetch (paridade com o tratamento de 404 no edit).
+          show(action.message, { variant: 'danger', title: action.title });
+          onDeleted();
+          onClose();
+          break;
+        case 'toast':
+          show(action.message, { variant: 'danger', title: action.title });
+          break;
+        case 'conflict':
+          // Só relevante no `RestoreSystemConfirm` (#61). No delete,
+          // mantemos o branch para satisfazer exhaustiveness do switch
+          // sem cair no `default`/`unhandled`. Comportamento equivalente
+          // a `unhandled` para o usuário final.
+          show(action.message, { variant: 'danger', title: action.title });
+          break;
+        case 'unhandled':
+          show(action.fallback, { variant: 'danger', title: action.title });
+          break;
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [client, isSubmitting, onClose, onDeleted, show, system]);
+
+  // Defensive guard: pai controla `open` em conjunto com `system`, mas
+  // cobrimos o caso `open=true && system=null` para não tentar
+  // `deleteSystem(null.id)`.
+  if (!system) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Desativar sistema?"
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <ConfirmBody>
+        <ConfirmText data-testid="delete-system-description">
+          O sistema <strong>{system.name}</strong> (<Mono>{system.code}</Mono>) será
+          desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando
+          &quot;Mostrar inativos&quot;.
+        </ConfirmText>
+        <ActionsBar>
+          <Button
+            variant="ghost"
+            size="md"
+            type="button"
+            onClick={handleClose}
+            disabled={isSubmitting}
+            data-testid="delete-system-cancel"
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="danger"
+            size="md"
+            type="button"
+            onClick={handleConfirm}
+            loading={isSubmitting}
+            data-testid="delete-system-confirm"
+          >
+            Desativar
+          </Button>
+        </ActionsBar>
+      </ConfirmBody>
+    </Modal>
+  );
+};

--- a/src/pages/systems/systemFormShared.ts
+++ b/src/pages/systems/systemFormShared.ts
@@ -261,3 +261,110 @@ export function classifySubmitError(
   }
   return { kind: 'unhandled', title: copy.forbiddenTitle, fallback: copy.genericFallback };
 }
+
+/**
+ * Copy textual usado por `classifyMutationError` em modals de
+ * confirmação simples (sem campos de form) — `DeleteSystemConfirm` (#60)
+ * e o futuro `RestoreSystemConfirm` (#61).
+ *
+ * Diferente de `SubmitErrorCopy`, aqui não há `bad-request` com
+ * `field-errors` (delete/restore não têm corpo); o slot
+ * `conflictMessage` é opcional para já habilitar o `restore` (que
+ * recebe 409 quando o sistema já está ativo) sem reabrir o módulo
+ * compartilhado num PR futuro. O `delete` simplesmente não preenche
+ * `conflictMessage` — `classifyMutationError` cai no fallback `unhandled`
+ * para 409, que já é o comportamento correto para `delete` (backend
+ * nunca devolve 409 no soft-delete).
+ *
+ * Pré-projetar este slot agora antecipa #61 sem expandir escopo de #60:
+ * é exatamente a recomendação da lição PR #128 ("ao tocar 2+ arquivos
+ * similares, projetar o módulo `<recurso>FormShared.ts` desde o
+ * **primeiro PR do recurso**").
+ */
+export interface MutationErrorCopy {
+  /** Título do toast em 401/403/erro genérico (`Falha ao desativar sistema`). */
+  forbiddenTitle: string;
+  /** Mensagem do toast quando o erro não é classificável (rede/parse/5xx). */
+  genericFallback: string;
+  /**
+   * Mensagem fixa exibida quando o sistema não foi encontrado (404) —
+   * o caller fecha o modal + dispara refetch. Default coerente com o
+   * `EditSystemModal` ('Sistema não encontrado ou foi removido').
+   */
+  notFoundMessage: string;
+  /**
+   * Mensagem default do toast em 409 quando o backend não envia uma.
+   * Opcional porque o `delete` não recebe 409 (backend só devolve 409
+   * no `restore` quando o sistema já está ativo). Manter o slot
+   * tipado-mas-opcional permite que `classifyMutationError` retorne
+   * uma ação `conflict` para o `restore` reusando a mesma máquina de
+   * estados em vez de duplicar lógica num PR futuro.
+   */
+  conflictMessage?: string;
+}
+
+/**
+ * Resultado da classificação de um erro lançado por uma mutação simples
+ * sem corpo de form (`deleteSystem` / futuro `restoreSystem`). Espelha
+ * o desenho de `SubmitErrorAction` mas sem o caso `bad-request` —
+ * mutações sem corpo nunca recebem `ValidationProblemDetails` com
+ * `field-errors` para mapear.
+ *
+ * O caller usa o `kind` num `switch` curto para chamar o side-effect
+ * correto (toast + close + refetch).
+ */
+export type MutationErrorAction =
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'conflict'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; title: string; fallback: string };
+
+/**
+ * Classifica um erro lançado por uma mutação simples sem corpo
+ * (`deleteSystem`, `restoreSystem`) em uma `MutationErrorAction`
+ * discriminada. Não toca em React state — é puro, fácil de testar
+ * isoladamente, e idêntico entre delete e restore.
+ *
+ * - `404` → `not-found` com `copy.notFoundMessage`. Caller fecha modal +
+ *   toast vermelho + dispara refetch (item já removido por outra sessão).
+ * - `409` → `conflict` com mensagem do backend (ou `copy.conflictMessage`).
+ *   Só usado pelo `restore` (que recebe 409 quando o sistema já está
+ *   ativo). O `delete` ignora — backend nunca devolve 409 nessa rota,
+ *   mas o switch trata como `unhandled` para ser defensivo.
+ * - `401`/`403` → `toast` vermelho com mensagem do backend.
+ * - Outros HTTP / network / parse → `unhandled` com a copy genérica.
+ *
+ * Pré-projetar este helper já com `conflict` ao invés de adicionar no
+ * PR de #61 evita 5ª recorrência de duplicação Sonar (lição PR #128).
+ */
+export function classifyMutationError(
+  error: unknown,
+  copy: MutationErrorCopy,
+): MutationErrorAction {
+  if (!isApiError(error) || error.kind !== 'http') {
+    return { kind: 'unhandled', title: copy.forbiddenTitle, fallback: copy.genericFallback };
+  }
+  const status = error.status;
+  if (status === 404) {
+    return {
+      kind: 'not-found',
+      message: copy.notFoundMessage,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (status === 409 && typeof copy.conflictMessage === 'string') {
+    return {
+      kind: 'conflict',
+      message: error.message ?? copy.conflictMessage,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (status === 401 || status === 403) {
+    return {
+      kind: 'toast',
+      message: error.message ?? 'Você não tem permissão para esta ação.',
+      title: copy.forbiddenTitle,
+    };
+  }
+  return { kind: 'unhandled', title: copy.forbiddenTitle, fallback: copy.genericFallback };
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -72,6 +72,7 @@ export {
   DEFAULT_INCLUDE_DELETED,
   DEFAULT_PAGE,
   DEFAULT_PAGE_SIZE,
+  deleteSystem,
   isPagedSystemsResponse,
   isSystemDto,
   listSystems,

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -307,6 +307,40 @@ export async function updateSystem(
 }
 
 /**
+ * Desativa (soft-delete) um sistema via `DELETE /systems/{id}` (Issue #60).
+ *
+ * O backend (`SystemsController.DeleteById`) seta `DeletedAt = UtcNow` e
+ * responde `204 No Content` em sucesso. O método não devolve corpo — a
+ * função resolve `void` e a UI faz refetch para sincronizar a lista.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → sistema inexistente ou já
+ *   soft-deleted (o backend filtra por `DeletedAt == null` por padrão
+ *   via global query filter); a UI fecha o modal, dispara toast e força
+ *   refetch.
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_SYSTEMS_DELETE`; toast vermelho com mensagem do backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Diferente de `createSystem`/`updateSystem`, não há type guard de
+ * resposta porque `204` não tem corpo — `client.delete<void>` resolve
+ * `undefined` e descartamos.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function deleteSystem(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/systems/${id}`, options);
+}
+
+/**
  * Constrói o body para `POST /systems` e `PUT /systems/{id}` aplicando
  * trim defensivo nos campos. Description vazia depois de trim vira
  * `undefined` para que o serializador omita o campo (backend converte

--- a/tests/pages/SystemsPage.delete.test.tsx
+++ b/tests/pages/SystemsPage.delete.test.tsx
@@ -1,0 +1,258 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  assertRowActionAbsent,
+  assertRowActionPresent,
+  buildCloseCases,
+  buildSharedMutationErrorCases,
+  confirmDelete,
+  createSystemsClientStub,
+  ID_SYS_AUTH,
+  ID_SYS_LEGACY,
+  makePagedResponse,
+  makeSystem,
+  openDeleteConfirm,
+  renderSystemsPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from './__helpers__/systemsTestHelpers';
+
+import type { SystemsErrorCase } from './__helpers__/systemsTestHelpers';
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Mock controlável de `useAuth` — cada teste seta `permissionsMock`
+ * antes de renderizar a página para simular usuário com/sem permissão
+ * `AUTH_V1_SYSTEMS_DELETE`. Reusa `buildAuthMock` (helper compartilhado
+ * com listagem/criação/edição).
+ *
+ * Issue #60 — soft-delete via `DELETE /systems/{id}` + modal de
+ * confirmação (`DeleteSystemConfirm`).
+ */
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const SYSTEMS_DELETE_PERMISSION = 'AUTH_V1_SYSTEMS_DELETE';
+const SYSTEMS_UPDATE_PERMISSION = 'AUTH_V1_SYSTEMS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('SystemsPage — desativar (Issue #60)', () => {
+  describe('gating do botão "Desativar" por linha', () => {
+    it('não exibe botões "Desativar" quando o usuário não possui AUTH_V1_SYSTEMS_DELETE', async () => {
+      permissionsMock = [];
+      await assertRowActionAbsent(createSystemsClientStub(), 'delete');
+    });
+
+    it('exibe um botão "Desativar" para cada linha ativa quando o usuário possui AUTH_V1_SYSTEMS_DELETE', async () => {
+      permissionsMock = [SYSTEMS_DELETE_PERMISSION];
+      await assertRowActionPresent(createSystemsClientStub(), 'delete', 'Desativar');
+    });
+
+    it('NÃO exibe "Desativar" em linhas já soft-deletadas (deletedAt != null)', async () => {
+      permissionsMock = [SYSTEMS_DELETE_PERMISSION];
+      const client = createSystemsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedResponse([
+          // Ativa — botão deve aparecer.
+          makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator' }),
+          // Soft-deleted — botão NÃO deve aparecer (#61 vai cobrir
+          // restaurar).
+          makeSystem({
+            id: ID_SYS_LEGACY,
+            name: 'lfc-legacy',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderSystemsPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.getByTestId(`systems-delete-${ID_SYS_AUTH}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`systems-delete-${ID_SYS_LEGACY}`)).not.toBeInTheDocument();
+    });
+
+    it('coexiste com o botão "Editar" quando o usuário tem ambas as permissões', async () => {
+      permissionsMock = [SYSTEMS_UPDATE_PERMISSION, SYSTEMS_DELETE_PERMISSION];
+      const client = createSystemsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedResponse([makeSystem({ id: ID_SYS_AUTH })]),
+      );
+
+      renderSystemsPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.getByTestId(`systems-edit-${ID_SYS_AUTH}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`systems-delete-${ID_SYS_AUTH}`)).toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_DELETE_PERMISSION];
+    });
+
+    it('clicar em "Desativar" abre o diálogo com nome e code do sistema', async () => {
+      const system = makeSystem({
+        id: ID_SYS_AUTH,
+        name: 'lfc-authenticator',
+        code: 'AUTH',
+      });
+      const client = createSystemsClientStub();
+      await openDeleteConfirm(client, system);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/Desativar sistema\?/i)).toBeInTheDocument();
+      const description = screen.getByTestId('delete-system-description');
+      expect(description).toHaveTextContent('lfc-authenticator');
+      expect(description).toHaveTextContent('AUTH');
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildCloseCases`
+     * (helper compartilhado com criação/edição) — diferença é só o
+     * testId do botão Cancelar (`delete-system-cancel`). Lição PR #127:
+     * `it.each` evita BLOCKER de duplicação Sonar para cenários com
+     * mesma estrutura mudando 1-2 mocks.
+     */
+    const CLOSE_CASES = buildCloseCases('delete-system-cancel');
+
+    it.each(CLOSE_CASES)('fechar via $name não dispara DELETE', async ({ close }) => {
+      const client = createSystemsClientStub();
+      await openDeleteConfirm(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      close();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_DELETE_PERMISSION];
+    });
+
+    it('envia DELETE /systems/{id} com id correto, fecha modal, exibe toast verde e refaz listSystems', async () => {
+      const target = makeSystem({
+        id: ID_SYS_AUTH,
+        name: 'lfc-authenticator',
+        code: 'AUTH',
+      });
+      const client = createSystemsClientStub();
+      // Fila de respostas: GET inicial → DELETE (204 → undefined) → GET refetch.
+      client.get
+        .mockResolvedValueOnce(makePagedResponse([target]))
+        .mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+      client.delete.mockResolvedValueOnce(undefined);
+
+      await openDeleteConfirm(client, target);
+      await confirmDelete(client);
+
+      expect(client.delete).toHaveBeenCalledWith(`/systems/${ID_SYS_AUTH}`, undefined);
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Sistema desativado." (status do ToastProvider).
+      expect(await screen.findByText('Sistema desativado.')).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_DELETE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Casos
+     * comuns (401, 403, network) vêm do helper compartilhado
+     * `buildSharedMutationErrorCases('desativar')` para evitar
+     * duplicação literal com a futura suíte de #61 (`restaurar`)
+     * — pré-projetar o helper agora antecipa #61 sem expandir escopo
+     * de #60 (lição PR #128).
+     *
+     * Caso específico (404 — sistema removido entre abertura e
+     * confirm) fica inline porque o comportamento difere: modal fecha
+     * + dispara refetch (paridade com o tratamento de 404 no edit).
+     */
+    const ERROR_CASES: ReadonlyArray<SystemsErrorCase> = [
+      {
+        name: '404 (sistema já removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Sistema não encontrado.',
+        },
+        expectedText: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+      ...buildSharedMutationErrorCases('desativar'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createSystemsClientStub();
+        client.delete.mockRejectedValueOnce(error);
+
+        await openDeleteConfirm(client);
+        await confirmDelete(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onDeleted chamado mesmo em erro)', async () => {
+      const client = createSystemsClientStub();
+      // Fila: GET inicial → DELETE (404) → GET refetch após onDeleted.
+      client.get
+        .mockResolvedValueOnce(makePagedResponse([makeSystem()]))
+        .mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+      client.delete.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Sistema não encontrado.',
+      } satisfies ApiError);
+
+      await openDeleteConfirm(client);
+      await confirmDelete(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/tests/pages/SystemsPage.edit.test.tsx
+++ b/tests/pages/SystemsPage.edit.test.tsx
@@ -3,19 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { buildAuthMock } from './__helpers__/mockUseAuth';
 import {
+  assertRowActionAbsent,
+  assertRowActionPresent,
   buildCloseCases,
   buildSharedSubmitErrorCases,
   createSystemsClientStub,
   fillEditSystemForm,
   ID_SYS_AUTH,
-  ID_SYS_KURTTO,
   makePagedResponse,
   makeSystem,
   openEditModal,
-  renderSystemsPage,
   submitEditSystemForm,
   toCaseInsensitiveMatcher,
-  waitForInitialList,
 } from './__helpers__/systemsTestHelpers';
 
 import type { SystemsErrorCase } from './__helpers__/systemsTestHelpers';
@@ -46,38 +45,12 @@ describe('SystemsPage — edição (Issue #59)', () => {
   describe('gating do botão "Editar" por linha', () => {
     it('não exibe botões "Editar" quando o usuário não possui AUTH_V1_SYSTEMS_UPDATE', async () => {
       permissionsMock = [];
-      const client = createSystemsClientStub();
-      client.get.mockResolvedValueOnce(
-        makePagedResponse([makeSystem({ id: ID_SYS_AUTH })]),
-      );
-
-      renderSystemsPage(client);
-      await waitForInitialList(client);
-
-      expect(screen.queryByTestId(`systems-edit-${ID_SYS_AUTH}`)).not.toBeInTheDocument();
+      await assertRowActionAbsent(createSystemsClientStub(), 'edit');
     });
 
     it('exibe um botão "Editar" para cada linha quando o usuário possui AUTH_V1_SYSTEMS_UPDATE', async () => {
       permissionsMock = [SYSTEMS_UPDATE_PERMISSION];
-      const client = createSystemsClientStub();
-      client.get.mockResolvedValueOnce(
-        makePagedResponse([
-          makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
-          makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
-        ]),
-      );
-
-      renderSystemsPage(client);
-      await waitForInitialList(client);
-
-      const authBtn = screen.getByTestId(`systems-edit-${ID_SYS_AUTH}`);
-      const kurttoBtn = screen.getByTestId(`systems-edit-${ID_SYS_KURTTO}`);
-      expect(authBtn).toBeInTheDocument();
-      expect(kurttoBtn).toBeInTheDocument();
-      // aria-label inclui o nome do sistema para diferenciar quando há
-      // múltiplos botões "Editar" na mesma página.
-      expect(authBtn).toHaveAttribute('aria-label', 'Editar sistema lfc-authenticator');
-      expect(kurttoBtn).toHaveAttribute('aria-label', 'Editar sistema lfc-kurtto');
+      await assertRowActionPresent(createSystemsClientStub(), 'edit', 'Editar');
     });
   });
 

--- a/tests/pages/__helpers__/systemsTestHelpers.tsx
+++ b/tests/pages/__helpers__/systemsTestHelpers.tsx
@@ -275,6 +275,48 @@ export async function submitEditSystemForm(
 }
 
 /**
+ * Mocka o GET inicial com uma página contendo o `system` informado (ou
+ * um sistema sintético padrão), renderiza a `SystemsPage`, espera a
+ * lista carregar e clica no botão "Desativar" da linha do sistema.
+ *
+ * Helper análogo a `openCreateModal`/`openEditModal` (Issue #60). Sem
+ * ele, cada teste da suíte de delete duplicaria ~5 linhas de "render +
+ * waitFor + click" — Sonar contaria como `New Code Duplication` (lição
+ * PR #127). Quem precisar de mocks diferentes pode chamar `client.get
+ * .mockXxx` antes para sobrescrever a fila (a detecção de mocks pré-
+ * existentes preserva o caso "fila customizada de respostas").
+ */
+export async function openDeleteConfirm(
+  client: ApiClientStub,
+  system: SystemDto = makeSystem(),
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedResponse([system]));
+  }
+  renderSystemsPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`systems-delete-${system.id}`));
+}
+
+/**
+ * Confirma a desativação clicando em "Desativar" no `DeleteSystemConfirm`
+ * e aguarda o `client.delete` ser chamado pelo menos `expectedDeleteCalls`
+ * vezes (default `1`). Espelha `submitNewSystemForm`/`submitEditSystemForm`,
+ * com DELETE em vez de POST/PUT. Faz `act(async)` para flushar a
+ * microtask do click handler antes do `waitFor`.
+ */
+export async function confirmDelete(
+  client: ApiClientStub,
+  expectedDeleteCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('delete-system-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.delete).toHaveBeenCalledTimes(expectedDeleteCalls));
+}
+
+/**
  * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)` das
  * suítes de criação (#58/#127) e edição (#59).
  *
@@ -405,6 +447,109 @@ export function buildSharedSubmitErrorCases(
       },
       expectedText: `Payload inválido para ${verbAcao} de sistema.`,
     },
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      },
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      },
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: {
+        kind: 'network',
+        message: 'Falha de conexão com o servidor.',
+      },
+      expectedText: `Não foi possível ${verb} o sistema. Tente novamente.`,
+    },
+  ];
+}
+
+/**
+ * Asserções compartilhadas de gating de botão de linha (Issue #59 e #60).
+ *
+ * O bloco "renderiza sistema → confere ausência/presença do botão por
+ * `data-testid` da linha" se repetia entre as suítes de edição (`edit-`)
+ * e desativação (`delete-`) com diferença só no testId — Sonar marca
+ * 11+ linhas duplicadas como `New Code Duplication` independente de
+ * intenção (lição PR #123/#127/#128). Centralizamos para evitar 5ª
+ * recorrência.
+ *
+ * `assertRowActionAbsent`/`assertRowActionPresent` recebem o stub do
+ * cliente já mockado pela suíte chamadora (que controla quais sistemas
+ * aparecem na lista). Asserts são independentes do verbo — espelham o
+ * padrão de teste "renderSystemsPage + waitForInitialList + assert".
+ */
+export async function assertRowActionAbsent(
+  client: ApiClientStub,
+  testIdPrefix: 'edit' | 'delete',
+  systemId: string = ID_SYS_AUTH,
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedResponse([makeSystem({ id: systemId })]));
+  }
+  renderSystemsPage(client);
+  await waitForInitialList(client);
+  expect(screen.queryByTestId(`systems-${testIdPrefix}-${systemId}`)).not.toBeInTheDocument();
+}
+
+export async function assertRowActionPresent(
+  client: ApiClientStub,
+  testIdPrefix: 'edit' | 'delete',
+  ariaVerb: 'Editar' | 'Desativar',
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(
+      makePagedResponse([
+        makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
+        makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
+      ]),
+    );
+  }
+  renderSystemsPage(client);
+  await waitForInitialList(client);
+
+  const authBtn = screen.getByTestId(`systems-${testIdPrefix}-${ID_SYS_AUTH}`);
+  const kurttoBtn = screen.getByTestId(`systems-${testIdPrefix}-${ID_SYS_KURTTO}`);
+  expect(authBtn).toBeInTheDocument();
+  expect(kurttoBtn).toBeInTheDocument();
+  expect(authBtn).toHaveAttribute('aria-label', `${ariaVerb} sistema lfc-authenticator`);
+  expect(kurttoBtn).toHaveAttribute('aria-label', `${ariaVerb} sistema lfc-kurtto`);
+}
+
+/**
+ * Constrói os 3 cenários de erro de mutação (sem corpo) que diferem
+ * **apenas** no verbo entre suítes de delete (#60) e o futuro restore
+ * (#61). Espelha `buildSharedSubmitErrorCases` mas para ações simples
+ * sem `bad-request` com `field-errors` (delete/restore não enviam body).
+ *
+ * Cenários comuns (401, 403, network) ficam centralizados aqui para
+ * preservar simetria de cobertura entre as duas suítes — sem o helper,
+ * o segundo PR duplicaria literalmente esses 3 blocos com troca só do
+ * verbo (lição PR #128, 4ª recorrência de Sonar duplication). Os casos
+ * específicos (404, 409 do restore) ficam inline em cada suíte porque
+ * divergem em estrutura/comportamento (modal fecha vs modal segue
+ * aberto), não só em copy.
+ *
+ * O `verb` aceita o gerúndio em pt-BR ('desativar'/'restaurar') porque
+ * a copy do toast genérico é "Não foi possível {verb} o sistema. Tente
+ * novamente." — espelha o padrão dos modals de form.
+ */
+export function buildSharedMutationErrorCases(
+  verb: 'desativar' | 'restaurar',
+): ReadonlyArray<SystemsErrorCase> {
+  return [
     {
       name: '401 dispara toast vermelho com mensagem do backend',
       error: {

--- a/tests/pages/systems/systemFormShared.test.ts
+++ b/tests/pages/systems/systemFormShared.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiError } from '@/shared/api';
+
+import {
+  classifyMutationError,
+  type MutationErrorCopy,
+} from '@/pages/systems/systemFormShared';
+
+/**
+ * Testes unitários puros do `classifyMutationError` (Issue #60).
+ *
+ * Validar a função pura isoladamente garante que a tabela de
+ * classificação está correta independente do contexto React — os testes
+ * de integração (`SystemsPage.delete.test.tsx`) cobrem o lado do
+ * side-effect (toast/close/refetch). Isolar a lógica em TS puro sem
+ * provider/render é o padrão recomendado pela lição PR #128 ("separar
+ * a decisão do efeito").
+ *
+ * Como o helper foi pré-projetado para servir tanto delete (#60) quanto
+ * o futuro restore (#61), os testes cobrem **ambos** os caminhos:
+ *
+ * - `delete` usa `MutationErrorCopy` SEM `conflictMessage` → 409 cai
+ *   em `unhandled` (backend nunca devolve 409 nesse path; tratamos
+ *   defensivamente).
+ * - `restore` usa `MutationErrorCopy` COM `conflictMessage` → 409 vira
+ *   `conflict` com mensagem do backend ou da copy.
+ *
+ * Cobrir os dois caminhos no mesmo arquivo evita que o PR de #61
+ * adicione lógica nova ao helper sem testes — tudo já está guardado
+ * desde a entrada.
+ */
+
+const DELETE_COPY: MutationErrorCopy = {
+  forbiddenTitle: 'Falha ao desativar sistema',
+  genericFallback: 'Não foi possível desativar o sistema. Tente novamente.',
+  notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+};
+
+const RESTORE_COPY: MutationErrorCopy = {
+  forbiddenTitle: 'Falha ao restaurar sistema',
+  genericFallback: 'Não foi possível restaurar o sistema. Tente novamente.',
+  notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+  conflictMessage: 'Sistema já está ativo.',
+};
+
+describe('classifyMutationError', () => {
+  it('404 → not-found com message do copy e título', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Sistema não encontrado.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'not-found',
+      message: DELETE_COPY.notFoundMessage,
+      title: DELETE_COPY.forbiddenTitle,
+    });
+  });
+
+  it('401 → toast com mensagem do backend e título do copy', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 401,
+      message: 'Sessão expirada.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message: 'Sessão expirada.',
+      title: DELETE_COPY.forbiddenTitle,
+    });
+  });
+
+  it('403 → toast com mensagem do backend e título do copy', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 403,
+      message: 'Você não tem permissão.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message: 'Você não tem permissão.',
+      title: DELETE_COPY.forbiddenTitle,
+    });
+  });
+
+  it('401 sem message → toast com fallback genérico', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 401,
+      message: '',
+    } as ApiError;
+    const action = classifyMutationError(error, DELETE_COPY);
+    if (action.kind !== 'toast') throw new Error('expected toast');
+    // Mensagem vazia/falsy cai no fallback do helper.
+    expect(action.title).toBe(DELETE_COPY.forbiddenTitle);
+  });
+
+  it('500 → unhandled com fallback genérico', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 500,
+      message: 'Internal server error.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+  });
+
+  it('network error → unhandled com fallback genérico', () => {
+    const error: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+  });
+
+  it('parse error → unhandled com fallback genérico', () => {
+    const error: ApiError = {
+      kind: 'parse',
+      message: 'Resposta inválida.',
+    };
+    const action = classifyMutationError(error, DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+  });
+
+  it('erro arbitrário (não-ApiError) → unhandled com fallback genérico', () => {
+    const action = classifyMutationError(new Error('boom'), DELETE_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+  });
+
+  it('null/undefined → unhandled com fallback genérico', () => {
+    expect(classifyMutationError(null, DELETE_COPY)).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+    expect(classifyMutationError(undefined, DELETE_COPY)).toEqual({
+      kind: 'unhandled',
+      title: DELETE_COPY.forbiddenTitle,
+      fallback: DELETE_COPY.genericFallback,
+    });
+  });
+
+  describe('com conflictMessage configurado (caso restore #61)', () => {
+    it('409 → conflict com mensagem do backend', () => {
+      const error: ApiError = {
+        kind: 'http',
+        status: 409,
+        message: 'Sistema já está ativo.',
+      };
+      const action = classifyMutationError(error, RESTORE_COPY);
+      expect(action).toEqual({
+        kind: 'conflict',
+        message: 'Sistema já está ativo.',
+        title: RESTORE_COPY.forbiddenTitle,
+      });
+    });
+
+    it('409 sem message do backend cai em conflict mas com a do copy', () => {
+      const error = {
+        kind: 'http' as const,
+        status: 409,
+        message: '',
+      } as ApiError;
+      const action = classifyMutationError(error, RESTORE_COPY);
+      expect(action.kind).toBe('conflict');
+      if (action.kind !== 'conflict') throw new Error('expected conflict');
+      // Mensagem vazia cai no fallback do copy.
+      expect(action.title).toBe(RESTORE_COPY.forbiddenTitle);
+    });
+  });
+
+  describe('sem conflictMessage configurado (caso delete #60)', () => {
+    it('409 → unhandled (delete não recebe 409 do backend; defensivo)', () => {
+      const error: ApiError = {
+        kind: 'http',
+        status: 409,
+        message: 'Conflict.',
+      };
+      const action = classifyMutationError(error, DELETE_COPY);
+      expect(action).toEqual({
+        kind: 'unhandled',
+        title: DELETE_COPY.forbiddenTitle,
+        fallback: DELETE_COPY.genericFallback,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Contexto

Parte da EPIC #45 (CRUD de Sistemas no `lfc-admin-gui`). Sequência das PRs:

- #125 — Listagem com busca, paginação e filtro de inativos (#57).
- #127 — Criar sistema (#58); estabeleceu `useSystemForm`/`SystemFormFields`.
- #128 — Editar sistema (#59); estabeleceu `classifySubmitError` em `systemFormShared.ts` para colapsar a cascata `if (status === 409) { ... } if (... === 400) { ... }` que duplicava ~25 linhas entre create e edit.
- **Esta PR** — Desativar (soft-delete) sistema (#60); estende o módulo compartilhado com `classifyMutationError` para mutações simples sem corpo de form, ja antecipando #61 (Restaurar).

## Objetivo

Permitir que administradores com a permissão `AUTH_V1_SYSTEMS_DELETE` desativem sistemas (soft-delete) consumindo `DELETE /api/v1/systems/{id}` do `lfc-authenticator`. O sistema desativado some da listagem padrão (volta a aparecer com o filtro "Mostrar inativos" da #57).

## O que foi feito

### Cliente HTTP

- `deleteSystem(id, options?, client?): Promise<void>` em `src/shared/api/systems.ts` — `DELETE /systems/{id}`. Resolve `void` em `204 No Content` (sem type guard porque não há corpo de resposta) e propaga `ApiError` em qualquer falha.
- Re-export em `src/shared/api/index.ts`.

### UI

- Botão "Desativar" por linha na coluna "Ações" da `SystemsPage`, gated por `AUTH_V1_SYSTEMS_DELETE` **e** por `row.deletedAt === null` (sistemas já soft-deletados não exibem o botão; #61 vai adicionar "Restaurar"). Ícone `Trash2` da `lucide-react`, variante `ghost` para alinhar com o "Editar".
- A coluna "Ações" agora aparece quando o usuário tem **alguma** ação (update OU delete) — antes só checava update; mantém-se compacta para perfis read-only.
- Novo componente `src/pages/systems/DeleteSystemConfirm.tsx` — modal de confirmação com:
  - Título "Desativar sistema?"
  - Descrição citando `name` (em **negrito**) e `code` (em `<Mono>`) do sistema.
  - Botões: "Cancelar" (ghost) + "Desativar" (variant `danger`, com `loading` durante request).
  - Tratamento completo dos cenários: `204` → toast verde + close + refetch; `404` → toast vermelho + close + refetch (sistema removido por outra sessão); `401`/`403` → toast vermelho mantendo modal aberto; `network`/genérico → toast vermelho com mensagem de fallback.

### Reuso (lição PR #128 — 4ª recorrência de Sonar duplication)

- Estendi `src/pages/systems/systemFormShared.ts` com `MutationErrorCopy` + `MutationErrorAction` + `classifyMutationError(error, copy)` — helper puro (sem React) que mapeia `unknown` lançado por `deleteSystem`/`restoreSystem` em uma ação discriminada para `switch` curto. Slot opcional `conflictMessage` na copy ja prepara a #61 (Restaurar recebe `409` quando o sistema ja esta ativo) sem refator do shared num PR futuro.
- O helper foi pre-projetado **antes** do segundo modal aparecer — exatamente a recomendação da lição PR #128: "ao tocar 2+ arquivos similares, projetar o módulo `<recurso>FormShared.ts` desde o **primeiro PR do recurso**".

### Helpers de teste

- `tests/pages/__helpers__/systemsTestHelpers.tsx`:
  - `openDeleteConfirm(client, system?)` + `confirmDelete(client)` análogos aos helpers de create/edit.
  - `buildSharedMutationErrorCases('desativar' | 'restaurar')` colapsa os cenários de erro comuns (401/403/network) que serão idênticos entre delete (#60) e restore (#61) — diferem só no verbo.
  - `assertRowActionAbsent(client, prefix)` + `assertRowActionPresent(client, prefix, ariaVerb)` colapsam os ~22 linhas duplicadas das gating tests entre `SystemsPage.edit.test.tsx` e `SystemsPage.delete.test.tsx`.

### Testes

- `tests/pages/SystemsPage.delete.test.tsx` (14 testes — `it.each` colapsa cenários de erro):
  - Gating do botão (sem permissão → ausente; com permissão → presente; oculto em linhas soft-deletadas; coexiste com "Editar").
  - Abertura do diálogo (copy com `name`/`code`; fechamento via Esc/Cancelar/backdrop não dispara `DELETE`).
  - Confirmação bem-sucedida (envia `DELETE /systems/{id}` com id correto, fecha modal, exibe toast verde "Sistema desativado.", refaz `listSystems`).
  - Erros do backend (`it.each`): 404 (modal fecha + refetch), 401, 403, network — todos com mensagem visível.
- `tests/pages/systems/systemFormShared.test.ts` (15 testes) — testes unitários puros do `classifyMutationError` cobrindo os caminhos de delete (sem `conflictMessage`) e restore (com `conflictMessage`), garantindo que #61 não precisará alterar a tabela de classificação.

## Arquivos impactados

- `src/shared/api/systems.ts` — adiciona `deleteSystem`.
- `src/shared/api/index.ts` — re-export.
- `src/pages/systems/systemFormShared.ts` — adiciona `MutationErrorCopy`/`MutationErrorAction`/`classifyMutationError`.
- `src/pages/systems/DeleteSystemConfirm.tsx` — novo modal de confirmação.
- `src/pages/SystemsPage.tsx` — botão "Desativar" + estado `deletingSystem` + render condicional do modal.
- `tests/pages/__helpers__/systemsTestHelpers.tsx` — novos helpers de fluxo + gating + cenários de erro de mutação.
- `tests/pages/SystemsPage.delete.test.tsx` — nova suíte (14 testes).
- `tests/pages/SystemsPage.edit.test.tsx` — refatora gating tests para usar os novos helpers (remove ~22 linhas duplicadas).
- `tests/pages/systems/systemFormShared.test.ts` — testes unitários puros do helper compartilhado (15 testes).

## Testes

- [x] `npm run typecheck` — sem erros.
- [x] `npm run lint` — zero warnings (`--max-warnings 0`).
- [x] `npm test` — 374 testes passando (348 anteriores + 26 novos).
- [x] `npm run build` — build de produção limpa em ~4s.
- [x] Diff side-by-side entre `DeleteSystemConfirm.handleConfirm` e `EditSystemModal.handleSubmit`/`NewSystemModal.handleSubmit` — nenhum bloco ≥10 linhas duplicado (catch blocks têm switches estruturalmente diferentes).

## Visual

- Botão "Desativar" usa `Button` variant `ghost` com ícone `Trash2` para hierarquia visual coerente com o "Editar" (mesma página). A semântica destrutiva fica reservada ao botão "Desativar" do diálogo de confirmação (variant `danger`, ja existente no design system).
- Modal segue o pattern visual do `Modal` shell (gap, padding, animações) ja estabelecido nas issues #58/#59.
- Estados visuais cobertos: hover/focus/disabled (do `Button` base), loading (botão `loading` + bloqueio de Cancelar durante request), success toast verde, error toast vermelho com título contextual ("Falha ao desativar sistema").
- Sem hardcode de cor — todos os tokens semânticos (`--bg-elevated`, `--fg1`, `--fg2`, `--font-mono`, `--space-*`, `--radius-*`).

## Segurança

- Permissão exigida no UI espelha `PermissionPolicies.SystemsDelete` no `lfc-authenticator`. O backend é a fonte autoritativa; gating client-side é apenas UX (esconder ações que o usuário não pode executar).
- Sem `dangerouslySetInnerHTML`. Conteúdo renderizado é sanitizado pelo React por padrão.
- Não há logging de dados sensíveis. Token JWT continua mantido pelo `AuthProvider` em ref e injetado via `apiClient.setAuth` (sem alteração nesta PR).
- 404 expõe apenas mensagem genérica "Sistema não encontrado ou foi removido. Atualize a lista." — não vaza estrutura interna do backend.

## Riscos

- O `case 'conflict'` no switch do `DeleteSystemConfirm` é dead code para o caminho de delete (backend nunca devolve 409 nesse path). Mantemos o branch para satisfazer a exhaustiveness do `MutationErrorAction` discriminado e porque #61 (Restore) **vai** usar 409. Documentado inline no comentário do caso.
- A estratégia "esconder botão em linhas soft-deletadas" é UX. Se um usuário com permissão receber linha desatualizada por race condition (outro admin desativou em paralelo), o backend devolverá 404 e o modal fará refetch automático — defensiva já coberta no `case 'not-found'`.

## Issue relacionada

Closes #60
