### PR TITLE
feat(systems): restaurar sistema (#61)

### DIFF
--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -6,6 +6,7 @@ import {
   RotateCcw,
   Search,
   Trash2,
+  Undo2,
 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -25,6 +26,7 @@ import { useAuth } from '../shared/auth';
 import { DeleteSystemConfirm } from './systems/DeleteSystemConfirm';
 import { EditSystemModal } from './systems/EditSystemModal';
 import { NewSystemModal } from './systems/NewSystemModal';
+import { RestoreSystemConfirm } from './systems/RestoreSystemConfirm';
 
 import type { TableColumn } from '../components/ui';
 import type { ApiClient, PagedResponse, SystemDto } from '../shared/api';
@@ -67,6 +69,18 @@ const SYSTEMS_UPDATE_PERMISSION = 'AUTH_V1_SYSTEMS_UPDATE';
  * esconder ações que o usuário não pode executar.
  */
 const SYSTEMS_DELETE_PERMISSION = 'AUTH_V1_SYSTEMS_DELETE';
+
+/**
+ * Code de permissão exigido para o botão "Restaurar" por linha (Issue
+ * #61, última sub-issue da EPIC #45). Espelha o `AUTH_V1_SYSTEMS_RESTORE`
+ * no `lfc-authenticator` — o backend é a fonte autoritativa
+ * (`POST /systems/{id}/restore` exige `PermissionPolicies.SystemsRestore`).
+ * Gating client-side é UX: esconder ações que o usuário não pode
+ * executar; complementado por `row.deletedAt !== null` no botão (só
+ * faz sentido restaurar linhas soft-deletadas — espelha a lógica
+ * inversa do botão "Desativar").
+ */
+const SYSTEMS_RESTORE_PERMISSION = 'AUTH_V1_SYSTEMS_RESTORE';
 
 interface SystemsPageProps {
   /**
@@ -278,6 +292,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
   const canCreateSystem = hasPermission(SYSTEMS_CREATE_PERMISSION);
   const canUpdateSystem = hasPermission(SYSTEMS_UPDATE_PERMISSION);
   const canDeleteSystem = hasPermission(SYSTEMS_DELETE_PERMISSION);
+  const canRestoreSystem = hasPermission(SYSTEMS_RESTORE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -309,6 +324,13 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
   // confirmação. `null` mantém o modal fechado.
   const [deletingSystem, setDeletingSystem] = useState<SystemDto | null>(null);
 
+  // Sistema selecionado para restauração (Issue #61, última sub-issue
+  // da EPIC #45). Mesma estratégia do `deletingSystem` — manter o
+  // objeto completo permite ao `RestoreSystemConfirm` exibir `name`/
+  // `code` na confirmação sem round-trip extra. `null` mantém o modal
+  // fechado.
+  const [restoringSystem, setRestoringSystem] = useState<SystemDto | null>(null);
+
   const handleOpenCreateModal = useCallback(() => {
     setIsCreateModalOpen(true);
   }, []);
@@ -331,6 +353,14 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
 
   const handleCloseDeleteConfirm = useCallback(() => {
     setDeletingSystem(null);
+  }, []);
+
+  const handleOpenRestoreConfirm = useCallback((row: SystemDto) => {
+    setRestoringSystem(row);
+  }, []);
+
+  const handleCloseRestoreConfirm = useCallback(() => {
+    setRestoringSystem(null);
   }, []);
 
   // Controller da request mais recente — usado para cancelar a anterior
@@ -529,11 +559,11 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
     ];
 
     // Coluna "Ações" só aparece quando o usuário tem **alguma** ação
-    // disponível (update ou delete). Esconder a coluna inteira para
-    // perfis read-only mantém a tabela compacta sem coluna vazia.
-    // Cada botão dentro tem seu próprio gating individual + (no caso
-    // do delete) check por linha (`row.deletedAt`).
-    if (canUpdateSystem || canDeleteSystem) {
+    // disponível (update, delete ou restore). Esconder a coluna inteira
+    // para perfis read-only mantém a tabela compacta sem coluna vazia.
+    // Cada botão dentro tem seu próprio gating individual + check por
+    // linha quando aplicável (`row.deletedAt`).
+    if (canUpdateSystem || canDeleteSystem || canRestoreSystem) {
       base.push({
         key: 'actions',
         label: 'Ações',
@@ -555,10 +585,9 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
             {canDeleteSystem && row.deletedAt === null && (
               // Botão "Desativar" só aparece em linhas ativas — não faz
               // sentido oferecer "desativar" pra um sistema já soft-
-              // deletado (#61 vai adicionar "Restaurar" pra essas
-              // linhas). O backend devolve 404 nesse caso, mas
-              // esconder no UI é o caminho ergonômico (lê a coluna
-              // Status como referência).
+              // deletado (Issue #61 cobre "Restaurar" pra essas linhas).
+              // O backend devolve 404 nesse caso, mas esconder no UI é
+              // o caminho ergonômico (lê a coluna Status como referência).
               <Button
                 variant="ghost"
                 size="sm"
@@ -570,13 +599,39 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
                 Desativar
               </Button>
             )}
+            {canRestoreSystem && row.deletedAt !== null && (
+              // Botão "Restaurar" é o inverso lógico do "Desativar":
+              // só aparece em linhas com `deletedAt != null`. O backend
+              // devolve 404 com mensagem específica se chamarem em
+              // sistema ativo ("Sistema não encontrado ou não está
+              // deletado."), mas escondemos no UI para reforçar a leitura
+              // visual: a coluna Status já mostra "Inativo" via Badge.
+              // Issue #61 — última sub-issue da EPIC #45.
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Undo2 size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenRestoreConfirm(row)}
+                aria-label={`Restaurar sistema ${row.name}`}
+                data-testid={`systems-restore-${row.id}`}
+              >
+                Restaurar
+              </Button>
+            )}
           </RowActions>
         ),
       });
     }
 
     return base;
-  }, [canDeleteSystem, canUpdateSystem, handleOpenDeleteConfirm, handleOpenEditModal]);
+  }, [
+    canDeleteSystem,
+    canRestoreSystem,
+    canUpdateSystem,
+    handleOpenDeleteConfirm,
+    handleOpenEditModal,
+    handleOpenRestoreConfirm,
+  ]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -763,6 +818,16 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
           system={deletingSystem}
           onClose={handleCloseDeleteConfirm}
           onDeleted={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canRestoreSystem && (
+        <RestoreSystemConfirm
+          open={restoringSystem !== null}
+          system={restoringSystem}
+          onClose={handleCloseRestoreConfirm}
+          onRestored={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/systems/DeleteSystemConfirm.tsx
+++ b/src/pages/systems/DeleteSystemConfirm.tsx
@@ -1,79 +1,56 @@
-import React, { useCallback, useState } from 'react';
-import styled from 'styled-components';
+import React from 'react';
 
-import { Button, Modal, useToast } from '../../components/ui';
 import { deleteSystem } from '../../shared/api';
 
 import {
-  classifyMutationError,
-  type MutationErrorCopy,
-} from './systemFormShared';
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from './MutationConfirmModal';
 
 import type { ApiClient, SystemDto } from '../../shared/api';
 
 /**
- * Copy injetado em `classifyMutationError` para o caminho de soft-delete
- * (Issue #60). O slot opcional `conflictMessage` fica intencionalmente
- * ausente — o backend nunca devolve 409 em `DELETE /systems/{id}`, e o
- * helper trata 409 como `unhandled` neste cenário (vide
- * `classifyMutationError`). Esse slot existe na assinatura para que o
- * `RestoreSystemConfirm` (#61) reuse a mesma máquina de classificação
- * sem refator do shared (lição PR #128 sobre projetar o módulo
- * compartilhado já no primeiro PR do recurso).
+ * Copy do diálogo de confirmação para soft-delete (Issue #60). O slot
+ * opcional `errorCopy.conflictMessage` fica intencionalmente ausente —
+ * o backend nunca devolve 409 em `DELETE /systems/{id}`, e o helper
+ * trata 409 como `unhandled` neste cenário (vide `classifyMutationError`).
+ * Esse slot existe na assinatura para que o `RestoreSystemConfirm` (#61)
+ * reuse a mesma máquina de classificação sem refator do shared (lição
+ * PR #128).
  */
-const MUTATION_ERROR_COPY: MutationErrorCopy = {
-  forbiddenTitle: 'Falha ao desativar sistema',
-  genericFallback: 'Não foi possível desativar o sistema. Tente novamente.',
-  notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+const DELETE_COPY: MutationConfirmCopy = {
+  title: 'Desativar sistema?',
+  descriptionPrefix: 'O sistema ',
+  descriptionSuffix:
+    ' será desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando "Mostrar inativos".',
+  confirmLabel: 'Desativar',
+  successMessage: 'Sistema desativado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao desativar sistema',
+    genericFallback: 'Não foi possível desativar o sistema. Tente novamente.',
+    notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+  },
 };
 
 /**
- * Mensagem de sucesso fixa exibida no toast verde após `204 No Content`
- * — não cita o nome porque o usuário acabou de selecionar a linha e a
- * tabela será atualizada na sequência.
+ * Função adapter `(system, client?) => Promise<void>` que delega para
+ * `deleteSystem(system.id, undefined, client)`. Mantemos a função fora
+ * do componente para não recriá-la a cada render — o `MutationConfirmModal`
+ * usa `mutate` em `useCallback`, então uma referência estável evita
+ * invalidação desnecessária.
  */
-const SUCCESS_MESSAGE = 'Sistema desativado.';
-
-/**
- * Modal de confirmação para soft-delete de sistema (Issue #60).
- *
- * Espelha o layout dos modals de criação/edição (`Modal` shell +
- * conteúdo customizado por feature), mas sem campos de form — só
- * descrição contextual e dois botões. Decisões:
- *
- * - **Confirmação obrigatória** (critério de aceite #60): o botão
- *   "Desativar" só dispara `DELETE` após clique explícito. O modal não
- *   tem foco automático no botão de ação para evitar `Enter` acidental
- *   fechar a tela com o sistema desativado por engano (o `Modal` joga o
- *   foco no primeiro elemento focável — vai cair no botão Cancelar
- *   porque ele aparece antes do "Desativar" no DOM).
- * - **Variant `danger`** no botão de ação destaca visualmente o caráter
- *   destrutivo. Já existe no design system local (`Button.tsx`); não
- *   precisamos hardcodar cor.
- * - **Copy mostra `name` + `code`** entre crases (`<Mono>` para `code`)
- *   como pista de identificação — `code` é o que o backend usa em
- *   `X-System-Id`/JWT, então o usuário precisa diferenciar mesmo entre
- *   sistemas com o mesmo `name`.
- * - **Cancelar/Esc/backdrop fecham sem persistir** (gerenciado pelo
- *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
- *   `isSubmitting` — evita request órfã.
- * - **Mapeamento de erros** via `classifyMutationError` (helper puro em
- *   `systemFormShared.ts`). Switch curto evita cascata `if/else` que o
- *   Sonar marca como Cognitive Complexity > 10 (lição PR #128).
- *
- * Não usa `useSystemForm` porque não há campos de form — só estado
- * `isSubmitting` simples. Qualquer outra confirmação simples futura
- * (`RestoreSystemConfirm` em #61) reusará o mesmo pattern + helper.
- */
+function performDelete(system: SystemDto, client?: ApiClient): Promise<void> {
+  return deleteSystem(system.id, undefined, client);
+}
 
 interface DeleteSystemConfirmProps {
   /** Estado de visibilidade controlado pelo pai. */
   open: boolean;
   /**
    * Sistema selecionado para soft-delete. Quando `null`, o modal não
-   * renderiza — caller controla `open` em conjunto com `system`. Mantemos
-   * o objeto completo (não só `id`) para que a copy exiba `name`/`code`
-   * sem precisar de re-fetch.
+   * renderiza — caller controla `open` em conjunto com `system`.
+   * Mantemos o objeto completo (não só `id`) para que a copy exiba
+   * `name`/`code` sem precisar de re-fetch.
    */
   system: SystemDto | null;
   /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
@@ -91,160 +68,56 @@ interface DeleteSystemConfirmProps {
   client?: ApiClient;
 }
 
-/* ─── Styled primitives ──────────────────────────────────── */
-
 /**
- * Container da descrição. Usa `--space-3` de gap entre parágrafos para
- * preservar a hierarquia visual sem encavalar — espelha o padrão dos
- * modals de form (`SystemFormBody`).
+ * Modal de confirmação para soft-delete de sistema (Issue #60).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (#61) — toda a estrutura
+ * visual + lógica de submissão/erro vive no shell compartilhado. Aqui
+ * só injetamos:
+ *
+ * - **Copy** (`DELETE_COPY`): título, descrição, label do botão e
+ *   mensagens de toast.
+ * - **Mutate** (`performDelete`): adapta `deleteSystem(id)` para a
+ *   assinatura `(system, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`danger`): destaca o caráter destrutivo. Já existe no
+ *   design system local (`Button.tsx`); não precisamos hardcodar cor.
+ * - **`testIdPrefix`** (`delete-system`): preserva os `data-testid`
+ *   legados das suítes de teste sem reescrever asserts.
+ *
+ * O `MutationConfirmModal` cuida de:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #60): o botão só
+ *   dispara `DELETE` após clique explícito. O foco vai para o botão
+ *   Cancelar (ordem do DOM) — Enter acidental fecha sem destruir.
+ * - **Cancelar/Esc/backdrop fecham sem persistir** (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
+ *   `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError` em
+ *   `systemFormShared.ts`. Switch curto evita cascata `if/else` que o
+ *   Sonar marca como Cognitive Complexity > 10 (lição PR #128).
+ *
+ * O `RestoreSystemConfirm` (#61, última sub-issue) reusa o mesmo shell
+ * com copy + variant + mutate diferentes — extrair `MutationConfirmModal`
+ * eliminou ~150 linhas que seriam duplicadas (BLOCKER de Sonar
+ * `New Code Duplication`, 5ª recorrência das lições
+ * PR #119/#123/#127/#128 evitada).
  */
-const ConfirmBody = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-`;
-
-const ConfirmText = styled.p`
-  font-size: var(--text-sm);
-  color: var(--fg2);
-  line-height: var(--leading-snug);
-`;
-
-/**
- * Barra de ações alinhada à direita — espelha o footer do
- * `SystemFormBody`. Mantém ordem "Cancelar (ghost) → Desativar (danger)"
- * para que o botão destrutivo fique após a saída segura, padrão de UX
- * em diálogos de confirmação (Material/Bootstrap/Polaris alinhados).
- */
-const ActionsBar = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--space-3);
-`;
-
-const Mono = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--fg1);
-  background: var(--bg-elevated);
-  padding: 0 var(--space-1);
-  border-radius: var(--radius-sm);
-`;
-
-/* ─── Component ──────────────────────────────────────────── */
-
 export const DeleteSystemConfirm: React.FC<DeleteSystemConfirmProps> = ({
   open,
   system,
   onClose,
   onDeleted,
   client,
-}) => {
-  const { show } = useToast();
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-
-  /**
-   * Fecha o modal sem persistir — handler único para Esc, backdrop, X e
-   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
-   * submissão é bloqueado para evitar request órfã (mesmo padrão dos
-   * modals de form).
-   */
-  const handleClose = useCallback(() => {
-    if (isSubmitting) return;
-    onClose();
-  }, [isSubmitting, onClose]);
-
-  const handleConfirm = useCallback(async () => {
-    if (isSubmitting || !system) return;
-    setIsSubmitting(true);
-    try {
-      await deleteSystem(system.id, undefined, client);
-      // Mensagem fixa — o usuário acabou de selecionar e a lista será
-      // atualizada. Toast verde sinaliza sucesso visual além do close.
-      show(SUCCESS_MESSAGE, { variant: 'success' });
-      // Ordem importa: refetch antes de fechar para o pai não ter que
-      // coordenar dois ticks separados (mesmo padrão dos demais modals).
-      onDeleted();
-      onClose();
-    } catch (error: unknown) {
-      // `classifyMutationError` colapsa a cascata `if (status === 404)
-      // { ... } if (... === 401 || === 403) { ... }`. Switch curto evita
-      // Cognitive Complexity > 10 e duplicação ≥10 linhas com o futuro
-      // `RestoreSystemConfirm` (lição PR #128 — pré-projetar o shared
-      // desde o 1º PR do recurso).
-      const action = classifyMutationError(error, MUTATION_ERROR_COPY);
-      switch (action.kind) {
-        case 'not-found':
-          // Sistema removido entre abertura e confirm. Fecha modal +
-          // toast + refetch (paridade com o tratamento de 404 no edit).
-          show(action.message, { variant: 'danger', title: action.title });
-          onDeleted();
-          onClose();
-          break;
-        case 'toast':
-          show(action.message, { variant: 'danger', title: action.title });
-          break;
-        case 'conflict':
-          // Só relevante no `RestoreSystemConfirm` (#61). No delete,
-          // mantemos o branch para satisfazer exhaustiveness do switch
-          // sem cair no `default`/`unhandled`. Comportamento equivalente
-          // a `unhandled` para o usuário final.
-          show(action.message, { variant: 'danger', title: action.title });
-          break;
-        case 'unhandled':
-          show(action.fallback, { variant: 'danger', title: action.title });
-          break;
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [client, isSubmitting, onClose, onDeleted, show, system]);
-
-  // Defensive guard: pai controla `open` em conjunto com `system`, mas
-  // cobrimos o caso `open=true && system=null` para não tentar
-  // `deleteSystem(null.id)`.
-  if (!system) {
-    return null;
-  }
-
-  return (
-    <Modal
-      open={open}
-      onClose={handleClose}
-      title="Desativar sistema?"
-      closeOnEsc={!isSubmitting}
-      closeOnBackdrop={!isSubmitting}
-    >
-      <ConfirmBody>
-        <ConfirmText data-testid="delete-system-description">
-          O sistema <strong>{system.name}</strong> (<Mono>{system.code}</Mono>) será
-          desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando
-          &quot;Mostrar inativos&quot;.
-        </ConfirmText>
-        <ActionsBar>
-          <Button
-            variant="ghost"
-            size="md"
-            type="button"
-            onClick={handleClose}
-            disabled={isSubmitting}
-            data-testid="delete-system-cancel"
-          >
-            Cancelar
-          </Button>
-          <Button
-            variant="danger"
-            size="md"
-            type="button"
-            onClick={handleConfirm}
-            loading={isSubmitting}
-            data-testid="delete-system-confirm"
-          >
-            Desativar
-          </Button>
-        </ActionsBar>
-      </ConfirmBody>
-    </Modal>
-  );
-};
+}) => (
+  <MutationConfirmModal
+    open={open}
+    system={system}
+    onClose={onClose}
+    onSuccess={onDeleted}
+    client={client}
+    mutate={performDelete}
+    copy={DELETE_COPY}
+    confirmVariant="danger"
+    testIdPrefix="delete-system"
+  />
+);

--- a/src/pages/systems/MutationConfirmModal.tsx
+++ b/src/pages/systems/MutationConfirmModal.tsx
@@ -1,0 +1,298 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { Button, Modal, useToast } from '../../components/ui';
+
+import {
+  classifyMutationError,
+  type MutationErrorCopy,
+} from './systemFormShared';
+
+import type { ButtonVariant } from '../../components/ui';
+import type { ApiClient, SystemDto } from '../../shared/api';
+
+/**
+ * Componente compartilhado para diálogos de confirmação de mutações
+ * simples (sem corpo de form) sobre um `SystemDto` — extraído na Issue
+ * #61 a partir do `DeleteSystemConfirm` (#60) para evitar duplicação de
+ * blocos ≥10 linhas com o `RestoreSystemConfirm`.
+ *
+ * Sonar marcaria a duplicação direta como `New Code Duplication > 3%`
+ * (5ª recorrência das lições PR #119/#123/#127/#128). Compartilhar o
+ * shell completo (Modal + descrição + ações + try/catch + classificação
+ * de erro) elimina a duplicação na raiz: cada caller só injeta copy +
+ * variant + ação assíncrona.
+ *
+ * **Por que extrair só agora (#61) e não em #60?**
+ * O programmer de #60 deixou `MutationErrorCopy.conflictMessage` como
+ * slot opcional — pré-projetando o helper `classifyMutationError` para
+ * servir delete e restore (lição PR #128 — projetar o módulo
+ * compartilhado já no primeiro PR do recurso). O componente shell ficou
+ * de fora porque a 2ª instância (`RestoreSystemConfirm`) só nasce em #61
+ * — extrair antes seria especulação, mas extrair agora é obrigatório
+ * para manter o pacto de não duplicar.
+ *
+ * Decisões de design:
+ *
+ * - **`copy: MutationConfirmCopy`** entrega títulos/mensagens em pt-BR
+ *   inertes (sem nome do sistema interpolado). O renderer constrói a
+ *   sentença final em JSX juntando `descriptionPrefix` + `<strong>name</strong>`
+ *   + `(<Mono>code</Mono>)` + `descriptionSuffix`. Manter como duas
+ *   strings (`prefix`/`suffix`) garante que a interpolação fique no
+ *   componente de apresentação — sem `dangerouslySetInnerHTML` ou
+ *   parsing de markdown.
+ * - **`confirmVariant: ButtonVariant`** controla a paleta do botão de
+ *   ação (delete usa `danger`, restore usa `primary`). Não engessamos:
+ *   futuras mutações podem usar `secondary`/`ghost` se for o caso.
+ * - **`testIdPrefix`** preserva os `data-testid` legados das suítes de
+ *   teste (`delete-system-*` / `restore-system-*`) sem reescrever todas
+ *   as assertions — o caller passa o prefixo e o componente concatena.
+ * - **`mutate: (system, client?) => Promise<unknown>`** entrega só a
+ *   chamada HTTP (caller injeta `deleteSystem`/`restoreSystem`). O shell
+ *   cuida de loading, success toast, classificação de erro e refetch.
+ * - **Sem `useSystemForm`** porque não há campos. Mantemos só
+ *   `isSubmitting` local — mesmo padrão do `DeleteSystemConfirm`
+ *   original (que vira fininho consumindo este shell).
+ */
+
+/**
+ * Copy textual usado pelo `MutationConfirmModal`. Concentra todos os
+ * literais em pt-BR num único objeto — caller injeta a sua versão
+ * (delete vs restore) sem tocar no shell.
+ */
+export interface MutationConfirmCopy {
+  /** Título do diálogo (`<h2>` no header do Modal). */
+  title: string;
+  /**
+   * Texto que vem **antes** do nome+code do sistema na descrição.
+   * Tipicamente termina com espaço (ex.: `'O sistema '`).
+   */
+  descriptionPrefix: string;
+  /**
+   * Texto que vem **depois** do nome+code do sistema na descrição.
+   * Tipicamente começa com espaço (ex.: `' será desativado e ...'`).
+   */
+  descriptionSuffix: string;
+  /** Rótulo do botão que confirma a mutação (ex.: 'Desativar', 'Restaurar'). */
+  confirmLabel: string;
+  /**
+   * Mensagem fixa exibida no toast verde após a mutação resolver com
+   * sucesso. Não interpolamos o nome porque o usuário acabou de
+   * selecionar a linha e a tabela será atualizada na sequência.
+   */
+  successMessage: string;
+  /**
+   * Copy injetada em `classifyMutationError` para o tratamento dos
+   * erros (404/401/403/network/...). Ver `MutationErrorCopy` em
+   * `systemFormShared.ts`.
+   */
+  errorCopy: MutationErrorCopy;
+}
+
+interface MutationConfirmModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Sistema selecionado para a mutação. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `system`.
+   * Mantemos o objeto completo (não só `id`) para que a copy exiba
+   * `name`/`code` sem precisar de re-fetch.
+   */
+  system: SystemDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após mutação bem-sucedida ou após detecção de
+   * 404 — em ambos casos a UI quer refetch para sincronizar a tabela
+   * com o estado real do backend (item já alterado por outra sessão,
+   * ou sumiu).
+   */
+  onSuccess: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `mutate` cai no singleton `apiClient` por meio do wrapper específico
+   * (`deleteSystem`/`restoreSystem`).
+   */
+  client?: ApiClient;
+  /**
+   * Função pura que dispara a mutação HTTP (`deleteSystem`/`restoreSystem`).
+   * O shell cuida do `isSubmitting`/toast/refetch — `mutate` só precisa
+   * lançar `ApiError` em falha e resolver em sucesso.
+   */
+  mutate: (system: SystemDto, client?: ApiClient) => Promise<unknown>;
+  /** Copy textual + error copy (ver `MutationConfirmCopy`). */
+  copy: MutationConfirmCopy;
+  /**
+   * Variante visual do botão de confirmação. `danger` para
+   * delete; `primary` para restore. Mantém a apresentação alinhada com
+   * a semântica da ação sem hardcode de cor.
+   */
+  confirmVariant: ButtonVariant;
+  /**
+   * Prefixo dos `data-testid` (ex.: `'delete-system'`, `'restore-system'`).
+   * Concatenado com `-description`/`-cancel`/`-confirm` para preservar
+   * compatibilidade com asserções legadas das suítes de teste.
+   */
+  testIdPrefix: string;
+}
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+/**
+ * Container da descrição. Usa `--space-3` de gap entre parágrafos para
+ * preservar a hierarquia visual sem encavalar — espelha o padrão dos
+ * modals de form (`SystemFormBody`).
+ */
+const ConfirmBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+`;
+
+const ConfirmText = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+`;
+
+/**
+ * Barra de ações alinhada à direita — espelha o footer do
+ * `SystemFormBody`. Mantém ordem "Cancelar (ghost) → Confirmar
+ * (variant)" para que o botão de ação fique após a saída segura, padrão
+ * de UX em diálogos de confirmação (Material/Bootstrap/Polaris alinhados).
+ */
+const ActionsBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg1);
+  background: var(--bg-elevated);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+`;
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
+  open,
+  system,
+  onClose,
+  onSuccess,
+  client,
+  mutate,
+  copy,
+  confirmVariant,
+  testIdPrefix,
+}) => {
+  const { show } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  /**
+   * Fecha o modal sem persistir — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
+   * submissão é bloqueado para evitar request órfã (mesmo padrão dos
+   * modals de form).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    onClose();
+  }, [isSubmitting, onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    if (isSubmitting || !system) return;
+    setIsSubmitting(true);
+    try {
+      await mutate(system, client);
+      // Mensagem fixa — o usuário acabou de selecionar e a lista será
+      // atualizada. Toast verde sinaliza sucesso visual além do close.
+      show(copy.successMessage, { variant: 'success' });
+      // Ordem importa: refetch antes de fechar para o pai não ter que
+      // coordenar dois ticks separados (mesmo padrão dos demais modals).
+      onSuccess();
+      onClose();
+    } catch (error: unknown) {
+      // `classifyMutationError` colapsa a cascata `if (status === 404)
+      // { ... } if (... === 409) { ... } if (... === 401 || === 403) { ... }`.
+      // Switch curto evita Cognitive Complexity > 10 e mantém o módulo
+      // compartilhado entre delete (#60) e restore (#61) — lição PR #128.
+      const action = classifyMutationError(error, copy.errorCopy);
+      switch (action.kind) {
+        case 'not-found':
+          // Item removido/já mutado entre abertura e confirm. Fecha
+          // modal + toast + refetch (paridade com o tratamento de 404
+          // no edit).
+          show(action.message, { variant: 'danger', title: action.title });
+          onSuccess();
+          onClose();
+          break;
+        case 'toast':
+          show(action.message, { variant: 'danger', title: action.title });
+          break;
+        case 'conflict':
+          // Relevante para o restore quando o backend evoluir para
+          // devolver 409 ("já está ativo"). Hoje o backend devolve
+          // 404 nesse caminho, mas o branch fica preparado.
+          show(action.message, { variant: 'danger', title: action.title });
+          break;
+        case 'unhandled':
+          show(action.fallback, { variant: 'danger', title: action.title });
+          break;
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [client, copy, isSubmitting, mutate, onClose, onSuccess, show, system]);
+
+  // Defensive guard: pai controla `open` em conjunto com `system`, mas
+  // cobrimos o caso `open=true && system=null` para não tentar
+  // `mutate(null)`.
+  if (!system) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title={copy.title}
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <ConfirmBody>
+        <ConfirmText data-testid={`${testIdPrefix}-description`}>
+          {copy.descriptionPrefix}
+          <strong>{system.name}</strong> (<Mono>{system.code}</Mono>)
+          {copy.descriptionSuffix}
+        </ConfirmText>
+        <ActionsBar>
+          <Button
+            variant="ghost"
+            size="md"
+            type="button"
+            onClick={handleClose}
+            disabled={isSubmitting}
+            data-testid={`${testIdPrefix}-cancel`}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant={confirmVariant}
+            size="md"
+            type="button"
+            onClick={handleConfirm}
+            loading={isSubmitting}
+            data-testid={`${testIdPrefix}-confirm`}
+          >
+            {copy.confirmLabel}
+          </Button>
+        </ActionsBar>
+      </ConfirmBody>
+    </Modal>
+  );
+};

--- a/src/pages/systems/RestoreSystemConfirm.tsx
+++ b/src/pages/systems/RestoreSystemConfirm.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+
+import { restoreSystem } from '../../shared/api';
+
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from './MutationConfirmModal';
+
+import type { ApiClient, SystemDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo de confirmação para restauração (Issue #61, última
+ * sub-issue do CRUD da EPIC #45).
+ *
+ * O slot `errorCopy.conflictMessage` está preenchido por previsão: o
+ * backend atual devolve **404** com mensagem específica quando o sistema
+ * já está ativo (em vez de 409 distinto), mas o `classifyMutationError`
+ * trata o eventual 409 com `kind: 'conflict'` quando esse slot existe
+ * — assim, qualquer mudança futura do contrato (split de 404/409) fica
+ * coberta sem reabrir o modal. Lição PR #128: pré-projetar o helper
+ * compartilhado é mais barato do que abrir um PR adicional.
+ */
+const RESTORE_COPY: MutationConfirmCopy = {
+  title: 'Restaurar sistema?',
+  descriptionPrefix: 'O sistema ',
+  descriptionSuffix: ' voltará a aparecer na listagem padrão.',
+  confirmLabel: 'Restaurar',
+  successMessage: 'Sistema restaurado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao restaurar sistema',
+    genericFallback: 'Não foi possível restaurar o sistema. Tente novamente.',
+    notFoundMessage: 'Sistema não encontrado ou já está ativo.',
+    conflictMessage: 'O sistema já está ativo.',
+  },
+};
+
+/**
+ * Função adapter `(system, client?) => Promise<void>` que delega para
+ * `restoreSystem(system.id, undefined, client)`. Espelha o `performDelete`
+ * do `DeleteSystemConfirm`. Função fora do componente para preservar
+ * referência estável entre renders (o `MutationConfirmModal` consome
+ * `mutate` em `useCallback`).
+ */
+function performRestore(system: SystemDto, client?: ApiClient): Promise<void> {
+  return restoreSystem(system.id, undefined, client);
+}
+
+interface RestoreSystemConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Sistema soft-deletado selecionado para restauração. Quando `null`,
+   * o modal não renderiza — caller controla `open` em conjunto com
+   * `system`. Mantemos o objeto completo (não só `id`) para que a copy
+   * exiba `name`/`code` sem precisar de re-fetch.
+   */
+  system: SystemDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após restauração bem-sucedida ou após detecção
+   * de 404 (sistema não encontrado ou já ativo) — em ambos casos a UI
+   * quer refetch para sincronizar a tabela com o estado real do backend.
+   */
+  onRestored: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `restoreSystem` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para restauração de sistema soft-deletado
+ * (Issue #61, última sub-issue da EPIC #45 — fecha o CRUD completo).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` — espelha o
+ * `DeleteSystemConfirm` em estrutura, mas injeta:
+ *
+ * - **Copy** (`RESTORE_COPY`): "Restaurar sistema?" + descrição
+ *   contextual; sem aviso de "ativar Mostrar inativos" porque o sistema
+ *   volta diretamente para a listagem padrão após o restore.
+ * - **Mutate** (`performRestore`): adapta `restoreSystem(id)` para a
+ *   assinatura `(system, client?) => Promise<unknown>` esperada pelo
+ *   shell.
+ * - **Variant** (`primary`): ação positiva (restaura/ativa) — o token
+ *   `--clr-lime`/`--clr-forest` do design system reforça o significado
+ *   sem hardcode de cor.
+ * - **`testIdPrefix`** (`restore-system`): identifica os elementos do
+ *   modal nas suítes de teste sem colidir com o delete.
+ *
+ * O `MutationConfirmModal` cuida de:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #61, espelhando #60).
+ * - **Cancelar/Esc/backdrop** fecham sem persistir (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
+ *   interna `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError` em
+ *   `systemFormShared.ts`:
+ *
+ *   - `404` → fecha modal + toast vermelho + refetch (sistema removido
+ *     ou já ativo entre abertura e submit). Backend devolve 404 com
+ *     mensagem `"Sistema não encontrado ou não está deletado."`; o
+ *     frontend exibe a copy traduzida `"Sistema não encontrado ou já
+ *     está ativo."`.
+ *   - `401`/`403` → toast vermelho com mensagem do backend (UI continua
+ *     no estado atual; cliente HTTP cuida do redirect 401).
+ *   - `409` → toast vermelho com `RESTORE_COPY.errorCopy.conflictMessage`.
+ *     Hoje o backend não devolve esse status, mas o slot fica preparado.
+ *   - Network/parse/5xx → toast vermelho genérico com fallback
+ *     (`"Não foi possível restaurar o sistema. Tente novamente."`).
+ */
+export const RestoreSystemConfirm: React.FC<RestoreSystemConfirmProps> = ({
+  open,
+  system,
+  onClose,
+  onRestored,
+  client,
+}) => (
+  <MutationConfirmModal
+    open={open}
+    system={system}
+    onClose={onClose}
+    onSuccess={onRestored}
+    client={client}
+    mutate={performRestore}
+    copy={RESTORE_COPY}
+    confirmVariant="primary"
+    testIdPrefix="restore-system"
+  />
+);

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -76,6 +76,7 @@ export {
   isPagedSystemsResponse,
   isSystemDto,
   listSystems,
+  restoreSystem,
   updateSystem,
 } from './systems';
 export type {

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -341,6 +341,52 @@ export async function deleteSystem(
 }
 
 /**
+ * Restaura (desfaz soft-delete) um sistema via `POST /systems/{id}/restore`
+ * (Issue #61, última sub-issue do CRUD da EPIC #45).
+ *
+ * O backend (`SystemsController.RestoreById`) limpa `DeletedAt` via
+ * `IgnoreQueryFilters()` e responde `200 OK` com `{ message: "Sistema
+ * restaurado com sucesso." }`. Diferente de `createSystem`/`updateSystem`,
+ * o corpo da resposta **não** é um `SystemDto` — é um envelope simples
+ * `{ message }` que descartamos. A UI faz refetch para sincronizar a
+ * lista (idêntico ao padrão do `deleteSystem`), então retornamos `void`.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → sistema inexistente **ou** já
+ *   ativo (o backend devolve 404 com mensagem específica em ambos os
+ *   casos: filtro `DeletedAt != null` no `WHERE`). A UI fecha o modal,
+ *   dispara toast e força refetch — o registro foi mexido por outra
+ *   sessão entre a abertura do modal e o submit, ou nem existe.
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_SYSTEMS_RESTORE`; toast vermelho com mensagem do backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Não há type guard de resposta porque `{ message }` é descartado —
+ * `client.post<void>` resolve com o body como `unknown` e ignoramos.
+ * Caso o backend evolua para devolver `SystemResponse` no futuro, basta
+ * ajustar este wrapper para validar com `isSystemDto` e atualizar o
+ * tipo de retorno.
+ *
+ * Recebe `BodyRequestOptions` (com `signal`) por simetria com `createSystem`/
+ * `updateSystem` — `POST` é tratado como mutação com corpo no cliente
+ * HTTP, ainda que aqui não enviemos payload. Passamos `undefined` como
+ * body para que o backend receba uma requisição vazia.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function restoreSystem(
+  id: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.post<void>(`/systems/${id}/restore`, undefined, options);
+}
+
+/**
  * Constrói o body para `POST /systems` e `PUT /systems/{id}` aplicando
  * trim defensivo nos campos. Description vazia depois de trim vira
  * `undefined` para que o serializador omita o campo (backend converte

--- a/tests/pages/SystemsPage.restore.test.tsx
+++ b/tests/pages/SystemsPage.restore.test.tsx
@@ -1,0 +1,288 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  assertRowActionAbsent,
+  assertRowActionPresent,
+  buildCloseCases,
+  buildSharedMutationErrorCases,
+  confirmRestore,
+  createSystemsClientStub,
+  ID_SYS_AUTH,
+  ID_SYS_LEGACY,
+  makePagedResponse,
+  makeSystem,
+  openRestoreConfirm,
+  renderSystemsPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from './__helpers__/systemsTestHelpers';
+
+import type { SystemsErrorCase } from './__helpers__/systemsTestHelpers';
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Mock controlável de `useAuth` — cada teste seta `permissionsMock`
+ * antes de renderizar a página para simular usuário com/sem permissão
+ * `AUTH_V1_SYSTEMS_RESTORE`. Reusa `buildAuthMock` (helper compartilhado
+ * com listagem/criação/edição/desativação).
+ *
+ * Issue #61 — restauração via `POST /systems/{id}/restore` + modal de
+ * confirmação (`RestoreSystemConfirm`). Última sub-issue da EPIC #45,
+ * fechando o CRUD completo de sistemas.
+ */
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const SYSTEMS_RESTORE_PERMISSION = 'AUTH_V1_SYSTEMS_RESTORE';
+const SYSTEMS_DELETE_PERMISSION = 'AUTH_V1_SYSTEMS_DELETE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('SystemsPage — restaurar (Issue #61)', () => {
+  describe('gating do botão "Restaurar" por linha', () => {
+    it('não exibe botões "Restaurar" quando o usuário não possui AUTH_V1_SYSTEMS_RESTORE', async () => {
+      permissionsMock = [];
+      await assertRowActionAbsent(createSystemsClientStub(), 'restore');
+    });
+
+    it('exibe um botão "Restaurar" para cada linha soft-deletada quando o usuário possui AUTH_V1_SYSTEMS_RESTORE', async () => {
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION];
+      await assertRowActionPresent(createSystemsClientStub(), 'restore', 'Restaurar');
+    });
+
+    it('NÃO exibe "Restaurar" em linhas ativas (deletedAt === null)', async () => {
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION];
+      const client = createSystemsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedResponse([
+          // Ativa — botão NÃO deve aparecer (espelha a lógica inversa
+          // do Desativar; só faz sentido restaurar linhas inativas).
+          makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator' }),
+          // Soft-deletada — botão deve aparecer.
+          makeSystem({
+            id: ID_SYS_LEGACY,
+            name: 'lfc-legacy',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderSystemsPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.queryByTestId(`systems-restore-${ID_SYS_AUTH}`)).not.toBeInTheDocument();
+      expect(screen.getByTestId(`systems-restore-${ID_SYS_LEGACY}`)).toBeInTheDocument();
+    });
+
+    it('coexiste com o botão "Desativar" só na linha onde faz sentido (delete em ativa, restore em inativa)', async () => {
+      // Caso real do toggle "Mostrar inativos": as duas ações aparecem
+      // na mesma tabela, mas cada uma em sua linha apropriada.
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION, SYSTEMS_DELETE_PERMISSION];
+      const client = createSystemsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedResponse([
+          makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator' }),
+          makeSystem({
+            id: ID_SYS_LEGACY,
+            name: 'lfc-legacy',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderSystemsPage(client);
+      await waitForInitialList(client);
+
+      // Linha ativa: Desativar visível, Restaurar oculto.
+      expect(screen.getByTestId(`systems-delete-${ID_SYS_AUTH}`)).toBeInTheDocument();
+      expect(screen.queryByTestId(`systems-restore-${ID_SYS_AUTH}`)).not.toBeInTheDocument();
+
+      // Linha inativa: Restaurar visível, Desativar oculto.
+      expect(screen.queryByTestId(`systems-delete-${ID_SYS_LEGACY}`)).not.toBeInTheDocument();
+      expect(screen.getByTestId(`systems-restore-${ID_SYS_LEGACY}`)).toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION];
+    });
+
+    it('clicar em "Restaurar" abre o diálogo com nome e code do sistema', async () => {
+      const system = makeSystem({
+        id: ID_SYS_LEGACY,
+        name: 'lfc-legacy',
+        code: 'LEGACY',
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createSystemsClientStub();
+      await openRestoreConfirm(client, system);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/Restaurar sistema\?/i)).toBeInTheDocument();
+      const description = screen.getByTestId('restore-system-description');
+      expect(description).toHaveTextContent('lfc-legacy');
+      expect(description).toHaveTextContent('LEGACY');
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildCloseCases`
+     * (helper compartilhado com criação/edição/desativação) — diferença
+     * é só o testId do botão Cancelar (`restore-system-cancel`). Lição
+     * PR #127: `it.each` evita BLOCKER de duplicação Sonar para
+     * cenários com mesma estrutura mudando 1-2 mocks.
+     */
+    const CLOSE_CASES = buildCloseCases('restore-system-cancel');
+
+    it.each(CLOSE_CASES)('fechar via $name não dispara POST', async ({ close }) => {
+      const client = createSystemsClientStub();
+      await openRestoreConfirm(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      close();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION];
+    });
+
+    it('envia POST /systems/{id}/restore com id correto, fecha modal, exibe toast verde e refaz listSystems', async () => {
+      const target = makeSystem({
+        id: ID_SYS_LEGACY,
+        name: 'lfc-legacy',
+        code: 'LEGACY',
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createSystemsClientStub();
+      // Fila de respostas:
+      //   GET inicial → POST /restore (200 com `{message}` — que descartamos) → GET refetch.
+      // O backend devolve `{ message: "Sistema restaurado com sucesso." }`,
+      // mas como `restoreSystem` retorna `void`, o teste só precisa que
+      // o `client.post` resolva — usamos `undefined` por simplicidade.
+      client.get
+        .mockResolvedValueOnce(makePagedResponse([target]))
+        .mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+      client.post.mockResolvedValueOnce(undefined);
+
+      await openRestoreConfirm(client, target);
+      await confirmRestore(client);
+
+      // POST com path correto e body undefined (backend não exige corpo).
+      expect(client.post).toHaveBeenCalledWith(
+        `/systems/${ID_SYS_LEGACY}/restore`,
+        undefined,
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Sistema restaurado." (status do ToastProvider).
+      expect(await screen.findByText('Sistema restaurado.')).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [SYSTEMS_RESTORE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Casos
+     * comuns (401, 403, network) vêm do helper compartilhado
+     * `buildSharedMutationErrorCases('restaurar')` para evitar
+     * duplicação literal com a suíte de #60 (`desativar`).
+     *
+     * Caso específico (404 — sistema não encontrado ou já ativo) fica
+     * inline porque o comportamento difere: modal fecha + dispara
+     * refetch (paridade com o tratamento de 404 no edit/delete). O
+     * backend devolve 404 com mensagem específica em ambas as
+     * situações: registro inexistente OU já ativo.
+     */
+    const ERROR_CASES: ReadonlyArray<SystemsErrorCase> = [
+      {
+        name: '404 (sistema não encontrado ou já ativo) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Sistema não encontrado ou não está deletado.',
+        },
+        expectedText: 'Sistema não encontrado ou já está ativo.',
+        modalStaysOpen: false,
+      },
+      ...buildSharedMutationErrorCases('restaurar'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createSystemsClientStub();
+        client.post.mockRejectedValueOnce(error);
+
+        await openRestoreConfirm(client);
+        await confirmRestore(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onRestored chamado mesmo em erro)', async () => {
+      const target = makeSystem({
+        id: ID_SYS_LEGACY,
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createSystemsClientStub();
+      // Fila: GET inicial → POST (404) → GET refetch após onRestored.
+      client.get
+        .mockResolvedValueOnce(makePagedResponse([target]))
+        .mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Sistema não encontrado ou não está deletado.',
+      } satisfies ApiError);
+
+      await openRestoreConfirm(client, target);
+      await confirmRestore(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/tests/pages/__helpers__/systemsTestHelpers.tsx
+++ b/tests/pages/__helpers__/systemsTestHelpers.tsx
@@ -317,6 +317,49 @@ export async function confirmDelete(
 }
 
 /**
+ * Mocka o GET inicial com uma página contendo o `system` informado e
+ * abre o `RestoreSystemConfirm` clicando no botão "Restaurar" da linha
+ * (Issue #61). Diferente de `openDeleteConfirm`, o sistema default já
+ * vem com `deletedAt` preenchido — restaurar só faz sentido em linhas
+ * soft-deletadas, e o gating no `SystemsPage` esconde o botão em
+ * linhas ativas. Helpers de teste devem refletir o gating.
+ *
+ * Quem precisar de mocks diferentes pode chamar `client.get.mockXxx`
+ * antes para sobrescrever a fila — a detecção de mocks pré-existentes
+ * preserva o caso "fila customizada de respostas" (ex.: cenários de
+ * erro 404 com refetch).
+ */
+export async function openRestoreConfirm(
+  client: ApiClientStub,
+  system: SystemDto = makeSystem({ deletedAt: '2026-02-01T00:00:00Z' }),
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedResponse([system]));
+  }
+  renderSystemsPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`systems-restore-${system.id}`));
+}
+
+/**
+ * Confirma a restauração clicando em "Restaurar" no `RestoreSystemConfirm`
+ * e aguarda o `client.post` ser chamado pelo menos `expectedPostCalls`
+ * vezes (default `1`). Espelha `confirmDelete` mas com POST (em
+ * `/systems/{id}/restore`) em vez de DELETE. Faz `act(async)` para
+ * flushar a microtask do click handler antes do `waitFor`.
+ */
+export async function confirmRestore(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('restore-system-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+}
+
+/**
  * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)` das
  * suítes de criação (#58/#127) e edição (#59).
  *
@@ -477,7 +520,15 @@ export function buildSharedSubmitErrorCases(
 }
 
 /**
- * Asserções compartilhadas de gating de botão de linha (Issue #59 e #60).
+ * Tipo da ação por linha cujos botões são testados (Issues #59, #60 e
+ * #61). Cada valor mapeia para o `data-testid` `systems-<verb>-<id>` do
+ * botão correspondente na coluna "Ações" da `SystemsPage`.
+ */
+export type SystemRowActionVerb = 'edit' | 'delete' | 'restore';
+
+/**
+ * Asserções compartilhadas de gating de botão de linha (Issue #59, #60
+ * e #61).
  *
  * O bloco "renderiza sistema → confere ausência/presença do botão por
  * `data-testid` da linha" se repetia entre as suítes de edição (`edit-`)
@@ -490,14 +541,28 @@ export function buildSharedSubmitErrorCases(
  * cliente já mockado pela suíte chamadora (que controla quais sistemas
  * aparecem na lista). Asserts são independentes do verbo — espelham o
  * padrão de teste "renderSystemsPage + waitForInitialList + assert".
+ *
+ * **Restore** (Issue #61): o gating do botão "Restaurar" depende de
+ * `row.deletedAt !== null`, então o helper popula automaticamente
+ * `deletedAt` quando o verbo é `'restore'` — caso contrário o botão
+ * nunca apareceria mesmo com a permissão. Edit/delete continuam usando
+ * sistemas ativos por default (`deletedAt: null`).
  */
 export async function assertRowActionAbsent(
   client: ApiClientStub,
-  testIdPrefix: 'edit' | 'delete',
+  testIdPrefix: SystemRowActionVerb,
   systemId: string = ID_SYS_AUTH,
 ): Promise<void> {
   if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
-    client.get.mockResolvedValueOnce(makePagedResponse([makeSystem({ id: systemId })]));
+    // Para restore, o sistema precisa estar soft-deletado para o gating
+    // de permissão ser o único motivo da ausência do botão (caso
+    // contrário, o teste não diferenciaria "sem permissão" de "linha
+    // ativa filtrada pelo `row.deletedAt !== null`").
+    const overrides: Partial<SystemDto> =
+      testIdPrefix === 'restore'
+        ? { id: systemId, deletedAt: '2026-02-01T00:00:00Z' }
+        : { id: systemId };
+    client.get.mockResolvedValueOnce(makePagedResponse([makeSystem(overrides)]));
   }
   renderSystemsPage(client);
   await waitForInitialList(client);
@@ -506,14 +571,30 @@ export async function assertRowActionAbsent(
 
 export async function assertRowActionPresent(
   client: ApiClientStub,
-  testIdPrefix: 'edit' | 'delete',
-  ariaVerb: 'Editar' | 'Desativar',
+  testIdPrefix: SystemRowActionVerb,
+  ariaVerb: 'Editar' | 'Desativar' | 'Restaurar',
 ): Promise<void> {
   if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    // Para restore, ambos os sistemas precisam estar soft-deletados —
+    // só assim o botão aparece nas duas linhas (gating
+    // `row.deletedAt !== null`). Edit/delete usam sistemas ativos por
+    // default.
+    const baseOverrides: Partial<SystemDto> =
+      testIdPrefix === 'restore' ? { deletedAt: '2026-02-01T00:00:00Z' } : {};
     client.get.mockResolvedValueOnce(
       makePagedResponse([
-        makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
-        makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
+        makeSystem({
+          ...baseOverrides,
+          id: ID_SYS_AUTH,
+          name: 'lfc-authenticator',
+          code: 'AUTH',
+        }),
+        makeSystem({
+          ...baseOverrides,
+          id: ID_SYS_KURTTO,
+          name: 'lfc-kurtto',
+          code: 'KURTTO',
+        }),
       ]),
     );
   }


### PR DESCRIPTION
## Contexto

Última sub-issue da **EPIC #45** (CRUD de sistemas). Fecha o ciclo completo do recurso `Systems` no painel admin:

- [x] #57 — Listagem com busca e paginação server-side
- [x] #58 — Criar novo sistema
- [x] #59 — Editar sistema
- [x] #60 — Desativar (soft-delete) sistema
- [x] #61 — Restaurar sistema desativado (esta PR)

## Objetivo

Permitir que admins com permissão `AUTH_V1_SYSTEMS_RESTORE` reativem sistemas soft-deletados via `POST /systems/{id}/restore`.

## O que foi feito

- **Cliente HTTP**: `restoreSystem(id, options?, client?)` em `src/shared/api/systems.ts`. Retorna `void` (backend devolve `{ message }` que descartamos — paridade com `deleteSystem`).
- **UI**: botão "Restaurar" (ícone `Undo2`) na coluna "Ações" da `SystemsPage`. Gated por `AUTH_V1_SYSTEMS_RESTORE` **e** `row.deletedAt !== null` (lógica inversa do botão "Desativar").
- **Modal**: `RestoreSystemConfirm` confirma a ação exibindo nome+code do sistema, seguindo o mesmo padrão visual do `DeleteSystemConfirm`.
- **Refator (importante)**: extrai `MutationConfirmModal` como shell compartilhado entre delete (#60) e restore (#61). O `DeleteSystemConfirm` virou wrapper fino sobre o shell, sem mudança de comportamento ou de `data-testid`. Esse refactor é **obrigatório** para evitar a 5ª recorrência de Sonar `New Code Duplication` (lições PR #119/#123/#127/#128). Sem ele, ~150 linhas seriam duplicadas literalmente entre os dois modais.
- **Tratamento de erro**: usa `classifyMutationError` + `MutationErrorCopy` já reservado pelo programmer da #60 (slot `conflictMessage` foi pré-projetado pensando nesta issue). 404 cobre "não existe" e "já ativo" (backend devolve mensagem específica em ambos).
- **Testes**: nova suíte `SystemsPage.restore.test.tsx` (14 testes) reusando `buildAuthMock`, `buildSharedMutationErrorCases('restaurar')`, `buildCloseCases('restore-system-cancel')` e `assertRowAction*`.

## Arquivos impactados

### Novos
- `src/pages/systems/MutationConfirmModal.tsx`
- `src/pages/systems/RestoreSystemConfirm.tsx`
- `tests/pages/SystemsPage.restore.test.tsx`

### Modificados
- `src/shared/api/systems.ts` (adiciona `restoreSystem`)
- `src/shared/api/index.ts` (exporta `restoreSystem`)
- `src/pages/SystemsPage.tsx` (botão "Restaurar" + permissão + modal)
- `src/pages/systems/DeleteSystemConfirm.tsx` (refatorado como wrapper fino — sem mudança de comportamento)
- `tests/pages/__helpers__/systemsTestHelpers.tsx` (`openRestoreConfirm`/`confirmRestore` + extensão de `assertRowAction*`)

## Testes

- `npm run typecheck` — passou
- `npm run lint --max-warnings 0` — passou (zero warnings)
- `npm test` — 33 arquivos / 388 testes passando (sem regressão; +14 novos do restore)
- `npm run build` — passou

## Visual

- Botão "Restaurar" usa variant `primary` reforçando ação positiva — diferencia visualmente do `danger` do "Desativar".
- Ícone `Undo2` (lucide-react) escolhido para evitar colisão semântica com `RotateCcw` já usado no botão "Tentar novamente" da listagem.
- Modal espelha o padrão visual do `DeleteSystemConfirm` — consistência entre confirmações de mutação.
- Estados visuais cobertos: hover/focus/active/disabled (delegados ao `Button`), loading no submit, modal animado com `prefers-reduced-motion`.

## Segurança

Nenhum impacto. Gating por permissão no frontend (`AUTH_V1_SYSTEMS_RESTORE`) é UX; o backend é a fonte autoritativa via `[Authorize(Policy = PermissionPolicies.SystemsRestore)]`. Não há renderização de HTML cru.

## Riscos

- **Sonar duplication**: diff side-by-side entre `RestoreSystemConfirm` e `DeleteSystemConfirm` mostra apenas 5 linhas contíguas idênticas (imports do shell). O resto diverge em literais. `MutationConfirmModal` é a única instância da estrutura visual/lógica — extrair preventivamente foi a decisão correta.
- **Backend não devolve 409 atual**: o `conflictMessage` no `RESTORE_COPY` fica preparado para evolução futura do contrato; o `classifyMutationError` já cobre o caminho.

## Issue relacionada

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
