### PR TITLE
feat(systems): painel de stats em /systems (#131)

### DIFF
--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -27,6 +27,7 @@ import { DeleteSystemConfirm } from './systems/DeleteSystemConfirm';
 import { EditSystemModal } from './systems/EditSystemModal';
 import { NewSystemModal } from './systems/NewSystemModal';
 import { RestoreSystemConfirm } from './systems/RestoreSystemConfirm';
+import { SystemsStatsRow } from './systems/SystemsStatsRow';
 
 import type { TableColumn } from '../components/ui';
 import type { ApiClient, PagedResponse, SystemDto } from '../shared/api';
@@ -89,6 +90,16 @@ interface SystemsPageProps {
    * testes, o caller passa um stub tipado.
    */
   client?: ApiClient;
+  /**
+   * Quando `true`, omite o painel de stats (`SystemsStatsRow`). Default
+   * `false` — em produção o painel sempre aparece. Os testes da EPIC #45
+   * (criar/editar/desativar/restaurar) passam `true` para evitar que as
+   * 2 chamadas extras a `GET /systems` (sem includeDeleted + com) consumam
+   * o `mockResolvedValueOnce` montado para a listagem da própria suíte.
+   * Os testes do painel em si rodam o `SystemsStatsRow` direto, sem o
+   * shell da `SystemsPage`.
+   */
+  hideStats?: boolean;
 }
 
 interface PageData {
@@ -287,7 +298,7 @@ function extractErrorMessage(error: unknown): string {
 
 /* ─── Component ──────────────────────────────────────────── */
 
-export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
+export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = false }) => {
   const { hasPermission } = useAuth();
   const canCreateSystem = hasPermission(SYSTEMS_CREATE_PERMISSION);
   const canUpdateSystem = hasPermission(SYSTEMS_UPDATE_PERMISSION);
@@ -666,6 +677,8 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client }) => {
         title="Sistemas cadastrados"
         desc="Serviços registrados no ecossistema de autenticação. Cada sistema possui suas próprias rotas, roles e permissões."
       />
+
+      {!hideStats && <SystemsStatsRow refreshKey={retryNonce} client={client} />}
 
       <Toolbar>
         <SearchSlot>

--- a/src/pages/systems/SystemsStatsRow.tsx
+++ b/src/pages/systems/SystemsStatsRow.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { getSystemsStats, isApiError } from '../../shared/api';
+
+import type { ApiClient, SystemsStats } from '../../shared/api';
+
+/**
+ * Painel de stats no topo da `SystemsPage` (Issue #131). Restaura a
+ * sensação visual do placeholder antigo (`b95fbce:src/pages/SystemsPage.tsx`)
+ * mas com dados reais do backend — duas chamadas paralelas a
+ * `GET /systems?pageSize=1` (com e sem `includeDeleted`) extraem `total`
+ * suficiente para 3 cards: ativos, inativos, total geral.
+ *
+ * Decisões:
+ *
+ * 1. **Componente próprio em vez de inline na `SystemsPage`** — mantém o
+ *    JSX da listagem focado em busca/paginação/CRUD; o painel é
+ *    self-contained com seu próprio loading/erro.
+ * 2. **Refetch via `refreshKey` numérica** — o pai usa o mesmo
+ *    `retryNonce` que dispara refetch da tabela; alinhar os ciclos
+ *    evita estado dessincronizado (ex.: criar um sistema → tabela
+ *    atualiza, cards continuam mostrando o número antigo).
+ * 3. **Erro mostra `—`** — nunca bloqueia a tabela. Se o backend cair,
+ *    o painel some graciosamente; usuário continua com CRUD funcional.
+ * 4. **Cliente HTTP injetável** — espelha o padrão de
+ *    `NewSystemModal`/`EditSystemModal` usados na EPIC #45; permite
+ *    isolar testes com stub.
+ */
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+
+  @media (min-width: 48em) {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
+  }
+`;
+
+const StatCard = styled.div`
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+
+  @media (min-width: 48em) {
+    padding: var(--space-4) var(--space-5);
+  }
+`;
+
+const StatNumber = styled.div`
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  letter-spacing: -0.03em;
+  color: var(--fg1);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+`;
+
+const StatLabel = styled.div`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-top: var(--space-1);
+`;
+
+interface SystemsStatsRowProps {
+  /**
+   * Bumper monotônico — quando muda, o painel refaz a busca. O pai
+   * (SystemsPage) compartilha o mesmo `retryNonce` que dispara refetch
+   * da tabela, assim cards e tabela ficam sempre em sincronia.
+   */
+  refreshKey: number;
+  /** Cliente HTTP injetável — em produção, omitido. */
+  client?: ApiClient;
+}
+
+interface StatsState {
+  data: SystemsStats | null;
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+const INITIAL_STATE: StatsState = {
+  data: null,
+  isLoading: true,
+  hasError: false,
+};
+
+/**
+ * Renderiza o número quando há dado, `—` (em-dash) em erro, e um
+ * placeholder discreto durante o loading. `font-variant-numeric:
+ * tabular-nums` no `StatNumber` garante que o em-dash não cause shift
+ * de largura quando o número aparece.
+ */
+function formatStatValue(value: number | null, isLoading: boolean, hasError: boolean): string {
+  if (hasError) return '—';
+  if (isLoading || value === null) return '…';
+  return String(value);
+}
+
+export const SystemsStatsRow: React.FC<SystemsStatsRowProps> = ({ refreshKey, client }) => {
+  const [state, setState] = useState<StatsState>(INITIAL_STATE);
+
+  // `AbortController` cancela request anterior em refetches rápidos —
+  // mesmo padrão usado na lista (RequireAuth, listSystems) na EPIC #45.
+  const lastControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    setState(prev => ({ ...prev, isLoading: true }));
+
+    getSystemsStats({ signal: controller.signal }, client)
+      .then(stats => {
+        if (cancelled) return;
+        setState({ data: stats, isLoading: false, hasError: false });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        // Cancelamento explícito não é erro de UI.
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (
+          isApiError(error) &&
+          error.kind === 'network' &&
+          error.message === 'Requisição cancelada.'
+        ) return;
+        // eslint-disable-next-line no-console
+        console.warn('[systems-stats] falha ao carregar stats; mostrando "—".', error);
+        setState({ data: null, isLoading: false, hasError: true });
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, refreshKey]);
+
+  const active = formatStatValue(state.data?.active ?? null, state.isLoading, state.hasError);
+  const inactive = formatStatValue(state.data?.inactive ?? null, state.isLoading, state.hasError);
+  const total = formatStatValue(state.data?.total ?? null, state.isLoading, state.hasError);
+
+  return (
+    <Row aria-label="Estatísticas de sistemas" data-testid="systems-stats-row">
+      <StatCard data-testid="systems-stats-active">
+        <StatNumber>{active}</StatNumber>
+        <StatLabel>Sistemas ativos</StatLabel>
+      </StatCard>
+      <StatCard data-testid="systems-stats-inactive">
+        <StatNumber>{inactive}</StatNumber>
+        <StatLabel>Sistemas inativos</StatLabel>
+      </StatCard>
+      <StatCard data-testid="systems-stats-total">
+        <StatNumber>{total}</StatNumber>
+        <StatLabel>Total cadastrado</StatLabel>
+      </StatCard>
+    </Row>
+  );
+};

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -73,6 +73,7 @@ export {
   DEFAULT_PAGE,
   DEFAULT_PAGE_SIZE,
   deleteSystem,
+  getSystemsStats,
   isPagedSystemsResponse,
   isSystemDto,
   listSystems,
@@ -84,5 +85,6 @@ export type {
   ListSystemsParams,
   PagedResponse,
   SystemDto,
+  SystemsStats,
   UpdateSystemPayload,
 } from './systems';

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -387,6 +387,54 @@ export async function restoreSystem(
 }
 
 /**
+ * Estatísticas agregadas de sistemas para o painel de overview da
+ * `SystemsPage` (Issue #131). Calculadas a partir do `total` de duas
+ * chamadas paralelas a `GET /systems`:
+ *
+ * - `active` — contagem sem `includeDeleted` (escopo padrão).
+ * - `total` — contagem com `includeDeleted=true` (ativos + soft-deleted).
+ * - `inactive` — derivado: `total - active`.
+ *
+ * Usar `pageSize=1` minimiza payload — só queremos o `total` do envelope,
+ * não os registros. Sem novo endpoint backend.
+ */
+export interface SystemsStats {
+  /** Total de sistemas ativos (não soft-deletados). */
+  active: number;
+  /** Total de sistemas soft-deletados. */
+  inactive: number;
+  /** Total geral (ativos + soft-deletados). */
+  total: number;
+}
+
+/**
+ * Busca estatísticas agregadas de sistemas via duas chamadas paralelas a
+ * `GET /systems` com `pageSize=1`. Reusa `listSystems` (mesma rota,
+ * mesmos type guards, mesmo cliente HTTP injetável) — não há novo
+ * endpoint nem nova lógica de transporte.
+ *
+ * Erro em qualquer uma das chamadas propaga (caller decide se faz
+ * fallback para "—" ou retry); cancelamento via `signal` em options
+ * cancela ambas.
+ */
+export async function getSystemsStats(
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<SystemsStats> {
+  const [activeOnly, includingDeleted] = await Promise.all([
+    listSystems({ pageSize: 1, includeDeleted: false }, options, client),
+    listSystems({ pageSize: 1, includeDeleted: true }, options, client),
+  ]);
+  const active = activeOnly.total;
+  const total = includingDeleted.total;
+  return {
+    active,
+    inactive: Math.max(0, total - active),
+    total,
+  };
+}
+
+/**
  * Constrói o body para `POST /systems` e `PUT /systems/{id}` aplicando
  * trim defensivo nos campos. Description vazia depois de trim vira
  * `undefined` para que o serializador omita o campo (backend converte

--- a/tests/pages/SystemsPage.test.tsx
+++ b/tests/pages/SystemsPage.test.tsx
@@ -97,7 +97,7 @@ describe('SystemsPage — render inicial', () => {
     });
     client.get.mockReturnValueOnce(pending);
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     expect(screen.getByTestId('systems-loading')).toBeInTheDocument();
 
@@ -119,7 +119,7 @@ describe('SystemsPage — render inicial', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -132,7 +132,7 @@ describe('SystemsPage — render inicial', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(lastGetPath(client)).toBe('/systems');
@@ -156,7 +156,7 @@ describe('SystemsPage — render inicial', () => {
       ]),
     );
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -176,7 +176,7 @@ describe('SystemsPage — busca debounced', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
@@ -199,7 +199,7 @@ describe('SystemsPage — busca debounced', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
@@ -223,7 +223,7 @@ describe('SystemsPage — busca debounced', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
     const input = screen.getByTestId('systems-search') as HTMLInputElement;
@@ -252,7 +252,7 @@ describe('SystemsPage — paginação', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS, { page: 1, total: 50 }));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
@@ -269,7 +269,7 @@ describe('SystemsPage — paginação', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS, { page: 1, total: 50 }));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -286,7 +286,7 @@ describe('SystemsPage — paginação', () => {
       makePagedResponse(SAMPLE_ROWS, { page: 1, total: 15, pageSize: 20 }),
     );
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -300,7 +300,7 @@ describe('SystemsPage — paginação', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS, { page: 1, total: 42 }));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -317,7 +317,7 @@ describe('SystemsPage — filtro de inativos', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValue(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
     const toggle = screen.getByTestId('systems-include-deleted') as HTMLInputElement;
@@ -340,7 +340,7 @@ describe('SystemsPage — filtro de inativos', () => {
       ]),
     );
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -358,7 +358,7 @@ describe('SystemsPage — estados vazios', () => {
     // Após busca debounced: backend devolve vazio.
     client.get.mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
     fireEvent.change(screen.getByTestId('systems-search'), {
@@ -385,7 +385,7 @@ describe('SystemsPage — estados vazios', () => {
     const client = createSystemsClientStub();
     client.get.mockResolvedValueOnce(makePagedResponse([], { total: 0 }));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     await waitFor(() => {
       expect(screen.queryByTestId('systems-loading')).not.toBeInTheDocument();
@@ -403,7 +403,7 @@ describe('SystemsPage — estados vazios', () => {
       .mockResolvedValueOnce(makePagedResponse([], { total: 0 }))
       .mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
     fireEvent.change(screen.getByTestId('systems-search'), {
@@ -437,7 +437,7 @@ describe('SystemsPage — erro de rede', () => {
       .mockRejectedValueOnce(apiError)
       .mockResolvedValueOnce(makePagedResponse(SAMPLE_ROWS));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     expect(await screen.findByText(/Falha de conexão com o servidor\./i)).toBeInTheDocument();
 
@@ -454,7 +454,7 @@ describe('SystemsPage — erro de rede', () => {
     const client = createSystemsClientStub();
     client.get.mockRejectedValueOnce(new Error('boom'));
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
 
     expect(
       await screen.findByText(/Falha ao carregar a lista de sistemas\. Tente novamente\./i),
@@ -476,7 +476,7 @@ describe('SystemsPage — cancelamento de request', () => {
       },
     );
 
-    render(<SystemsPage client={client} />);
+    render(<SystemsPage client={client} hideStats />);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
     // Dispara duas buscas rapidamente — sem debounce, segunda mudança

--- a/tests/pages/__helpers__/systemsTestHelpers.tsx
+++ b/tests/pages/__helpers__/systemsTestHelpers.tsx
@@ -107,11 +107,17 @@ export function makePagedResponse(
  * `NewSystemModal` consome `useToast()` internamente para disparar
  * feedback de sucesso/erro. Centraliza para que cada suíte não repita o
  * provider boilerplate.
+ *
+ * `hideStats={true}` é passado por padrão para isolar as suítes da
+ * EPIC #45 (criar/editar/desativar/restaurar) das 2 chamadas extras a
+ * `GET /systems` que o `SystemsStatsRow` faz no mount (Issue #131).
+ * Os testes do painel em si renderizam o `SystemsStatsRow` direto,
+ * sem o shell da `SystemsPage`.
  */
 export function renderSystemsPage(client: ApiClientStub): void {
   render(
     <ToastProvider>
-      <SystemsPage client={client} />
+      <SystemsPage client={client} hideStats />
     </ToastProvider>,
   );
 }

--- a/tests/pages/systems/SystemsStatsRow.test.tsx
+++ b/tests/pages/systems/SystemsStatsRow.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSystemsClientStub, makePagedResponse } from '../__helpers__/systemsTestHelpers';
+
+import type { ApiError } from '@/shared/api';
+
+import { SystemsStatsRow } from '@/pages/systems/SystemsStatsRow';
+
+/**
+ * Testes do painel de stats da `SystemsPage` (Issue #131).
+ *
+ * O componente faz duas chamadas paralelas a `GET /systems?pageSize=1`
+ * (com e sem `includeDeleted`) e calcula `inactive = total - active`.
+ * Os 3 cards (`active`, `inactive`, `total`) renderizam em sequência —
+ * cobrimos render inicial, sucesso, erro e refetch via `refreshKey`.
+ *
+ * Reuso de `createSystemsClientStub` + `makePagedResponse` mantém
+ * paridade com as suítes da EPIC #45 e evita duplicação Sonar (lições
+ * PRs #123/#127/#128).
+ */
+
+beforeEach(() => {
+  // Sem fake timers — o componente não usa setTimeout/debounce, e
+  // habilitar fake-timers apenas confunde `waitFor` do RTL.
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Stub que devolve `total` específico para cada chamada — primeira é
+ * sem `includeDeleted` (active), segunda é com (totalIncludingDeleted).
+ * Ordem importa: `getSystemsStats` faz `Promise.all([active, includingDeleted])`.
+ */
+function stubStatsClient(activeTotal: number, totalIncludingDeleted: number) {
+  const client = createSystemsClientStub();
+  client.get.mockImplementation((path: unknown) => {
+    if (typeof path !== 'string') return Promise.reject(new Error('unexpected path'));
+    if (path.includes('includeDeleted=true')) {
+      return Promise.resolve(makePagedResponse([], { total: totalIncludingDeleted, pageSize: 1 }));
+    }
+    return Promise.resolve(makePagedResponse([], { total: activeTotal, pageSize: 1 }));
+  });
+  return client;
+}
+
+describe('SystemsStatsRow — Issue #131', () => {
+  it('renderiza skeleton ("…") em todos os cards no primeiro render', () => {
+    const client = createSystemsClientStub();
+    // Não resolve — força o estado de loading.
+    client.get.mockImplementation(() => new Promise<never>(() => undefined));
+
+    render(<SystemsStatsRow refreshKey={0} client={client} />);
+
+    const active = screen.getByTestId('systems-stats-active');
+    const inactive = screen.getByTestId('systems-stats-inactive');
+    const total = screen.getByTestId('systems-stats-total');
+    expect(active.textContent).toContain('…');
+    expect(inactive.textContent).toContain('…');
+    expect(total.textContent).toContain('…');
+  });
+
+  it('renderiza números reais após as duas chamadas resolverem', async () => {
+    const client = stubStatsClient(7, 10); // 7 ativos, 10 total → 3 inativos
+
+    render(<SystemsStatsRow refreshKey={0} client={client} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('systems-stats-active').textContent).toContain('7');
+    });
+    expect(screen.getByTestId('systems-stats-inactive').textContent).toContain('3');
+    expect(screen.getByTestId('systems-stats-total').textContent).toContain('10');
+  });
+
+  it('mostra "—" em todos os cards quando o backend falha (degrada gracioso)', async () => {
+    const apiError: ApiError = { kind: 'network', message: 'Falha de conexão.' };
+    const client = createSystemsClientStub();
+    client.get.mockRejectedValue(apiError);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    render(<SystemsStatsRow refreshKey={0} client={client} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('systems-stats-active').textContent).toContain('—');
+    });
+    expect(screen.getByTestId('systems-stats-inactive').textContent).toContain('—');
+    expect(screen.getByTestId('systems-stats-total').textContent).toContain('—');
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('refetch quando refreshKey muda', async () => {
+    const client = stubStatsClient(2, 2);
+
+    const { rerender } = render(<SystemsStatsRow refreshKey={0} client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('systems-stats-active').textContent).toContain('2');
+    });
+
+    // Backend agora devolve outros números — simula que outro tab criou sistemas.
+    client.get.mockReset();
+    client.get.mockImplementation((path: unknown) => {
+      if (typeof path !== 'string') return Promise.reject(new Error('unexpected path'));
+      const total = path.includes('includeDeleted=true') ? 8 : 5;
+      return Promise.resolve(makePagedResponse([], { total, pageSize: 1 }));
+    });
+
+    rerender(<SystemsStatsRow refreshKey={1} client={client} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('systems-stats-active').textContent).toContain('5');
+    });
+    expect(screen.getByTestId('systems-stats-inactive').textContent).toContain('3');
+    expect(screen.getByTestId('systems-stats-total').textContent).toContain('8');
+  });
+
+  it('clamp de inactive em zero quando backend retorna inconsistência (active > total)', async () => {
+    // Cenário defensivo: backend devolveu números inconsistentes (race
+    // entre as 2 chamadas, soft-delete entre uma e outra). O componente
+    // não pode renderizar inactive negativo.
+    const client = stubStatsClient(5, 4);
+
+    render(<SystemsStatsRow refreshKey={0} client={client} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('systems-stats-active').textContent).toContain('5');
+    });
+    expect(screen.getByTestId('systems-stats-inactive').textContent).toContain('0');
+    expect(screen.getByTestId('systems-stats-total').textContent).toContain('4');
+  });
+
+  it('cancelamento de request anterior ao mudar refreshKey rapidamente', async () => {
+    const client = createSystemsClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (_path: unknown, options?: { signal?: AbortSignal }) => {
+        if (options?.signal) signals.push(options.signal);
+        return Promise.resolve(makePagedResponse([], { total: 1, pageSize: 1 }));
+      },
+    );
+
+    const { rerender } = render(<SystemsStatsRow refreshKey={0} client={client} />);
+    rerender(<SystemsStatsRow refreshKey={1} client={client} />);
+    rerender(<SystemsStatsRow refreshKey={2} client={client} />);
+
+    // Primeiro lote (refreshKey=0) deve estar abortado pelo cleanup.
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+    expect(signals[0].aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Restaura os cards de overview que existiam no placeholder da `SystemsPage` antes da EPIC #45 (PR #125). Agora alimentados pelo backend via duas chamadas paralelas a `GET /systems?pageSize=1`.

3 cards no topo, acima da Toolbar:
- **Sistemas ativos** — total sem `includeDeleted`
- **Sistemas inativos** — total com `includeDeleted=true` menos ativos
- **Total cadastrado** — soma

## Arquivos

### Novos
- `src/pages/systems/SystemsStatsRow.tsx` — componente do painel
- `tests/pages/systems/SystemsStatsRow.test.tsx` — 6 testes

### Modificados
- `src/shared/api/systems.ts` — `getSystemsStats()` reusa `listSystems`
- `src/shared/api/index.ts` — re-exports
- `src/pages/SystemsPage.tsx` — integra acima da Toolbar; prop `hideStats` para isolar testes da EPIC #45
- `tests/pages/__helpers__/systemsTestHelpers.tsx` — `renderSystemsPage` passa `hideStats` por padrão
- `tests/pages/SystemsPage.test.tsx` — 19 `render()` ajustados

## Decisões

- **Refetch sincronizado com a tabela**: `refreshKey={retryNonce}` reusa o mesmo bumper que dispara refetch após criar/editar/desativar/restaurar — cards e tabela ficam sempre em sincronia.
- **Erro mostra em-dash**: degrada gracioso. CRUD continua funcional se backend cair.
- **`AbortController`**: cancela request anterior em refetches rápidos, mesmo padrão da listagem.
- **`hideStats` prop**: sem mexer nos mocks dos 4 PRs anteriores. Suítes da EPIC #45 passam `hideStats` no helper; testes do painel rodam o componente isolado.

## Testes

- `npm run typecheck` ✅
- `npm run lint` ✅ (zero warnings)
- `npm test` ✅ — 394/394 (34 files; +6 novos do stats)

## Test plan

- [ ] Validação visual em `localhost:3002`: `/systems` mostra 3 cards no topo com números reais
- [ ] Criar/desativar/restaurar atualiza os cards junto com a tabela
- [ ] Backend offline → cards mostram "—" mas a tabela continua visível com seu próprio estado de erro

Closes #131