### PR TITLE
feat(routes): listagem por sistema (#62)

### DIFF
--- a/src/hooks/usePaginatedFetch.ts
+++ b/src/hooks/usePaginatedFetch.ts
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { isApiError } from '../shared/api';
+
+import type { PagedResponse, SafeRequestOptions } from '../shared/api';
+
+/**
+ * Estado retornado por `usePaginatedFetch` para o componente consumir.
+ *
+ * - `rows` — itens da página corrente (vazio em loading/erro).
+ * - `pageSize` — tamanho aplicado pelo backend (pode diferir do
+ *   solicitado quando o backend impõe limite).
+ * - `total` — total filtrado (para cálculo de `totalPages`).
+ * - `isInitialLoading` — `true` enquanto a primeira request não
+ *   completou (sucesso OU erro). Mantém o componente exibindo spinner
+ *   cheio em vez de overlay.
+ * - `isFetching` — `true` enquanto qualquer refetch subsequente está
+ *   em curso (depois da primeira). Liga o overlay leve sobre os dados
+ *   anteriores.
+ * - `errorMessage` — mensagem amigável quando o fetch falhou; `null`
+ *   em sucesso ou cancelamento.
+ * - `refetch` — bumper monotônico que força reexecutar o fetch sem
+ *   alterar parâmetros (usado pelo botão "Tentar novamente" e pelos
+ *   callbacks pós-mutação `onCreated`/`onUpdated`/`onDeleted`).
+ */
+export interface UsePaginatedFetchResult<T> {
+  rows: ReadonlyArray<T>;
+  pageSize: number;
+  total: number;
+  isInitialLoading: boolean;
+  isFetching: boolean;
+  errorMessage: string | null;
+  refetch: () => void;
+}
+
+/**
+ * Função de fetch consumida pelo hook. Recebe `options` com `signal`
+ * para cancelamento e devolve uma `Promise` do envelope paginado.
+ *
+ * Tipada com `void` em retorno auxiliar permitiria parametrizar mas
+ * complica em uso — preferimos `Promise<PagedResponse<T>>` direto, que
+ * é o contrato do `lfc-authenticator` para todos os endpoints de
+ * listagem (`GET /systems`, `GET /systems/routes`, etc.).
+ */
+export type PaginatedFetcher<T> = (
+  options: SafeRequestOptions,
+) => Promise<PagedResponse<T>>;
+
+interface UsePaginatedFetchConfig<T> {
+  /**
+   * Função que executa a request — recebe `signal` para cancelamento e
+   * devolve o envelope paginado. **Crucial:** o caller deve memoizar
+   * com `useCallback` (com dependências sobre os params reais) para
+   * que o hook saiba quando refazer fetch. Toda vez que `fetcher`
+   * mudar de identidade, o effect dispara nova request.
+   */
+  fetcher: PaginatedFetcher<T>;
+  /**
+   * Mensagem genérica usada quando o erro não é um `ApiError` (ex.:
+   * `Error('boom')` lançado por algum middleware fora do contrato).
+   * Cada página passa sua própria copy em pt-BR ("Falha ao carregar a
+   * lista de sistemas..." / "Falha ao carregar a lista de rotas...").
+   */
+  fallbackErrorMessage: string;
+  /**
+   * Quando `true`, o effect skipa a request (não chama `fetcher`) e
+   * desliga `isInitialLoading`. Usado pela `RoutesPage` quando o
+   * `:systemId` da URL é inválido — o componente exibe o aviso
+   * dedicado e nunca bate no backend.
+   */
+  skip?: boolean;
+}
+
+/**
+ * Hook compartilhado que encapsula o pattern de listagem paginada com
+ * cancelamento via AbortController, distinção entre loading inicial e
+ * refetch, tratamento padrão de erro e bumper de retry.
+ *
+ * Originalmente o pattern vivia inline na `SystemsPage` (Issue #126/
+ * EPIC #45). A duplicação previsível em `RoutesPage` (Issue #62/EPIC
+ * #46) — e nas próximas pages de listagem (Roles, Permissions, Users)
+ * — exigiu extrair em hook compartilhado **agora**, no primeiro PR da
+ * EPIC nova, em vez de esperar o segundo módulo aparecer e depois
+ * refatorar. Lição PR #128: "ao tocar 2+ arquivos similares, projetar
+ * shared helpers desde o primeiro PR do recurso, não esperar o segundo
+ * modal aparecer e depois refatorar".
+ *
+ * Decisões importantes:
+ *
+ * 1. **`fetcher` em vez de `(params) => promise`** — o caller já tem
+ *    seus próprios estados de busca/page/filter; passa-los como
+ *    parâmetros do hook duplicaria o estado em duas camadas. O caller
+ *    memoiza `fetcher` via `useCallback` com dependências sobre os
+ *    params, e o hook simplesmente reage à mudança de identidade —
+ *    padrão recomendado pelo React quando "params" são heterogêneos
+ *    (cada listagem tem seu shape próprio).
+ *
+ * 2. **`skip` opt-in para validação client-side** — algumas pages
+ *    precisam evitar a request quando params são inválidos (ex.:
+ *    `RoutesPage` com `:systemId` ausente). Em vez de exigir que cada
+ *    caller faça `if (invalid) return early` antes do hook (impossível
+ *    porque o hook **deve** ser chamado em todo render), passamos
+ *    `skip` como flag. Quando `true`, o hook desliga `isInitialLoading`
+ *    e mantém o resto do estado quieto.
+ *
+ * 3. **Cancelamento via AbortController** — o cleanup do effect
+ *    dispara `abort()` no controller anterior antes da próxima
+ *    execução. O catch ignora `AbortError` para que cancelamento não
+ *    vire toast/Alert — fluxo normal, não erro de UI.
+ *
+ * 4. **`refetch` é um bumper, não uma chamada direta** — devolver uma
+ *    função que dispara fetch fora do useEffect quebra o invariante
+ *    "controller.abort() do anterior". Em vez disso, `refetch`
+ *    incrementa um nonce monotônico que entra como dependência do
+ *    effect, e o React rerunneia o ciclo completo (cleanup + run).
+ */
+export function usePaginatedFetch<T>(
+  config: UsePaginatedFetchConfig<T>,
+): UsePaginatedFetchResult<T> {
+  const { fetcher, fallbackErrorMessage, skip = false } = config;
+
+  const [rows, setRows] = useState<ReadonlyArray<T>>([]);
+  const [pageSize, setPageSize] = useState<number>(0);
+  const [total, setTotal] = useState<number>(0);
+  const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState<number>(0);
+
+  // Controller da request mais recente — usado para cancelar a
+  // anterior em mudanças rápidas de params.
+  const lastControllerRef = useRef<AbortController | null>(null);
+  // Sinaliza se a primeira request já completou. Após o primeiro
+  // ciclo, refetches usam `isFetching=true` em vez de
+  // `isInitialLoading=true` (overlay leve em vez de spinner cheio).
+  const hasCompletedFirstRequestRef = useRef<boolean>(false);
+
+  const refetch = useCallback(() => {
+    setRetryNonce((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (skip) {
+      // Reset hard quando o caller pede skip (ex.: `:systemId` inválido).
+      // Não disparamos `setIsFetching(false)` porque o overlay não está
+      // ligado — e mantemos `errorMessage` como está (caller controla).
+      setIsInitialLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    if (hasCompletedFirstRequestRef.current) {
+      setIsFetching(true);
+    }
+
+    fetcher({ signal: controller.signal })
+      .then((response) => {
+        if (cancelled) return;
+        setRows(response.data);
+        setPageSize(response.pageSize);
+        setTotal(response.total);
+        setErrorMessage(null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        // Cancelamento explícito (fetch abortado) é fluxo normal — não
+        // vira erro de UI. Cobrimos os dois shapes possíveis: o
+        // `DOMException(AbortError)` lançado pelo `fetch` nativo e o
+        // `ApiError(network)` que o `apiClient` traduz quando o signal
+        // é abortado antes da resposta.
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        if (
+          isApiError(error) &&
+          error.kind === 'network' &&
+          error.message === 'Requisição cancelada.'
+        ) {
+          return;
+        }
+        setErrorMessage(extractErrorMessage(error, fallbackErrorMessage));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        hasCompletedFirstRequestRef.current = true;
+        setIsInitialLoading(false);
+        setIsFetching(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [fetcher, fallbackErrorMessage, retryNonce, skip]);
+
+  return {
+    rows,
+    pageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch,
+  };
+}
+
+/**
+ * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
+ *
+ * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
+ * resolveu fallbacks por status). Para erros arbitrários, usamos a
+ * `fallback` em pt-BR específica da página chamadora — preserva
+ * privacidade da arquitetura (não vaza stack/objeto cru) sem mascarar
+ * a origem do problema.
+ *
+ * Centralizada aqui porque é parte intrínseca do contrato do hook —
+ * cada caller passa sua própria copy via `fallbackErrorMessage`.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -23,6 +23,11 @@ interface RouteTitleEntry {
  * por isso ordene do mais específico ao mais genérico.
  */
 const ROUTE_TITLES: RouteTitleEntry[] = [
+  // Issue #62: `/systems/:systemId/routes` precisa vir ANTES de
+  // `/systems` — `matchPath` com `end: false` faz prefix-match e o
+  // primeiro padrão que casar ganha. Sem essa ordem, a Topbar exibiria
+  // "Sistemas" na página de listagem de rotas escopada a um sistema.
+  { pattern: '/systems/:systemId/routes', title: 'Rotas' },
   { pattern: '/systems', title: 'Sistemas' },
   { pattern: '/routes', title: 'Rotas' },
   { pattern: '/roles', title: 'Roles' },

--- a/src/pages/RoutesPage.tsx
+++ b/src/pages/RoutesPage.tsx
@@ -1,0 +1,771 @@
+import { ArrowLeft, ChevronLeft, ChevronRight, RotateCcw, Search } from 'lucide-react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { PageHeader } from '../components/layout/PageHeader';
+import { Alert, Badge, Button, Input, Spinner, Switch, Table } from '../components/ui';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../hooks/usePaginatedFetch';
+import {
+  DEFAULT_ROUTES_INCLUDE_DELETED,
+  DEFAULT_ROUTES_PAGE,
+  DEFAULT_ROUTES_PAGE_SIZE,
+  listRoutes,
+} from '../shared/api';
+
+import type { TableColumn } from '../components/ui';
+import type { ApiClient, RouteDto, SafeRequestOptions } from '../shared/api';
+
+/**
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
+ * o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 request por caractere. Espelha o valor
+ * usado pela `SystemsPage` — mantemos a constante local porque a página
+ * é o único call site (extrair em módulo compartilhado só compensa
+ * quando ≥ 2 páginas reusam, lição PR #128).
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface RoutesPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido — a
+   * página usa o singleton `apiClient` por trás de `listRoutes`. Em
+   * testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+const BackLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  margin-left: -4px;
+
+  &:hover {
+    color: var(--fg2);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-6);
+  }
+`;
+
+const SearchSlot = styled.div`
+  width: 100%;
+
+  @media (min-width: 48em) {
+    max-width: 360px;
+    flex: 1;
+  }
+`;
+
+const ToolbarActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-3);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-4);
+  }
+`;
+
+const TableShell = styled.div`
+  position: relative;
+`;
+
+/**
+ * Visibilidade da `Table` (desktop) e do bloco de cards (mobile). A
+ * `Table` do design system é HTML semântico — em mobile fica oculta para
+ * favorecer a leitura em coluna única via cards (critério da issue
+ * "quebra responsiva mostra cards"). O switch acontece em
+ * `--bp-md` (48em ≈ 768px), espelhando o breakpoint usado no resto do
+ * shell.
+ */
+const TableForDesktop = styled.div`
+  display: none;
+
+  @media (min-width: 48em) {
+    display: block;
+  }
+`;
+
+const CardListForMobile = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+
+  @media (min-width: 48em) {
+    display: none;
+  }
+`;
+
+/**
+ * Card individual da listagem mobile. Mantém os mesmos campos da tabela
+ * (código, descrição, política JWT alvo, status) com hierarquia tipográfica
+ * dedicada — o monoespaçado destaca o `code`, a descrição segue em
+ * parágrafo legível e o token type aparece como Badge pequeno.
+ */
+const RouteCard = styled.article`
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  transition: background var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    background: var(--bg-ghost-hover);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+`;
+
+const CardHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+`;
+
+const CardCode = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg1);
+  font-weight: var(--weight-medium);
+  word-break: break-word;
+`;
+
+const CardName = styled.h3`
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: -0.01em;
+`;
+
+const CardDescription = styled.p`
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-base);
+`;
+
+const CardMeta = styled.dl`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+  font-size: var(--text-xs);
+`;
+
+const CardMetaTerm = styled.dt`
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+`;
+
+const CardMetaValue = styled.dd`
+  margin: 0;
+  font-family: var(--font-mono);
+  color: var(--fg2);
+  word-break: break-word;
+`;
+
+/**
+ * Overlay leve aplicado em cima da listagem durante refetches subsequentes
+ * (busca/paginação/toggle). Mantém os dados anteriores visíveis para
+ * evitar flicker enquanto sinaliza atividade — o spinner ancorado ao
+ * topo deixa claro que algo está em curso sem mover a tabela. Espelha o
+ * padrão da `SystemsPage`.
+ */
+const Overlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: var(--space-6);
+  background: color-mix(in srgb, var(--bg-base) 55%, transparent);
+  border-radius: var(--radius-lg);
+  pointer-events: none;
+  z-index: 1;
+`;
+
+const InitialLoading = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-12) 0;
+`;
+
+const ErrorBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+`;
+
+const FootBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: stretch;
+  margin-top: var(--space-5);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+`;
+
+const PageInfo = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
+`;
+
+const PageNav = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+`;
+
+const EmptyMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+`;
+
+const EmptyTitle = styled.span`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+`;
+
+const EmptyHint = styled.span`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg2);
+`;
+
+const DescriptionCell = styled.span`
+  display: inline-block;
+  max-width: 36ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--fg2);
+`;
+
+const Placeholder = styled.span`
+  color: var(--text-muted);
+  font-style: italic;
+`;
+
+const InvalidIdNotice = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+`;
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Calcula a quantidade total de páginas a partir do `total` filtrado e
+ * do `pageSize` aplicado. Com `total === 0`, devolve `1` para que os
+ * controles de paginação sigam exibindo "página 1 de 1" (e ambos prev/
+ * next apareçam desabilitados) — preserva consistência visual no estado
+ * vazio. Espelha o helper da `SystemsPage` (centralizar em módulo
+ * compartilhado vai acontecer quando ≥ 3 listagens reusarem; por
+ * enquanto, mantemos local em cada página para evitar abstração
+ * prematura — duas instâncias é ainda "regra de três" não atingida).
+ */
+function computeTotalPages(total: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  if (total <= 0) return 1;
+  return Math.ceil(total / pageSize);
+}
+
+/**
+ * Heurística leve para descartar `:systemId` claramente inválido antes
+ * de bater no backend — evita request desperdiçada e produz feedback
+ * imediato ("ID inválido"). Aceita qualquer string não-vazia com pelo
+ * menos um caractere não-whitespace, deixando a validação rigorosa
+ * (UUID v4) a cargo do backend (que devolve 400). Não exigimos UUID
+ * estrito aqui porque o frontend não deveria depender de detalhes do
+ * formato de chave do banco — qualquer `string` no path basta para a
+ * UI; o backend é a fonte de verdade.
+ */
+function isProbablyValidSystemId(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Renderiza a célula da política JWT alvo. O backend devolve string
+ * vazia em `systemTokenTypeCode`/`systemTokenTypeName` quando o
+ * SystemTokenType referenciado foi soft-deletado pós-criação (LEFT JOIN
+ * intencional no controller — a rota fica órfã até o admin restaurar o
+ * token type ou alterar a referência). A UI sinaliza isso com "—".
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile —
+ * centralizar evita duplicação visual (lição PR #127/#128).
+ */
+function renderTokenPolicy(row: RouteDto): React.ReactNode {
+  if (row.systemTokenTypeCode.length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return (
+    <Badge variant="info" dot>
+      {row.systemTokenTypeName.length > 0
+        ? row.systemTokenTypeName
+        : row.systemTokenTypeCode}
+    </Badge>
+  );
+}
+
+/**
+ * Renderiza a célula de descrição truncando textos longos via
+ * `text-overflow: ellipsis`. Quando o backend devolve `description: null`
+ * (campo opcional), exibimos "—" em itálico — espelha o tratamento de
+ * `systemTokenTypeCode` vazio para manter consistência visual.
+ */
+function renderDescription(row: RouteDto): React.ReactNode {
+  if (row.description === null || row.description.trim().length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return <DescriptionCell title={row.description}>{row.description}</DescriptionCell>;
+}
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
+  // `useParams` devolve `string | undefined` — nunca lançamos: rota
+  // sem `:systemId` pinta o `InvalidIdNotice` no lugar da listagem.
+  // A rota é declarada em `AppRoutes` com o param obrigatório, mas
+  // defendemos o componente como reusável em testes que renderizem
+  // direto sem MemoryRouter.
+  const { systemId } = useParams<{ systemId: string }>();
+  const hasValidSystemId = isProbablyValidSystemId(systemId);
+
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_ROUTES_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_ROUTES_PAGE);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
+   * 3 itens, mas continuo na página 5 vazia". `page` é setado direto
+   * pelos callbacks dos controles para manter o efeito previsível.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`: capture os params
+   * derivados e devolva uma função que aceita `signal` no `options`.
+   * O hook reage a mudanças na identidade de `fetcher` para
+   * reexecutar — `useCallback` com as deps corretas mantém o ciclo
+   * previsível. Skipa montar params quando `:systemId` é inválido,
+   * caso em que `usePaginatedFetch` recebe `skip: true` e nem chama
+   * o `fetcher`.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listRoutes(
+        {
+          systemId: hasValidSystemId ? systemId : '',
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_ROUTES_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, hasValidSystemId, includeDeleted, page, systemId, trimmedSearchInput],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<RouteDto>({
+    fetcher,
+    fallbackErrorMessage: 'Falha ao carregar a lista de rotas. Tente novamente.',
+    skip: !hasValidSystemId,
+  });
+
+  const totalPages = useMemo(
+    () => computeTotalPages(total, appliedPageSize > 0 ? appliedPageSize : DEFAULT_ROUTES_PAGE_SIZE),
+    [appliedPageSize, total],
+  );
+
+  const isFirstPage = page <= 1;
+  const isLastPage = page >= totalPages;
+
+  const handlePrevPage = useCallback(() => {
+    setPage((prev) => (prev > 1 ? prev - 1 : prev));
+  }, []);
+
+  const handleNextPage = useCallback(() => {
+    setPage((prev) => (prev < totalPages ? prev + 1 : prev));
+  }, [totalPages]);
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio sem busca → "nenhuma rota cadastrada" + dica sobre o toggle
+   *   "Mostrar inativos" caso esteja desligado.
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhuma rota encontrada para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="routes-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhuma rota cadastrada para este sistema.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Rotas removidas podem ser visualizadas ativando &quot;Mostrar inativas&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  const columns = useMemo<ReadonlyArray<TableColumn<RouteDto>>>(
+    () => [
+      {
+        key: 'code',
+        label: 'Código',
+        render: (row) => <Mono>{row.code}</Mono>,
+      },
+      {
+        key: 'description',
+        label: 'Descrição',
+        render: renderDescription,
+      },
+      {
+        key: 'tokenPolicy',
+        label: 'Política JWT alvo',
+        width: '200px',
+        render: renderTokenPolicy,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '120px',
+        render: (row) =>
+          row.deletedAt ? (
+            <Badge variant="danger" dot>
+              Inativa
+            </Badge>
+          ) : (
+            <Badge variant="success" dot>
+              Ativa
+            </Badge>
+          ),
+      },
+    ],
+    [],
+  );
+
+  const showOverlay = isFetching && !isInitialLoading;
+
+  // ARIA-live: anuncia o estado da listagem quando muda. Em loading
+  // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
+  // total. Em erro, o `<Alert role="alert">` já cobre.
+  const liveMessage = useMemo<string>(() => {
+    if (isInitialLoading) return 'Carregando lista de rotas.';
+    if (isFetching) return 'Atualizando lista de rotas.';
+    if (errorMessage) return '';
+    if (total === 0) {
+      return hasActiveSearch
+        ? `Nenhuma rota encontrada para ${trimmedSearch}.`
+        : 'Nenhuma rota cadastrada para este sistema.';
+    }
+    return `${total} rota(s) encontrada(s). Página ${page} de ${totalPages}.`;
+  }, [
+    total,
+    errorMessage,
+    hasActiveSearch,
+    isFetching,
+    isInitialLoading,
+    page,
+    totalPages,
+    trimmedSearch,
+  ]);
+
+  if (!hasValidSystemId) {
+    return (
+      <>
+        <BackLink to="/systems" data-testid="routes-back">
+          <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+          Voltar para Sistemas
+        </BackLink>
+        <PageHeader
+          eyebrow="02 Rotas"
+          title="Rotas registradas"
+          desc="Selecione um sistema para visualizar suas rotas."
+        />
+        <InvalidIdNotice data-testid="routes-invalid-id">
+          <Alert variant="warning">
+            ID de sistema ausente ou inválido na URL. Volte para a listagem de
+            sistemas e selecione um sistema para visualizar suas rotas.
+          </Alert>
+        </InvalidIdNotice>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <BackLink to="/systems" data-testid="routes-back">
+        <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+        Voltar para Sistemas
+      </BackLink>
+      <PageHeader
+        eyebrow="02 Rotas"
+        title="Rotas do sistema"
+        desc="Endpoints registrados pelo sistema selecionado. Cada rota possui código, descrição e política JWT alvo."
+      />
+
+      <Toolbar>
+        <SearchSlot>
+          <Input
+            label="Buscar"
+            type="search"
+            placeholder="Código da rota"
+            icon={<Search size={14} strokeWidth={1.5} />}
+            value={searchTerm}
+            onChange={handleSearchChange}
+            aria-label="Buscar rotas por código"
+            data-testid="routes-search"
+          />
+        </SearchSlot>
+        <ToolbarActions>
+          <Switch
+            label="Mostrar inativas"
+            helperText="Inclui rotas com remoção lógica."
+            checked={includeDeleted}
+            onChange={handleIncludeDeletedChange}
+            data-testid="routes-include-deleted"
+          />
+        </ToolbarActions>
+      </Toolbar>
+
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+        data-testid="routes-live"
+      >
+        {liveMessage}
+      </span>
+
+      {isInitialLoading && (
+        <InitialLoading data-testid="routes-loading">
+          <Spinner size="lg" label="Carregando rotas" />
+        </InitialLoading>
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorBlock>
+          <Alert variant="danger">{errorMessage}</Alert>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<RotateCcw size={14} strokeWidth={1.5} />}
+            onClick={handleRefetch}
+            data-testid="routes-retry"
+          >
+            Tentar novamente
+          </Button>
+        </ErrorBlock>
+      )}
+
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          <TableForDesktop>
+            <Table<RouteDto>
+              caption="Lista de rotas do sistema selecionado."
+              columns={columns}
+              data={rows}
+              getRowKey={(row) => row.id}
+              emptyState={emptyContent}
+            />
+          </TableForDesktop>
+          <CardListForMobile
+            role="list"
+            aria-label="Lista de rotas do sistema selecionado"
+            data-testid="routes-card-list"
+          >
+            {rows.length === 0 && emptyContent}
+            {rows.map((row) => (
+              <RouteCard
+                key={row.id}
+                role="listitem"
+                tabIndex={0}
+                data-testid={`routes-card-${row.id}`}
+              >
+                <CardHeader>
+                  <CardCode>{row.code}</CardCode>
+                  {row.deletedAt ? (
+                    <Badge variant="danger" dot>
+                      Inativa
+                    </Badge>
+                  ) : (
+                    <Badge variant="success" dot>
+                      Ativa
+                    </Badge>
+                  )}
+                </CardHeader>
+                <CardName>{row.name}</CardName>
+                {row.description !== null && row.description.trim().length > 0 && (
+                  <CardDescription>{row.description}</CardDescription>
+                )}
+                <CardMeta>
+                  <CardMetaTerm>JWT</CardMetaTerm>
+                  <CardMetaValue>{renderTokenPolicy(row)}</CardMetaValue>
+                </CardMeta>
+              </RouteCard>
+            ))}
+          </CardListForMobile>
+          {showOverlay && (
+            <Overlay aria-hidden="true" data-testid="routes-overlay">
+              <Spinner size="md" label="Atualizando" />
+            </Overlay>
+          )}
+        </TableShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && total > 0 && (
+        <FootBar>
+          <PageInfo data-testid="routes-page-info">
+            Página {page} de {totalPages} · {total} resultado(s)
+          </PageInfo>
+          <PageNav>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ChevronLeft size={14} strokeWidth={1.5} />}
+              disabled={isFirstPage}
+              onClick={handlePrevPage}
+              aria-label="Ir para a página anterior"
+              data-testid="routes-prev"
+            >
+              Anterior
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ChevronRight size={14} strokeWidth={1.5} />}
+              disabled={isLastPage}
+              onClick={handleNextPage}
+              aria-label="Ir para a próxima página"
+              data-testid="routes-next"
+            >
+              Próxima
+            </Button>
+          </PageNav>
+        </FootBar>
+      )}
+    </>
+  );
+};

--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -8,17 +8,17 @@ import {
   Trash2,
   Undo2,
 } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { PageHeader } from '../components/layout/PageHeader';
 import { Alert, Badge, Button, Input, Spinner, Switch, Table } from '../components/ui';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../hooks/usePaginatedFetch';
 import {
   DEFAULT_INCLUDE_DELETED,
   DEFAULT_PAGE,
   DEFAULT_PAGE_SIZE,
-  isApiError,
   listSystems,
 } from '../shared/api';
 import { useAuth } from '../shared/auth';
@@ -30,7 +30,7 @@ import { RestoreSystemConfirm } from './systems/RestoreSystemConfirm';
 import { SystemsStatsRow } from './systems/SystemsStatsRow';
 
 import type { TableColumn } from '../components/ui';
-import type { ApiClient, PagedResponse, SystemDto } from '../shared/api';
+import type { ApiClient, SafeRequestOptions, SystemDto } from '../shared/api';
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
@@ -101,21 +101,6 @@ interface SystemsPageProps {
    */
   hideStats?: boolean;
 }
-
-interface PageData {
-  /** Itens da página corrente devolvidos pelo backend. */
-  rows: ReadonlyArray<SystemDto>;
-  /** Tamanho de página efetivamente aplicado. */
-  pageSize: number;
-  /** Total filtrado (antes do skip/take). */
-  total: number;
-}
-
-const INITIAL_PAGE_DATA: PageData = {
-  rows: [],
-  pageSize: DEFAULT_PAGE_SIZE,
-  total: 0,
-};
 
 /* ─── Styled primitives ──────────────────────────────────── */
 
@@ -281,21 +266,6 @@ function computeTotalPages(total: number, pageSize: number): number {
   return Math.ceil(total / pageSize);
 }
 
-/**
- * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
- *
- * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
- * resolveu fallbacks por status). Para erros arbitrários, usamos uma
- * mensagem genérica em pt-BR — preserva privacidade da arquitetura
- * (não vaza stack/objeto cru) sem mascarar a origem do problema.
- */
-function extractErrorMessage(error: unknown): string {
-  if (isApiError(error)) {
-    return error.message;
-  }
-  return 'Falha ao carregar a lista de sistemas. Tente novamente.';
-}
-
 /* ─── Component ──────────────────────────────────────────── */
 
 export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = false }) => {
@@ -311,11 +281,6 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
 
   const [includeDeleted, setIncludeDeleted] = useState<boolean>(DEFAULT_INCLUDE_DELETED);
   const [page, setPage] = useState<number>(DEFAULT_PAGE);
-
-  const [data, setData] = useState<PageData>(INITIAL_PAGE_DATA);
-  const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
-  const [isFetching, setIsFetching] = useState<boolean>(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Estado de abertura do modal "Novo sistema" (Issue #58). O modal é
   // controlado por essa página para que a Toolbar consiga ocultar o
@@ -374,14 +339,6 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
     setRestoringSystem(null);
   }, []);
 
-  // Controller da request mais recente — usado para cancelar a anterior
-  // em mudanças rápidas de busca/paginação/toggle.
-  const lastControllerRef = useRef<AbortController | null>(null);
-  // Sinaliza se a primeira request já completou (sucesso OU erro). O
-  // estado `isInitialLoading` deve cair na primeira resposta para que o
-  // próximo refetch use o overlay leve em vez do spinner cheio.
-  const hasCompletedFirstRequestRef = useRef<boolean>(false);
-
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
    * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
@@ -403,89 +360,72 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
     setPage(DEFAULT_PAGE);
   }, []);
 
-  // Bumper monotônico para forçar refetch via "Tentar novamente" sem
-  // mexer em filtros — dependência sintética do useEffect. Reusado pelo
-  // callback `onCreated` do modal de criação (Issue #58): após criação
-  // bem-sucedida, incrementamos o nonce para reexecutar `listSystems`
-  // mantendo a página/filtros atuais. Mais simples que exigir que o pai
-  // conheça `setData` e propagar manualmente o item novo (ainda que
-  // custe um round-trip extra, é coerente com o resto dos refetches da
-  // página e evita estado inconsistente quando outras pessoas estão
-  // criando sistemas em paralelo).
-  //
-  // O mesmo callback (`handleRefetch`) cobre os dois call sites — antes
-  // havia duas funções idênticas (`handleRetry` + `handleCreatedRefetch`)
-  // que o Sonar marcou como duplicação no PR #127. Colapsadas em uma só.
-  const [retryNonce, setRetryNonce] = useState<number>(0);
-  const handleRefetch = useCallback(() => {
-    setRetryNonce((n) => n + 1);
-  }, []);
-
   /**
-   * Dispara `listSystems` sempre que mudam: termo debounced, página,
-   * filtro de inativos ou bumper de retry. Cancela qualquer request em
-   * voo antes de disparar a nova — ignorando `AbortError` no catch.
+   * `fetcher` memoizado para o `usePaginatedFetch`. Captura os params
+   * derivados (busca debounced, page, filtro) e devolve uma função que
+   * aceita `signal` no `options`. O hook reage à mudança de identidade
+   * do `fetcher` para reexecutar — `useCallback` com as deps corretas
+   * mantém o ciclo previsível.
+   *
+   * Reusado pelo callback `onCreated`/`onUpdated`/`onDeleted` dos
+   * modais (Issues #58/#59/#60/#61) via `refetch` devolvido pelo hook:
+   * após mutação bem-sucedida, incrementamos o nonce interno para
+   * reexecutar `listSystems` mantendo a página/filtros atuais. Mais
+   * simples que exigir que o pai conheça `setData` e propagar
+   * manualmente o item novo (ainda que custe um round-trip extra, é
+   * coerente com o resto dos refetches da página e evita estado
+   * inconsistente quando outras pessoas estão mutando em paralelo).
+   *
+   * O mesmo callback (`handleRefetch`) cobre os múltiplos call sites
+   * (retry + onCreated/onUpdated/onDeleted/onRestored) — antes havia
+   * funções separadas que o Sonar marcou como duplicação no PR #127.
    */
-  useEffect(() => {
-    let cancelled = false;
-    const controller = new AbortController();
-    lastControllerRef.current?.abort();
-    lastControllerRef.current = controller;
+  const trimmedSearchInput = debouncedSearch.trim();
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listSystems(
+        {
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, includeDeleted, page, trimmedSearchInput],
+  );
 
-    if (hasCompletedFirstRequestRef.current) {
-      setIsFetching(true);
-    }
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: refetchList,
+  } = usePaginatedFetch<SystemDto>({
+    fetcher,
+    fallbackErrorMessage: 'Falha ao carregar a lista de sistemas. Tente novamente.',
+  });
 
-    const trimmed = debouncedSearch.trim();
-    const params = {
-      q: trimmed.length > 0 ? trimmed : undefined,
-      page,
-      pageSize: DEFAULT_PAGE_SIZE,
-      includeDeleted,
-    };
-
-    listSystems(params, { signal: controller.signal }, client)
-      .then((response: PagedResponse<SystemDto>) => {
-        if (cancelled) return;
-        setData({
-          rows: response.data,
-          pageSize: response.pageSize,
-          total: response.total,
-        });
-        setErrorMessage(null);
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
-        // Cancelamento explícito (fetch abortado) é fluxo normal —
-        // não vira erro de UI.
-        if (error instanceof DOMException && error.name === 'AbortError') {
-          return;
-        }
-        if (
-          isApiError(error) &&
-          error.kind === 'network' &&
-          error.message === 'Requisição cancelada.'
-        ) {
-          return;
-        }
-        setErrorMessage(extractErrorMessage(error));
-      })
-      .finally(() => {
-        if (cancelled) return;
-        hasCompletedFirstRequestRef.current = true;
-        setIsInitialLoading(false);
-        setIsFetching(false);
-      });
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [client, debouncedSearch, includeDeleted, page, retryNonce]);
+  // Bumper duplicado para o painel de stats (`SystemsStatsRow`). Antes
+  // o painel usava o mesmo `retryNonce` da tabela porque ambos viviam
+  // no mesmo `useState` da página. Após extrair o ciclo de fetch para
+  // `usePaginatedFetch` (Issue #62), o nonce ficou encapsulado no hook
+  // e o `SystemsStatsRow` precisa de um sinal próprio para refetchear.
+  // Mantemos os dois alinhados disparando ambos do mesmo callback —
+  // assim "Tentar novamente" e os refetches pós-mutação continuam
+  // atualizando tabela e painel ao mesmo tempo (Issue #131).
+  const [statsRefreshKey, setStatsRefreshKey] = useState<number>(0);
+  const handleRefetch = useCallback(() => {
+    refetchList();
+    setStatsRefreshKey((n) => n + 1);
+  }, [refetchList]);
 
   const totalPages = useMemo(
-    () => computeTotalPages(data.total, data.pageSize),
-    [data.total, data.pageSize],
+    () => computeTotalPages(total, appliedPageSize > 0 ? appliedPageSize : DEFAULT_PAGE_SIZE),
+    [appliedPageSize, total],
   );
 
   const isFirstPage = page <= 1;
@@ -503,7 +443,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
   const hasActiveSearch = trimmedSearch.length > 0;
 
   /**
-   * Decide qual mensagem renderizar quando `data.rows` está vazio:
+   * Decide qual mensagem renderizar quando `rows` está vazio:
    *
    * - Vazio com busca ativa → cita o termo + sugere limpar.
    * - Vazio com toggle "incluir inativos" mas sem busca → mensagem
@@ -653,14 +593,14 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
     if (isInitialLoading) return 'Carregando lista de sistemas.';
     if (isFetching) return 'Atualizando lista de sistemas.';
     if (errorMessage) return '';
-    if (data.total === 0) {
+    if (total === 0) {
       return hasActiveSearch
         ? `Nenhum sistema encontrado para ${trimmedSearch}.`
         : 'Nenhum sistema cadastrado.';
     }
-    return `${data.total} sistema(s) encontrado(s). Página ${page} de ${totalPages}.`;
+    return `${total} sistema(s) encontrado(s). Página ${page} de ${totalPages}.`;
   }, [
-    data.total,
+    total,
     errorMessage,
     hasActiveSearch,
     isFetching,
@@ -678,7 +618,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
         desc="Serviços registrados no ecossistema de autenticação. Cada sistema possui suas próprias rotas, roles e permissões."
       />
 
-      {!hideStats && <SystemsStatsRow refreshKey={retryNonce} client={client} />}
+      {!hideStats && <SystemsStatsRow refreshKey={statsRefreshKey} client={client} />}
 
       <Toolbar>
         <SearchSlot>
@@ -762,7 +702,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
           <Table<SystemDto>
             caption="Lista de sistemas cadastrados no auth-service."
             columns={columns}
-            data={data.rows}
+            data={rows}
             getRowKey={(row) => row.id}
             emptyState={emptyContent}
           />
@@ -774,10 +714,10 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
         </TableShell>
       )}
 
-      {!isInitialLoading && !errorMessage && data.total > 0 && (
+      {!isInitialLoading && !errorMessage && total > 0 && (
         <FootBar>
           <PageInfo data-testid="systems-page-info">
-            Página {page} de {totalPages} · {data.total} resultado(s)
+            Página {page} de {totalPages} · {total} resultado(s)
           </PageInfo>
           <PageNav>
             <Button

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { NotFoundPage } from '../pages/NotFoundPage';
 import { PermissionsPage } from '../pages/PermissionsPage';
 import { PlaceholderPage } from '../pages/PlaceholderPage';
 import { RolesPage } from '../pages/RolesPage';
+import { RoutesPage } from '../pages/RoutesPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { ShowcasePage } from '../pages/ShowcasePage';
 import { SystemsPage } from '../pages/SystemsPage';
@@ -94,13 +95,21 @@ export const AppRoutes: React.FC = () => (
         }
       />
       <Route
+        path="/systems/:systemId/routes"
+        element={
+          <RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST">
+            <RoutesPage />
+          </RequirePermission>
+        }
+      />
+      <Route
         path="/routes"
         element={
           <RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST">
             <PlaceholderPage
               eyebrow="02 Rotas"
               title="Rotas registradas"
-              desc="Endpoints registrados por sistema. Cada rota possui método, path e permissões associadas."
+              desc="Endpoints registrados por sistema. Cada rota possui método, path e permissões associadas. Para listar as rotas de um sistema específico, abra o sistema correspondente."
             />
           </RequirePermission>
         }

--- a/src/routes/routeCodes.ts
+++ b/src/routes/routeCodes.ts
@@ -51,8 +51,18 @@ interface RouteCodeEntry {
  * privadas.
  */
 const ROUTE_CODES: ReadonlyArray<RouteCodeEntry> = [
+  // Issue #62 (EPIC #46): listagem de rotas escopada a um sistema.
+  // O `/systems/:id/routes` é o caminho real cadastrado no
+  // `AuthenticatorRoutesSeeder` para `AUTH_V1_SYSTEMS_ROUTES_LIST`. A
+  // página global `/routes` é placeholder herdado da fundação (#43) e
+  // será desativada quando a EPIC #46 concluir; até lá ela continua no
+  // `AppRoutes` gated apenas pelo `RequirePermission` client-side, sem
+  // entrada própria nesta tabela — `resolveRouteCode('/routes')`
+  // devolve `null` e o `RequireAuth` pula o `verify-token`. Isso é
+  // intencional para preservar o invariante "um routeCode por linha"
+  // exigido pelos testes de sanidade.
+  { pattern: '/systems/:id/routes', routeCode: 'AUTH_V1_SYSTEMS_ROUTES_LIST' },
   { pattern: '/systems', routeCode: 'AUTH_V1_SYSTEMS_LIST' },
-  { pattern: '/routes', routeCode: 'AUTH_V1_SYSTEMS_ROUTES_LIST' },
   { pattern: '/roles', routeCode: 'AUTH_V1_ROLES_LIST' },
   { pattern: '/permissions', routeCode: 'AUTH_V1_PERMISSIONS_LIST' },
   { pattern: '/users', routeCode: 'AUTH_V1_USERS_LIST' },

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -88,3 +88,20 @@ export type {
   SystemsStats,
   UpdateSystemPayload,
 } from './systems';
+export {
+  createRoute,
+  DEFAULT_ROUTES_INCLUDE_DELETED,
+  DEFAULT_ROUTES_PAGE,
+  DEFAULT_ROUTES_PAGE_SIZE,
+  deleteRoute,
+  isPagedRoutesResponse,
+  isRouteDto,
+  listRoutes,
+  updateRoute,
+} from './routes';
+export type {
+  CreateRoutePayload,
+  ListRoutesParams,
+  RouteDto,
+  UpdateRoutePayload,
+} from './routes';

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -1,0 +1,370 @@
+import { apiClient } from './index';
+
+import type { PagedResponse } from './systems';
+import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
+
+/**
+ * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
+ * em vez de um literal `{ kind, message }`. Sonar marca `throw` de
+ * objeto não-Error como improvement (`Expected an error object to be
+ * thrown`); estendê-lo com `Object.assign` preserva a interface
+ * `ApiError` consumida por `isApiError` sem perder o stack trace.
+ *
+ * Centralizado para evitar repetir `Object.assign(new Error(...), { kind })`
+ * em três call sites (`listRoutes`/`createRoute`/`updateRoute`) — o
+ * Sonar contaria a repetição como duplicação. Espelha o padrão do
+ * `systems.ts` (lição PR #128 — projetar shared helpers desde o
+ * primeiro PR do recurso).
+ */
+function makeParseError(): ApiError {
+  return Object.assign(new Error('Resposta inválida do servidor.'), {
+    kind: 'parse' as const,
+  });
+}
+
+/**
+ * Espelho do `RouteResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Routes.RoutesController.RouteResponse`).
+ *
+ * O backend serializa as datas em ISO 8601 (UTC) — mantemos como `string`
+ * porque a UI consome via `Intl.DateTimeFormat`/`new Date()` quando
+ * precisar exibir; converter no boundary do cliente HTTP traria custo
+ * sem benefício. `deletedAt !== null` indica soft-delete.
+ *
+ * Os campos `systemTokenTypeCode` e `systemTokenTypeName` são
+ * denormalizações do `SystemTokenType` referenciado (LEFT JOIN no
+ * controller — quando o token type referenciado foi soft-deletado, o
+ * backend devolve strings vazias, e a UI exibe "—" como fallback).
+ *
+ * Issue #62 (EPIC #46) — primeiro DTO da listagem; create/update/delete
+ * (#63/#64/#65) reutilizam o mesmo shape no response.
+ */
+export interface RouteDto {
+  id: string;
+  systemId: string;
+  name: string;
+  code: string;
+  description: string | null;
+  systemTokenTypeId: string;
+  /** Code do `SystemTokenType` ("política JWT alvo"). String vazia quando o token type referenciado foi soft-deletado. */
+  systemTokenTypeCode: string;
+  /** Nome amigável do `SystemTokenType`. String vazia quando o token type referenciado foi soft-deletado. */
+  systemTokenTypeName: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `RouteDto`. Tolera `description`/`deletedAt` ausentes
+ * (tratados como `null`) — outros campos são obrigatórios e checados em
+ * runtime.
+ *
+ * Exportado para que outros call sites (ex.: `createRoute` validando o
+ * `RouteResponse` devolvido pelo backend nas próximas issues #63/#64)
+ * reusem a mesma fonte de verdade — evita duplicação de validação de
+ * shape (lição PR #123, "type guards quase idênticos em arquivos
+ * diferentes precisam de helper compartilhado").
+ */
+export function isRouteDto(value: unknown): value is RouteDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.systemId === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.code === 'string' &&
+    typeof record.systemTokenTypeId === 'string' &&
+    typeof record.systemTokenTypeCode === 'string' &&
+    typeof record.systemTokenTypeName === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.description === null ||
+      record.description === undefined ||
+      typeof record.description === 'string') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<RouteDto>`. Valida o envelope antes de
+ * confiar no payload — protege contra divergência silenciosa de versão
+ * entre frontend e backend (proxy intermediário cortando campos, deploy
+ * desalinhado). Espelha `isPagedSystemsResponse` em `systems.ts`.
+ */
+export function isPagedRoutesResponse(value: unknown): value is PagedResponse<RouteDto> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isRouteDto);
+}
+
+/**
+ * Defaults usados pela `listRoutes` para omitir parâmetros que coincidem
+ * com o backend — preserva a URL "limpa" no caminho default
+ * (`GET /systems/routes?systemId=<guid>` em vez de
+ * `GET /systems/routes?systemId=<guid>&q=&page=1&pageSize=20&includeDeleted=false`).
+ *
+ * `DEFAULT_PAGE`/`DEFAULT_PAGE_SIZE`/`DEFAULT_INCLUDE_DELETED` são
+ * compartilhados com `systems.ts` via reexport intencional — backend usa
+ * os mesmos valores para `Routes` (`DefaultPageSize = 20`,
+ * `MaxPageSize = 100`). Exportar daqui mantém a UI da `RoutesPage`
+ * desacoplada do módulo `systems` mesmo quando o valor numérico
+ * coincide (caso o backend evolua para diferenciar limites por recurso).
+ */
+export const DEFAULT_ROUTES_PAGE = 1;
+export const DEFAULT_ROUTES_PAGE_SIZE = 20;
+export const DEFAULT_ROUTES_INCLUDE_DELETED = false;
+
+/**
+ * Parâmetros aceitos por `listRoutes`. Apenas `systemId` é semanticamente
+ * obrigatório nesta primeira sub-issue (#62 — listagem **por sistema**).
+ * Os demais são opcionais — quando omitidos (ou iguais aos defaults),
+ * são removidos da querystring.
+ *
+ * `systemId` é tipado como `string` (UUID v4 esperado pelo backend) e
+ * obrigatório no contrato dessa função: a `RoutesPage` lê o `:id` da URL
+ * e nunca chama sem ele. O backend aceita `systemId` opcional em
+ * `GET /systems/routes` e devolve todas as rotas quando ausente, mas
+ * essa rota global ("listar tudo") é objeto da sub-issue #63 (criar)
+ * via dropdown de sistema — não desta listagem.
+ */
+export interface ListRoutesParams {
+  /** UUID do sistema dono das rotas. Obrigatório nesta listagem. */
+  systemId: string;
+  /** Termo de busca (case-insensitive em `Name` e `Code`). */
+  q?: string;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
+  pageSize?: number;
+  /** Quando `true`, inclui rotas com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de proxy.
+ *
+ * `q` é trimado e omitido quando vazio para evitar `?q=` literal (que o
+ * backend trataria como busca por string vazia, mas a UI sinalizaria
+ * estado de "busca ativa" no `q`). Espelha `buildQueryString` de
+ * `systems.ts`, mas adiciona `systemId` sempre — é o eixo do recurso
+ * desta issue.
+ */
+function buildQueryString(params: ListRoutesParams): string {
+  const search = new URLSearchParams();
+
+  // `systemId` sempre presente — é o eixo da listagem por sistema.
+  search.set('systemId', params.systemId);
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set('q', q);
+  }
+
+  if (typeof params.page === 'number' && params.page !== DEFAULT_ROUTES_PAGE) {
+    search.set('page', String(params.page));
+  }
+
+  if (typeof params.pageSize === 'number' && params.pageSize !== DEFAULT_ROUTES_PAGE_SIZE) {
+    search.set('pageSize', String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === 'boolean' &&
+    params.includeDeleted !== DEFAULT_ROUTES_INCLUDE_DELETED
+  ) {
+    search.set('includeDeleted', String(params.includeDeleted));
+  }
+
+  return `?${search.toString()}`;
+}
+
+/**
+ * Lista rotas de um sistema via `GET /systems/routes?systemId=<guid>` com
+ * busca, paginação e filtro de soft-deleted.
+ *
+ * Retorna o envelope tipado `PagedResponse<RouteDto>`. Lança `ApiError`
+ * em falhas (rede, parse, HTTP); o caller deve tratar com try/catch.
+ *
+ * Cancelamento: aceita `signal` em `options` (via AbortController) — em
+ * navegações rápidas, o caller cancela a request anterior antes de
+ * disparar a nova, evitando race em `setState` (mesmo padrão da
+ * `SystemsPage`).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); o default usa o singleton `apiClient`
+ * configurado com `baseUrl` + `systemId` reais.
+ *
+ * Issue #62 — primeira sub-issue da EPIC #46 (CRUD de Rotas por Sistema).
+ * As próximas issues (#63 criar, #64 editar, #65 excluir) reutilizam o
+ * mesmo módulo (`createRoute`/`updateRoute`/`deleteRoute`) seguindo o
+ * padrão estabelecido pela EPIC #45 em `systems.ts`. Já mantemos os
+ * hooks de extensão (`makeParseError`, `RouteDto`, `isRouteDto`) prontos
+ * para evitar refatorações destrutivas no segundo PR (lição PR #128 —
+ * projetar shared helpers desde o primeiro PR do recurso).
+ */
+export async function listRoutes(
+  params: ListRoutesParams,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<RouteDto>> {
+  const path = `/systems/routes${buildQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedRoutesResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Body aceito pelo `POST /systems/routes` no `lfc-authenticator`
+ * (`RoutesController.CreateRouteRequest`).
+ *
+ * Definido aqui (e não em #63) por dois motivos: (i) `isRouteDto` já
+ * cobre o response, então mantemos input/output simétricos no mesmo
+ * módulo; (ii) lição PR #128 — desde o primeiro PR do recurso, projetar
+ * tipos compartilhados para evitar duplicação no PR seguinte.
+ *
+ * - `systemId` (obrigatório) — UUID do sistema dono. Backend valida que
+ *   exista e esteja ativo.
+ * - `name` (obrigatório, máx. 80 chars) — nome amigável da rota.
+ * - `code` (obrigatório, máx. 50 chars) — identificador único global no
+ *   `lfc-authenticator` (UX_Routes_Code é único globalmente — colidir
+ *   com Code de outro sistema retorna 409).
+ * - `description` (opcional, máx. 500 chars) — descrição livre.
+ * - `systemTokenTypeId` (obrigatório) — UUID da política JWT alvo.
+ *
+ * Backend trima `Name`/`Code` e converte `Description` vazia em `null`.
+ */
+export interface CreateRoutePayload {
+  systemId: string;
+  name: string;
+  code: string;
+  description?: string;
+  systemTokenTypeId: string;
+}
+
+/**
+ * Body aceito pelo `PUT /systems/routes/{id}` no `lfc-authenticator`
+ * (`RoutesController.UpdateRouteRequest`). Mesmo shape do create — segue
+ * o padrão do `systems.ts` (alias intencional para preservar simetria
+ * de contrato — divergência futura no backend pega ambos os call sites
+ * de uma vez). Issue #64 implementa o caller; já declarado aqui pelo
+ * mesmo motivo de `CreateRoutePayload` (lição PR #128).
+ */
+export type UpdateRoutePayload = CreateRoutePayload;
+
+/**
+ * Cria uma nova rota via `POST /systems/routes` (Issue #63).
+ *
+ * Retorna o `RouteDto` recém-criado (`201 Created` com `RouteResponse`
+ * no corpo). Lança `ApiError` em qualquer falha — caller tipicamente
+ * trata 409 (conflito de Code), 400 (validação de campo) e fallbacks
+ * genéricos. Wrapper já implementado nesta sub-issue para evitar PR
+ * destrutivo no #63 (lição PR #128).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function createRoute(
+  payload: CreateRoutePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<RouteDto> {
+  const body = buildRouteMutationBody(payload);
+  const data = await client.post<unknown>('/systems/routes', body, options);
+  if (!isRouteDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Atualiza uma rota existente via `PUT /systems/routes/{id}` (Issue #64).
+ *
+ * Retorna o `RouteDto` atualizado (`200 OK` com `RouteResponse` no
+ * corpo). Lança `ApiError` em qualquer falha — caller tipicamente
+ * trata 409 (conflito de Code), 404 (rota não encontrada/soft-deletada),
+ * 400 (validação de campo). Wrapper já implementado para evitar PR
+ * destrutivo no #64 (lição PR #128).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function updateRoute(
+  id: string,
+  payload: UpdateRoutePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<RouteDto> {
+  const body = buildRouteMutationBody(payload);
+  const data = await client.put<unknown>(`/systems/routes/${id}`, body, options);
+  if (!isRouteDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Desativa (soft-delete) uma rota via `DELETE /systems/routes/{id}`
+ * (Issue #65).
+ *
+ * O backend (`RoutesController.DeleteById`) seta `DeletedAt = UtcNow` e
+ * responde `204 No Content` em sucesso. O método não devolve corpo — a
+ * função resolve `void` e a UI faz refetch para sincronizar a lista.
+ *
+ * Lança `ApiError` em qualquer falha (404, 401, 403, 409 quando há
+ * Permissions ativas vinculadas, 5xx, network). Wrapper já implementado
+ * nesta sub-issue para evitar PR destrutivo no #65 (lição PR #128 —
+ * projetar shared helpers desde o primeiro PR do recurso).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function deleteRoute(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/systems/routes/${id}`, options);
+}
+
+/**
+ * Constrói o body para `POST /systems/routes` e `PUT /systems/routes/{id}`
+ * aplicando trim defensivo nos campos. Description vazia depois de trim
+ * vira `undefined` para que o serializador omita o campo (backend
+ * converte para `null`). Centralizar essa montagem garante que create e
+ * update enviem exatamente o mesmo payload — qualquer divergência
+ * futura no shape (ex.: backend aceitando `tags`) ajusta um único
+ * helper. Espelha `buildSystemMutationBody` de `systems.ts`.
+ */
+function buildRouteMutationBody(
+  payload: CreateRoutePayload | UpdateRoutePayload,
+): CreateRoutePayload {
+  const body: CreateRoutePayload = {
+    systemId: payload.systemId,
+    name: payload.name.trim(),
+    code: payload.code.trim(),
+    systemTokenTypeId: payload.systemTokenTypeId,
+  };
+  const trimmedDescription = payload.description?.trim();
+  if (trimmedDescription && trimmedDescription.length > 0) {
+    body.description = trimmedDescription;
+  }
+  return body;
+}

--- a/tests/hooks/usePaginatedFetch.test.tsx
+++ b/tests/hooks/usePaginatedFetch.test.tsx
@@ -1,0 +1,251 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiError, PagedResponse, SafeRequestOptions } from '@/shared/api';
+
+import { usePaginatedFetch } from '@/hooks/usePaginatedFetch';
+
+/**
+ * Suíte do hook compartilhado `usePaginatedFetch` (Issue #62, EPIC #46).
+ *
+ * Originalmente o pattern vivia inline na `SystemsPage` (EPIC #45) e
+ * foi extraído quando a `RoutesPage` introduziu o segundo call site.
+ * Lição PR #128: projetar shared helpers desde o primeiro PR do
+ * recurso em vez de esperar o segundo módulo aparecer e depois
+ * refatorar — o hook centraliza loading/refetch/cancelamento que cada
+ * listagem precisaria reimplementar.
+ *
+ * Estratégia de teste: passar um `fetcher` mockado e validar
+ * - Estados de loading (initial/refetch).
+ * - Cancelamento via AbortController em refetches sucessivos.
+ * - Mensagem de erro em falhas (com fallback genérico).
+ * - Skip não chama o fetcher e desliga `isInitialLoading`.
+ * - Refetch dispara nova chamada sem mudar params.
+ */
+
+interface ListItem {
+  id: string;
+}
+
+function makePaged(data: ReadonlyArray<ListItem>, total = data.length): PagedResponse<ListItem> {
+  return { data, page: 1, pageSize: 20, total };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('usePaginatedFetch — primeiro fetch', () => {
+  it('inicia com isInitialLoading=true e popula rows após sucesso', async () => {
+    const fetcher = vi.fn(async () => makePaged([{ id: 'a' }, { id: 'b' }]));
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'Falha genérica.',
+      }),
+    );
+
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.rows).toEqual([]);
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+
+    expect(result.current.rows).toEqual([{ id: 'a' }, { id: 'b' }]);
+    expect(result.current.total).toBe(2);
+    expect(result.current.errorMessage).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('passa signal AbortController ao fetcher', async () => {
+    const signals: AbortSignal[] = [];
+    const fetcher = vi.fn(async (options: SafeRequestOptions) => {
+      if (options.signal) signals.push(options.signal);
+      return makePaged([]);
+    });
+
+    renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'X',
+      }),
+    );
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalled());
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('usePaginatedFetch — refetch e cancelamento', () => {
+  it('refetch() incrementa nonce e re-executa o fetcher mantendo isInitialLoading=false', async () => {
+    const fetcher = vi.fn(async () => makePaged([{ id: 'a' }]));
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'X',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    // No segundo fetch, é refetch (não initial), portanto
+    // isInitialLoading permanece false e isFetching transita.
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+
+  it('cancela o fetch anterior quando o fetcher muda de identidade', async () => {
+    const signals: AbortSignal[] = [];
+    let fetcherKey = 'a';
+    const makeFetcher = (key: string) => () => {
+      const fn = vi.fn(async (options: SafeRequestOptions) => {
+        if (options.signal) signals.push(options.signal);
+        return makePaged([{ id: key }]);
+      });
+      return fn;
+    };
+
+    const { result, rerender } = renderHook(
+      ({ fetcher }: { fetcher: (options: SafeRequestOptions) => Promise<PagedResponse<ListItem>> }) =>
+        usePaginatedFetch<ListItem>({ fetcher, fallbackErrorMessage: 'X' }),
+      { initialProps: { fetcher: makeFetcher(fetcherKey)() } },
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+
+    fetcherKey = 'b';
+    rerender({ fetcher: makeFetcher(fetcherKey)() });
+
+    await waitFor(() => expect(signals.length).toBeGreaterThanOrEqual(2));
+
+    // O signal #1 (o anterior) deve estar abortado pelo cleanup do
+    // useEffect quando o fetcher mudou.
+    expect(signals[0].aborted).toBe(true);
+  });
+});
+
+describe('usePaginatedFetch — erros', () => {
+  it('exibe message do ApiError quando fetcher rejeita com ApiError', async () => {
+    const apiError: ApiError = {
+      kind: 'http',
+      status: 500,
+      message: 'Erro interno do servidor.',
+    };
+    const fetcher = vi.fn(async () => {
+      throw apiError;
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'Falha genérica.',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.errorMessage).toBe('Erro interno do servidor.');
+  });
+
+  it('usa fallbackErrorMessage quando fetcher rejeita com erro arbitrário', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error('boom');
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'Falha customizada.',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.errorMessage).toBe('Falha customizada.');
+  });
+
+  it('não exibe erro quando fetcher rejeita com AbortError', async () => {
+    const fetcher = vi.fn(async () => {
+      throw new DOMException('Aborted', 'AbortError');
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'X',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('não exibe erro quando fetcher rejeita com ApiError(network) "Requisição cancelada."', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Requisição cancelada.',
+    };
+    const fetcher = vi.fn(async () => {
+      throw apiError;
+    });
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'X',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(result.current.errorMessage).toBeNull();
+  });
+});
+
+describe('usePaginatedFetch — skip', () => {
+  it('não chama o fetcher e desliga isInitialLoading quando skip=true', async () => {
+    const fetcher = vi.fn(async () => makePaged([]));
+
+    const { result } = renderHook(() =>
+      usePaginatedFetch<ListItem>({
+        fetcher,
+        fallbackErrorMessage: 'X',
+        skip: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.rows).toEqual([]);
+  });
+
+  it('volta a chamar o fetcher quando skip muda de true para false', async () => {
+    const fetcher = vi.fn(async () => makePaged([{ id: 'a' }]));
+
+    const { result, rerender } = renderHook(
+      ({ skip }: { skip: boolean }) =>
+        usePaginatedFetch<ListItem>({ fetcher, fallbackErrorMessage: 'X', skip }),
+      { initialProps: { skip: true } },
+    );
+
+    await waitFor(() => expect(result.current.isInitialLoading).toBe(false));
+    expect(fetcher).not.toHaveBeenCalled();
+
+    rerender({ skip: false });
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.rows).toEqual([{ id: 'a' }]));
+  });
+});

--- a/tests/pages/RoutesPage.test.tsx
+++ b/tests/pages/RoutesPage.test.tsx
@@ -1,0 +1,543 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createRoutesClientStub,
+  ID_ROUTE_CREATE,
+  ID_ROUTE_LEGACY,
+  ID_ROUTE_LIST,
+  ID_SYS_AUTH,
+  lastGetPath,
+  makePagedRoutes,
+  makeRoute,
+  renderRoutesPage,
+  waitForInitialList,
+} from './__helpers__/routesTestHelpers';
+
+import type { ApiError, PagedResponse, RouteDto } from '@/shared/api';
+
+import { RoutesPage } from '@/pages/RoutesPage';
+
+/**
+ * Suíte da `RoutesPage` (Issue #62, EPIC #46 — listagem de rotas por
+ * sistema). Estratégia espelha `SystemsPage.test.tsx`: stub de
+ * `ApiClient` injetado, asserts sobre querystring/estados visuais,
+ * paginação, busca debounced, toggle "incluir inativas", erros e
+ * cancelamento de request.
+ *
+ * Diferenças com `SystemsPage.test.tsx`:
+ *
+ * - A `RoutesPage` lê `:systemId` de `useParams`, então renderizamos
+ *   dentro de `MemoryRouter` (centralizado em `renderRoutesPage`).
+ * - O endpoint é `/systems/routes?systemId=...` em vez de `/systems`.
+ * - A página exibe cards no mobile (testIDs `routes-card-<id>`) além
+ *   da tabela desktop — testes verificam ambos.
+ * - Não há gating de criação/edição (sub-issues futuras), portanto
+ *   sem `vi.mock('@/shared/auth')` aqui.
+ */
+
+/**
+ * Atraso de debounce esperado pela página (300 ms). Espelha o valor
+ * interno da `RoutesPage` — alterar em ambos os lados quando ajustar a
+ * UX.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_ROWS: ReadonlyArray<RouteDto> = [
+  makeRoute({
+    id: ID_ROUTE_LIST,
+    name: 'Listar sistemas',
+    code: 'AUTH_V1_SYSTEMS_LIST',
+    description: 'GET /api/v1/systems',
+    systemTokenTypeName: 'Acesso padrão',
+  }),
+  makeRoute({
+    id: ID_ROUTE_CREATE,
+    name: 'Criar sistema',
+    code: 'AUTH_V1_SYSTEMS_CREATE',
+    description: 'POST /api/v1/systems',
+    systemTokenTypeName: 'Acesso padrão',
+  }),
+  makeRoute({
+    id: ID_ROUTE_LEGACY,
+    name: 'Legado',
+    code: 'AUTH_V1_LEGACY',
+    description: null,
+    systemTokenTypeCode: '',
+    systemTokenTypeName: '',
+    deletedAt: '2026-02-01T00:00:00Z',
+  }),
+];
+
+beforeEach(() => {
+  // `shouldAdvanceTime: true` permite que `setTimeout` interno do
+  // testing-library (`waitFor`/`findBy*`) avance com o relógio real
+  // enquanto `vi.advanceTimersByTime(...)` ainda controla manualmente o
+  // debounce da busca. Mesmo padrão do `SystemsPage.test.tsx`.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('RoutesPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e depois popula a tabela', async () => {
+    const client = createRoutesClientStub();
+    let resolveFn: (value: PagedResponse<RouteDto>) => void = () => undefined;
+    const pending = new Promise<PagedResponse<RouteDto>>((resolve) => {
+      resolveFn = resolve;
+    });
+    client.get.mockReturnValueOnce(pending);
+
+    renderRoutesPage(client);
+
+    expect(screen.getByTestId('routes-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(makePagedRoutes(SAMPLE_ROWS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('routes-loading')).not.toBeInTheDocument();
+    });
+
+    // Tabela desktop e cards mobile renderizam o mesmo conteúdo lado a
+    // lado (CSS controla qual aparece). Asserir presença sem exigir
+    // unicidade — o `getAllByText` cobre os dois.
+    expect(screen.getAllByText('AUTH_V1_SYSTEMS_LIST').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('AUTH_V1_SYSTEMS_CREATE').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('AUTH_V1_LEGACY').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza header da página com título "Rotas do sistema"', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+
+    expect(screen.getByRole('heading', { name: /Rotas do sistema/i })).toBeInTheDocument();
+  });
+
+  it('chama backend com systemId e omite defaults no primeiro render', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+    expect(lastGetPath(client)).toBe(`/systems/routes?systemId=${ID_SYS_AUTH}`);
+  });
+
+  it('renderiza badge "Inativa" para rotas com deletedAt e "Ativa" para as demais', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+
+    // jsdom aplica `display: none` do `TableForDesktop` (a media query
+    // `min-width: 48em` falha em viewport zero), então a tabela desktop
+    // fica fora da accessibility tree e `getByRole('row')` ignora as
+    // linhas. Asserir nas cards mobile (que são a versão visível em
+    // jsdom) cobre o mesmo dado e mantém o teste focado em UI real.
+    const listCard = screen.getByTestId(`routes-card-${ID_ROUTE_LIST}`);
+    const legacyCard = screen.getByTestId(`routes-card-${ID_ROUTE_LEGACY}`);
+    expect(within(listCard).getByText('Ativa')).toBeInTheDocument();
+    expect(within(legacyCard).getByText('Inativa')).toBeInTheDocument();
+  });
+
+  it('exibe placeholder "—" quando systemTokenTypeCode está vazio (token type órfão)', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedRoutes([
+        makeRoute({
+          id: ID_ROUTE_LEGACY,
+          systemTokenTypeCode: '',
+          systemTokenTypeName: '',
+        }),
+      ]),
+    );
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+
+    // O placeholder "—" aparece tanto na tabela desktop quanto nos
+    // cards mobile (mesmo helper `renderTokenPolicy`).
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('exibe nome do tokenType quando presente, code como fallback caso name esteja vazio', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedRoutes([
+        makeRoute({
+          id: ID_ROUTE_LIST,
+          systemTokenTypeCode: 'admin',
+          systemTokenTypeName: '',
+        }),
+      ]),
+    );
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+
+    expect(screen.getAllByText('admin').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza cards mobile com testId estável por rota', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId(`routes-card-${ID_ROUTE_LIST}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`routes-card-${ID_ROUTE_CREATE}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`routes-card-${ID_ROUTE_LEGACY}`)).toBeInTheDocument();
+  });
+});
+
+describe('RoutesPage — busca debounced', () => {
+  it('digitar não dispara request imediato; após 300ms dispara com q=systems', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValue(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('routes-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'systems' } });
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    const path = lastGetPath(client);
+    expect(path).toContain(`systemId=${ID_SYS_AUTH}`);
+    expect(path).toContain('q=systems');
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValue(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('routes-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 's' } });
+    fireEvent.change(input, { target: { value: 'sy' } });
+    fireEvent.change(input, { target: { value: 'sys' } });
+    fireEvent.change(input, { target: { value: 'systems' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toContain('q=systems');
+  });
+
+  it('busca limpa volta para o caminho default (apenas systemId)', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValue(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('routes-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'systems' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(input, { target: { value: '' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe(`/systems/routes?systemId=${ID_SYS_AUTH}`);
+  });
+});
+
+describe('RoutesPage — paginação', () => {
+  it('clicar "próxima" chama com page=2; "anterior" volta para page default', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValue(makePagedRoutes(SAMPLE_ROWS, { page: 1, total: 50 }));
+
+    renderRoutesPage(client);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('routes-next'));
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toContain('page=2');
+
+    fireEvent.click(screen.getByTestId('routes-prev'));
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe(`/systems/routes?systemId=${ID_SYS_AUTH}`);
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS, { page: 1, total: 50 }));
+
+    renderRoutesPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('routes-prev')).toBeDisabled();
+    expect(screen.getByTestId('routes-next')).toBeEnabled();
+  });
+
+  it('botão "próxima" desabilita quando totalPages é 1', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedRoutes(SAMPLE_ROWS, { page: 1, total: 15, pageSize: 20 }),
+    );
+
+    renderRoutesPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('routes-prev')).toBeDisabled();
+    expect(screen.getByTestId('routes-next')).toBeDisabled();
+  });
+
+  it('exibe indicador "página X de Y" com total filtrado', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS, { page: 1, total: 42 }));
+
+    renderRoutesPage(client);
+    await waitForInitialList(client);
+
+    const info = screen.getByTestId('routes-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('RoutesPage — filtro de inativas', () => {
+  it('liga toggle dispara request com includeDeleted=true', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValue(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const toggle = screen.getByTestId('routes-include-deleted') as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toContain('includeDeleted=true');
+  });
+});
+
+describe('RoutesPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedRoutes([], { total: 0 }));
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('routes-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Nenhuma rota encontrada para/i).length).toBeGreaterThan(0);
+    });
+    // O botão "Limpar busca" aparece tanto na tabela quanto nos cards
+    // (mesmo `emptyContent` reusado), portanto `getAllByTestId`.
+    expect(screen.getAllByTestId('routes-empty-clear').length).toBeGreaterThan(0);
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockResolvedValueOnce(makePagedRoutes([], { total: 0 }));
+
+    renderRoutesPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getAllByText(/Nenhuma rota cadastrada para este sistema\./i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Rotas removidas podem ser visualizadas/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('clicar em "limpar busca" reseta termo e dispara nova request', async () => {
+    const client = createRoutesClientStub();
+    client.get
+      .mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS))
+      .mockResolvedValueOnce(makePagedRoutes([], { total: 0 }))
+      .mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('routes-search'), {
+      target: { value: 'naoexiste' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    // O botão pode aparecer duplicado (tabela + cards). Pegamos o
+    // primeiro — clicar em qualquer um dispara o mesmo callback.
+    fireEvent.click((await screen.findAllByTestId('routes-empty-clear'))[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe(`/systems/routes?systemId=${ID_SYS_AUTH}`);
+  });
+});
+
+describe('RoutesPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createRoutesClientStub();
+    client.get
+      .mockRejectedValueOnce(apiError)
+      .mockResolvedValueOnce(makePagedRoutes(SAMPLE_ROWS));
+
+    renderRoutesPage(client);
+
+    expect(await screen.findByText(/Falha de conexão com o servidor\./i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('routes-retry'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('AUTH_V1_SYSTEMS_LIST').length).toBeGreaterThan(0);
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createRoutesClientStub();
+    client.get.mockRejectedValueOnce(new Error('boom'));
+
+    renderRoutesPage(client);
+
+    expect(
+      await screen.findByText(/Falha ao carregar a lista de rotas\. Tente novamente\./i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RoutesPage — cancelamento de request', () => {
+  it('mudanças sucessivas de filtro abortam a request anterior via AbortController', async () => {
+    const client = createRoutesClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (_path: string, options?: { signal?: AbortSignal }): Promise<PagedResponse<RouteDto>> => {
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        return Promise.resolve(makePagedRoutes(SAMPLE_ROWS));
+      },
+    );
+
+    renderRoutesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('routes-search'), {
+      target: { value: 'systems' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(screen.getByTestId('routes-search'), {
+      target: { value: 'systems-list' },
+    });
+
+    expect(client.get).toHaveBeenCalledTimes(2);
+
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+
+    // O signal da request "systems" deve estar abortado: o cleanup do
+    // useEffect que rodou para "systems" foi chamado quando
+    // `debouncedSearch` mudou para "systems-list".
+    expect(signals[1].aborted).toBe(true);
+  });
+});
+
+describe('RoutesPage — systemId inválido', () => {
+  it('renderiza alerta de "ID inválido" e não chama o backend quando :systemId é vazio', async () => {
+    const client = createRoutesClientStub();
+
+    // Renderizamos diretamente o roteador para entregar `:systemId`
+    // ausente da URL. `renderRoutesPage` recebe o id no path; aqui
+    // queremos o caminho onde `useParams` devolve só whitespace —
+    // `isProbablyValidSystemId` rejeita após trim. `act(async)`
+    // permite que o effect inicial flushe (que chama
+    // `setIsInitialLoading(false)`) antes do assert, evitando warning
+    // de "update not wrapped in act".
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/systems/%20/routes']}>
+          <Routes>
+            <Route
+              path="/systems/:systemId/routes"
+              element={<RoutesPage client={client} />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('routes-invalid-id')).toBeInTheDocument();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pages/__helpers__/routesTestHelpers.tsx
+++ b/tests/pages/__helpers__/routesTestHelpers.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { expect, vi } from 'vitest';
+
+import type { ApiClient, PagedResponse, RouteDto } from '@/shared/api';
+
+import { RoutesPage } from '@/pages/RoutesPage';
+
+/**
+ * Helpers de teste compartilhados pela suíte da `RoutesPage` (Issue
+ * #62) e pelas próximas (#63 criar, #64 editar, #65 excluir).
+ *
+ * Extraídos para evitar duplicação de blocos de fixtures (lição PR
+ * #123/#127/#128 — Sonar conta blocos de 10+ linhas como duplicação
+ * independente da intenção). Mantemos apenas o que é genuinamente
+ * compartilhado:
+ *
+ * - `ApiClientStub` + `createRoutesClientStub` para isolar a página da
+ *   camada de transporte;
+ * - `makeRoute` + `makePagedRoutes` para construir payloads do contrato
+ *   `RouteDto`/`PagedResponse<RouteDto>` sem repetir todos os campos;
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderRoutesPage` envolvendo a página no `MemoryRouter` apontando
+ *   para `/systems/:systemId/routes` (a página lê `useParams`);
+ * - `waitForInitialList` colapsando o "esperar listagem" repetido em
+ *   praticamente todos os testes.
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_SYS_AUTH = '11111111-1111-1111-1111-111111111111';
+export const ID_ROUTE_LIST = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+export const ID_ROUTE_CREATE = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+export const ID_ROUTE_LEGACY = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+export const ID_TOKEN_TYPE_DEFAULT = '99999999-9999-9999-9999-999999999999';
+
+/**
+ * Stub de `ApiClient` injetado em `<RoutesPage client={stub} />` —
+ * mesmo padrão de injeção usado nos testes da `SystemsPage`. Reusa o
+ * shape de `ApiClientStub` em `systemsTestHelpers.tsx`, mas declarado
+ * localmente para que cada suíte mantenha seu próprio módulo de
+ * fixtures (acoplar os dois levaria à inversão "tests dependem de
+ * tests" que dificulta reorganizar).
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createRoutesClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `RouteDto` com defaults — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos do contrato.
+ */
+export function makeRoute(overrides: Partial<RouteDto> = {}): RouteDto {
+  return {
+    id: ID_ROUTE_LIST,
+    systemId: ID_SYS_AUTH,
+    name: 'Listar sistemas',
+    code: 'AUTH_V1_SYSTEMS_LIST',
+    description: 'GET /api/v1/systems',
+    systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+    systemTokenTypeCode: 'default',
+    systemTokenTypeName: 'Acesso padrão',
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend — `total` reflete o
+ * `data.length` por default; testes que cobrem paginação sobrescrevem.
+ */
+export function makePagedRoutes(
+  data: ReadonlyArray<RouteDto>,
+  overrides: Partial<PagedResponse<RouteDto>> = {},
+): PagedResponse<RouteDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Renderiza a `RoutesPage` envolvendo no `MemoryRouter` apontando para
+ * `/systems/:systemId/routes`. A página consome `useParams<{ systemId }>`
+ * — sem o roteador, `systemId` ficaria `undefined` e a página entraria
+ * no estado `InvalidIdNotice` em vez de carregar a listagem.
+ *
+ * `systemId` é parametrizável para que o teste de `:systemId` inválido
+ * possa simular a URL `/systems/ /routes` (whitespace) e cair no
+ * `InvalidIdNotice` — espelhando o comportamento real do componente.
+ */
+export function renderRoutesPage(
+  client: ApiClientStub,
+  systemId: string = ID_SYS_AUTH,
+): void {
+  render(
+    <MemoryRouter initialEntries={[`/systems/${systemId}/routes`]}>
+      <Routes>
+        <Route path="/systems/:systemId/routes" element={<RoutesPage client={client} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a `RoutesPage` faz
+ * `listRoutes` no mount). Centraliza o "esperar listagem" para que cada
+ * teste comece em estado estável sem precisar replicar `waitFor` para
+ * `client.get`. Espelha `waitForInitialList` em `systemsTestHelpers.tsx`.
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('routes-loading')).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Helper para extrair o `query` do path passado a `client.get`. Usado em
+ * asserts que verificam a serialização da querystring. Espelha o
+ * helper em `SystemsPage.test.tsx` (não centralizado lá porque era
+ * privado da suíte; à medida que mais suítes precisam, faz sentido
+ * compartilhar).
+ */
+export function lastGetPath(client: ApiClientStub): string {
+  const calls = client.get.mock.calls;
+  if (calls.length === 0) return '';
+  const path = calls[calls.length - 1][0];
+  return typeof path === 'string' ? path : '';
+}

--- a/tests/routes/routeCodes.test.ts
+++ b/tests/routes/routeCodes.test.ts
@@ -16,7 +16,14 @@ interface ResolveCase {
 
 const POSITIVE_CASES: ReadonlyArray<ResolveCase> = [
   { pathname: '/systems', expected: 'AUTH_V1_SYSTEMS_LIST' },
-  { pathname: '/routes', expected: 'AUTH_V1_SYSTEMS_ROUTES_LIST' },
+  // Issue #62: a listagem real de rotas vive em `/systems/:id/routes` e
+  // resolve para `AUTH_V1_SYSTEMS_ROUTES_LIST`. A ordem da tabela em
+  // `routeCodes.ts` garante que esse pattern, mais específico, tenha
+  // prioridade sobre `/systems` no `matchPath`.
+  {
+    pathname: '/systems/11111111-1111-1111-1111-111111111111/routes',
+    expected: 'AUTH_V1_SYSTEMS_ROUTES_LIST',
+  },
   { pathname: '/roles', expected: 'AUTH_V1_ROLES_LIST' },
   { pathname: '/permissions', expected: 'AUTH_V1_PERMISSIONS_LIST' },
   { pathname: '/users', expected: 'AUTH_V1_USERS_LIST' },
@@ -26,7 +33,10 @@ const POSITIVE_CASES: ReadonlyArray<ResolveCase> = [
 /**
  * `/settings` e `/showcase` não têm rota equivalente cadastrada no
  * `AuthenticatorRoutesSeeder` — `resolveRouteCode` devolve `null` e o
- * `RequireAuth` pula a chamada de `verify-token`.
+ * `RequireAuth` pula a chamada de `verify-token`. Incluímos também
+ * `/routes` (Issue #62): a página global continua no `AppRoutes` como
+ * placeholder gated apenas client-side, sem entrada própria nesta
+ * tabela — a listagem real de rotas vive em `/systems/:id/routes`.
  */
 const NEGATIVE_CASES: ReadonlyArray<string> = [
   '/',
@@ -36,6 +46,7 @@ const NEGATIVE_CASES: ReadonlyArray<string> = [
   '/rota-inexistente',
   '/settings',
   '/showcase',
+  '/routes',
   '',
 ];
 

--- a/tests/shared/api/routes.test.ts
+++ b/tests/shared/api/routes.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, PagedResponse, RouteDto } from '@/shared/api';
+
+import {
+  createRoute,
+  deleteRoute,
+  isPagedRoutesResponse,
+  isRouteDto,
+  listRoutes,
+  updateRoute,
+} from '@/shared/api';
+
+/**
+ * Suíte do módulo `src/shared/api/routes.ts` (Issue #62, EPIC #46).
+ *
+ * Estratégia: stubar o `ApiClient` injetado e validar querystring,
+ * paths, body, type guards e propagação de `ApiError`. Não bate em
+ * `fetch` — cobertura de transporte HTTP é responsabilidade dos
+ * testes em `client.test.ts`.
+ *
+ * Nesta primeira sub-issue só `listRoutes` é consumido pela UI; os
+ * wrappers `createRoute`/`updateRoute`/`deleteRoute` foram declarados
+ * já agora para evitar PR destrutivo nas próximas sub-issues (lição
+ * PR #128 — projetar shared helpers desde o primeiro PR do recurso),
+ * portanto cobrimos todos com asserts mínimos.
+ */
+
+/** UUID de sistema sintético — asserts comparam strings estáveis. */
+const SYS_ID = '11111111-1111-1111-1111-111111111111';
+const ROUTE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const TOKEN_TYPE_ID = '99999999-9999-9999-9999-999999999999';
+
+interface ClientStub {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Cria um stub mínimo de `ApiClient` — espelha o pattern usado em
+ * `tests/pages/__helpers__/systemsTestHelpers.tsx` mas sem importar de
+ * lá: o módulo de helpers de pages depende do `@testing-library/react`
+ * e o teste de API não precisa do DOM. Manter local evita sobrecarga
+ * de imports no boot da suíte.
+ */
+function createStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  };
+}
+
+/**
+ * Constrói um `RouteDto` válido — testes só sobrescrevem o que importa
+ * para o cenário sem repetir todos os campos. Espelha `makeRoute` dos
+ * helpers de página, mas declarado aqui para evitar dependência cruzada
+ * (mesmo motivo do stub local).
+ */
+function makeRouteDto(overrides: Partial<RouteDto> = {}): RouteDto {
+  return {
+    id: ROUTE_ID,
+    systemId: SYS_ID,
+    name: 'Listar sistemas',
+    code: 'AUTH_V1_SYSTEMS_LIST',
+    description: 'GET /api/v1/systems',
+    systemTokenTypeId: TOKEN_TYPE_ID,
+    systemTokenTypeCode: 'default',
+    systemTokenTypeName: 'Acesso padrão',
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makePaged(
+  data: ReadonlyArray<RouteDto>,
+  overrides: Partial<PagedResponse<RouteDto>> = {},
+): PagedResponse<RouteDto> {
+  return { data, page: 1, pageSize: 20, total: data.length, ...overrides };
+}
+
+describe('isRouteDto', () => {
+  it('aceita payload completo do contrato', () => {
+    expect(isRouteDto(makeRouteDto())).toBe(true);
+  });
+
+  it('aceita description ausente/null/undefined', () => {
+    expect(isRouteDto(makeRouteDto({ description: null }))).toBe(true);
+    const { description: _omit, ...withoutDescription } = makeRouteDto();
+    expect(isRouteDto(withoutDescription)).toBe(true);
+  });
+
+  it('aceita deletedAt ausente/null/undefined', () => {
+    expect(isRouteDto(makeRouteDto({ deletedAt: null }))).toBe(true);
+    const { deletedAt: _omit, ...withoutDeleted } = makeRouteDto();
+    expect(isRouteDto(withoutDeleted)).toBe(true);
+  });
+
+  it('rejeita objetos sem campos obrigatórios', () => {
+    expect(isRouteDto(null)).toBe(false);
+    expect(isRouteDto(undefined)).toBe(false);
+    expect(isRouteDto({})).toBe(false);
+    expect(isRouteDto({ id: 1, systemId: SYS_ID })).toBe(false);
+    const missingTokenTypeName = makeRouteDto();
+    delete (missingTokenTypeName as Partial<RouteDto>).systemTokenTypeName;
+    expect(isRouteDto(missingTokenTypeName)).toBe(false);
+  });
+
+  it('rejeita description ou deletedAt com tipo inválido', () => {
+    expect(isRouteDto(makeRouteDto({ description: 123 as unknown as string }))).toBe(false);
+    expect(isRouteDto(makeRouteDto({ deletedAt: 0 as unknown as string }))).toBe(false);
+  });
+});
+
+describe('isPagedRoutesResponse', () => {
+  it('aceita envelope válido com dados', () => {
+    expect(isPagedRoutesResponse(makePaged([makeRouteDto()]))).toBe(true);
+  });
+
+  it('aceita envelope vazio', () => {
+    expect(isPagedRoutesResponse(makePaged([], { total: 0 }))).toBe(true);
+  });
+
+  it('rejeita envelope sem campos', () => {
+    expect(isPagedRoutesResponse(null)).toBe(false);
+    expect(isPagedRoutesResponse({ data: [] })).toBe(false);
+    expect(isPagedRoutesResponse({ data: [], page: '1', pageSize: 20, total: 0 })).toBe(false);
+  });
+
+  it('rejeita data com itens inválidos', () => {
+    expect(isPagedRoutesResponse(makePaged([{ broken: true } as unknown as RouteDto]))).toBe(false);
+  });
+});
+
+describe('listRoutes', () => {
+  it('emite GET com systemId obrigatório e omite defaults', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePaged([makeRouteDto()]));
+
+    await listRoutes({ systemId: SYS_ID }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe(`/systems/routes?systemId=${SYS_ID}`);
+  });
+
+  it('serializa q (após trim), page, pageSize, includeDeleted quando diferentes do default', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listRoutes(
+      {
+        systemId: SYS_ID,
+        q: '  auth  ',
+        page: 2,
+        pageSize: 50,
+        includeDeleted: true,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const path = client.get.mock.calls[0][0] as string;
+    expect(path).toContain(`systemId=${SYS_ID}`);
+    expect(path).toContain('q=auth');
+    expect(path).toContain('page=2');
+    expect(path).toContain('pageSize=50');
+    expect(path).toContain('includeDeleted=true');
+  });
+
+  it('omite q quando vazio após trim, mas mantém systemId', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listRoutes(
+      { systemId: SYS_ID, q: '   ' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(`/systems/routes?systemId=${SYS_ID}`);
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+    const controller = new AbortController();
+
+    await listRoutes(
+      { systemId: SYS_ID },
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      listRoutes({ systemId: SYS_ID }, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    });
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 401, message: 'Sessão expirada.' };
+    client.get.mockRejectedValueOnce(apiError);
+
+    await expect(
+      listRoutes({ systemId: SYS_ID }, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+});
+
+describe('createRoute', () => {
+  it('emite POST /systems/routes com body trimado e devolve RouteDto', async () => {
+    const client = createStub();
+    const created = makeRouteDto();
+    client.post.mockResolvedValueOnce(created);
+
+    const result = await createRoute(
+      {
+        systemId: SYS_ID,
+        name: '  Listar  ',
+        code: ' AUTH_V1_X ',
+        description: '  desc  ',
+        systemTokenTypeId: TOKEN_TYPE_ID,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    const [path, body] = client.post.mock.calls[0];
+    expect(path).toBe('/systems/routes');
+    expect(body).toEqual({
+      systemId: SYS_ID,
+      name: 'Listar',
+      code: 'AUTH_V1_X',
+      description: 'desc',
+      systemTokenTypeId: TOKEN_TYPE_ID,
+    });
+    expect(result).toEqual(created);
+  });
+
+  it('omite description quando string vazia/whitespace após trim', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeRouteDto());
+
+    await createRoute(
+      {
+        systemId: SYS_ID,
+        name: 'Listar',
+        code: 'AUTH_V1_X',
+        description: '   ',
+        systemTokenTypeId: TOKEN_TYPE_ID,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][1]).toEqual({
+      systemId: SYS_ID,
+      name: 'Listar',
+      code: 'AUTH_V1_X',
+      systemTokenTypeId: TOKEN_TYPE_ID,
+    });
+  });
+
+  it('lança ApiError(parse) quando resposta não é RouteDto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      createRoute(
+        {
+          systemId: SYS_ID,
+          name: 'X',
+          code: 'X',
+          systemTokenTypeId: TOKEN_TYPE_ID,
+        },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('updateRoute', () => {
+  it('emite PUT /systems/routes/{id} com body trimado e devolve RouteDto', async () => {
+    const client = createStub();
+    const updated = makeRouteDto({ name: 'Listar (atualizado)' });
+    client.put.mockResolvedValueOnce(updated);
+
+    const result = await updateRoute(
+      ROUTE_ID,
+      {
+        systemId: SYS_ID,
+        name: '  Listar (atualizado)  ',
+        code: 'AUTH_V1_SYSTEMS_LIST',
+        systemTokenTypeId: TOKEN_TYPE_ID,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    const [path, body] = client.put.mock.calls[0];
+    expect(path).toBe(`/systems/routes/${ROUTE_ID}`);
+    expect(body).toEqual({
+      systemId: SYS_ID,
+      name: 'Listar (atualizado)',
+      code: 'AUTH_V1_SYSTEMS_LIST',
+      systemTokenTypeId: TOKEN_TYPE_ID,
+    });
+    expect(result).toEqual(updated);
+  });
+
+  it('lança ApiError(parse) quando resposta não é RouteDto', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(null);
+
+    await expect(
+      updateRoute(
+        ROUTE_ID,
+        {
+          systemId: SYS_ID,
+          name: 'X',
+          code: 'X',
+          systemTokenTypeId: TOKEN_TYPE_ID,
+        },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('deleteRoute', () => {
+  it('emite DELETE /systems/routes/{id} e resolve void', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    await expect(
+      deleteRoute(ROUTE_ID, undefined, client as unknown as ApiClient),
+    ).resolves.toBeUndefined();
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete.mock.calls[0][0]).toBe(`/systems/routes/${ROUTE_ID}`);
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 404, message: 'Route não encontrada.' };
+    client.delete.mockRejectedValueOnce(apiError);
+
+    await expect(
+      deleteRoute(ROUTE_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+});


### PR DESCRIPTION
## Contexto

Issue **#62** (parte da EPIC #46 — CRUD de Rotas por Sistema). Primeira sub-issue da EPIC, focada exclusivamente em listagem.

## Objetivo

Implementar a listagem de rotas escopada a um sistema selecionado, com tabela responsiva (cards no mobile), busca por código com debounce, paginação, toggle "Mostrar inativas" e estados de loading/erro/vazio.

## O que foi feito

- Nova rota privada `/systems/:systemId/routes`, gated por `AUTH_V1_SYSTEMS_ROUTES_LIST`.
- Página `RoutesPage`:
  - Tabela desktop com colunas **Código** (mono), **Descrição** (truncada com tooltip), **Política JWT alvo** (Badge com `systemTokenTypeName`/`Code`, ou "—" quando token type órfão), **Status** (Ativa/Inativa).
  - Cards mobile (`< 48em`) renderizando os mesmos campos com hierarquia tipográfica adaptada.
  - Busca por código com debounce de 300 ms, paginação prev/next com indicador "Página X de Y · N resultado(s)", toggle "Mostrar inativas".
  - Estados completos: loading inicial (Spinner cheio), refetch (overlay leve), erro (Alert + retry), vazio com/sem busca (mensagens dedicadas), aviso quando `:systemId` é inválido (não dispara request).
  - `aria-live` com mensagem dinâmica do estado da listagem.
- Módulo `src/shared/api/routes.ts` espelhando `systems.ts`:
  - `RouteDto`, `isRouteDto`, `isPagedRoutesResponse`, `listRoutes`, `createRoute`, `updateRoute`, `deleteRoute` (wrappers para create/update/delete já declarados para evitar PR destrutivo nas sub-issues #63/#64/#65 — lição PR #128).
- Hook compartilhado `usePaginatedFetch<T>` extraído da `SystemsPage`:
  - Encapsula loading inicial vs. refetch, cancelamento via AbortController, tratamento de `ApiError`/`AbortError`, refetch via nonce monotônico.
  - `SystemsPage` refatorada para consumir o mesmo hook — preempte duplicação Sonar (>3% New Code) entre as duas listagens.
- Roteamento:
  - `src/routes/index.tsx`: novo `<Route path="/systems/:systemId/routes">` montando `<RoutesPage>` sob `RequirePermission`.
  - `src/routes/routeCodes.ts`: pattern `/systems/:id/routes` antes de `/systems` para que `matchPath` resolva o code correto (`AUTH_V1_SYSTEMS_ROUTES_LIST`); placeholder `/routes` continua no AppRoutes mas removido da tabela de codes (nota explicativa no comentário).
  - `src/layouts/AppLayout.tsx`: novo título "Rotas" para `/systems/:systemId/routes` (também antes de `/systems`).

## Arquivos impactados

- `src/shared/api/routes.ts` (novo — DTOs/type guards/wrappers)
- `src/shared/api/index.ts` (exports)
- `src/pages/RoutesPage.tsx` (novo)
- `src/pages/SystemsPage.tsx` (refatorado para usar `usePaginatedFetch`)
- `src/hooks/usePaginatedFetch.ts` (novo — extraído da SystemsPage)
- `src/routes/index.tsx` (nova rota privada)
- `src/routes/routeCodes.ts` (pattern `/systems/:id/routes`)
- `src/layouts/AppLayout.tsx` (título da Topbar)
- `tests/shared/api/routes.test.ts` (novo)
- `tests/pages/RoutesPage.test.tsx` (novo)
- `tests/pages/__helpers__/routesTestHelpers.tsx` (novo)
- `tests/hooks/usePaginatedFetch.test.tsx` (novo)
- `tests/routes/routeCodes.test.ts` (atualizado com o novo pattern)

## Testes

- 449/449 testes passando via container Docker (`docker compose exec web npm test -- --run`).
- Novos testes:
  - `routes.test.ts` (22) — cobre type guards, querystring, wrappers create/update/delete, propagação de erro.
  - `RoutesPage.test.tsx` (22) — render inicial, busca debounced, paginação, toggle, vazio (com/sem busca), erro, cancelamento, `:systemId` inválido.
  - `usePaginatedFetch.test.tsx` (10) — primeiro fetch, refetch, cancelamento por mudança de fetcher, fallback de erro, skip.
- Lint zero warnings: `npm run lint`.
- Typecheck limpo: `npx tsc --noEmit`.
- Build OK: `npm run build`.

## Visual

- Cores via tokens do design system (`--bg-surface`, `--accent`, `--danger`, etc.); zero hardcode.
- Hover/focus tratados em todos os elementos interativos (BackLink, RouteCard, Buttons herdando do design system).
- Loading (Spinner cheio + overlay leve), erro (Alert + retry), vazio (mensagem dedicada com botão "Limpar busca" quando há termo).
- Responsivo: tabela desktop em `≥ 48em`, cards mobile abaixo. Breakpoint espelha o resto do shell.
- `aria-live` polite para anunciar estado da listagem; `caption` acessível na tabela; `role="list"`/`listitem` nos cards mobile.

## Segurança

- Nada de `dangerouslySetInnerHTML` ou `eval`. Todos os campos do `RouteDto` são strings serializadas pelo backend e renderizadas como texto.
- O `:systemId` lido de `useParams` é repassado para `listRoutes` que coloca no header `X-System-Id`/querystring; backend é fonte autoritativa de validação.
- Heurística client-side `isProbablyValidSystemId` filtra somente vazios/whitespace antes de bater no backend (validação real fica no backend).

## Riscos

- **Mudança no contrato de `routeCodes.ts`:** o placeholder `/routes` agora não dispara `verify-token` (nota no código). Não compromete a sessão — `RequirePermission` continua client-side. A página real `/systems/:id/routes` faz `verify-token` corretamente com o code novo.
- **Refatoração da `SystemsPage`:** o ciclo de fetch foi movido para `usePaginatedFetch`. Comportamento preservado e todos os testes da EPIC #45 continuam passando (5 suítes — listagem/criar/editar/desativar/restaurar/stats — todas verdes). Risco baixo, mas vale destacar para o reviewer.

## Issue relacionada

Closes #62