### PR TITLE
feat(routes): desativar rota (#65)

### DIFF
--- a/src/pages/RoutesPage.tsx
+++ b/src/pages/RoutesPage.tsx
@@ -6,29 +6,39 @@ import {
   Plus,
   RotateCcw,
   Search,
-} from 'lucide-react';
-import React, { useCallback, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import styled from 'styled-components';
+  Trash2,
+} from "lucide-react";
+import React, { useCallback, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import styled from "styled-components";
 
-import { PageHeader } from '../components/layout/PageHeader';
-import { Alert, Badge, Button, Input, Spinner, Switch, Table } from '../components/ui';
-import { useDebouncedValue } from '../hooks/useDebouncedValue';
-import { usePaginatedFetch } from '../hooks/usePaginatedFetch';
-import { usePaginationControls } from '../hooks/usePaginationControls';
+import { PageHeader } from "../components/layout/PageHeader";
+import {
+  Alert,
+  Badge,
+  Button,
+  Input,
+  Spinner,
+  Switch,
+  Table,
+} from "../components/ui";
+import { useDebouncedValue } from "../hooks/useDebouncedValue";
+import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
+import { usePaginationControls } from "../hooks/usePaginationControls";
 import {
   DEFAULT_ROUTES_INCLUDE_DELETED,
   DEFAULT_ROUTES_PAGE,
   DEFAULT_ROUTES_PAGE_SIZE,
   listRoutes,
-} from '../shared/api';
-import { useAuth } from '../shared/auth';
+} from "../shared/api";
+import { useAuth } from "../shared/auth";
 
-import { EditRouteModal } from './routes/EditRouteModal';
-import { NewRouteModal } from './routes/NewRouteModal';
+import { DeleteRouteConfirm } from "./routes/DeleteRouteConfirm";
+import { EditRouteModal } from "./routes/EditRouteModal";
+import { NewRouteModal } from "./routes/NewRouteModal";
 
-import type { TableColumn } from '../components/ui';
-import type { ApiClient, RouteDto, SafeRequestOptions } from '../shared/api';
+import type { TableColumn } from "../components/ui";
+import type { ApiClient, RouteDto, SafeRequestOptions } from "../shared/api";
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
@@ -51,7 +61,7 @@ const SEARCH_DEBOUNCE_MS = 300;
  * gating client-side é apenas UX — esconder ações que o usuário não
  * pode executar.
  */
-const ROUTES_CREATE_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_CREATE';
+const ROUTES_CREATE_PERMISSION = "AUTH_V1_SYSTEMS_ROUTES_CREATE";
 
 /**
  * Code de permissão exigido para o botão "Editar" por linha (Issue #64).
@@ -63,7 +73,24 @@ const ROUTES_CREATE_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_CREATE';
  * gating client-side é apenas UX — esconder ações que o usuário não
  * pode executar.
  */
-const ROUTES_UPDATE_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_UPDATE';
+const ROUTES_UPDATE_PERMISSION = "AUTH_V1_SYSTEMS_ROUTES_UPDATE";
+
+/**
+ * Code de permissão exigido para o botão "Desativar" por linha
+ * (Issue #65, última sub-issue da EPIC #46).
+ *
+ * Espelha o `AUTH_V1_SYSTEMS_ROUTES_DELETE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`DELETE /systems/routes/{id}` valida via
+ * `[Authorize(Policy = PermissionPolicies.SystemsRoutesDelete)]`); o
+ * gating client-side é apenas UX — esconder ações que o usuário não
+ * pode executar.
+ *
+ * Sobre **soft vs hard delete**: o controller faz soft (seta
+ * `DeletedAt = UtcNow` e responde 204). A copy do botão e do diálogo
+ * usa "Desativar/Inativa" para manter paridade com Sistemas (#60).
+ */
+const ROUTES_DELETE_PERMISSION = "AUTH_V1_SYSTEMS_ROUTES_DELETE";
 
 interface RoutesPageProps {
   /**
@@ -383,7 +410,7 @@ const InvalidIdNotice = styled.div`
  * UI; o backend é a fonte de verdade.
  */
 function isProbablyValidSystemId(value: string | undefined): value is string {
-  return typeof value === 'string' && value.trim().length > 0;
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 /**
@@ -419,7 +446,9 @@ function renderDescription(row: RouteDto): React.ReactNode {
   if (row.description === null || row.description.trim().length === 0) {
     return <Placeholder>—</Placeholder>;
   }
-  return <DescriptionCell title={row.description}>{row.description}</DescriptionCell>;
+  return (
+    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
+  );
 }
 
 /* ─── Component ──────────────────────────────────────────── */
@@ -436,9 +465,10 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   const { hasPermission } = useAuth();
   const canCreateRoute = hasPermission(ROUTES_CREATE_PERMISSION);
   const canUpdateRoute = hasPermission(ROUTES_UPDATE_PERMISSION);
+  const canDeleteRoute = hasPermission(ROUTES_DELETE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [searchTerm, setSearchTerm] = useState<string>("");
   const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
 
   const [includeDeleted, setIncludeDeleted] = useState<boolean>(
@@ -460,6 +490,13 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   // referenciado.
   const [editingRoute, setEditingRoute] = useState<RouteDto | null>(null);
 
+  // Rota selecionada para soft-delete (Issue #65). Quando definida, abre
+  // o `DeleteRouteConfirm` com o `name`/`code` na descrição; `null`
+  // mantém o modal fechado. Mesma estratégia do `editingRoute` — manter
+  // o objeto completo permite ao diálogo exibir copy contextualizada
+  // sem refetch.
+  const [deletingRoute, setDeletingRoute] = useState<RouteDto | null>(null);
+
   const handleOpenCreateModal = useCallback(() => {
     setIsCreateModalOpen(true);
   }, []);
@@ -476,6 +513,14 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
     setEditingRoute(null);
   }, []);
 
+  const handleOpenDeleteConfirm = useCallback((row: RouteDto) => {
+    setDeletingRoute(row);
+  }, []);
+
+  const handleCloseDeleteConfirm = useCallback(() => {
+    setDeletingRoute(null);
+  }, []);
+
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
    * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
@@ -488,7 +533,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   }, []);
 
   const handleClearSearch = useCallback(() => {
-    setSearchTerm('');
+    setSearchTerm("");
     setPage(DEFAULT_ROUTES_PAGE);
   }, []);
 
@@ -511,7 +556,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
     (options: SafeRequestOptions) =>
       listRoutes(
         {
-          systemId: hasValidSystemId ? systemId : '',
+          systemId: hasValidSystemId ? systemId : "",
           q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
           page,
           pageSize: DEFAULT_ROUTES_PAGE_SIZE,
@@ -520,7 +565,14 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
         options,
         client,
       ),
-    [client, hasValidSystemId, includeDeleted, page, systemId, trimmedSearchInput],
+    [
+      client,
+      hasValidSystemId,
+      includeDeleted,
+      page,
+      systemId,
+      trimmedSearchInput,
+    ],
   );
 
   const {
@@ -533,7 +585,8 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
     refetch: handleRefetch,
   } = usePaginatedFetch<RouteDto>({
     fetcher,
-    fallbackErrorMessage: 'Falha ao carregar a lista de rotas. Tente novamente.',
+    fallbackErrorMessage:
+      "Falha ao carregar a lista de rotas. Tente novamente.",
     skip: !hasValidSystemId,
   });
 
@@ -541,14 +594,19 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   // (lição PR #134 — bloco de 28 linhas duplicado com `SystemsPage`
   // reprovou o SonarCloud Quality Gate). Mesma semântica do bloco
   // inline original, com a única cópia agora em `src/hooks/`.
-  const { totalPages, isFirstPage, isLastPage, handlePrevPage, handleNextPage } =
-    usePaginationControls({
-      total,
-      appliedPageSize,
-      defaultPageSize: DEFAULT_ROUTES_PAGE_SIZE,
-      page,
-      setPage,
-    });
+  const {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+  } = usePaginationControls({
+    total,
+    appliedPageSize,
+    defaultPageSize: DEFAULT_ROUTES_PAGE_SIZE,
+    page,
+    setPage,
+  });
 
   const trimmedSearch = debouncedSearch.trim();
   const hasActiveSearch = trimmedSearch.length > 0;
@@ -583,7 +641,8 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
         <EmptyTitle>Nenhuma rota cadastrada para este sistema.</EmptyTitle>
         {!includeDeleted && (
           <EmptyHint>
-            Rotas removidas podem ser visualizadas ativando &quot;Mostrar inativas&quot;.
+            Rotas removidas podem ser visualizadas ativando &quot;Mostrar
+            inativas&quot;.
           </EmptyHint>
         )}
       </EmptyMessage>
@@ -593,25 +652,25 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   const columns = useMemo<ReadonlyArray<TableColumn<RouteDto>>>(() => {
     const base: Array<TableColumn<RouteDto>> = [
       {
-        key: 'code',
-        label: 'Código',
+        key: "code",
+        label: "Código",
         render: (row) => <Mono>{row.code}</Mono>,
       },
       {
-        key: 'description',
-        label: 'Descrição',
+        key: "description",
+        label: "Descrição",
         render: renderDescription,
       },
       {
-        key: 'tokenPolicy',
-        label: 'Política JWT alvo',
-        width: '200px',
+        key: "tokenPolicy",
+        label: "Política JWT alvo",
+        width: "200px",
         render: renderTokenPolicy,
       },
       {
-        key: 'status',
-        label: 'Status',
-        width: '120px',
+        key: "status",
+        label: "Status",
+        width: "120px",
         render: (row) =>
           row.deletedAt ? (
             <Badge variant="danger" dot>
@@ -626,13 +685,15 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
     ];
 
     // Coluna "Ações" só aparece quando o usuário tem alguma ação
-    // disponível. Hoje só "Editar" (Issue #64); a #65 vai adicionar
-    // "Desativar"/"Restaurar". Cada botão tem seu próprio gating
-    // individual + check por linha quando aplicável (`row.deletedAt`).
-    if (canUpdateRoute) {
+    // disponível. Hoje "Editar" (Issue #64) e "Desativar" (Issue #65);
+    // a paridade total com Sistemas (restore, #61) fica para uma issue
+    // futura quando a UI de "Restaurar rota" for priorizada. Cada botão
+    // tem seu próprio gating individual + check por linha quando
+    // aplicável (`row.deletedAt`).
+    if (canUpdateRoute || canDeleteRoute) {
       base.push({
-        key: 'actions',
-        label: 'Ações',
+        key: "actions",
+        label: "Ações",
         isActions: true,
         render: (row) => (
           <RowActions>
@@ -653,13 +714,36 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
                 Editar
               </Button>
             )}
+            {canDeleteRoute && row.deletedAt === null && (
+              // "Desativar" só aparece em rotas ativas — o backend
+              // devolve 404 ao tentar DELETE em rota já soft-deletada
+              // (`Routes.FirstOrDefaultAsync` cai no query filter
+              // global), mas esconder no UI alinha com a coluna
+              // Status. Espelha a estratégia do botão "Desativar" em
+              // `SystemsPage`.
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Trash2 size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenDeleteConfirm(row)}
+                aria-label={`Desativar rota ${row.name}`}
+                data-testid={`routes-delete-${row.id}`}
+              >
+                Desativar
+              </Button>
+            )}
           </RowActions>
         ),
       });
     }
 
     return base;
-  }, [canUpdateRoute, handleOpenEditModal]);
+  }, [
+    canDeleteRoute,
+    canUpdateRoute,
+    handleOpenDeleteConfirm,
+    handleOpenEditModal,
+  ]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -667,13 +751,13 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
   // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
   // total. Em erro, o `<Alert role="alert">` já cobre.
   const liveMessage = useMemo<string>(() => {
-    if (isInitialLoading) return 'Carregando lista de rotas.';
-    if (isFetching) return 'Atualizando lista de rotas.';
-    if (errorMessage) return '';
+    if (isInitialLoading) return "Carregando lista de rotas.";
+    if (isFetching) return "Atualizando lista de rotas.";
+    if (errorMessage) return "";
     if (total === 0) {
       return hasActiveSearch
         ? `Nenhuma rota encontrada para ${trimmedSearch}.`
-        : 'Nenhuma rota cadastrada para este sistema.';
+        : "Nenhuma rota cadastrada para este sistema.";
     }
     return `${total} rota(s) encontrada(s). Página ${page} de ${totalPages}.`;
   }, [
@@ -760,14 +844,14 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
         aria-live="polite"
         aria-atomic="true"
         style={{
-          position: 'absolute',
+          position: "absolute",
           width: 1,
           height: 1,
           padding: 0,
           margin: -1,
-          overflow: 'hidden',
-          clip: 'rect(0, 0, 0, 0)',
-          whiteSpace: 'nowrap',
+          overflow: "hidden",
+          clip: "rect(0, 0, 0, 0)",
+          whiteSpace: "nowrap",
           border: 0,
         }}
         data-testid="routes-live"
@@ -833,30 +917,46 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
                   )}
                 </CardHeader>
                 <CardName>{row.name}</CardName>
-                {row.description !== null && row.description.trim().length > 0 && (
-                  <CardDescription>{row.description}</CardDescription>
-                )}
+                {row.description !== null &&
+                  row.description.trim().length > 0 && (
+                    <CardDescription>{row.description}</CardDescription>
+                  )}
                 <CardMeta>
                   <CardMetaTerm>JWT</CardMetaTerm>
                   <CardMetaValue>{renderTokenPolicy(row)}</CardMetaValue>
                 </CardMeta>
-                {canUpdateRoute && row.deletedAt === null && (
-                  // Ações na versão mobile espelham a coluna "Ações" do
-                  // desktop. Só aparecem quando o usuário tem permissão
-                  // e a linha é ativa — coerente com o gating da tabela.
-                  <RowActions>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      icon={<Pencil size={14} strokeWidth={1.5} />}
-                      onClick={() => handleOpenEditModal(row)}
-                      aria-label={`Editar rota ${row.name}`}
-                      data-testid={`routes-card-edit-${row.id}`}
-                    >
-                      Editar
-                    </Button>
-                  </RowActions>
-                )}
+                {(canUpdateRoute || canDeleteRoute) &&
+                  row.deletedAt === null && (
+                    // Ações na versão mobile espelham a coluna "Ações" do
+                    // desktop. Só aparecem quando o usuário tem permissão
+                    // e a linha é ativa — coerente com o gating da tabela.
+                    <RowActions>
+                      {canUpdateRoute && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          icon={<Pencil size={14} strokeWidth={1.5} />}
+                          onClick={() => handleOpenEditModal(row)}
+                          aria-label={`Editar rota ${row.name}`}
+                          data-testid={`routes-card-edit-${row.id}`}
+                        >
+                          Editar
+                        </Button>
+                      )}
+                      {canDeleteRoute && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          icon={<Trash2 size={14} strokeWidth={1.5} />}
+                          onClick={() => handleOpenDeleteConfirm(row)}
+                          aria-label={`Desativar rota ${row.name}`}
+                          data-testid={`routes-card-delete-${row.id}`}
+                        >
+                          Desativar
+                        </Button>
+                      )}
+                    </RowActions>
+                  )}
               </RouteCard>
             ))}
           </CardListForMobile>
@@ -916,6 +1016,16 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
           route={editingRoute}
           onClose={handleCloseEditModal}
           onUpdated={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canDeleteRoute && (
+        <DeleteRouteConfirm
+          open={deletingRoute !== null}
+          route={deletingRoute}
+          onClose={handleCloseDeleteConfirm}
+          onDeleted={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/routes/DeleteRouteConfirm.tsx
+++ b/src/pages/routes/DeleteRouteConfirm.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+
+import { deleteRoute } from "../../shared/api";
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from "../systems/MutationConfirmModal";
+
+import type { ApiClient, RouteDto } from "../../shared/api";
+
+/**
+ * Copy do diálogo de confirmação para soft-delete de rota (Issue #65,
+ * última sub-issue da EPIC #46 — fecha o CRUD completo de rotas).
+ *
+ * O backend (`RoutesController.DeleteById`) faz **soft-delete**: seta
+ * `DeletedAt = UtcNow` e responde `204 No Content`. Por isso a copy usa
+ * "desativar" em vez de "excluir" — espelha o vocabulário consagrado em
+ * Sistemas (#60). Restaurar é endpoint cooperativo
+ * (`POST /systems/routes/{id}/restore`) e fica para uma issue futura
+ * que feche a paridade com `RestoreSystemConfirm` (#61).
+ *
+ * O slot `errorCopy.conflictMessage` está preenchido porque o backend
+ * **bloqueia o delete com 409** quando há `Permissions` ativas
+ * vinculadas à rota — `RoutesController.DeleteBlockedByPermissionsMessage`
+ * é a copy estável devolvida pelo controller. O `classifyMutationError`
+ * usa o `error.message` quando presente (mensagem do backend) e cai no
+ * `conflictMessage` apenas se o backend não enviar nenhuma — manter o
+ * slot tipado garante que o switch encontre um branch `conflict` mesmo
+ * sem mensagem do servidor (defensive default).
+ */
+const DELETE_COPY: MutationConfirmCopy = {
+  title: "Desativar rota?",
+  descriptionPrefix: "A rota ",
+  descriptionSuffix:
+    ' será desativada e sumirá da listagem padrão. Você poderá restaurá-la depois ativando "Mostrar inativas".',
+  confirmLabel: "Desativar",
+  successMessage: "Rota desativada.",
+  errorCopy: {
+    forbiddenTitle: "Falha ao desativar rota",
+    genericFallback: "Não foi possível desativar a rota. Tente novamente.",
+    notFoundMessage: "Rota não encontrada ou foi removida. Atualize a lista.",
+    conflictMessage:
+      "Esta rota está vinculada a permissões ativas. Remova os vínculos antes de desativá-la.",
+  },
+};
+
+/**
+ * Função adapter `(route, client?) => Promise<void>` que delega para
+ * `deleteRoute(route.id, undefined, client)`. Mantemos a função fora do
+ * componente para não recriá-la a cada render — o `MutationConfirmModal`
+ * usa `mutate` em `useCallback`, então uma referência estável evita
+ * invalidação desnecessária. Espelha `performDelete` em
+ * `DeleteSystemConfirm`.
+ */
+function performDelete(route: RouteDto, client?: ApiClient): Promise<void> {
+  return deleteRoute(route.id, undefined, client);
+}
+
+interface DeleteRouteConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Rota selecionada para soft-delete. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `route`.
+   * Mantemos o objeto completo (não só `id`) para que a copy exiba
+   * `name`/`code` sem precisar de re-fetch.
+   */
+  route: RouteDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após desativação bem-sucedida ou após detecção
+   * de 404 (rota foi removida em paralelo ou nunca existiu) — em ambos
+   * casos a UI quer refetch para sincronizar a tabela com o estado real
+   * do backend.
+   */
+  onDeleted: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `deleteRoute` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para soft-delete de rota (Issue #65, última
+ * sub-issue da EPIC #46).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (extraído na #61 e
+ * generalizado na #65) — toda a estrutura visual + lógica de submissão/
+ * erro vive no shell compartilhado. Aqui só injetamos:
+ *
+ * - **Copy** (`DELETE_COPY`): título, descrição, label do botão,
+ *   mensagens de toast e a copy de 409 (mensagem de bloqueio por
+ *   permissões vinculadas vinda do backend).
+ * - **Mutate** (`performDelete`): adapta `deleteRoute(id)` para a
+ *   assinatura `(route, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`danger`): destaca o caráter destrutivo. Já existe no
+ *   design system local (`Button.tsx`); não precisamos hardcodar cor.
+ * - **`testIdPrefix`** (`delete-route`): identifica os elementos do
+ *   modal nas suítes de teste sem colidir com `delete-system`.
+ *
+ * O `MutationConfirmModal` cuida de:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #65): o botão só
+ *   dispara `DELETE` após clique explícito. O foco vai para o botão
+ *   Cancelar (ordem do DOM) — Enter acidental fecha sem destruir.
+ * - **Cancelar/Esc/backdrop fecham sem persistir** (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
+ *   `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError` em
+ *   `systemFormShared.ts`:
+ *
+ *   - `204` → fecha modal + toast verde + refetch.
+ *   - `404` → fecha modal + toast vermelho informativo + refetch (rota
+ *     removida em paralelo ou nunca existiu).
+ *   - `409` → toast vermelho com a **mensagem do backend**
+ *     (`DeleteBlockedByPermissionsMessage` — `"Não é possível excluir a
+ *     rota: existem permissões ativas vinculadas. Remova as permissões
+ *     antes."`); modal permanece aberto para o usuário entender o
+ *     bloqueio. Esse caminho é o critério de aceite "tratamento de
+ *     erro caso a rota tenha vínculos".
+ *   - `401`/`403` → toast vermelho com mensagem do backend.
+ *   - Network/parse/5xx → toast vermelho com fallback genérico.
+ *
+ * Sobre **hard vs soft delete**: o controller faz soft (`DeletedAt =
+ * UtcNow`) — o vocabulário "Desativar/Inativa" mantém paridade com
+ * Sistemas (#60). O endpoint `POST /systems/routes/{id}/restore` já
+ * existe no backend mas a UI de restore é uma issue futura (não está
+ * no escopo da #65).
+ */
+export const DeleteRouteConfirm: React.FC<DeleteRouteConfirmProps> = ({
+  open,
+  route,
+  onClose,
+  onDeleted,
+  client,
+}) => (
+  <MutationConfirmModal<RouteDto>
+    open={open}
+    target={route}
+    onClose={onClose}
+    onSuccess={onDeleted}
+    client={client}
+    mutate={performDelete}
+    copy={DELETE_COPY}
+    confirmVariant="danger"
+    testIdPrefix="delete-route"
+  />
+);

--- a/src/pages/systems/DeleteSystemConfirm.tsx
+++ b/src/pages/systems/DeleteSystemConfirm.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 
-import { deleteSystem } from '../../shared/api';
+import { deleteSystem } from "../../shared/api";
 
 import {
   MutationConfirmModal,
   type MutationConfirmCopy,
-} from './MutationConfirmModal';
+} from "./MutationConfirmModal";
 
-import type { ApiClient, SystemDto } from '../../shared/api';
+import type { ApiClient, SystemDto } from "../../shared/api";
 
 /**
  * Copy do diálogo de confirmação para soft-delete (Issue #60). O slot
@@ -19,16 +19,17 @@ import type { ApiClient, SystemDto } from '../../shared/api';
  * PR #128).
  */
 const DELETE_COPY: MutationConfirmCopy = {
-  title: 'Desativar sistema?',
-  descriptionPrefix: 'O sistema ',
+  title: "Desativar sistema?",
+  descriptionPrefix: "O sistema ",
   descriptionSuffix:
     ' será desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando "Mostrar inativos".',
-  confirmLabel: 'Desativar',
-  successMessage: 'Sistema desativado.',
+  confirmLabel: "Desativar",
+  successMessage: "Sistema desativado.",
   errorCopy: {
-    forbiddenTitle: 'Falha ao desativar sistema',
-    genericFallback: 'Não foi possível desativar o sistema. Tente novamente.',
-    notFoundMessage: 'Sistema não encontrado ou foi removido. Atualize a lista.',
+    forbiddenTitle: "Falha ao desativar sistema",
+    genericFallback: "Não foi possível desativar o sistema. Tente novamente.",
+    notFoundMessage:
+      "Sistema não encontrado ou foi removido. Atualize a lista.",
   },
 };
 
@@ -109,9 +110,9 @@ export const DeleteSystemConfirm: React.FC<DeleteSystemConfirmProps> = ({
   onDeleted,
   client,
 }) => (
-  <MutationConfirmModal
+  <MutationConfirmModal<SystemDto>
     open={open}
-    system={system}
+    target={system}
     onClose={onClose}
     onSuccess={onDeleted}
     client={client}

--- a/src/pages/systems/MutationConfirmModal.tsx
+++ b/src/pages/systems/MutationConfirmModal.tsx
@@ -1,21 +1,46 @@
-import React, { useCallback, useState } from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useState } from "react";
+import styled from "styled-components";
 
-import { Button, Modal, useToast } from '../../components/ui';
+import { Button, Modal, useToast } from "../../components/ui";
 
 import {
   classifyMutationError,
   type MutationErrorCopy,
-} from './systemFormShared';
+} from "./systemFormShared";
 
-import type { ButtonVariant } from '../../components/ui';
-import type { ApiClient, SystemDto } from '../../shared/api';
+import type { ButtonVariant } from "../../components/ui";
+import type { ApiClient } from "../../shared/api";
+
+/**
+ * Shape mínimo exigido para um item alvo de mutação simples — qualquer
+ * DTO com `name` (label legível) e `code` (identificador estável)
+ * encaixa. Generaliza o componente para servir `SystemDto` (Issues
+ * #60/#61) e `RouteDto` (Issue #65) sem duplicar o shell visual entre
+ * `pages/systems/` e `pages/routes/` (lição PR #128 — qualquer trecho
+ * de 10+ linhas em 2+ arquivos vira `New Code Duplication` no Sonar).
+ *
+ * O renderer só consome `name`/`code` para a frase do diálogo; o
+ * caller injeta a função `mutate(target, client?)` sabendo qual `id`
+ * extrair internamente.
+ */
+export interface MutationTarget {
+  /** Texto visível em destaque na descrição do diálogo. */
+  name: string;
+  /**
+   * Identificador curto, exibido em monoespaçado entre parênteses.
+   * Ex.: `'AUTH'` (sistema), `'AUTH_V1_SYSTEMS_ROUTES_LIST'` (rota).
+   */
+  code: string;
+}
 
 /**
  * Componente compartilhado para diálogos de confirmação de mutações
- * simples (sem corpo de form) sobre um `SystemDto` — extraído na Issue
- * #61 a partir do `DeleteSystemConfirm` (#60) para evitar duplicação de
- * blocos ≥10 linhas com o `RestoreSystemConfirm`.
+ * simples (sem corpo de form) sobre uma entidade `MutationTarget` —
+ * extraído na Issue #61 a partir do `DeleteSystemConfirm` (#60) para
+ * evitar duplicação de blocos ≥10 linhas com o `RestoreSystemConfirm`,
+ * e generalizado na Issue #65 para servir `RouteDto` em
+ * `DeleteRouteConfirm` (mesma 5ª recorrência da lição PR #128 evitada
+ * de novo).
  *
  * Sonar marcaria a duplicação direta como `New Code Duplication > 3%`
  * (5ª recorrência das lições PR #119/#123/#127/#128). Compartilhar o
@@ -89,16 +114,20 @@ export interface MutationConfirmCopy {
   errorCopy: MutationErrorCopy;
 }
 
-interface MutationConfirmModalProps {
+interface MutationConfirmModalProps<T extends MutationTarget> {
   /** Estado de visibilidade controlado pelo pai. */
   open: boolean;
   /**
-   * Sistema selecionado para a mutação. Quando `null`, o modal não
-   * renderiza — caller controla `open` em conjunto com `system`.
+   * Item selecionado para a mutação. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `target`.
    * Mantemos o objeto completo (não só `id`) para que a copy exiba
    * `name`/`code` sem precisar de re-fetch.
+   *
+   * Tipado por generic `T` para que o caller mantenha tipos fortes do
+   * próprio recurso (`SystemDto`/`RouteDto`/...) e o `mutate` receba
+   * o objeto certo sem cast.
    */
-  system: SystemDto | null;
+  target: T | null;
   /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
   onClose: () => void;
   /**
@@ -111,15 +140,15 @@ interface MutationConfirmModalProps {
   /**
    * Cliente HTTP injetável para isolar testes — em produção, omitido,
    * `mutate` cai no singleton `apiClient` por meio do wrapper específico
-   * (`deleteSystem`/`restoreSystem`).
+   * (`deleteSystem`/`restoreSystem`/`deleteRoute`).
    */
   client?: ApiClient;
   /**
-   * Função pura que dispara a mutação HTTP (`deleteSystem`/`restoreSystem`).
-   * O shell cuida do `isSubmitting`/toast/refetch — `mutate` só precisa
-   * lançar `ApiError` em falha e resolver em sucesso.
+   * Função pura que dispara a mutação HTTP (`deleteSystem`/`restoreSystem`/
+   * `deleteRoute`). O shell cuida do `isSubmitting`/toast/refetch —
+   * `mutate` só precisa lançar `ApiError` em falha e resolver em sucesso.
    */
-  mutate: (system: SystemDto, client?: ApiClient) => Promise<unknown>;
+  mutate: (target: T, client?: ApiClient) => Promise<unknown>;
   /** Copy textual + error copy (ver `MutationConfirmCopy`). */
   copy: MutationConfirmCopy;
   /**
@@ -129,9 +158,10 @@ interface MutationConfirmModalProps {
    */
   confirmVariant: ButtonVariant;
   /**
-   * Prefixo dos `data-testid` (ex.: `'delete-system'`, `'restore-system'`).
-   * Concatenado com `-description`/`-cancel`/`-confirm` para preservar
-   * compatibilidade com asserções legadas das suítes de teste.
+   * Prefixo dos `data-testid` (ex.: `'delete-system'`, `'restore-system'`,
+   * `'delete-route'`). Concatenado com `-description`/`-cancel`/`-confirm`
+   * para preservar compatibilidade com asserções legadas das suítes de
+   * teste.
    */
   testIdPrefix: string;
 }
@@ -179,9 +209,9 @@ const Mono = styled.span`
 
 /* ─── Component ──────────────────────────────────────────── */
 
-export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
+export function MutationConfirmModal<T extends MutationTarget>({
   open,
-  system,
+  target,
   onClose,
   onSuccess,
   client,
@@ -189,7 +219,7 @@ export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
   copy,
   confirmVariant,
   testIdPrefix,
-}) => {
+}: MutationConfirmModalProps<T>): React.ReactElement | null {
   const { show } = useToast();
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
@@ -205,13 +235,13 @@ export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
   }, [isSubmitting, onClose]);
 
   const handleConfirm = useCallback(async () => {
-    if (isSubmitting || !system) return;
+    if (isSubmitting || !target) return;
     setIsSubmitting(true);
     try {
-      await mutate(system, client);
+      await mutate(target, client);
       // Mensagem fixa — o usuário acabou de selecionar e a lista será
       // atualizada. Toast verde sinaliza sucesso visual além do close.
-      show(copy.successMessage, { variant: 'success' });
+      show(copy.successMessage, { variant: "success" });
       // Ordem importa: refetch antes de fechar para o pai não ter que
       // coordenar dois ticks separados (mesmo padrão dos demais modals).
       onSuccess();
@@ -223,36 +253,36 @@ export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
       // compartilhado entre delete (#60) e restore (#61) — lição PR #128.
       const action = classifyMutationError(error, copy.errorCopy);
       switch (action.kind) {
-        case 'not-found':
+        case "not-found":
           // Item removido/já mutado entre abertura e confirm. Fecha
           // modal + toast + refetch (paridade com o tratamento de 404
           // no edit).
-          show(action.message, { variant: 'danger', title: action.title });
+          show(action.message, { variant: "danger", title: action.title });
           onSuccess();
           onClose();
           break;
-        case 'toast':
-          show(action.message, { variant: 'danger', title: action.title });
+        case "toast":
+          show(action.message, { variant: "danger", title: action.title });
           break;
-        case 'conflict':
+        case "conflict":
           // Relevante para o restore quando o backend evoluir para
           // devolver 409 ("já está ativo"). Hoje o backend devolve
           // 404 nesse caminho, mas o branch fica preparado.
-          show(action.message, { variant: 'danger', title: action.title });
+          show(action.message, { variant: "danger", title: action.title });
           break;
-        case 'unhandled':
-          show(action.fallback, { variant: 'danger', title: action.title });
+        case "unhandled":
+          show(action.fallback, { variant: "danger", title: action.title });
           break;
       }
     } finally {
       setIsSubmitting(false);
     }
-  }, [client, copy, isSubmitting, mutate, onClose, onSuccess, show, system]);
+  }, [client, copy, isSubmitting, mutate, onClose, onSuccess, show, target]);
 
-  // Defensive guard: pai controla `open` em conjunto com `system`, mas
-  // cobrimos o caso `open=true && system=null` para não tentar
+  // Defensive guard: pai controla `open` em conjunto com `target`, mas
+  // cobrimos o caso `open=true && target=null` para não tentar
   // `mutate(null)`.
-  if (!system) {
+  if (!target) {
     return null;
   }
 
@@ -267,7 +297,7 @@ export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
       <ConfirmBody>
         <ConfirmText data-testid={`${testIdPrefix}-description`}>
           {copy.descriptionPrefix}
-          <strong>{system.name}</strong> (<Mono>{system.code}</Mono>)
+          <strong>{target.name}</strong> (<Mono>{target.code}</Mono>)
           {copy.descriptionSuffix}
         </ConfirmText>
         <ActionsBar>
@@ -295,4 +325,4 @@ export const MutationConfirmModal: React.FC<MutationConfirmModalProps> = ({
       </ConfirmBody>
     </Modal>
   );
-};
+}

--- a/src/pages/systems/RestoreSystemConfirm.tsx
+++ b/src/pages/systems/RestoreSystemConfirm.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React from "react";
 
-import { restoreSystem } from '../../shared/api';
+import { restoreSystem } from "../../shared/api";
 
 import {
   MutationConfirmModal,
   type MutationConfirmCopy,
-} from './MutationConfirmModal';
+} from "./MutationConfirmModal";
 
-import type { ApiClient, SystemDto } from '../../shared/api';
+import type { ApiClient, SystemDto } from "../../shared/api";
 
 /**
  * Copy do diálogo de confirmação para restauração (Issue #61, última
@@ -22,16 +22,16 @@ import type { ApiClient, SystemDto } from '../../shared/api';
  * compartilhado é mais barato do que abrir um PR adicional.
  */
 const RESTORE_COPY: MutationConfirmCopy = {
-  title: 'Restaurar sistema?',
-  descriptionPrefix: 'O sistema ',
-  descriptionSuffix: ' voltará a aparecer na listagem padrão.',
-  confirmLabel: 'Restaurar',
-  successMessage: 'Sistema restaurado.',
+  title: "Restaurar sistema?",
+  descriptionPrefix: "O sistema ",
+  descriptionSuffix: " voltará a aparecer na listagem padrão.",
+  confirmLabel: "Restaurar",
+  successMessage: "Sistema restaurado.",
   errorCopy: {
-    forbiddenTitle: 'Falha ao restaurar sistema',
-    genericFallback: 'Não foi possível restaurar o sistema. Tente novamente.',
-    notFoundMessage: 'Sistema não encontrado ou já está ativo.',
-    conflictMessage: 'O sistema já está ativo.',
+    forbiddenTitle: "Falha ao restaurar sistema",
+    genericFallback: "Não foi possível restaurar o sistema. Tente novamente.",
+    notFoundMessage: "Sistema não encontrado ou já está ativo.",
+    conflictMessage: "O sistema já está ativo.",
   },
 };
 
@@ -118,9 +118,9 @@ export const RestoreSystemConfirm: React.FC<RestoreSystemConfirmProps> = ({
   onRestored,
   client,
 }) => (
-  <MutationConfirmModal
+  <MutationConfirmModal<SystemDto>
     open={open}
-    system={system}
+    target={system}
     onClose={onClose}
     onSuccess={onRestored}
     client={client}

--- a/tests/pages/RoutesPage.delete.test.tsx
+++ b/tests/pages/RoutesPage.delete.test.tsx
@@ -1,0 +1,364 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildAuthMock } from "./__helpers__/mockUseAuth";
+import {
+  buildRoutesCloseCases,
+  buildSharedRouteMutationErrorCases,
+  confirmDeleteRoute,
+  createRoutesClientStub,
+  ID_ROUTE_LEGACY,
+  ID_ROUTE_LIST,
+  makePagedRoutes,
+  makeRoute,
+  openDeleteRouteConfirm,
+  renderRoutesPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from "./__helpers__/routesTestHelpers";
+
+import type { RoutesErrorCase } from "./__helpers__/routesTestHelpers";
+import type { ApiError } from "@/shared/api";
+
+/**
+ * Mock controlável de `useAuth` — cada teste seta `permissionsMock`
+ * antes de renderizar a página para simular usuário com/sem permissão
+ * `AUTH_V1_SYSTEMS_ROUTES_DELETE`. Reusa `buildAuthMock` (helper
+ * compartilhado com listagem/criação/edição).
+ *
+ * Issue #65 — soft-delete via `DELETE /systems/routes/{id}` + modal de
+ * confirmação (`DeleteRouteConfirm`). Última sub-issue da EPIC #46.
+ */
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock("@/shared/auth", () => buildAuthMock(() => permissionsMock));
+
+const ROUTES_DELETE_PERMISSION = "AUTH_V1_SYSTEMS_ROUTES_DELETE";
+const ROUTES_UPDATE_PERMISSION = "AUTH_V1_SYSTEMS_ROUTES_UPDATE";
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = "";
+});
+
+describe("RoutesPage — desativar (Issue #65)", () => {
+  describe('gating do botão "Desativar" por linha', () => {
+    it('não exibe botões "Desativar" quando o usuário não possui AUTH_V1_SYSTEMS_ROUTES_DELETE', async () => {
+      permissionsMock = [];
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedRoutes([makeRoute({ id: ID_ROUTE_LIST })]),
+      );
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`routes-delete-${ID_ROUTE_LIST}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe um botão "Desativar" para cada linha ativa quando o usuário possui AUTH_V1_SYSTEMS_ROUTES_DELETE', async () => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedRoutes([
+          makeRoute({
+            id: ID_ROUTE_LIST,
+            name: "Listar",
+            code: "AUTH_V1_LIST",
+          }),
+          makeRoute({
+            id: ID_ROUTE_LEGACY,
+            name: "Legado",
+            code: "AUTH_V1_LEGACY",
+          }),
+        ]),
+      );
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      const listBtn = screen.getByTestId(`routes-delete-${ID_ROUTE_LIST}`);
+      const legacyBtn = screen.getByTestId(`routes-delete-${ID_ROUTE_LEGACY}`);
+      expect(listBtn).toBeInTheDocument();
+      expect(legacyBtn).toBeInTheDocument();
+      expect(listBtn).toHaveAttribute("aria-label", "Desativar rota Listar");
+      expect(legacyBtn).toHaveAttribute("aria-label", "Desativar rota Legado");
+    });
+
+    it('NÃO exibe "Desativar" em linhas já soft-deletadas (deletedAt != null)', async () => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedRoutes([
+          // Ativa — botão deve aparecer.
+          makeRoute({ id: ID_ROUTE_LIST }),
+          // Soft-deleted — botão NÃO deve aparecer (issue futura cobre
+          // restaurar; o gating client-side esconde a ação que o
+          // backend rejeita com 404).
+          makeRoute({
+            id: ID_ROUTE_LEGACY,
+            name: "Legado",
+            code: "AUTH_V1_LEGACY",
+            deletedAt: "2026-02-01T00:00:00Z",
+          }),
+        ]),
+      );
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.getByTestId(`routes-delete-${ID_ROUTE_LIST}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`routes-delete-${ID_ROUTE_LEGACY}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('coexiste com o botão "Editar" quando o usuário tem ambas as permissões', async () => {
+      permissionsMock = [ROUTES_UPDATE_PERMISSION, ROUTES_DELETE_PERMISSION];
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedRoutes([makeRoute({ id: ID_ROUTE_LIST })]),
+      );
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.getByTestId(`routes-edit-${ID_ROUTE_LIST}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`routes-delete-${ID_ROUTE_LIST}`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("abertura do diálogo de confirmação", () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+    });
+
+    it('clicar em "Desativar" abre o diálogo com nome e code da rota', async () => {
+      const route = makeRoute({
+        id: ID_ROUTE_LIST,
+        name: "Listar sistemas",
+        code: "AUTH_V1_SYSTEMS_LIST",
+      });
+      const client = createRoutesClientStub();
+      await openDeleteRouteConfirm(client, route);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Desativar rota\?/i)).toBeInTheDocument();
+      const description = screen.getByTestId("delete-route-description");
+      expect(description).toHaveTextContent("Listar sistemas");
+      expect(description).toHaveTextContent("AUTH_V1_SYSTEMS_LIST");
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildRoutesCloseCases`
+     * (helper compartilhado) — diferença é só o testId do botão Cancelar
+     * (`delete-route-cancel`). Lição PR #127: `it.each` evita BLOCKER de
+     * duplicação Sonar para cenários com mesma estrutura mudando 1-2
+     * mocks.
+     */
+    const CLOSE_CASES = buildRoutesCloseCases("delete-route-cancel");
+
+    it.each(CLOSE_CASES)(
+      "fechar via $name não dispara DELETE",
+      async ({ close }) => {
+        const client = createRoutesClientStub();
+        await openDeleteRouteConfirm(client);
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        });
+        expect(client.delete).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe("confirmação bem-sucedida", () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+    });
+
+    it("envia DELETE /systems/routes/{id} com id correto, fecha modal, exibe toast verde e refaz listRoutes", async () => {
+      const target = makeRoute({
+        id: ID_ROUTE_LIST,
+        name: "Listar sistemas",
+        code: "AUTH_V1_SYSTEMS_LIST",
+      });
+      const client = createRoutesClientStub();
+      // Fila: GET inicial → DELETE (204 → undefined) → GET refetch.
+      client.get
+        .mockResolvedValueOnce(makePagedRoutes([target]))
+        .mockResolvedValueOnce(makePagedRoutes([], { total: 0 }));
+      client.delete.mockResolvedValueOnce(undefined);
+
+      await openDeleteRouteConfirm(client, target);
+      await confirmDeleteRoute(client);
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/systems/routes/${ID_ROUTE_LIST}`,
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Rota desativada." (status do ToastProvider).
+      expect(await screen.findByText("Rota desativada.")).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("tratamento de erros do backend", () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Casos
+     * comuns (401, 403, network) vêm do helper compartilhado
+     * `buildSharedRouteMutationErrorCases('desativar')` para evitar
+     * duplicação literal com a futura suíte de "restaurar rota" — pré-
+     * projetar o helper desde o primeiro PR do recurso (lição PR #128).
+     *
+     * Casos específicos ficam inline porque o comportamento difere:
+     *
+     * - **404** — rota removida entre abertura e confirm. Modal fecha,
+     *   toast vermelho informativo e dispara refetch (paridade com
+     *   tratamento de 404 no edit/delete de sistema).
+     * - **409** — rota tem permissões ativas vinculadas. Modal segue
+     *   aberto (usuário precisa entender o bloqueio antes de fechar) e
+     *   exibe a mensagem do backend
+     *   (`DeleteBlockedByPermissionsMessage`). Critério de aceite #65:
+     *   "Tratamento de erro caso a rota tenha vínculos (mensagem clara)".
+     */
+    const ERROR_CASES: ReadonlyArray<RoutesErrorCase> = [
+      {
+        name: "404 (rota já removida) fecha modal, exibe toast e dispara refetch",
+        error: {
+          kind: "http",
+          status: 404,
+          message: "Route não encontrada.",
+        },
+        expectedText: "Rota não encontrada ou foi removida. Atualize a lista.",
+        modalStaysOpen: false,
+      },
+      {
+        name: "409 (vínculos com permissões) usa a mensagem do backend e mantém o modal aberto",
+        error: {
+          kind: "http",
+          status: 409,
+          message:
+            "Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes.",
+        },
+        expectedText:
+          "Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes.",
+      },
+      ...buildSharedRouteMutationErrorCases("desativar"),
+    ];
+
+    it.each(ERROR_CASES)(
+      "mapeia $name",
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createRoutesClientStub();
+        client.delete.mockRejectedValueOnce(error);
+
+        await openDeleteRouteConfirm(client);
+        await confirmDeleteRoute(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole("dialog")).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it("404 dispara refetch (onDeleted chamado mesmo em erro)", async () => {
+      const client = createRoutesClientStub();
+      // Fila: GET inicial → DELETE (404) → GET refetch após onDeleted.
+      client.get
+        .mockResolvedValueOnce(makePagedRoutes([makeRoute()]))
+        .mockResolvedValueOnce(makePagedRoutes([], { total: 0 }));
+      client.delete.mockRejectedValueOnce({
+        kind: "http",
+        status: 404,
+        message: "Route não encontrada.",
+      } satisfies ApiError);
+
+      await openDeleteRouteConfirm(client);
+      await confirmDeleteRoute(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("mobile cards", () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_DELETE_PERMISSION];
+    });
+
+    it('exibe botão "Desativar" no card mobile quando o usuário tem permissão', async () => {
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedRoutes([makeRoute({ id: ID_ROUTE_LIST, name: "Listar" })]),
+      );
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      const cardBtn = screen.getByTestId(`routes-card-delete-${ID_ROUTE_LIST}`);
+      expect(cardBtn).toBeInTheDocument();
+      expect(cardBtn).toHaveAttribute("aria-label", "Desativar rota Listar");
+    });
+
+    it('clicar no botão "Desativar" do card abre o mesmo diálogo de confirmação', async () => {
+      const route = makeRoute({
+        id: ID_ROUTE_LIST,
+        name: "Listar sistemas",
+        code: "AUTH_V1_SYSTEMS_LIST",
+      });
+      const client = createRoutesClientStub();
+      client.get.mockResolvedValueOnce(makePagedRoutes([route]));
+
+      renderRoutesPage(client);
+      await waitForInitialList(client);
+
+      fireEvent.click(screen.getByTestId(`routes-card-delete-${route.id}`));
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Desativar rota\?/i)).toBeInTheDocument();
+      expect(screen.getByTestId("delete-route-description")).toHaveTextContent(
+        "Listar sistemas",
+      );
+    });
+  });
+});

--- a/tests/pages/__helpers__/routesTestHelpers.tsx
+++ b/tests/pages/__helpers__/routesTestHelpers.tsx
@@ -1,12 +1,24 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { expect, vi } from 'vitest';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { expect, vi } from "vitest";
 
-import type { ApiClient, ApiError, PagedResponse, RouteDto, TokenTypeDto } from '@/shared/api';
+import type {
+  ApiClient,
+  ApiError,
+  PagedResponse,
+  RouteDto,
+  TokenTypeDto,
+} from "@/shared/api";
 
-import { ToastProvider } from '@/components/ui';
-import { RoutesPage } from '@/pages/RoutesPage';
+import { ToastProvider } from "@/components/ui";
+import { RoutesPage } from "@/pages/RoutesPage";
 
 /**
  * Helpers de teste compartilhados pela suíte da `RoutesPage` (Issue
@@ -29,11 +41,11 @@ import { RoutesPage } from '@/pages/RoutesPage';
  */
 
 /** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
-export const ID_SYS_AUTH = '11111111-1111-1111-1111-111111111111';
-export const ID_ROUTE_LIST = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-export const ID_ROUTE_CREATE = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
-export const ID_ROUTE_LEGACY = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
-export const ID_TOKEN_TYPE_DEFAULT = '99999999-9999-9999-9999-999999999999';
+export const ID_SYS_AUTH = "11111111-1111-1111-1111-111111111111";
+export const ID_ROUTE_LIST = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+export const ID_ROUTE_CREATE = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+export const ID_ROUTE_LEGACY = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+export const ID_TOKEN_TYPE_DEFAULT = "99999999-9999-9999-9999-999999999999";
 
 /**
  * Stub de `ApiClient` injetado em `<RoutesPage client={stub} />` —
@@ -63,7 +75,7 @@ export function createRoutesClientStub(): ApiClientStub {
     patch: vi.fn(),
     delete: vi.fn(),
     setAuth: vi.fn(),
-    getSystemId: vi.fn(() => 'system-test-uuid'),
+    getSystemId: vi.fn(() => "system-test-uuid"),
   } as unknown as ApiClientStub;
 }
 
@@ -75,14 +87,14 @@ export function makeRoute(overrides: Partial<RouteDto> = {}): RouteDto {
   return {
     id: ID_ROUTE_LIST,
     systemId: ID_SYS_AUTH,
-    name: 'Listar sistemas',
-    code: 'AUTH_V1_SYSTEMS_LIST',
-    description: 'GET /api/v1/systems',
+    name: "Listar sistemas",
+    code: "AUTH_V1_SYSTEMS_LIST",
+    description: "GET /api/v1/systems",
     systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
-    systemTokenTypeCode: 'default',
-    systemTokenTypeName: 'Acesso padrão',
-    createdAt: '2026-01-10T12:00:00Z',
-    updatedAt: '2026-01-10T12:00:00Z',
+    systemTokenTypeCode: "default",
+    systemTokenTypeName: "Acesso padrão",
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
     deletedAt: null,
     ...overrides,
   };
@@ -129,7 +141,10 @@ export function renderRoutesPage(
     <ToastProvider>
       <MemoryRouter initialEntries={[`/systems/${systemId}/routes`]}>
         <Routes>
-          <Route path="/systems/:systemId/routes" element={<RoutesPage client={client} />} />
+          <Route
+            path="/systems/:systemId/routes"
+            element={<RoutesPage client={client} />}
+          />
         </Routes>
       </MemoryRouter>
     </ToastProvider>,
@@ -145,7 +160,7 @@ export function renderRoutesPage(
 export async function waitForInitialList(client: ApiClientStub): Promise<void> {
   await waitFor(() => expect(client.get).toHaveBeenCalled());
   await waitFor(() => {
-    expect(screen.queryByTestId('routes-loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId("routes-loading")).not.toBeInTheDocument();
   });
 }
 
@@ -158,9 +173,9 @@ export async function waitForInitialList(client: ApiClientStub): Promise<void> {
  */
 export function lastGetPath(client: ApiClientStub): string {
   const calls = client.get.mock.calls;
-  if (calls.length === 0) return '';
+  if (calls.length === 0) return "";
   const path = calls[calls.length - 1][0];
-  return typeof path === 'string' ? path : '';
+  return typeof path === "string" ? path : "";
 }
 
 /* ─── Helpers para suítes de mutação (Issue #63 — criar) ───── */
@@ -175,21 +190,23 @@ export function lastGetPath(client: ApiClientStub): string {
  * também precisa fabricar dummies — Sonar marca a duplicação dessa
  * factory de ~10 linhas se aparecer nos dois lugares (lição PR #128).
  */
-export function makeTokenType(overrides: Partial<TokenTypeDto> = {}): TokenTypeDto {
+export function makeTokenType(
+  overrides: Partial<TokenTypeDto> = {},
+): TokenTypeDto {
   return {
     id: ID_TOKEN_TYPE_DEFAULT,
-    name: 'Acesso padrão',
-    code: 'default',
+    name: "Acesso padrão",
+    code: "default",
     description: null,
-    createdAt: '2026-01-10T12:00:00Z',
-    updatedAt: '2026-01-10T12:00:00Z',
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
     deletedAt: null,
     ...overrides,
   };
 }
 
 /** UUID adicional usado nos testes da suíte de criação para um token type alternativo. */
-export const ID_TOKEN_TYPE_ADMIN = '88888888-8888-8888-8888-888888888888';
+export const ID_TOKEN_TYPE_ADMIN = "88888888-8888-8888-8888-888888888888";
 
 /**
  * Empilha respostas no stub do cliente para simular a sequência típica
@@ -244,12 +261,15 @@ export async function openCreateRouteModal(
     tokenTypes?: ReadonlyArray<TokenTypeDto>;
   } = {},
 ): Promise<void> {
-  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
     mockOpenCreateModalResponses(client, options);
   }
   renderRoutesPage(client);
   await waitForInitialList(client);
-  fireEvent.click(screen.getByTestId('routes-create-open'));
+  fireEvent.click(screen.getByTestId("routes-create-open"));
   // Aguarda o segundo GET (token types) — sem isso, o `<Select>`
   // continua disabled e os testes de `fillNewRouteForm` não conseguem
   // setar o valor.
@@ -261,7 +281,7 @@ export async function openCreateRouteModal(
   // "Selecione uma política JWT" quando a lista carregou). Asserir o
   // testid específico do form é suficiente.
   await waitFor(() => {
-    expect(screen.getByTestId('new-route-form')).toBeInTheDocument();
+    expect(screen.getByTestId("new-route-form")).toBeInTheDocument();
   });
 }
 
@@ -282,22 +302,22 @@ export function fillNewRouteForm(values: {
   systemTokenTypeId?: string;
 }): void {
   if (values.name !== undefined) {
-    fireEvent.change(screen.getByTestId('new-route-name'), {
+    fireEvent.change(screen.getByTestId("new-route-name"), {
       target: { value: values.name },
     });
   }
   if (values.code !== undefined) {
-    fireEvent.change(screen.getByTestId('new-route-code'), {
+    fireEvent.change(screen.getByTestId("new-route-code"), {
       target: { value: values.code },
     });
   }
   if (values.description !== undefined) {
-    fireEvent.change(screen.getByTestId('new-route-description'), {
+    fireEvent.change(screen.getByTestId("new-route-description"), {
       target: { value: values.description },
     });
   }
   if (values.systemTokenTypeId !== undefined) {
-    fireEvent.change(screen.getByTestId('new-route-system-token-type-id'), {
+    fireEvent.change(screen.getByTestId("new-route-system-token-type-id"), {
       target: { value: values.systemTokenTypeId },
     });
   }
@@ -315,10 +335,12 @@ export async function submitNewRouteForm(
   expectedPostCalls = 1,
 ): Promise<void> {
   await act(async () => {
-    fireEvent.submit(screen.getByTestId('new-route-form'));
+    fireEvent.submit(screen.getByTestId("new-route-form"));
     await Promise.resolve();
   });
-  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+  await waitFor(() =>
+    expect(client.post).toHaveBeenCalledTimes(expectedPostCalls),
+  );
 }
 
 /**
@@ -347,10 +369,10 @@ export interface RoutesErrorCase {
  * `toCaseInsensitiveMatcher` em `systemsTestHelpers.tsx`.
  */
 export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
-  if (typeof text !== 'string') {
+  if (typeof text !== "string") {
     return text;
   }
-  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), 'i');
+  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), "i");
 }
 
 /**
@@ -363,57 +385,57 @@ export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
  * (lição PR #128 — projetar shared helpers desde o primeiro PR).
  */
 export function buildSharedRouteSubmitErrorCases(
-  verb: 'criar' | 'atualizar',
+  verb: "criar" | "atualizar",
 ): ReadonlyArray<RoutesErrorCase> {
-  const verbAcao = verb === 'criar' ? 'criação' : 'atualização';
+  const verbAcao = verb === "criar" ? "criação" : "atualização";
   return [
     {
-      name: '400 com errors mapeia mensagens para os campos correspondentes',
+      name: "400 com errors mapeia mensagens para os campos correspondentes",
       error: {
-        kind: 'http',
+        kind: "http",
         status: 400,
-        message: 'Erro de validação.',
+        message: "Erro de validação.",
         details: {
           errors: {
-            Name: ['Name é obrigatório e não pode ser apenas espaços.'],
-            Code: ['Code deve ter no máximo 50 caracteres.'],
+            Name: ["Name é obrigatório e não pode ser apenas espaços."],
+            Code: ["Code deve ter no máximo 50 caracteres."],
           },
         },
       },
-      expectedText: 'Name é obrigatório e não pode ser apenas espaços.',
+      expectedText: "Name é obrigatório e não pode ser apenas espaços.",
     },
     {
-      name: '400 sem errors mapeáveis exibe Alert no topo do form',
+      name: "400 sem errors mapeáveis exibe Alert no topo do form",
       error: {
-        kind: 'http',
+        kind: "http",
         status: 400,
         message: `Payload inválido para ${verbAcao} de rota.`,
       },
       expectedText: `Payload inválido para ${verbAcao} de rota.`,
     },
     {
-      name: '401 dispara toast vermelho com mensagem do backend',
+      name: "401 dispara toast vermelho com mensagem do backend",
       error: {
-        kind: 'http',
+        kind: "http",
         status: 401,
-        message: 'Sessão expirada. Faça login novamente.',
+        message: "Sessão expirada. Faça login novamente.",
       },
-      expectedText: 'Sessão expirada. Faça login novamente.',
+      expectedText: "Sessão expirada. Faça login novamente.",
     },
     {
-      name: '403 dispara toast vermelho com mensagem do backend',
+      name: "403 dispara toast vermelho com mensagem do backend",
       error: {
-        kind: 'http',
+        kind: "http",
         status: 403,
-        message: 'Você não tem permissão para esta ação.',
+        message: "Você não tem permissão para esta ação.",
       },
-      expectedText: 'Você não tem permissão para esta ação.',
+      expectedText: "Você não tem permissão para esta ação.",
     },
     {
-      name: 'erro genérico de rede dispara toast vermelho genérico',
+      name: "erro genérico de rede dispara toast vermelho genérico",
       error: {
-        kind: 'network',
-        message: 'Falha de conexão com o servidor.',
+        kind: "network",
+        message: "Falha de conexão com o servidor.",
       },
       expectedText: `Não foi possível ${verb} a rota. Tente novamente.`,
     },
@@ -470,8 +492,14 @@ export async function openEditRouteModal(
   } = {},
 ): Promise<void> {
   const route = options.route ?? makeRoute();
-  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
-    mockOpenEditModalResponses(client, { route, tokenTypes: options.tokenTypes });
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    mockOpenEditModalResponses(client, {
+      route,
+      tokenTypes: options.tokenTypes,
+    });
   }
   renderRoutesPage(client);
   await waitForInitialList(client);
@@ -483,7 +511,7 @@ export async function openEditRouteModal(
   // Garante que o efeito do modal terminou — checamos a presença do
   // form para indicar que o `<Select>` saiu de "Carregando…".
   await waitFor(() => {
-    expect(screen.getByTestId('edit-route-form')).toBeInTheDocument();
+    expect(screen.getByTestId("edit-route-form")).toBeInTheDocument();
   });
 }
 
@@ -500,22 +528,22 @@ export function fillEditRouteForm(values: {
   systemTokenTypeId?: string;
 }): void {
   if (values.name !== undefined) {
-    fireEvent.change(screen.getByTestId('edit-route-name'), {
+    fireEvent.change(screen.getByTestId("edit-route-name"), {
       target: { value: values.name },
     });
   }
   if (values.code !== undefined) {
-    fireEvent.change(screen.getByTestId('edit-route-code'), {
+    fireEvent.change(screen.getByTestId("edit-route-code"), {
       target: { value: values.code },
     });
   }
   if (values.description !== undefined) {
-    fireEvent.change(screen.getByTestId('edit-route-description'), {
+    fireEvent.change(screen.getByTestId("edit-route-description"), {
       target: { value: values.description },
     });
   }
   if (values.systemTokenTypeId !== undefined) {
-    fireEvent.change(screen.getByTestId('edit-route-system-token-type-id'), {
+    fireEvent.change(screen.getByTestId("edit-route-system-token-type-id"), {
       target: { value: values.systemTokenTypeId },
     });
   }
@@ -531,10 +559,12 @@ export async function submitEditRouteForm(
   expectedPutCalls = 1,
 ): Promise<void> {
   await act(async () => {
-    fireEvent.submit(screen.getByTestId('edit-route-form'));
+    fireEvent.submit(screen.getByTestId("edit-route-form"));
     await Promise.resolve();
   });
-  await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
+  await waitFor(() =>
+    expect(client.put).toHaveBeenCalledTimes(expectedPutCalls),
+  );
 }
 
 /**
@@ -549,20 +579,120 @@ export interface RoutesModalCloseCase {
   close: () => void;
 }
 
-export function buildRoutesCloseCases(cancelTestId: string): ReadonlyArray<RoutesModalCloseCase> {
+export function buildRoutesCloseCases(
+  cancelTestId: string,
+): ReadonlyArray<RoutesModalCloseCase> {
   return [
     {
-      name: 'Esc',
+      name: "Esc",
       // eslint-disable-next-line no-restricted-globals
-      close: () => fireEvent.keyDown(window, { key: 'Escape' }),
+      close: () => fireEvent.keyDown(window, { key: "Escape" }),
     },
     {
-      name: 'botão Cancelar',
+      name: "botão Cancelar",
       close: () => fireEvent.click(screen.getByTestId(cancelTestId)),
     },
     {
-      name: 'clique no backdrop',
-      close: () => fireEvent.mouseDown(screen.getByTestId('modal-backdrop')),
+      name: "clique no backdrop",
+      close: () => fireEvent.mouseDown(screen.getByTestId("modal-backdrop")),
+    },
+  ];
+}
+
+/* ─── Helpers para suíte de exclusão (Issue #65) ──────────────── */
+
+/**
+ * Mocka o GET inicial com uma página contendo a `route` informada (ou
+ * uma rota sintética padrão), renderiza a `RoutesPage`, espera a lista
+ * carregar e clica no botão "Desativar" da linha da rota (Issue #65).
+ *
+ * Helper análogo a `openCreateRouteModal`/`openEditRouteModal`. Sem ele,
+ * cada teste da suíte de exclusão duplicaria ~5 linhas de "render +
+ * waitFor + click" — Sonar contaria como `New Code Duplication` (lição
+ * PR #127). Espelha `openDeleteConfirm` em `systemsTestHelpers.tsx`.
+ *
+ * Quem precisar de mocks diferentes pode chamar `client.get.mockXxx`
+ * antes para sobrescrever a fila — a detecção de mocks pré-existentes
+ * preserva o caso "fila customizada de respostas" (ex.: cenários de
+ * erro 404/409 com refetch).
+ */
+export async function openDeleteRouteConfirm(
+  client: ApiClientStub,
+  route: RouteDto = makeRoute(),
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce(makePagedRoutes([route]));
+  }
+  renderRoutesPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`routes-delete-${route.id}`));
+}
+
+/**
+ * Confirma a desativação clicando em "Desativar" no `DeleteRouteConfirm`
+ * e aguarda o `client.delete` ser chamado pelo menos `expectedDeleteCalls`
+ * vezes (default `1`). Espelha `confirmDelete` em `systemsTestHelpers.tsx`,
+ * com `delete-route-*` em vez de `delete-system-*`. Faz `act(async)`
+ * para flushar a microtask do click handler antes do `waitFor`.
+ */
+export async function confirmDeleteRoute(
+  client: ApiClientStub,
+  expectedDeleteCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("delete-route-confirm"));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.delete).toHaveBeenCalledTimes(expectedDeleteCalls),
+  );
+}
+
+/**
+ * Constrói os 3 cenários de erro de mutação simples que diferem
+ * **apenas** no verbo entre as suítes de exclusão de rota (#65) e
+ * eventuais futuras (restore de rota). Cenários comuns (401, 403,
+ * network) ficam centralizados para preservar simetria de cobertura —
+ * sem o helper, o teste duplicaria literalmente os 3 blocos.
+ *
+ * Espelha `buildSharedMutationErrorCases` em `systemsTestHelpers.tsx`,
+ * mas com o sufixo "a rota" em vez de "o sistema" no toast genérico.
+ * Centralizar aqui evita que o `RoutesPage.delete.test.tsx` declare
+ * 26 linhas de array literal idênticas às do `SystemsPage.delete.test.tsx`
+ * (lição PR #128 — Sonar marca como duplicação).
+ */
+export function buildSharedRouteMutationErrorCases(
+  verb: "desativar",
+): ReadonlyArray<RoutesErrorCase> {
+  return [
+    {
+      name: "401 dispara toast vermelho com mensagem do backend",
+      error: {
+        kind: "http",
+        status: 401,
+        message: "Sessão expirada. Faça login novamente.",
+      },
+      expectedText: "Sessão expirada. Faça login novamente.",
+    },
+    {
+      name: "403 dispara toast vermelho com mensagem do backend",
+      error: {
+        kind: "http",
+        status: 403,
+        message: "Você não tem permissão para esta ação.",
+      },
+      expectedText: "Você não tem permissão para esta ação.",
+    },
+    {
+      name: "erro genérico de rede dispara toast vermelho genérico",
+      error: {
+        kind: "network",
+        message: "Falha de conexão com o servidor.",
+      },
+      expectedText: `Não foi possível ${verb} a rota. Tente novamente.`,
     },
   ];
 }


### PR DESCRIPTION
## Resumo

Última sub-issue da EPIC #46 (CRUD de Rotas por Sistema). Implementa o **soft-delete de rota** via `DELETE /systems/routes/{id}` com modal de confirmação e tratamento explícito do **409** emitido pelo backend quando a rota tem permissões ativas vinculadas.

Closes #65

### Decisões críticas

- **Soft delete** (não hard): o controller faz `entity.DeletedAt = UtcNow` e responde `204 No Content`. Adotamos o vocabulário "Desativar/Inativa" para manter paridade com Sistemas (#60). Botão chamado "Desativar".
- **Mensagem de 409**: o backend é fonte da verdade — usa `RoutesController.DeleteBlockedByPermissionsMessage`: _"Não é possível excluir a rota: existem permissões ativas vinculadas. Remova as permissões antes."_ A copy `conflictMessage` da UI fica como fallback caso o backend regrida.
- **Restaurar rota**: endpoint `POST /systems/routes/{id}/restore` já existe no backend (paridade com `RestoreSystemConfirm` #61), mas a UI fica para uma issue futura — **fora do escopo da #65**.

### Arquitetura: anti-duplicação Sonar (lição PR #128)

O `MutationConfirmModal` em `pages/systems/` foi **generalizado com TS generic** `<T extends MutationTarget>` em vez de duplicar o shell em `pages/routes/`:

- `DeleteSystemConfirm` / `RestoreSystemConfirm` continuam tipados com `SystemDto` (sem regressão).
- `DeleteRouteConfirm` consome o mesmo shell tipado com `RouteDto`.
- Renomeação cosmética: prop `system` → `target` (semanticamente correto para o shell genérico).
- Sem mover arquivo entre pastas — preserva histórico do git.

Quinta recorrência da lição "qualquer trecho ≥10 linhas em 2+ arquivos vira `New Code Duplication` no Sonar" evitada.

### Pipeline esperado

- ✅ `npm run typecheck` — OK
- ✅ `npm run lint` — OK  
- ✅ `npm run build` — OK (419 KB gzipped 121 KB)
- ✅ `npm test` — 567 passes (+17 novos testes em `RoutesPage.delete.test.tsx`)
- ⏳ Quality Gate Sonar — aguardar CI

## Test plan

- [x] Gating: botão "Desativar" só aparece com `AUTH_V1_SYSTEMS_ROUTES_DELETE` e em rotas ativas (`row.deletedAt === null`).
- [x] Coexistência com botão "Editar" quando o usuário tem ambas permissões.
- [x] Modal abre com nome + code da rota; fecha via Esc / Cancelar / backdrop sem disparar DELETE.
- [x] Sucesso: `DELETE /systems/routes/{id}` → toast verde "Rota desativada." + refetch + modal fecha.
- [x] **404** (rota já removida): modal fecha + toast informativo + refetch.
- [x] **409** (vínculo com permissões): modal segue aberto + toast com **mensagem do backend**. Critério de aceite atendido.
- [x] **401/403**: toast com mensagem do backend.
- [x] **Network/parse/5xx**: toast com fallback genérico.
- [x] Mobile: card mobile expõe `routes-card-delete-${id}` análogo ao desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)