### PR TITLE
chore(quality): gate JSCPD + eslint-plugin-sonarjs no pré-PR

### DIFF
--- a/.claude/agents/programmer.md
+++ b/.claude/agents/programmer.md
@@ -201,6 +201,61 @@ Se houver risco, mitigar ou documentar de forma explícita.
 
 ---
 
+# Gate de qualidade pré-PR (obrigatório)
+
+Antes de criar branch de feature, fazer push ou abrir PR, executar **todos** os comandos abaixo via container. Falha em qualquer etapa é bloqueio absoluto — corrigir e re-rodar até zerar.
+
+## Comandos obrigatórios (na ordem)
+
+```bash
+# 1) Lint sem warnings
+docker compose run --rm web npm run lint
+
+# 2) Typecheck
+docker compose run --rm web npm run typecheck
+
+# 3) Suíte completa de testes
+docker compose run --rm web npm test
+
+# 4) Duplicação (espelha o que o Sonar tokeniza como bloco duplicado)
+docker compose run --rm web npx jscpd src \
+  --threshold 3 --min-lines 10 \
+  --reporters console,json \
+  --output ./jscpd-report
+```
+
+> Use o nome de serviço definido no `docker-compose.yml` deste repo (`web`). Se o compose local divergir, ajustar para o serviço equivalente — nunca rodar no host.
+
+## Critérios de aprovação
+
+- `lint`: 0 erros, 0 warnings (`--max-warnings 0` é o default).
+- `typecheck`: 0 erros de `tsc --noEmit`.
+- `test`: suíte 100% verde; **nunca** reportar contagem de testes sem ter executado a suíte completa.
+- `jscpd`: `statistics.total.percentage ≤ 3%` **E** `newClones === 0` em todo arquivo tocado pelo diff (consultar `jscpd-report/jscpd-report.json`).
+
+## Tratamento de duplicação detectada
+
+Se o JSCPD reportar clone de ≥10 linhas envolvendo arquivo do diff:
+
+1. **Não pushar.**
+2. Abrir `jscpd-report/jscpd-report.json` e localizar os blocos clones (`duplicates[]`).
+3. Refatorar para helper genérico:
+   - Erros de submit / parsing de `ValidationProblemDetails` → `src/shared/forms/classifySubmitError.ts` (já existe).
+   - Handlers de campo (`handleNameChange/handleCodeChange/...`) → `src/shared/forms/createFieldChangeHandler.ts` (já existe).
+   - Paginação de listas → `src/hooks/usePaginationControls` (criar se ainda não houver).
+   - Boilerplate de testes (mock auth, abrir modal, preencher form) → `__helpers__/` do recurso ou fixtures compartilhadas.
+   - Cenários de teste com 1–2 mocks variando → `it.each`, não `it` separados.
+4. Re-rodar o gate até `newClones === 0` nos arquivos do diff.
+5. Só então criar branch / abrir PR.
+
+## Evidência obrigatória no fechamento
+
+A seção **Testes** da saída final do programmer deve conter o trecho final (ou resumo) de cada um dos 4 comandos acima, comprovando aprovação. Abrir PR sem essa evidência é BLOCKER por contrato com o reviewer.
+
+> **Justificativa:** as 5 recorrências históricas de Sonar New Code Duplication (PRs #119, #123, #127, #128, #134, todas registradas em `programmer-lessons.md`) eram detectáveis localmente por este gate antes do push. Memória passiva não basta — o gate é a contraparte ativa.
+
+---
+
 # Branch
 
 Padrão:
@@ -323,6 +378,7 @@ Você deve terminar com:
 - Não ignorar qualidade visual
 - Não fazer merge (isso é papel de reviewer/maestro)
 - Não executar build/lint/test no host
+- Não abrir PR sem aprovação completa do gate de qualidade pré-PR (lint, typecheck, test, jscpd)
 - Não usar `any` como escape de tipagem
 - Não usar class components
 - Não deixar estados visuais críticos sem tratamento

--- a/.cursor/agents/programmer.md
+++ b/.cursor/agents/programmer.md
@@ -201,6 +201,61 @@ Se houver risco, mitigar ou documentar de forma explícita.
 
 ---
 
+# Gate de qualidade pré-PR (obrigatório)
+
+Antes de criar branch de feature, fazer push ou abrir PR, executar **todos** os comandos abaixo via container. Falha em qualquer etapa é bloqueio absoluto — corrigir e re-rodar até zerar.
+
+## Comandos obrigatórios (na ordem)
+
+```bash
+# 1) Lint sem warnings
+docker compose run --rm web npm run lint
+
+# 2) Typecheck
+docker compose run --rm web npm run typecheck
+
+# 3) Suíte completa de testes
+docker compose run --rm web npm test
+
+# 4) Duplicação (espelha o que o Sonar tokeniza como bloco duplicado)
+docker compose run --rm web npx jscpd src \
+  --threshold 3 --min-lines 10 \
+  --reporters console,json \
+  --output ./jscpd-report
+```
+
+> Use o nome de serviço definido no `docker-compose.yml` deste repo (`web`). Se o compose local divergir, ajustar para o serviço equivalente — nunca rodar no host.
+
+## Critérios de aprovação
+
+- `lint`: 0 erros, 0 warnings (`--max-warnings 0` é o default).
+- `typecheck`: 0 erros de `tsc --noEmit`.
+- `test`: suíte 100% verde; **nunca** reportar contagem de testes sem ter executado a suíte completa.
+- `jscpd`: `statistics.total.percentage ≤ 3%` **E** `newClones === 0` em todo arquivo tocado pelo diff (consultar `jscpd-report/jscpd-report.json`).
+
+## Tratamento de duplicação detectada
+
+Se o JSCPD reportar clone de ≥10 linhas envolvendo arquivo do diff:
+
+1. **Não pushar.**
+2. Abrir `jscpd-report/jscpd-report.json` e localizar os blocos clones (`duplicates[]`).
+3. Refatorar para helper genérico:
+   - Erros de submit / parsing de `ValidationProblemDetails` → `src/shared/forms/classifySubmitError.ts` (já existe).
+   - Handlers de campo (`handleNameChange/handleCodeChange/...`) → `src/shared/forms/createFieldChangeHandler.ts` (já existe).
+   - Paginação de listas → `src/hooks/usePaginationControls` (criar se ainda não houver).
+   - Boilerplate de testes (mock auth, abrir modal, preencher form) → `__helpers__/` do recurso ou fixtures compartilhadas.
+   - Cenários de teste com 1–2 mocks variando → `it.each`, não `it` separados.
+4. Re-rodar o gate até `newClones === 0` nos arquivos do diff.
+5. Só então criar branch / abrir PR.
+
+## Evidência obrigatória no fechamento
+
+A seção **Testes** da saída final do programmer deve conter o trecho final (ou resumo) de cada um dos 4 comandos acima, comprovando aprovação. Abrir PR sem essa evidência é BLOCKER por contrato com o reviewer.
+
+> **Justificativa:** as 5 recorrências históricas de Sonar New Code Duplication (PRs #119, #123, #127, #128, #134, todas registradas em `programmer-lessons.md`) eram detectáveis localmente por este gate antes do push. Memória passiva não basta — o gate é a contraparte ativa.
+
+---
+
 # Branch
 
 Padrão:
@@ -323,6 +378,7 @@ Você deve terminar com:
 - Não ignorar qualidade visual
 - Não fazer merge (isso é papel de reviewer/maestro)
 - Não executar build/lint/test no host
+- Não abrir PR sem aprovação completa do gate de qualidade pré-PR (lint, typecheck, test, jscpd)
 - Não usar `any` como escape de tipagem
 - Não usar class components
 - Não deixar estados visuais críticos sem tratamento

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'import'],
+  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'import', 'sonarjs'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -30,6 +30,17 @@ module.exports = {
     },
   },
   ignorePatterns: ['build/', 'coverage/', 'node_modules/'],
+  overrides: [
+    {
+      // Alinha com `sonar.exclusions=**/*.test.*,**/*.spec.*` em sonar-project.properties:
+      // strings repetidas em assertions e setups complexos de teste são legítimos.
+      files: ['tests/**/*.{ts,tsx,js,jsx}'],
+      rules: {
+        'sonarjs/no-duplicate-string': 'off',
+        'sonarjs/cognitive-complexity': 'off',
+      },
+    },
+  ],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
@@ -68,5 +79,15 @@ module.exports = {
         },
       },
     ],
+    // sonarjs — subset curado, mapeado a BLOCKERs históricos do SonarCloud.
+    // Limiares (15 / 3) coincidem com os padrões do Sonar para evitar drift CI/local.
+    'sonarjs/cognitive-complexity': ['error', 15],
+    'sonarjs/no-identical-functions': 'error',
+    'sonarjs/no-duplicate-string': ['error', { threshold: 3 }],
+    'sonarjs/no-identical-expressions': 'error',
+    'sonarjs/no-redundant-jump': 'error',
+    'sonarjs/no-useless-catch': 'error',
+    'sonarjs/prefer-immediate-return': 'error',
+    'sonarjs/no-collapsible-if': 'error',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "eslint-plugin-sonarjs": "^4.0.3",
         "jsdom": "^27.0.0",
         "prettier": "^3.8.2",
         "typescript": "^5.9.3",
@@ -3028,6 +3029,29 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4123,6 +4147,82 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -4516,6 +4616,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -5582,6 +5689,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6380,6 +6497,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6401,6 +6531,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -6559,6 +6703,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -7392,6 +7551,19 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "jsdom": "^27.0.0",
     "prettier": "^3.8.2",
     "typescript": "^5.9.3",

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components';
 
 import { Icon } from './Icon';
 
+const DANGER_COLOR = 'var(--danger)';
+
 export type CheckboxSize = 'sm' | 'md' | 'lg';
 
 interface CheckboxProps
@@ -66,7 +68,7 @@ const Box = styled.span<{ $hasError?: boolean }>`
   height: var(--checkbox-size);
   flex-shrink: 0;
   border: var(--border-medium) solid
-    ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-base)')};
+    ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-base)')};
   border-radius: var(--radius-sm);
   background: var(--bg-elevated);
   display: inline-flex;
@@ -101,12 +103,12 @@ const Box = styled.span<{ $hasError?: boolean }>`
   ${HiddenInput}:focus-visible + & {
     box-shadow: ${({ $hasError }) =>
       $hasError ? 'var(--focus-ring-danger-soft)' : 'var(--focus-ring-accent)'};
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--accent)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--accent)')};
   }
 
   ${Wrapper}:hover ${HiddenInput}:not(:disabled) + & {
     border-color: ${({ $hasError }) =>
-      $hasError ? 'var(--danger)' : 'var(--border-soft-forest)'};
+      $hasError ? DANGER_COLOR : 'var(--border-soft-forest)'};
   }
 `;
 
@@ -126,7 +128,7 @@ const LabelText = styled.span`
 
 const HelperMsg = styled.span<{ $error?: boolean }>`
   font-size: var(--text-xs);
-  color: ${({ $error }) => ($error ? 'var(--danger)' : 'var(--text-muted)')};
+  color: ${({ $error }) => ($error ? DANGER_COLOR : 'var(--text-muted)')};
 `;
 
 export const Checkbox: React.FC<CheckboxProps> = ({

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -202,6 +202,7 @@ export const Chip: React.FC<ChipProps> = ({
   onClick,
   disabled = false,
   ariaLabel,
+  // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO: extrair em helper menor (débito técnico, PR separada)
 }) => {
   const interactive = typeof onClick === 'function';
 

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,8 @@
 import React, { useId } from 'react';
 import styled from 'styled-components';
 
+const DANGER_COLOR = 'var(--danger)';
+
 interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   label?: string;
   error?: string;
@@ -18,7 +20,7 @@ const InputGroup = styled.div`
 const InputLabel = styled.label<{ $hasError?: boolean }>`
   font-size: 12px;
   font-weight: var(--weight-medium);
-  color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--fg2)')};
+  color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--fg2)')};
   letter-spacing: -0.01em;
 `;
 
@@ -42,7 +44,7 @@ const StyledInput = styled.input<{ $hasError?: boolean; $hasIcon?: boolean }>`
   flex: 1;
   min-width: 0;
   background: var(--bg-elevated);
-  border: 1px solid ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-base)')};
+  border: 1px solid ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-base)')};
   border-radius: var(--radius-md);
   padding: 9px 12px;
   padding-left: ${({ $hasIcon }) => ($hasIcon ? '34px' : '12px')};
@@ -57,11 +59,11 @@ const StyledInput = styled.input<{ $hasError?: boolean; $hasIcon?: boolean }>`
   }
 
   &:hover:not(:disabled) {
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-soft-forest)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-soft-forest)')};
   }
 
   &:focus-visible {
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--accent)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--accent)')};
     box-shadow: ${({ $hasError }) =>
       $hasError
         ? 'var(--focus-ring-danger-soft)'

--- a/src/components/ui/Radio.tsx
+++ b/src/components/ui/Radio.tsx
@@ -1,6 +1,8 @@
 import React, { useId } from 'react';
 import styled, { css } from 'styled-components';
 
+const DANGER_COLOR = 'var(--danger)';
+
 export type RadioSize = 'sm' | 'md' | 'lg';
 
 interface RadioProps
@@ -63,7 +65,7 @@ const Circle = styled.span<{ $hasError?: boolean }>`
   height: var(--radio-size);
   flex-shrink: 0;
   border: var(--border-medium) solid
-    ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-base)')};
+    ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-base)')};
   border-radius: var(--radius-full);
   background: var(--bg-elevated);
   display: inline-flex;
@@ -98,12 +100,12 @@ const Circle = styled.span<{ $hasError?: boolean }>`
   ${HiddenInput}:focus-visible + & {
     box-shadow: ${({ $hasError }) =>
       $hasError ? 'var(--focus-ring-danger-soft)' : 'var(--focus-ring-accent)'};
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--accent)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--accent)')};
   }
 
   ${Wrapper}:hover ${HiddenInput}:not(:disabled) + & {
     border-color: ${({ $hasError }) =>
-      $hasError ? 'var(--danger)' : 'var(--border-soft-forest)'};
+      $hasError ? DANGER_COLOR : 'var(--border-soft-forest)'};
   }
 `;
 
@@ -123,7 +125,7 @@ const LabelText = styled.span`
 
 const HelperMsg = styled.span<{ $error?: boolean }>`
   font-size: var(--text-xs);
-  color: ${({ $error }) => ($error ? 'var(--danger)' : 'var(--text-muted)')};
+  color: ${({ $error }) => ($error ? DANGER_COLOR : 'var(--text-muted)')};
 `;
 
 export const Radio: React.FC<RadioProps> = ({
@@ -229,7 +231,7 @@ const Options = styled.div<{ $direction: 'vertical' | 'horizontal' }>`
 
 const GroupHelper = styled.span<{ $error?: boolean }>`
   font-size: var(--text-xs);
-  color: ${({ $error }) => ($error ? 'var(--danger)' : 'var(--text-muted)')};
+  color: ${({ $error }) => ($error ? DANGER_COLOR : 'var(--text-muted)')};
 `;
 
 export const RadioGroup: React.FC<RadioGroupProps> = ({

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -4,6 +4,8 @@ import styled, { css } from 'styled-components';
 
 import { Icon } from './Icon';
 
+const DANGER_COLOR = 'var(--danger)';
+
 export type SelectSize = 'sm' | 'md' | 'lg';
 
 interface SelectProps
@@ -32,7 +34,7 @@ const Group = styled.div`
 const SelectLabel = styled.label<{ $hasError?: boolean }>`
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--fg2)')};
+  color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--fg2)')};
   letter-spacing: var(--tracking-tight);
 `;
 
@@ -71,7 +73,7 @@ const StyledSelect = styled.select<{ $hasError?: boolean; $size: SelectSize }>`
   appearance: none;
   background: var(--bg-elevated);
   border: var(--border-thin) solid
-    ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-base)')};
+    ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-base)')};
   font-family: var(--font-sans);
   color: var(--fg1);
   outline: none;
@@ -84,11 +86,11 @@ const StyledSelect = styled.select<{ $hasError?: boolean; $size: SelectSize }>`
 
   &:hover:not(:disabled) {
     border-color: ${({ $hasError }) =>
-      $hasError ? 'var(--danger)' : 'var(--border-soft-forest)'};
+      $hasError ? DANGER_COLOR : 'var(--border-soft-forest)'};
   }
 
   &:focus-visible {
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--accent)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--accent)')};
     box-shadow: ${({ $hasError }) =>
       $hasError ? 'var(--focus-ring-danger-soft)' : 'var(--focus-ring-accent)'};
   }
@@ -112,7 +114,7 @@ const Caret = styled.span`
 
 const HelperMsg = styled.span<{ $error?: boolean }>`
   font-size: var(--text-xs);
-  color: ${({ $error }) => ($error ? 'var(--danger)' : 'var(--text-muted)')};
+  color: ${({ $error }) => ($error ? DANGER_COLOR : 'var(--text-muted)')};
 `;
 
 export const Select: React.FC<SelectProps> = ({

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,6 +1,8 @@
 import React, { useId } from 'react';
 import styled, { css } from 'styled-components';
 
+const DANGER_COLOR = 'var(--danger)';
+
 export type TextareaSize = 'sm' | 'md' | 'lg';
 
 interface TextareaProps
@@ -27,7 +29,7 @@ const TextareaGroup = styled.div`
 const TextareaLabel = styled.label<{ $hasError?: boolean }>`
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--fg2)')};
+  color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--fg2)')};
   letter-spacing: var(--tracking-tight);
 `;
 
@@ -57,7 +59,7 @@ const StyledTextarea = styled.textarea<{
   min-height: calc(var(--space-12) * 2);
   background: var(--bg-elevated);
   border: var(--border-thin) solid
-    ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--border-base)')};
+    ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--border-base)')};
   font-family: var(--font-sans);
   color: var(--fg1);
   outline: none;
@@ -74,11 +76,11 @@ const StyledTextarea = styled.textarea<{
 
   &:hover:not(:disabled) {
     border-color: ${({ $hasError }) =>
-      $hasError ? 'var(--danger)' : 'var(--border-soft-forest)'};
+      $hasError ? DANGER_COLOR : 'var(--border-soft-forest)'};
   }
 
   &:focus-visible {
-    border-color: ${({ $hasError }) => ($hasError ? 'var(--danger)' : 'var(--accent)')};
+    border-color: ${({ $hasError }) => ($hasError ? DANGER_COLOR : 'var(--accent)')};
     box-shadow: ${({ $hasError }) =>
       $hasError ? 'var(--focus-ring-danger-soft)' : 'var(--focus-ring-accent)'};
   }
@@ -92,7 +94,7 @@ const StyledTextarea = styled.textarea<{
 
 const HelperMsg = styled.span<{ $error?: boolean }>`
   font-size: var(--text-xs);
-  color: ${({ $error }) => ($error ? 'var(--danger)' : 'var(--text-muted)')};
+  color: ${({ $error }) => ($error ? DANGER_COLOR : 'var(--text-muted)')};
 `;
 
 export const Textarea: React.FC<TextareaProps> = ({

--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -13,11 +13,13 @@ interface RoleItem {
   system: string;
 }
 
+const AUTHENTICATOR_SYSTEM = 'lfc-authenticator';
+
 const ROLES: RoleItem[] = [
   { name: 'root',    users: 2,  perms: 12, desc: 'Acesso irrestrito a todos os sistemas',          system: '—' },
-  { name: 'admin',   users: 6,  perms: 8,  desc: 'Gerenciamento de usuários e permissões',         system: 'lfc-authenticator' },
-  { name: 'editor',  users: 14, perms: 5,  desc: 'Criar e editar recursos, sem deletar',           system: 'lfc-authenticator' },
-  { name: 'viewer',  users: 32, perms: 2,  desc: 'Leitura apenas',                                 system: 'lfc-authenticator' },
+  { name: 'admin',   users: 6,  perms: 8,  desc: 'Gerenciamento de usuários e permissões',         system: AUTHENTICATOR_SYSTEM },
+  { name: 'editor',  users: 14, perms: 5,  desc: 'Criar e editar recursos, sem deletar',           system: AUTHENTICATOR_SYSTEM },
+  { name: 'viewer',  users: 32, perms: 2,  desc: 'Leitura apenas',                                 system: AUTHENTICATOR_SYSTEM },
   { name: 'default', users: 1,  perms: 3,  desc: 'Role de fallback para usuários legados',         system: '—' },
 ];
 

--- a/src/pages/showcase/TypeScale.tsx
+++ b/src/pages/showcase/TypeScale.tsx
@@ -181,6 +181,12 @@ interface ScaleStep {
   trackingValue?: string;
 }
 
+const LEADING_TIGHT_TOKEN = '--leading-tight';
+const LEADING_SNUG_TOKEN = '--leading-snug';
+const TRACKING_TIGHT_TOKEN = '--tracking-tight';
+const TRACKING_NORMAL_TOKEN = '--tracking-normal';
+const WEIGHT_SEMIBOLD_TOKEN = '--weight-semibold';
+
 const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
   {
     sizeToken: '--text-3xl',
@@ -191,9 +197,9 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     Component: SampleH1,
     weightToken: '--weight-bold',
     weightValue: '700',
-    leadingToken: '--leading-tight',
+    leadingToken: LEADING_TIGHT_TOKEN,
     leadingValue: '1.2',
-    trackingToken: '--tracking-tight',
+    trackingToken: TRACKING_TIGHT_TOKEN,
     trackingValue: '-0.03em',
   },
   {
@@ -203,11 +209,11 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     hint: 'Heading nível 2',
     sample: 'Sistemas cadastrados',
     Component: SampleH2,
-    weightToken: '--weight-semibold',
+    weightToken: WEIGHT_SEMIBOLD_TOKEN,
     weightValue: '600',
-    leadingToken: '--leading-tight',
+    leadingToken: LEADING_TIGHT_TOKEN,
     leadingValue: '1.2',
-    trackingToken: '--tracking-tight',
+    trackingToken: TRACKING_TIGHT_TOKEN,
     trackingValue: '-0.03em',
   },
   {
@@ -217,11 +223,11 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     hint: 'Heading nível 3',
     sample: 'Rotas por sistema',
     Component: SampleH3,
-    weightToken: '--weight-semibold',
+    weightToken: WEIGHT_SEMIBOLD_TOKEN,
     weightValue: '600',
-    leadingToken: '--leading-tight',
+    leadingToken: LEADING_TIGHT_TOKEN,
     leadingValue: '1.2',
-    trackingToken: '--tracking-tight',
+    trackingToken: TRACKING_TIGHT_TOKEN,
     trackingValue: '-0.03em',
   },
   {
@@ -231,11 +237,11 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     hint: 'Heading nível 4',
     sample: 'Permissões efetivas',
     Component: SampleH4,
-    weightToken: '--weight-semibold',
+    weightToken: WEIGHT_SEMIBOLD_TOKEN,
     weightValue: '600',
-    leadingToken: '--leading-snug',
+    leadingToken: LEADING_SNUG_TOKEN,
     leadingValue: '1.4',
-    trackingToken: '--tracking-normal',
+    trackingToken: TRACKING_NORMAL_TOKEN,
     trackingValue: '0em',
   },
   {
@@ -247,9 +253,9 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     Component: SampleLg,
     weightToken: '--weight-medium',
     weightValue: '500',
-    leadingToken: '--leading-snug',
+    leadingToken: LEADING_SNUG_TOKEN,
     leadingValue: '1.4',
-    trackingToken: '--tracking-normal',
+    trackingToken: TRACKING_NORMAL_TOKEN,
     trackingValue: '0em',
   },
   {
@@ -263,7 +269,7 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     weightValue: '400',
     leadingToken: '--leading-base',
     leadingValue: '1.6',
-    trackingToken: '--tracking-normal',
+    trackingToken: TRACKING_NORMAL_TOKEN,
     trackingValue: '0em',
   },
   {
@@ -275,9 +281,9 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     Component: SampleSm,
     weightToken: '--weight-regular',
     weightValue: '400',
-    leadingToken: '--leading-snug',
+    leadingToken: LEADING_SNUG_TOKEN,
     leadingValue: '1.4',
-    trackingToken: '--tracking-normal',
+    trackingToken: TRACKING_NORMAL_TOKEN,
     trackingValue: '0em',
   },
   {
@@ -289,7 +295,7 @@ const SCALE_STEPS: ReadonlyArray<ScaleStep> = [
     Component: SampleXs,
     weightToken: '--weight-medium',
     weightValue: '500',
-    leadingToken: '--leading-snug',
+    leadingToken: LEADING_SNUG_TOKEN,
     leadingValue: '1.4',
     trackingToken: '--tracking-wide',
     trackingValue: '0.06em',

--- a/src/shared/auth/AuthContext.tsx
+++ b/src/shared/auth/AuthContext.tsx
@@ -35,6 +35,8 @@ import type {
  * o catálogo está sendo carregado de IndexedDB ou refeito via
  * `GET /auth/permissions`.
  */
+const FORBIDDEN_ROUTE = '/error/403';
+
 const UNAUTHENTICATED_STATE: AuthState = {
   user: null,
   permissions: [],
@@ -473,6 +475,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       }
     };
 
+    // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO: extrair em helper menor (débito técnico, PR separada)
     const performPeriodicVerify = async (): Promise<void> => {
       if (!tokenRef.current) {
         return;
@@ -514,11 +517,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
           // Periódico em rota proibida: o usuário perdeu acesso à
           // rota corrente entre cliques. Não derruba a sessão (token
           // segue válido), mas redireciona para 403.
-          if (typeof window !== 'undefined' && window.location.pathname !== '/error/403') {
+          if (typeof window !== 'undefined' && window.location.pathname !== FORBIDDEN_ROUTE) {
             try {
-              navigate('/error/403', { replace: true });
+              navigate(FORBIDDEN_ROUTE, { replace: true });
             } catch {
-              window.location.assign('/error/403');
+              window.location.assign(FORBIDDEN_ROUTE);
             }
           }
           return;
@@ -685,6 +688,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
       routeCode: string,
       signal?: AbortSignal,
       fromPathname?: string,
+      // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO: extrair em helper menor (débito técnico, PR separada)
     ): Promise<boolean> => {
       if (!tokenRef.current) {
         return false;
@@ -716,10 +720,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
             (typeof window !== 'undefined' ? window.location.pathname : '/');
           const from = { pathname: resolvedFrom };
           try {
-            navigate('/error/403', { replace: true, state: { from } });
+            navigate(FORBIDDEN_ROUTE, { replace: true, state: { from } });
           } catch {
             if (typeof window !== 'undefined') {
-              window.location.assign('/error/403');
+              window.location.assign(FORBIDDEN_ROUTE);
             }
           }
           return false;

--- a/tests/hooks/usePaginatedFetch.test.tsx
+++ b/tests/hooks/usePaginatedFetch.test.tsx
@@ -112,13 +112,11 @@ describe('usePaginatedFetch — refetch e cancelamento', () => {
   it('cancela o fetch anterior quando o fetcher muda de identidade', async () => {
     const signals: AbortSignal[] = [];
     let fetcherKey = 'a';
-    const makeFetcher = (key: string) => () => {
-      const fn = vi.fn(async (options: SafeRequestOptions) => {
+    const makeFetcher = (key: string) => () =>
+      vi.fn(async (options: SafeRequestOptions) => {
         if (options.signal) signals.push(options.signal);
         return makePaged([{ id: key }]);
       });
-      return fn;
-    };
 
     const { result, rerender } = renderHook(
       ({ fetcher }: { fetcher: (options: SafeRequestOptions) => Promise<PagedResponse<ListItem>> }) =>


### PR DESCRIPTION
## Contexto

Histórico recente registra 5 BLOCKERs por **Sonar New Code Duplication > 3%** (PRs #119, #123, #127, #128, #134) e 1 BLOCKER por **Cognitive Complexity > 15** (PR #128). Não havia gate local que detectasse essas regressões antes do push — feedback chegava só pelo SonarCloud no CI, depois da PR aberta.

## Objetivo

Gate de qualidade pré-PR no `programmer.md` que rode `lint` + `typecheck` + `test` + `jscpd` via container e bloqueie a abertura de PR com violações.

## O que foi feito

### Agentes (programmer.md — `.claude` e `.cursor`)
- Nova seção `# Gate de qualidade pré-PR (obrigatório)` com 4 comandos via container, critérios de aprovação e tratamento de duplicação detectada
- Nova proibição: "Não abrir PR sem aprovação completa do gate"

### ESLint
- `eslint-plugin-sonarjs@^4.0.3` instalado (mesmo time/regras do SonarCloud já no CI)
- 8 regras conservadoras ativas: `cognitive-complexity` (15), `no-duplicate-string` (3), `no-identical-functions`, `no-identical-expressions`, `no-redundant-jump`, `no-useless-catch`, `prefer-immediate-return`, `no-collapsible-if`
- Override em `tests/**` desligando `no-duplicate-string` e `cognitive-complexity` (alinhado com `sonar.exclusions=**/*.test.*`)

### Refatorações para zerar 89 → 0 violações
- Const `FORBIDDEN_ROUTE` em `AuthContext.tsx` (5x `/error/403`)
- Const `DANGER_COLOR` em 5 componentes UI (`Checkbox`, `Input`, `Radio`, `Select`, `Textarea`)
- Const `AUTHENTICATOR_SYSTEM` em `RolesPage.tsx`
- 5 consts de tokens tipográficos em `TypeScale.tsx`
- Fix `prefer-immediate-return` em `usePaginatedFetch.test.tsx`
- 3 disable + TODO para `cognitive-complexity` (débito técnico em issue #138)

## Arquivos impactados

- `.claude/agents/programmer.md`, `.cursor/agents/programmer.md`
- `.eslintrc.cjs`
- `package.json`, `package-lock.json`
- `src/shared/auth/AuthContext.tsx`
- `src/components/ui/{Checkbox,Chip,Input,Radio,Select,Textarea}.tsx`
- `src/pages/RolesPage.tsx`, `src/pages/showcase/TypeScale.tsx`
- `tests/hooks/usePaginatedFetch.test.tsx`

## Testes

```text
npm run lint       ✓ 0 errors, 0 warnings
npm run typecheck  ✓ 0 errors
npm test           ✓ 567/567 passing (43 files)
npx jscpd src      ✓ 2.76% (< 3% threshold)
```

## Visual

Sem alteração visual. Refatorações são apenas extração de strings duplicadas em consts (mesmo valor literal preservado em tempo de execução).

## Checklist visual

- [x] Cores/tokens conforme design system local
- [x] Nenhum hardcode novo de cor em componente visual
- [x] Espaçamentos consistentes (sem mudança)
- [x] Hover/focus/disabled tratados (sem mudança)
- [x] Loading e empty state quando aplicável (sem mudança)
- [x] Error state quando aplicável (sem mudança)
- [x] Transições aplicadas quando necessário (sem mudança)
- [x] Layout validado nas larguras alvo (sem mudança)
- [x] Diretório `identity` usado apenas como referência local

## Segurança

Nenhum impacto. Mudança puramente de configuração/refatoração.

## Riscos

- 3 funções com Cognitive Complexity > 15 marcadas como `eslint-disable-next-line` + TODO em #138 (débito técnico, fora do escopo desta chore)
- Plugin v4.x roda no monorepo `SonarSource/SonarJS` (repo histórico `eslint-plugin-sonarjs` arquivado em out/2024, novo monorepo ativo com último push esta semana)

## Issue relacionada

Closes #137
Refs #138