### PR TITLE
chore(sonar): documentar exclusao de identity/ e bulk-WONTFIX legacy issues

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,26 @@ sonar.organization=lf-calegari
 sonar.sources=src
 sonar.tests=tests
 
+# Exclusoes do scan principal.
+# - identity/**: showcase/mockup do design system (HTML/CSS/JSX de demonstracao),
+#   nao e codigo de runtime e nao deve ser analisado pelo Sonar.
+# - **/*.test.* e **/*.spec.*: arquivos de teste sao avaliados via sonar.tests
+#   abaixo, nao via fonte principal.
+#
+# Nota historica (2026-04-30): antes da aplicacao desta exclusao, 180 issues
+# legadas foram criadas no SonarCloud para arquivos em identity/**. Essas issues
+# foram resolvidas em massa como WONTFIX via SonarCloud API com o comentario:
+#   "Showcase/mockup HTML/CSS/JSX em identity/ nao e codigo de runtime.
+#    Ja excluido de sonar.sources via sonar.exclusions=identity/**.
+#    Issues legadas resolvidas como WONTFIX."
+# Resultado: 180/180 sucesso. Total de issues abertas no SonarCloud caiu de 340
+# para 160.
 sonar.exclusions=identity/**,**/*.test.*,**/*.spec.*
+
+# Garante que o detector de codigo duplicado (CPD) tambem ignore identity/**,
+# evitando ruido por blocos repetidos em mockups/showcase.
+sonar.cpd.exclusions=identity/**
+
 sonar.test.inclusions=tests/**/*.{test,spec}.{ts,tsx}
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Contexto

O folder `identity/` deste repo contem o **showcase/mockup do design system** (HTML estatico, JSX de UI kits, CSS de demonstracao, manifest do design system). Nao e codigo de runtime e nao deve ser analisado pelo SonarCloud.

A exclusao ja existia em `sonar-project.properties` via `sonar.exclusions=identity/**,**/*.test.*,**/*.spec.*`. Porem, **180 issues legadas** criadas no SonarCloud antes da aplicacao da exclusao permaneciam abertas para arquivos em `identity/**`.

## O que mudou

Apenas `sonar-project.properties` (somente comentarios + uma linha):

- Adicionados comentarios em pt-BR explicando:
  - O que e `identity/` (showcase/mockup do design system, nao-runtime).
  - Justificativa da exclusao.
  - Nota historica da resolucao em massa de 180 issues legadas como `WONTFIX` em 2026-04-30, com o resultado da chamada API.
- Adicionada `sonar.cpd.exclusions=identity/**` para garantir que o detector de codigo duplicado (CPD) tambem ignore o folder, evitando ruido por blocos repetidos em mockups/showcase.

`index.html` da raiz **nao** foi excluido por ser entrada do app e dever permanecer no scan.

## Acao paralela via SonarCloud API

Em paralelo a esta PR, foi executado `do_transition=wontfix` em massa via SonarCloud API nas 180 issues legadas em `identity/**`, com o comentario:

> "Showcase/mockup HTML/CSS/JSX em identity/ nao e codigo de runtime. Ja excluido de sonar.sources via sonar.exclusions=identity/**. Issues legadas resolvidas como WONTFIX."

Resultado da API:

```json
{"total":180,"success":180,"ignored":0,"failures":0}
```

## Resultado

- Total de issues abertas no SonarCloud caiu de **340 para 160**.
- Decisao agora esta documentada no proprio repo, garantindo auditabilidade.

## Arquivos impactados

- `sonar-project.properties` (apenas comentarios + `sonar.cpd.exclusions`)

## Testes

- Nao aplicavel: mudanca apenas em arquivo de configuracao do SonarCloud.
- CI deve passar trivialmente (Lint/Typecheck/Test/Build/Audit/Sonar).

## Visual

- Nao aplicavel.

## Seguranca

- Nenhum impacto.

## Riscos

- Minimos. Apenas documentacao + ajuste de exclusao do CPD para o mesmo escopo ja excluido em `sonar.exclusions`.