### PR TITLE
chore(sonar): refactor mecânico em tests/ (104 issues)

### DIFF
--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -49,7 +49,7 @@ function makeInertClient(): ApiClient {
  * todas as rotas listadas.
  */
 async function seedAdminSession(): Promise<void> {
-  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-admin-test');
+  globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-admin-test');
   await permissionsCache.save({
     user: {
       id: 'u-admin',
@@ -78,7 +78,7 @@ function renderAt(path: string) {
 
 beforeEach(() => {
   installFakeIndexedDB();
-  window.localStorage.clear();
+  globalThis.localStorage.clear();
 });
 
 afterEach(() => {

--- a/tests/components/layout/Sidebar.test.tsx
+++ b/tests/components/layout/Sidebar.test.tsx
@@ -12,7 +12,7 @@ import { THEME_STORAGE_KEY } from '@/hooks/useTheme';
  * dark do SO, basta passar `dark = true`.
  */
 const installMatchMedia = (dark = false) => {
-  Object.defineProperty(window, 'matchMedia', {
+  Object.defineProperty(globalThis, 'matchMedia', {
     writable: true,
     configurable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -34,7 +34,7 @@ const installMatchMedia = (dark = false) => {
  * própria URL.
  */
 const decodeLogoSrc = (src: string): string => {
-  const dataUrlMatch = src.match(/^data:image\/svg\+xml;base64,(.+)$/);
+  const dataUrlMatch = /^data:image\/svg\+xml;base64,(.+)$/.exec(src);
   if (dataUrlMatch) return atob(dataUrlMatch[1]);
   return src;
 };
@@ -50,8 +50,8 @@ function renderSidebar(open = false, onClose: () => void = vi.fn()) {
 describe('Sidebar', () => {
   beforeEach(() => {
     installMatchMedia(false);
-    window.localStorage.clear();
-    document.documentElement.removeAttribute('data-theme');
+    globalThis.localStorage.clear();
+    delete document.documentElement.dataset.theme;
   });
 
   it('renderiza navegação acessível com itens principais', () => {
@@ -147,7 +147,7 @@ describe('Sidebar', () => {
   });
 
   it('renderiza logo clara quando preferência persistida é dark (sobrepõe SO light)', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     renderSidebar(false);
 
     const logo = screen.getByTestId('sidebar-logo') as HTMLImageElement;

--- a/tests/components/ui/ThemeToggle.test.tsx
+++ b/tests/components/ui/ThemeToggle.test.tsx
@@ -5,7 +5,7 @@ import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { THEME_STORAGE_KEY } from '@/hooks/useTheme';
 
 const installMatchMedia = (initialDark: boolean) => {
-  vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => ({
+  vi.spyOn(globalThis, 'matchMedia').mockImplementation((query: string) => ({
     matches: query.includes('dark') ? initialDark : false,
     media: query,
     onchange: null,
@@ -19,8 +19,8 @@ const installMatchMedia = (initialDark: boolean) => {
 
 describe('ThemeToggle', () => {
   beforeEach(() => {
-    window.localStorage.clear();
-    document.documentElement.removeAttribute('data-theme');
+    globalThis.localStorage.clear();
+    delete document.documentElement.dataset.theme;
   });
 
   afterEach(() => {
@@ -40,11 +40,11 @@ describe('ThemeToggle', () => {
     render(<ThemeToggle />);
 
     const button = screen.getByTestId('theme-toggle');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
 
     fireEvent.click(button);
 
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
     expect(button).toHaveAttribute('aria-pressed', 'true');
     expect(button).toHaveAttribute('aria-label', 'Ativar tema claro');
   });
@@ -55,23 +55,23 @@ describe('ThemeToggle', () => {
 
     fireEvent.click(screen.getByTestId('theme-toggle'));
 
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
   });
 
   it('respeita preferência de sistema (dark) no primeiro render', () => {
     installMatchMedia(true);
     render(<ThemeToggle />);
 
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
     expect(screen.getByTestId('theme-toggle')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('respeita preferência persistida sobre o sistema', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'light');
     installMatchMedia(true);
     render(<ThemeToggle />);
 
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
     expect(screen.getByTestId('theme-toggle')).toHaveAttribute('aria-pressed', 'false');
   });
 

--- a/tests/hooks/useTheme.test.ts
+++ b/tests/hooks/useTheme.test.ts
@@ -59,8 +59,8 @@ const createMatchMedia = (initialDark: boolean) => {
 
 describe('useTheme', () => {
   beforeEach(() => {
-    window.localStorage.clear();
-    document.documentElement.removeAttribute('data-theme');
+    globalThis.localStorage.clear();
+    delete document.documentElement.dataset.theme;
   });
 
   afterEach(() => {
@@ -69,7 +69,7 @@ describe('useTheme', () => {
 
   it('default é "system" quando localStorage está vazio', () => {
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
@@ -78,40 +78,40 @@ describe('useTheme', () => {
 
   it('resolve "system" para "dark" quando prefers-color-scheme: dark', () => {
     const { matchMedia } = createMatchMedia(true);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
     expect(result.current.theme).toBe('system');
     expect(result.current.resolvedTheme).toBe('dark');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
   });
 
   it('resolve "system" para "light" quando prefers-color-scheme: light', () => {
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
     expect(result.current.resolvedTheme).toBe('light');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
   });
 
   it('lê preferência persistida do localStorage', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
     expect(result.current.theme).toBe('dark');
     expect(result.current.resolvedTheme).toBe('dark');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
   });
 
   it('setTheme persiste e aplica no DOM imediatamente', () => {
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
@@ -119,27 +119,27 @@ describe('useTheme', () => {
 
     expect(result.current.theme).toBe('dark');
     expect(result.current.resolvedTheme).toBe('dark');
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
   });
 
   it('setTheme("system") remove a chave do localStorage', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
     act(() => result.current.setTheme('system'));
 
     expect(result.current.theme).toBe('system');
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
     expect(result.current.resolvedTheme).toBe('light');
   });
 
   it('toggleTheme alterna binariamente light ↔ dark', () => {
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
@@ -149,17 +149,17 @@ describe('useTheme', () => {
     act(() => result.current.toggleTheme());
     expect(result.current.theme).toBe('dark');
     expect(result.current.resolvedTheme).toBe('dark');
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
+    expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
 
     act(() => result.current.toggleTheme());
     expect(result.current.theme).toBe('light');
     expect(result.current.resolvedTheme).toBe('light');
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+    expect(globalThis.localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
   });
 
   it('reage a mudanças do SO quando theme === "system"', () => {
     const { matchMedia, setSystemDark } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
@@ -168,13 +168,13 @@ describe('useTheme', () => {
     act(() => setSystemDark(true));
 
     expect(result.current.resolvedTheme).toBe('dark');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
   });
 
   it('NÃO reage a mudanças do SO quando theme é explícito', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'light');
     const { matchMedia, setSystemDark } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 
@@ -184,13 +184,13 @@ describe('useTheme', () => {
 
     // Permaneceu light — preferência explícita tem precedência sobre SO.
     expect(result.current.resolvedTheme).toBe('light');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.dataset.theme).toBe('light');
   });
 
   it('ignora valores inválidos no localStorage e cai para "system"', () => {
-    window.localStorage.setItem(THEME_STORAGE_KEY, 'rainbow');
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'rainbow');
     const { matchMedia } = createMatchMedia(false);
-    vi.spyOn(window, 'matchMedia').mockImplementation(matchMedia);
+    vi.spyOn(globalThis, 'matchMedia').mockImplementation(matchMedia);
 
     const { result } = renderHook(() => useTheme());
 

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -112,8 +112,8 @@ function renderLogin(options: RenderOptions = {}): { client: ClientStub } {
 
 beforeEach(() => {
   installFakeIndexedDB();
-  window.localStorage.clear();
-  document.documentElement.removeAttribute('data-theme');
+  globalThis.localStorage.clear();
+  delete document.documentElement.dataset.theme;
 });
 
 afterEach(() => {

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -12,8 +12,8 @@ import { afterEach, vi } from 'vitest';
  * `prefers-color-scheme: dark` substituem esta implementação via
  * `vi.spyOn(window, 'matchMedia')` no próprio teste.
  */
-if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
-  Object.defineProperty(window, 'matchMedia', {
+if (typeof globalThis.window !== 'undefined' && typeof globalThis.matchMedia !== 'function') {
+  Object.defineProperty(globalThis, 'matchMedia', {
     writable: true,
     configurable: true,
     value: vi.fn().mockImplementation((query: string) => ({
@@ -35,14 +35,14 @@ if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
  * `<html>` para não vazar estado entre suites.
  */
 afterEach(() => {
-  if (typeof window !== 'undefined') {
+  if (typeof globalThis.window !== 'undefined') {
     try {
-      window.localStorage.clear();
+      globalThis.localStorage.clear();
     } catch {
       // ignore — modo privado/cota zerada não quebra o teste seguinte.
     }
   }
   if (typeof document !== 'undefined') {
-    document.documentElement.removeAttribute('data-theme');
+    delete document.documentElement.dataset.theme;
   }
 });

--- a/tests/shared/api/client.test.ts
+++ b/tests/shared/api/client.test.ts
@@ -35,11 +35,34 @@ function noContentResponse(): Response {
   return new Response(null, { status: 204 });
 }
 
+// Tipo do spy de `fetch` reutilizado entre helpers de módulo e o describe.
+type FetchSpy = ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<Response>>>;
+
+/**
+ * Helper que dispara um GET único com o cliente configurado e retorna
+ * os headers efetivamente enviados ao `fetch`. Centraliza o boilerplate
+ * (mock de resposta + leitura dos headers da call) para que os testes
+ * expressem só o cenário sendo coberto — configuração e expectativa.
+ *
+ * Mantida top-level (Sonar S7721) recebendo `fetchSpy` por parâmetro;
+ * o `let fetchSpy` do `describe` é injetado em cada chamada.
+ */
+async function captureHeaders(
+  fetchSpy: FetchSpy,
+  configOverrides: Partial<Parameters<typeof createApiClient>[0]>,
+  requestOptions?: { headers?: Record<string, string> },
+): Promise<Headers> {
+  fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+  const client = createApiClient({ baseUrl: '', ...configOverrides });
+  await client.get('/r', requestOptions);
+  return new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
+}
+
 describe('createApiClient', () => {
   // Mock tipado de `fetch`. `unknown[]` no input afrouxa a comparação com a
   // assinatura sobrecarregada do `fetch` global sem perder o `Response`
   // como retorno — basta para os asserts feitos pelos testes.
-  let fetchSpy: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<Response>>>;
+  let fetchSpy: FetchSpy;
 
   beforeEach(() => {
     fetchSpy = vi.fn();
@@ -137,24 +160,6 @@ describe('createApiClient', () => {
   });
 
   describe('X-System-Id (Issue #118)', () => {
-    /**
-     * Helper que dispara um GET único com o cliente configurado e
-     * retorna os headers efetivamente enviados ao `fetch`. Centraliza
-     * o boilerplate (mock de resposta + leitura dos headers da call)
-     * para que os testes expressem só o cenário sendo coberto —
-     * configuração e expectativa — eliminando duplicação que dispara
-     * o Quality Gate do SonarCloud.
-     */
-    async function captureHeaders(
-      configOverrides: Partial<Parameters<typeof createApiClient>[0]>,
-      requestOptions?: { headers?: Record<string, string> },
-    ): Promise<Headers> {
-      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
-      const client = createApiClient({ baseUrl: '', ...configOverrides });
-      await client.get('/r', requestOptions);
-      return new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers);
-    }
-
     test.each([
       {
         name: 'injeta X-System-Id quando o cliente é configurado com systemId',
@@ -182,7 +187,7 @@ describe('createApiClient', () => {
         expected: 'override',
       },
     ])('$name', async ({ config, options, expected }) => {
-      const headers = await captureHeaders(config, options);
+      const headers = await captureHeaders(fetchSpy, config, options);
       if (expected === null) {
         expect(headers.has('X-System-Id')).toBe(false);
       } else {

--- a/tests/shared/auth/AuthProvider.test.tsx
+++ b/tests/shared/auth/AuthProvider.test.tsx
@@ -43,7 +43,7 @@ import { STORAGE_KEYS } from '@/shared/auth/storage';
  */
 beforeEach(() => {
   installFakeIndexedDB();
-  window.localStorage.clear();
+  globalThis.localStorage.clear();
 });
 
 afterEach(() => {
@@ -89,14 +89,14 @@ describe('AuthProvider — estado inicial', () => {
   });
 
   test('migração: clearLegacyKeys remove lfc-admin-auth-user no boot', () => {
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       STORAGE_KEYS.legacyUser,
       JSON.stringify({ user: SAMPLE_USER, permissions: [] }),
     );
     const client = createAuthClientStub();
     renderHook(() => useAuth(), { wrapper: makeAuthWrapper(client) });
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
   });
 });
 
@@ -122,22 +122,21 @@ describe('AuthProvider — login (Issue #122)', () => {
   });
 
   test('login persiste catálogo em IndexedDB', async () => {
-    const { result: _ } = await setupLoggedInProvider();
+    await setupLoggedInProvider();
 
-    // Aguarda o `void permissionsCache.save(...)` resolver.
+    // Aguarda o `permissionsCache.save(...)` resolver.
     await waitFor(async () => {
       const cached = await permissionsCache.load();
       expect(cached?.user.email).toBe('ada@lfc.com.br');
     });
     const cached = await permissionsCache.load();
     expect(cached?.routes).toEqual(SAMPLE_PERMISSIONS.routes);
-    void _;
   });
 
   test('login persiste token em localStorage', async () => {
     await setupLoggedInProvider();
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-xyz');
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-xyz');
   });
 
   test('tokenRef é setado ANTES do /auth/permissions (header Authorization presente)', async () => {
@@ -202,7 +201,7 @@ describe('AuthProvider — login (Issue #122)', () => {
     expect(result.current.isLoading).toBe(false);
 
     // Storage limpo — a sessão parcial foi descartada.
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
 
     // Token injetado no client também foi zerado.
     const latest = lastCall(client.setAuth.mock.calls)?.[0];
@@ -254,7 +253,7 @@ describe('AuthProvider — login (Issue #122)', () => {
 
     expect(captured).toMatchObject({ kind: 'parse' });
     expect(result.current.isAuthenticated).toBe(false);
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 });
 
@@ -297,7 +296,7 @@ describe('AuthProvider — logout', () => {
     expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
     if (expectsWarning) {
       expect(warnSpy).toHaveBeenCalled();
     } else {
@@ -342,7 +341,7 @@ describe('AuthProvider — logout', () => {
 
     expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
     expect(result.current.isAuthenticated).toBe(false);
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
     expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
@@ -402,7 +401,7 @@ describe('AuthProvider — logout', () => {
 
     await waitFor(() => expect(capturedPath).toBe('/login'));
     expect(client.get).toHaveBeenLastCalledWith('/auth/logout');
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 });
 
@@ -457,7 +456,7 @@ describe('AuthProvider — hidratação (Issue #122)', () => {
   });
 
   test('com cache vazio mas token presente, dispara /auth/permissions', async () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
     const client = createAuthClientStub();
     client.get.mockResolvedValueOnce(SAMPLE_PERMISSIONS);
 
@@ -479,7 +478,7 @@ describe('AuthProvider — hidratação (Issue #122)', () => {
   });
 
   test('hidratação com /auth/permissions em 401 limpa sessão', async () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
     const client = createAuthClientStub();
     client.get.mockImplementationOnce(async () => {
       const config = lastCall(client.setAuth.mock.calls)?.[0];
@@ -494,11 +493,11 @@ describe('AuthProvider — hidratação (Issue #122)', () => {
     await waitFor(() => expect(result.current.isAuthenticated).toBe(false));
     expect(result.current.user).toBeNull();
     expect(result.current.permissions).toEqual([]);
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 
   test('hidratação com falha de rede mantém sessão local intacta (warning)', async () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const client = createAuthClientStub();
     client.get.mockRejectedValueOnce(NETWORK_ERROR);
@@ -507,14 +506,14 @@ describe('AuthProvider — hidratação (Issue #122)', () => {
 
     // Sessão local preservada — usuário continua autenticado.
     expect(result.current.isAuthenticated).toBe(true);
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-persistido');
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBe('jwt-persistido');
     expect(warnSpy).toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });
 
   test('renderiza splash enquanto hidratação está em curso (token sem cache)', async () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
     const client = createAuthClientStub();
     let resolveFetch: ((value: PermissionsResponse) => void) | null = null;
     client.get.mockImplementationOnce(
@@ -567,7 +566,7 @@ describe('AuthProvider — hidratação (Issue #122)', () => {
   });
 
   test('unmount cancela /auth/permissions pendente via AbortController', async () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
     const client = createAuthClientStub();
     let abortSignal: AbortSignal | undefined;
     client.get.mockImplementationOnce((_path: string, options?: { signal?: AbortSignal }) => {

--- a/tests/shared/auth/__helpers__/authTestHelpers.tsx
+++ b/tests/shared/auth/__helpers__/authTestHelpers.tsx
@@ -142,11 +142,11 @@ export async function renderAuthHook(
 
 /**
  * Pré-popula token (`localStorage`) e catálogo (IndexedDB) com a
- * sessão de exemplo. Usado em todo cenário que precisa de "usuário
+ * sessão de exemplo. Usado em qualquer cenário que precisa de "usuário
  * autenticado já hidratado" (logout, verifyRoute, RequireAuth).
  */
 export async function seedPersistedSession(): Promise<void> {
-  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
+  globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-persistido');
   await permissionsCache.save({
     user: SAMPLE_USER,
     routes: SAMPLE_PERMISSIONS.routes,

--- a/tests/shared/auth/__helpers__/fakeIndexedDB.ts
+++ b/tests/shared/auth/__helpers__/fakeIndexedDB.ts
@@ -50,32 +50,38 @@ let originalIndexedDB: IDBFactory | undefined;
 let installed = false;
 
 /**
+ * Cria um IDBRequest simulado que dispara `onsuccess` na microtask
+ * seguinte, espelhando o comportamento assíncrono real do IndexedDB.
+ *
+ * Mantida em escopo de módulo (top-level) — não depende de nenhum
+ * binding interno do `createFakeStore`, então não precisa estar
+ * aninhada (Sonar S7721).
+ */
+function makeRequest<T>(result: T): IDBRequest<T> {
+  const request: MutableRequest<T> = {
+    result,
+    error: null,
+    onsuccess: null,
+    onerror: null,
+  };
+  queueMicrotask(() => {
+    request.onsuccess?.call(request as unknown as IDBRequest<T>, new Event('success'));
+  });
+  return request as unknown as IDBRequest<T>;
+}
+
+/**
  * Cria um IDBObjectStore mínimo que opera sobre o `Map` interno do
- * banco. Cada `request` resolvido aciona `onsuccess` na microtask
- * seguinte, simulando o comportamento assíncrono real do IndexedDB.
+ * banco.
  */
 function createFakeStore(state: FakeStoreState): IDBObjectStore {
-  function makeRequest<T>(result: T): IDBRequest<T> {
-    const request: MutableRequest<T> = {
-      result,
-      error: null,
-      onsuccess: null,
-      onerror: null,
-    };
-    queueMicrotask(() => {
-      request.onsuccess?.call(request as unknown as IDBRequest<T>, new Event('success'));
-    });
-    return request as unknown as IDBRequest<T>;
-  }
-
   return {
     get(key: IDBValidKey): IDBRequest<unknown> {
       return makeRequest(state.data.get(key));
     },
-    put(value: unknown, key?: IDBValidKey): IDBRequest<IDBValidKey> {
-      const k = key ?? 'current';
-      state.data.set(k, value);
-      return makeRequest<IDBValidKey>(k);
+    put(value: unknown, key: IDBValidKey = 'current'): IDBRequest<IDBValidKey> {
+      state.data.set(key, value);
+      return makeRequest<IDBValidKey>(key);
     },
     delete(key: IDBValidKey): IDBRequest<undefined> {
       state.data.delete(key);
@@ -191,8 +197,7 @@ function createFakeFactory(): IDBFactory {
       };
       let state = databases.get(name);
       const requestedVersion = version ?? 1;
-      const isNew = !state;
-      const needsUpgrade = !state || (state && state.version < requestedVersion);
+      const needsUpgrade = !state || state.version < requestedVersion;
       if (!state) {
         state = { version: requestedVersion, stores: new Map() };
         databases.set(name, state);
@@ -208,9 +213,6 @@ function createFakeFactory(): IDBFactory {
             new Event('upgradeneeded') as IDBVersionChangeEvent,
           );
         }
-        // Ignora o `isNew` para silenciar warning de não uso quando a
-        // semântica `needsUpgrade` já cobre o disparo.
-        void isNew;
         request.onsuccess?.call(
           request as unknown as IDBOpenDBRequest,
           new Event('success'),
@@ -257,11 +259,11 @@ export function installFakeIndexedDB(): void {
   if (installed) {
     return;
   }
-  if (typeof window === 'undefined') {
+  if (typeof globalThis.window === 'undefined') {
     return;
   }
-  originalIndexedDB = window.indexedDB;
-  Object.defineProperty(window, 'indexedDB', {
+  originalIndexedDB = globalThis.indexedDB;
+  Object.defineProperty(globalThis, 'indexedDB', {
     configurable: true,
     writable: true,
     value: createFakeFactory(),
@@ -275,10 +277,10 @@ export function installFakeIndexedDB(): void {
  */
 export function uninstallFakeIndexedDB(): void {
   databases.clear();
-  if (!installed || typeof window === 'undefined') {
+  if (!installed || typeof globalThis.window === 'undefined') {
     return;
   }
-  Object.defineProperty(window, 'indexedDB', {
+  Object.defineProperty(globalThis, 'indexedDB', {
     configurable: true,
     writable: true,
     value: originalIndexedDB,
@@ -287,12 +289,13 @@ export function uninstallFakeIndexedDB(): void {
 }
 
 /**
- * Remove o `indexedDB` do `window` para simular browser sem suporte.
- * Útil para testar o caminho de fallback gracioso do `permissionsCache`.
+ * Remove o `indexedDB` do contexto global para simular browser sem
+ * suporte. Útil para testar o caminho de fallback gracioso do
+ * `permissionsCache`.
  */
 export function disableIndexedDB(): void {
-  if (typeof window === 'undefined') return;
-  Object.defineProperty(window, 'indexedDB', {
+  if (typeof globalThis.window === 'undefined') return;
+  Object.defineProperty(globalThis, 'indexedDB', {
     configurable: true,
     writable: true,
     value: undefined,

--- a/tests/shared/auth/guards.test.tsx
+++ b/tests/shared/auth/guards.test.tsx
@@ -34,7 +34,7 @@ import { STORAGE_KEYS } from '@/shared/auth/storage';
 async function seedSession(
   routes: ReadonlyArray<string> = ['AUTH_V1_SYSTEMS_LIST'],
 ): Promise<void> {
-  window.localStorage.setItem(STORAGE_KEYS.token, 'jwt-test');
+  globalThis.localStorage.setItem(STORAGE_KEYS.token, 'jwt-test');
   await permissionsCache.save({
     user: SAMPLE_USER,
     routes,
@@ -124,7 +124,7 @@ function renderRequireAuthWithContext(options: {
 
 beforeEach(() => {
   installFakeIndexedDB();
-  window.localStorage.clear();
+  globalThis.localStorage.clear();
 });
 
 afterEach(() => {

--- a/tests/shared/auth/storage.test.ts
+++ b/tests/shared/auth/storage.test.ts
@@ -15,7 +15,7 @@ const SAMPLE_TOKEN = 'jwt-abc-123';
  * possa configurar pré-condições sem assumir ordem de execução.
  */
 beforeEach(() => {
-  window.localStorage.clear();
+  globalThis.localStorage.clear();
 });
 
 afterEach(() => {
@@ -34,19 +34,19 @@ describe('tokenStorage.load', () => {
   });
 
   test('retorna null quando o valor é vazio (defensivo)', () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, '');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, '');
 
     expect(tokenStorage.load()).toBeNull();
   });
 
   test('retorna null quando o valor é apenas whitespace', () => {
-    window.localStorage.setItem(STORAGE_KEYS.token, '   ');
+    globalThis.localStorage.setItem(STORAGE_KEYS.token, '   ');
 
     expect(tokenStorage.load()).toBeNull();
   });
 
   test('retorna null quando localStorage.getItem lança', () => {
-    vi.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+    vi.spyOn(Object.getPrototypeOf(globalThis.localStorage), 'getItem').mockImplementation(() => {
       throw new Error('storage indisponível');
     });
 
@@ -58,7 +58,7 @@ describe('tokenStorage.save', () => {
   test('persiste token na chave namespaced', () => {
     tokenStorage.save(SAMPLE_TOKEN);
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe(SAMPLE_TOKEN);
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBe(SAMPLE_TOKEN);
   });
 
   test('sobrescreve token existente', () => {
@@ -66,12 +66,12 @@ describe('tokenStorage.save', () => {
     const novoToken = 'jwt-rotacionado';
     tokenStorage.save(novoToken);
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe(novoToken);
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBe(novoToken);
     expect(tokenStorage.load()).toBe(novoToken);
   });
 
   test('não propaga exceção quando setItem lança (quota / private mode)', () => {
-    vi.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => {
+    vi.spyOn(Object.getPrototypeOf(globalThis.localStorage), 'setItem').mockImplementation(() => {
       throw new Error('quota exceeded');
     });
 
@@ -85,16 +85,16 @@ describe('tokenStorage.clear', () => {
 
     tokenStorage.clear();
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 
   test('é idempotente quando não há token persistido', () => {
     expect(() => tokenStorage.clear()).not.toThrow();
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBeNull();
   });
 
   test('não propaga exceção quando removeItem lança', () => {
-    vi.spyOn(window.localStorage.__proto__, 'removeItem').mockImplementation(() => {
+    vi.spyOn(Object.getPrototypeOf(globalThis.localStorage), 'removeItem').mockImplementation(() => {
       throw new Error('storage indisponível');
     });
 
@@ -111,34 +111,34 @@ describe('tokenStorage.clear', () => {
 
 describe('tokenStorage.clearLegacyKeys (Issue #122 — migração)', () => {
   test('remove a chave legada lfc-admin-auth-user quando presente', () => {
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       STORAGE_KEYS.legacyUser,
       JSON.stringify({ user: { id: 'u-1' }, permissions: [] }),
     );
 
     tokenStorage.clearLegacyKeys();
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
   });
 
   test('é idempotente quando a chave legada não existe', () => {
     expect(() => tokenStorage.clearLegacyKeys()).not.toThrow();
-    expect(window.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
   });
 
   test('não toca na chave do token (token sobrevive à migração)', () => {
     tokenStorage.save(SAMPLE_TOKEN);
-    window.localStorage.setItem(STORAGE_KEYS.legacyUser, '{}');
+    globalThis.localStorage.setItem(STORAGE_KEYS.legacyUser, '{}');
 
     tokenStorage.clearLegacyKeys();
 
-    expect(window.localStorage.getItem(STORAGE_KEYS.token)).toBe(SAMPLE_TOKEN);
-    expect(window.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.token)).toBe(SAMPLE_TOKEN);
+    expect(globalThis.localStorage.getItem(STORAGE_KEYS.legacyUser)).toBeNull();
   });
 
   test('não propaga exceção quando removeItem lança', () => {
-    window.localStorage.setItem(STORAGE_KEYS.legacyUser, '{}');
-    vi.spyOn(window.localStorage.__proto__, 'removeItem').mockImplementation(() => {
+    globalThis.localStorage.setItem(STORAGE_KEYS.legacyUser, '{}');
+    vi.spyOn(Object.getPrototypeOf(globalThis.localStorage), 'removeItem').mockImplementation(() => {
       throw new Error('storage indisponível');
     });
 


### PR DESCRIPTION
## Contexto

Parte do plano de cleanup do SonarCloud em 3 PRs sequenciais para zerar todas as issues abertas em `lfc-admin-gui`:

- **PR-A** (mergeada em #140) — `chore(sonar): documentar exclusao de identity/ e bulk-WONTFIX legacy issues`. Documentou exclusão do diretório `identity/` e fechou 180 issues legadas via API.
- **PR-B** (esta) — refactor mecânico em `tests/` para resolver as 104 issues abertas em arquivos de teste.
- **PR-C** (próxima) — refactor real em `src/` + revisão de hotspots.

Resolve 104 open issues do SonarCloud em `tests/**` (parte do plano de cleanup completo, ver PR #140).

## Objetivo

Aplicar correções puramente sintáticas/cosméticas em `tests/` para satisfazer regras do SonarCloud, sem alterar nenhum comportamento de teste.

## Regras endereçadas

| Regra | Severidade | Qtde | Tipo de fix |
|-------|------------|-----:|-------------|
| `typescript:S7764` | MINOR | 78 | `window` → `globalThis` (ou `globalThis.window` quando precisa do tipo `Window`) |
| `typescript:S7761` | MAJOR | 15 | `element.dataset.<chave>` em vez de `(get|set|remove)Attribute('data-...')` |
| `typescript:S6654` | MINOR | 4 | `__proto__` deprecated → `Object.getPrototypeOf(globalThis.localStorage)` |
| `typescript:S7721` | MAJOR | 2 | `makeRequest` (em `fakeIndexedDB.ts`) e `captureHeaders` (em `client.test.ts`) movidas para top-level |
| `typescript:S3735` | CRITICAL | 2 | Removidos os usos de `void` operator (`void _;` no `AuthProvider.test.tsx` e `void isNew` no `fakeIndexedDB.ts`) |
| `typescript:S7760` | MAJOR | 1 | `put(value, key = 'current')` em vez de reassignment |
| `typescript:S6594` | MINOR | 1 | `RegExp.exec()` em vez de `.match()` no `Sidebar.test.tsx` |
| `typescript:S1135` | INFO | 1 | Comentário "todo cenário" → "qualquer cenário" no `authTestHelpers.tsx` (era falso positivo de TODO em prosa) |

**Total: 104 issues abertas resolvidas.**

## Decisões nos 2 `void` (CRITICAL)

1. **`tests/shared/auth/__helpers__/fakeIndexedDB.ts:213`** — havia `const isNew = !state` calculado mas nunca consumido (apenas `needsUpgrade` é usado depois). O `void isNew` silenciava unused-var. Remoção da declaração elimina ambos os `void` e a variável morta.
2. **`tests/shared/auth/AuthProvider.test.tsx:134`** — `{ result: _ } = await setupLoggedInProvider()` + `void _;` — o teste só precisa do side-effect de `setupLoggedInProvider` (popular IndexedDB), não do `result`. Substituído por `await setupLoggedInProvider();` (descarta retorno).

Ambos preservam o comportamento original.

## Arquivos impactados

- `tests/App.test.tsx` (2)
- `tests/components/layout/Sidebar.test.tsx` (5)
- `tests/components/ui/ThemeToggle.test.tsx` (9)
- `tests/hooks/useTheme.test.ts` (26)
- `tests/pages/LoginPage.test.tsx` (2)
- `tests/setupTests.ts` (6)
- `tests/shared/api/client.test.ts` (1)
- `tests/shared/auth/AuthProvider.test.tsx` (17)
- `tests/shared/auth/__helpers__/authTestHelpers.tsx` (2)
- `tests/shared/auth/__helpers__/fakeIndexedDB.ts` (10)
- `tests/shared/auth/guards.test.tsx` (2)
- `tests/shared/auth/storage.test.ts` (22)

## Testes

Suite completa rodada via container (`docker compose run --rm web sh -c 'npm ci --include=dev && npm test'`):

- `Test Files  43 passed (43)`
- `Tests  567 passed (567)`

Gate pré-PR via container Docker (todos verdes):

- `npm run lint` — 0 erros, 0 warnings.
- `npm run typecheck` — 0 erros TypeScript.
- `npm test` — 567/567 passando.
- `npx jscpd src --threshold 3 --min-lines 10` — 2.78% total, dentro do limite. Nenhum arquivo do diff (todos sob `tests/`) introduzido em clones.

## Visual

Sem mudanças visuais (refactor exclusivo de arquivos de teste).

## Segurança

Sem mudanças de superfície. `Object.getPrototypeOf(globalThis.localStorage)` é equivalente a `globalThis.localStorage.__proto__` em runtime e remove o uso de propriedade deprecada.

## Riscos

- Baixo: refactor puramente cosmético em testes. Nenhuma alteração no código de produção.
- Em caso de dúvida sobre paridade comportamental, basta verificar o diff cleanup mecânico (window→globalThis, removeAttribute('data-X')→delete dataset.X, etc.).

## Issue relacionada

Nenhuma issue diretamente — esta PR faz parte do plano de cleanup Sonar (3 PRs). Ver PR #140 (PR-A) para contexto completo.