### PR TITLE
feat(roles): listagem por sistema (#66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,7 @@ $RECYCLE.BIN/
 
 # CI artifacts
 audit-report.json
+
+# jscpd reports (gerados pelo gate pré-PR; nunca commitados)
+jscpd-report/
+jscpd-report-base/

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -28,6 +28,9 @@ const ROUTE_TITLES: RouteTitleEntry[] = [
   // primeiro padrão que casar ganha. Sem essa ordem, a Topbar exibiria
   // "Sistemas" na página de listagem de rotas escopada a um sistema.
   { pattern: '/systems/:systemId/routes', title: 'Rotas' },
+  // Issue #66: mesma regra — `/systems/:systemId/roles` precisa vir
+  // ANTES de `/systems`, pelo mesmo motivo do `matchPath` prefix-match.
+  { pattern: '/systems/:systemId/roles', title: 'Roles' },
   { pattern: '/systems', title: 'Sistemas' },
   { pattern: '/routes', title: 'Rotas' },
   { pattern: '/roles', title: 'Roles' },

--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -1,165 +1,439 @@
-import { Plus, MoreHorizontal } from 'lucide-react';
-import React from 'react';
-import styled from 'styled-components';
+import { ArrowLeft } from "lucide-react";
+import React, { useCallback, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 
-import { PageHeader } from '../components/layout/PageHeader';
-import { Button, Badge } from '../components/ui';
+import { PageHeader } from "../components/layout/PageHeader";
+import {
+  Alert,
+  Button,
+  Table,
+} from "../components/ui";
+import { useDebouncedValue } from "../hooks/useDebouncedValue";
+import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
+import { usePaginationControls } from "../hooks/usePaginationControls";
+import {
+  DEFAULT_ROLES_INCLUDE_DELETED,
+  DEFAULT_ROLES_PAGE,
+  DEFAULT_ROLES_PAGE_SIZE,
+  listRoles,
+} from "../shared/api";
+import {
+  BackLink,
+  CardCode,
+  CardDescription,
+  CardHeader,
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
+  DescriptionCell,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ErrorRetryBlock,
+  InitialLoadingSpinner,
+  InvalidIdNotice,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  PaginationFooter,
+  Placeholder,
+  RefetchOverlay,
+  StatusBadge,
+  TableForDesktop,
+  TableShell,
+  useListingLiveMessage,
+} from "../shared/listing";
 
-interface RoleItem {
-  name: string;
-  users: number;
-  perms: number;
-  desc: string;
-  system: string;
-}
-
-const AUTHENTICATOR_SYSTEM = 'lfc-authenticator';
-
-const ROLES: RoleItem[] = [
-  { name: 'root',    users: 2,  perms: 12, desc: 'Acesso irrestrito a todos os sistemas',          system: '—' },
-  { name: 'admin',   users: 6,  perms: 8,  desc: 'Gerenciamento de usuários e permissões',         system: AUTHENTICATOR_SYSTEM },
-  { name: 'editor',  users: 14, perms: 5,  desc: 'Criar e editar recursos, sem deletar',           system: AUTHENTICATOR_SYSTEM },
-  { name: 'viewer',  users: 32, perms: 2,  desc: 'Leitura apenas',                                 system: AUTHENTICATOR_SYSTEM },
-  { name: 'default', users: 1,  perms: 3,  desc: 'Role de fallback para usuários legados',         system: '—' },
-];
+import type { TableColumn } from "../components/ui";
+import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
 
 /**
- * Em mobile permitimos `overflow-x: auto` para que tabelas largas
- * mantenham todas as colunas sem espremer texto; o container restringe o
- * scroll ao card e impede que ele afete o layout principal.
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
+ * o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 request por caractere. Espelha o valor
+ * usado pela `RoutesPage`/`SystemsPage`.
  */
-const TableWrap = styled.div`
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  background: var(--bg-surface);
-`;
+const SEARCH_DEBOUNCE_MS = 300;
 
-const Table = styled.table`
-  width: 100%;
-  min-width: 640px;
-  border-collapse: collapse;
-  font-size: 13.5px;
+interface RolesPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido — a
+   * página usa o singleton `apiClient` por trás de `listRoles`. Em
+   * testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
 
-  @media (min-width: 48em) {
-    min-width: 0;
+/**
+ * Heurística leve para descartar `:systemId` claramente inválido antes
+ * de bater no backend — evita request desperdiçada e produz feedback
+ * imediato ("ID inválido"). Aceita qualquer string não-vazia com pelo
+ * menos um caractere não-whitespace, deixando a validação rigorosa
+ * (UUID v4) a cargo do backend. Espelha `RoutesPage` (lição PR #128 —
+ * shared helpers desde o primeiro PR do recurso).
+ */
+function isProbablyValidSystemId(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Renderiza a célula de descrição truncando textos longos via
+ * `text-overflow: ellipsis`. **Hoje** o backend não devolve
+ * `description` em `RoleResponse` (TODO no model `AppRole` — ver
+ * `src/shared/api/roles.ts`), então a coluna tipicamente exibe "—".
+ * Quando o backend evoluir, a UI mostra automaticamente sem mudar
+ * código.
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile —
+ * centralizar evita duplicação visual.
+ */
+function renderDescription(row: RoleDto): React.ReactNode {
+  if (
+    row.description === null ||
+    row.description === undefined ||
+    row.description.trim().length === 0
+  ) {
+    return <Placeholder>—</Placeholder>;
   }
+  return (
+    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
+  );
+}
 
-  thead {
-    background: var(--bg-elevated);
+/**
+ * Renderiza a contagem de permissões/usuários da role. **Hoje** o
+ * backend não devolve esses campos (TODO documentado no DTO); a UI
+ * exibe "—" enquanto o valor for `null`/`undefined`. Quando o
+ * backend ganhar `permissionsCount`/`usersCount`, a UI passa a
+ * exibir o número formatado sem mudar a página.
+ *
+ * Centralizado em função pura para reuso entre tabela desktop e
+ * cards mobile.
+ */
+function renderCount(value: number | null | undefined): React.ReactNode {
+  if (typeof value !== "number") {
+    return <Placeholder>—</Placeholder>;
   }
+  return <Mono>{value}</Mono>;
+}
 
-  th {
-    padding: 11px 18px;
-    text-align: left;
-    font-family: var(--font-mono);
-    font-size: 10.5px;
-    font-weight: var(--weight-semibold);
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--fg3);
-    border-bottom: 1px solid var(--border-subtle);
-  }
+export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
+  // `useParams` devolve `string | undefined` — nunca lançamos: rota
+  // sem `:systemId` pinta o `InvalidIdNotice` no lugar da listagem.
+  const { systemId } = useParams<{ systemId: string }>();
+  const hasValidSystemId = isProbablyValidSystemId(systemId);
 
-  tbody tr {
-    border-bottom: 1px solid var(--border-subtle);
-    transition: background 100ms;
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
 
-    &:last-child {
-      border-bottom: none;
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_ROLES_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_ROLES_PAGE);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
+   * 3 itens, mas continuo na página 5 vazia". Espelha `RoutesPage`.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm("");
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`: capture os params
+   * derivados e devolva uma função que aceita `signal` no `options`.
+   * Skipa montar params quando `:systemId` é inválido — o hook
+   * recebe `skip: true` e nem chama o `fetcher`.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listRoles(
+        {
+          systemId: hasValidSystemId ? systemId : "",
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_ROLES_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [
+      client,
+      hasValidSystemId,
+      includeDeleted,
+      page,
+      systemId,
+      trimmedSearchInput,
+    ],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<RoleDto>({
+    fetcher,
+    fallbackErrorMessage:
+      "Falha ao carregar a lista de roles. Tente novamente.",
+    skip: !hasValidSystemId,
+  });
+
+  const {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+  } = usePaginationControls({
+    total,
+    appliedPageSize,
+    defaultPageSize: DEFAULT_ROLES_PAGE_SIZE,
+    page,
+    setPage,
+  });
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio sem busca → "nenhuma role cadastrada" + dica sobre o toggle
+   *   "Mostrar inativas" caso esteja desligado.
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhuma role encontrada para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="roles-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
     }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhuma role cadastrada para este sistema.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Roles removidas podem ser visualizadas ativando &quot;Mostrar
+            inativas&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
 
-    &:hover {
-      background: var(--bg-elevated);
-    }
+  const columns = useMemo<ReadonlyArray<TableColumn<RoleDto>>>(
+    () => [
+      {
+        key: "name",
+        label: "Nome",
+        render: (row) => row.name,
+      },
+      {
+        key: "description",
+        label: "Descrição",
+        render: renderDescription,
+      },
+      {
+        key: "permissionsCount",
+        label: "Permissões",
+        width: "140px",
+        render: (row) => renderCount(row.permissionsCount),
+      },
+      {
+        key: "usersCount",
+        label: "Usuários",
+        width: "120px",
+        render: (row) => renderCount(row.usersCount),
+      },
+      {
+        key: "status",
+        label: "Status",
+        width: "120px",
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
+      },
+    ],
+    [],
+  );
+
+  const showOverlay = isFetching && !isInitialLoading;
+
+  // ARIA-live: anuncia o estado da listagem quando muda. Em loading
+  // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
+  // total. Em erro, o `<Alert role="alert">` já cobre. O hook
+  // `useListingLiveMessage` centraliza a árvore de decisão (lição
+  // PR #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: "role",
+      pluralCarregando: "roles",
+      vazioSemBusca: "Nenhuma role cadastrada para este sistema.",
+    },
+  });
+
+  if (!hasValidSystemId) {
+    return (
+      <>
+        <BackLink to="/systems" data-testid="roles-back">
+          <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+          Voltar para Sistemas
+        </BackLink>
+        <PageHeader
+          eyebrow="03 Roles"
+          title="Roles do sistema"
+          desc="Selecione um sistema para visualizar suas roles."
+        />
+        <InvalidIdNotice data-testid="roles-invalid-id">
+          <Alert variant="warning">
+            ID de sistema ausente ou inválido na URL. Volte para a listagem de
+            sistemas e selecione um sistema para visualizar suas roles.
+          </Alert>
+        </InvalidIdNotice>
+      </>
+    );
   }
 
-  td {
-    padding: 12px 18px;
-    color: var(--fg2);
-    vertical-align: middle;
+  return (
+    <>
+      <BackLink to="/systems" data-testid="roles-back">
+        <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+        Voltar para Sistemas
+      </BackLink>
+      <PageHeader
+        eyebrow="03 Roles"
+        title="Roles do sistema"
+        desc="Roles agrupam permissões e podem ser atribuídas a usuários do sistema selecionado. Cada role expõe nome, descrição e contagem de permissões/usuários."
+      />
 
-    &:first-child {
-      color: var(--fg1);
-      font-weight: var(--weight-medium);
-    }
-  }
-`;
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome ou código da role"
+        searchAriaLabel="Buscar roles por nome ou código"
+        searchTestId="roles-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui roles com remoção lógica."
+        includeDeletedTestId="roles-include-deleted"
+      />
 
-const MonoMuted = styled.span`
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--fg3);
-`;
+      <LiveRegion message={liveMessage} testId="roles-live" />
 
-const Mono = styled.span`
-  font-family: var(--font-mono);
-  font-size: 12px;
-`;
+      {isInitialLoading && (
+        <InitialLoadingSpinner testId="roles-loading" label="Carregando roles" />
+      )}
 
-const IconBtn = styled.button`
-  appearance: none;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  width: 28px;
-  height: 28px;
-  cursor: pointer;
-  color: var(--fg3);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+      {!isInitialLoading && errorMessage && (
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="roles-retry"
+        />
+      )}
 
-  &:hover {
-    background: var(--bg-elevated);
-    color: var(--fg1);
-    border-color: var(--border-subtle);
-  }
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          <TableForDesktop>
+            <Table<RoleDto>
+              caption="Lista de roles do sistema selecionado."
+              columns={columns}
+              data={rows}
+              getRowKey={(row) => row.id}
+              emptyState={emptyContent}
+            />
+          </TableForDesktop>
+          <CardListForMobile
+            role="list"
+            aria-label="Lista de roles do sistema selecionado"
+            data-testid="roles-card-list"
+          >
+            {rows.length === 0 && emptyContent}
+            {rows.map((row) => (
+              <EntityCard
+                key={row.id}
+                role="listitem"
+                tabIndex={0}
+                data-testid={`roles-card-${row.id}`}
+              >
+                <CardHeader>
+                  <CardCode>{row.code}</CardCode>
+                  <StatusBadge deletedAt={row.deletedAt} />
+                </CardHeader>
+                <CardName>{row.name}</CardName>
+                {row.description !== null &&
+                  row.description !== undefined &&
+                  row.description.trim().length > 0 && (
+                    <CardDescription>{row.description}</CardDescription>
+                  )}
+                <CardMeta>
+                  <CardMetaTerm>Permissões</CardMetaTerm>
+                  <CardMetaValue>{renderCount(row.permissionsCount)}</CardMetaValue>
+                  <CardMetaTerm>Usuários</CardMetaTerm>
+                  <CardMetaValue>{renderCount(row.usersCount)}</CardMetaValue>
+                </CardMeta>
+              </EntityCard>
+            ))}
+          </CardListForMobile>
+          {showOverlay && <RefetchOverlay testId="roles-overlay" />}
+        </TableShell>
+      )}
 
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-`;
-
-export const RolesPage: React.FC = () => (
-  <>
-    <PageHeader
-      eyebrow="03 Roles"
-      title="Gerenciamento de Roles"
-      desc="Roles agrupam permissões e podem ser atribuídas a usuários. Permissões diretas sobrescrevem as da role."
-      actions={<Button variant="primary" icon={<Plus size={14} strokeWidth={1.5} />}>Nova role</Button>}
-    />
-    <TableWrap>
-      <Table>
-        <thead>
-          <tr>
-            <th>Role</th>
-            <th>Sistema</th>
-            <th>Permissões</th>
-            <th>Usuários</th>
-            <th>Descrição</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {ROLES.map(r => (
-            <tr key={r.name}>
-              <td><Badge variant="neutral">{r.name}</Badge></td>
-              <td><MonoMuted>{r.system}</MonoMuted></td>
-              <td><Mono>{r.perms} permissões</Mono></td>
-              <td><Mono>{r.users}</Mono></td>
-              <td>{r.desc}</td>
-              <td>
-                <IconBtn aria-label="Mais opções">
-                  <MoreHorizontal size={14} strokeWidth={1.5} />
-                </IconBtn>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    </TableWrap>
-  </>
-);
+      {!isInitialLoading && !errorMessage && total > 0 && (
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={handlePrevPage}
+          onNext={handleNextPage}
+          pageInfoTestId="roles-page-info"
+          prevTestId="roles-prev"
+          nextTestId="roles-next"
+        />
+      )}
+    </>
+  );
+};

--- a/src/pages/RoutesPage.tsx
+++ b/src/pages/RoutesPage.tsx
@@ -1,25 +1,17 @@
 import {
   ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
   Pencil,
   Plus,
-  RotateCcw,
-  Search,
   Trash2,
 } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
-import styled from "styled-components";
+import { useParams } from "react-router-dom";
 
 import { PageHeader } from "../components/layout/PageHeader";
 import {
   Alert,
   Badge,
   Button,
-  Input,
-  Spinner,
-  Switch,
   Table,
 } from "../components/ui";
 import { useDebouncedValue } from "../hooks/useDebouncedValue";
@@ -32,6 +24,36 @@ import {
   listRoutes,
 } from "../shared/api";
 import { useAuth } from "../shared/auth";
+import {
+  BackLink,
+  CardCode,
+  CardDescription,
+  CardHeader,
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
+  DescriptionCell,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ErrorRetryBlock,
+  InitialLoadingSpinner,
+  InvalidIdNotice,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  PaginationFooter,
+  Placeholder,
+  RefetchOverlay,
+  RowActions,
+  StatusBadge,
+  TableForDesktop,
+  TableShell,
+  useListingLiveMessage,
+} from "../shared/listing";
 
 import { DeleteRouteConfirm } from "./routes/DeleteRouteConfirm";
 import { EditRouteModal } from "./routes/EditRouteModal";
@@ -103,293 +125,13 @@ interface RoutesPageProps {
 
 /* ─── Styled primitives ──────────────────────────────────── */
 
-const BackLink = styled(Link)`
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  margin-bottom: var(--space-3);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  text-decoration: none;
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
-  border-radius: var(--radius-sm);
-  padding: 2px 4px;
-  margin-left: -4px;
-
-  &:hover {
-    color: var(--fg2);
-  }
-
-  &:focus-visible {
-    outline: var(--border-thick) solid var(--accent);
-    outline-offset: 2px;
-  }
-`;
-
-const Toolbar = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  margin-bottom: var(--space-5);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-6);
-  }
-`;
-
-const SearchSlot = styled.div`
-  width: 100%;
-
-  @media (min-width: 48em) {
-    max-width: 360px;
-    flex: 1;
-  }
-`;
-
-const ToolbarActions = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--space-3);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    gap: var(--space-4);
-  }
-`;
-
-const TableShell = styled.div`
-  position: relative;
-`;
-
-/**
- * Visibilidade da `Table` (desktop) e do bloco de cards (mobile). A
- * `Table` do design system é HTML semântico — em mobile fica oculta para
- * favorecer a leitura em coluna única via cards (critério da issue
- * "quebra responsiva mostra cards"). O switch acontece em
- * `--bp-md` (48em ≈ 768px), espelhando o breakpoint usado no resto do
- * shell.
- */
-const TableForDesktop = styled.div`
-  display: none;
-
-  @media (min-width: 48em) {
-    display: block;
-  }
-`;
-
-const CardListForMobile = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-
-  @media (min-width: 48em) {
-    display: none;
-  }
-`;
-
-/**
- * Card individual da listagem mobile. Mantém os mesmos campos da tabela
- * (código, descrição, política JWT alvo, status) com hierarquia tipográfica
- * dedicada — o monoespaçado destaca o `code`, a descrição segue em
- * parágrafo legível e o token type aparece como Badge pequeno.
- */
-const RouteCard = styled.article`
-  border: var(--border-thin) solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  background: var(--bg-surface);
-  padding: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  transition: background var(--duration-fast) var(--ease-default);
-
-  &:hover {
-    background: var(--bg-ghost-hover);
-  }
-
-  &:focus-visible {
-    outline: var(--border-thick) solid var(--accent);
-    outline-offset: 2px;
-  }
-`;
-
-const CardHeader = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-`;
-
-const CardCode = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  color: var(--fg1);
-  font-weight: var(--weight-medium);
-  word-break: break-word;
-`;
-
-const CardName = styled.h3`
-  font-size: var(--text-md);
-  font-weight: var(--weight-semibold);
-  color: var(--fg1);
-  margin: 0;
-  letter-spacing: -0.01em;
-`;
-
-const CardDescription = styled.p`
-  margin: 0;
-  font-size: var(--text-sm);
-  color: var(--fg2);
-  line-height: var(--leading-base);
-`;
-
-const CardMeta = styled.dl`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: var(--space-1) var(--space-3);
-  margin: 0;
-  font-size: var(--text-xs);
-`;
-
-const CardMetaTerm = styled.dt`
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-wider);
-  text-transform: uppercase;
-`;
-
-const CardMetaValue = styled.dd`
-  margin: 0;
-  font-family: var(--font-mono);
-  color: var(--fg2);
-  word-break: break-word;
-`;
-
-/**
- * Overlay leve aplicado em cima da listagem durante refetches subsequentes
- * (busca/paginação/toggle). Mantém os dados anteriores visíveis para
- * evitar flicker enquanto sinaliza atividade — o spinner ancorado ao
- * topo deixa claro que algo está em curso sem mover a tabela. Espelha o
- * padrão da `SystemsPage`.
- */
-const Overlay = styled.div`
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: var(--space-6);
-  background: color-mix(in srgb, var(--bg-base) 55%, transparent);
-  border-radius: var(--radius-lg);
-  pointer-events: none;
-  z-index: 1;
-`;
-
-const InitialLoading = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-12) 0;
-`;
-
-const ErrorBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: flex-start;
-`;
-
-const FootBar = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: stretch;
-  margin-top: var(--space-5);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-`;
-
-const PageInfo = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-wider);
-`;
-
-const PageNav = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-`;
-
-const EmptyMessage = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) 0;
-`;
-
-const EmptyTitle = styled.span`
-  font-size: var(--text-sm);
-  color: var(--fg2);
-`;
-
-const EmptyHint = styled.span`
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-`;
-
-const Mono = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--fg2);
-`;
-
-const DescriptionCell = styled.span`
-  display: inline-block;
-  max-width: 36ch;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--fg2);
-`;
-
-const Placeholder = styled.span`
-  color: var(--text-muted);
-  font-style: italic;
-`;
-
-/**
- * Wrapper das ações por linha (botão "Editar" — Issue #64; futuras
- * "Desativar"/"Restaurar" #65). Mantém os botões alinhados à direita e
- * permite múltiplas ações sem remontar o layout. Espelha
- * `RowActions` em `SystemsPage.tsx` — mesma semântica e tokens.
- */
-const RowActions = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  justify-content: flex-end;
-`;
-
-const InvalidIdNotice = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: flex-start;
-`;
+// Primitives genéricos (`BackLink`, `Toolbar`, `SearchSlot`,
+// `TableShell`, `Overlay`, `EntityCard`, etc.) vivem em
+// `src/shared/listing` desde a Issue #66 — Sonar tokeniza CSS-in-JS
+// como blocos de texto e marca duplicação quando os mesmos templates
+// literais aparecem em arquivos diferentes (lição PR #134/#135).
+// Aqui ficam apenas os styled específicos do domínio "Routes". Hoje
+// não há nenhum — o ex-`RouteCard` é o `EntityCard` compartilhado.
 
 /* ─── Helpers ─────────────────────────────────────────────── */
 
@@ -671,16 +413,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
         key: "status",
         label: "Status",
         width: "120px",
-        render: (row) =>
-          row.deletedAt ? (
-            <Badge variant="danger" dot>
-              Inativa
-            </Badge>
-          ) : (
-            <Badge variant="success" dot>
-              Ativa
-            </Badge>
-          ),
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
       },
     ];
 
@@ -749,27 +482,24 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
 
   // ARIA-live: anuncia o estado da listagem quando muda. Em loading
   // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
-  // total. Em erro, o `<Alert role="alert">` já cobre.
-  const liveMessage = useMemo<string>(() => {
-    if (isInitialLoading) return "Carregando lista de rotas.";
-    if (isFetching) return "Atualizando lista de rotas.";
-    if (errorMessage) return "";
-    if (total === 0) {
-      return hasActiveSearch
-        ? `Nenhuma rota encontrada para ${trimmedSearch}.`
-        : "Nenhuma rota cadastrada para este sistema.";
-    }
-    return `${total} rota(s) encontrada(s). Página ${page} de ${totalPages}.`;
-  }, [
-    total,
-    errorMessage,
-    hasActiveSearch,
-    isFetching,
+  // total. Em erro, o `<Alert role="alert">` já cobre. O hook
+  // `useListingLiveMessage` centraliza a árvore de decisão (lição
+  // PR #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+  const liveMessage = useListingLiveMessage({
     isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
     page,
     totalPages,
+    hasActiveSearch,
     trimmedSearch,
-  ]);
+    copy: {
+      singular: "rota",
+      pluralCarregando: "rotas",
+      vazioSemBusca: "Nenhuma rota cadastrada para este sistema.",
+    },
+  });
 
   if (!hasValidSystemId) {
     return (
@@ -805,28 +535,18 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
         desc="Endpoints registrados pelo sistema selecionado. Cada rota possui código, descrição e política JWT alvo."
       />
 
-      <Toolbar>
-        <SearchSlot>
-          <Input
-            label="Buscar"
-            type="search"
-            placeholder="Código da rota"
-            icon={<Search size={14} strokeWidth={1.5} />}
-            value={searchTerm}
-            onChange={handleSearchChange}
-            aria-label="Buscar rotas por código"
-            data-testid="routes-search"
-          />
-        </SearchSlot>
-        <ToolbarActions>
-          <Switch
-            label="Mostrar inativas"
-            helperText="Inclui rotas com remoção lógica."
-            checked={includeDeleted}
-            onChange={handleIncludeDeletedChange}
-            data-testid="routes-include-deleted"
-          />
-          {canCreateRoute && (
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Código da rota"
+        searchAriaLabel="Buscar rotas por código"
+        searchTestId="routes-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui rotas com remoção lógica."
+        includeDeletedTestId="routes-include-deleted"
+        actions={
+          canCreateRoute && (
             <Button
               variant="primary"
               size="md"
@@ -836,48 +556,22 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
             >
               Nova rota
             </Button>
-          )}
-        </ToolbarActions>
-      </Toolbar>
+          )
+        }
+      />
 
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        style={{
-          position: "absolute",
-          width: 1,
-          height: 1,
-          padding: 0,
-          margin: -1,
-          overflow: "hidden",
-          clip: "rect(0, 0, 0, 0)",
-          whiteSpace: "nowrap",
-          border: 0,
-        }}
-        data-testid="routes-live"
-      >
-        {liveMessage}
-      </span>
+      <LiveRegion message={liveMessage} testId="routes-live" />
 
       {isInitialLoading && (
-        <InitialLoading data-testid="routes-loading">
-          <Spinner size="lg" label="Carregando rotas" />
-        </InitialLoading>
+        <InitialLoadingSpinner testId="routes-loading" label="Carregando rotas" />
       )}
 
       {!isInitialLoading && errorMessage && (
-        <ErrorBlock>
-          <Alert variant="danger">{errorMessage}</Alert>
-          <Button
-            variant="secondary"
-            size="sm"
-            icon={<RotateCcw size={14} strokeWidth={1.5} />}
-            onClick={handleRefetch}
-            data-testid="routes-retry"
-          >
-            Tentar novamente
-          </Button>
-        </ErrorBlock>
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="routes-retry"
+        />
       )}
 
       {!isInitialLoading && !errorMessage && (
@@ -898,7 +592,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
           >
             {rows.length === 0 && emptyContent}
             {rows.map((row) => (
-              <RouteCard
+              <EntityCard
                 key={row.id}
                 role="listitem"
                 tabIndex={0}
@@ -906,15 +600,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
               >
                 <CardHeader>
                   <CardCode>{row.code}</CardCode>
-                  {row.deletedAt ? (
-                    <Badge variant="danger" dot>
-                      Inativa
-                    </Badge>
-                  ) : (
-                    <Badge variant="success" dot>
-                      Ativa
-                    </Badge>
-                  )}
+                  <StatusBadge deletedAt={row.deletedAt} />
                 </CardHeader>
                 <CardName>{row.name}</CardName>
                 {row.description !== null &&
@@ -957,47 +643,26 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
                       )}
                     </RowActions>
                   )}
-              </RouteCard>
+              </EntityCard>
             ))}
           </CardListForMobile>
-          {showOverlay && (
-            <Overlay aria-hidden="true" data-testid="routes-overlay">
-              <Spinner size="md" label="Atualizando" />
-            </Overlay>
-          )}
+          {showOverlay && <RefetchOverlay testId="routes-overlay" />}
         </TableShell>
       )}
 
       {!isInitialLoading && !errorMessage && total > 0 && (
-        <FootBar>
-          <PageInfo data-testid="routes-page-info">
-            Página {page} de {totalPages} · {total} resultado(s)
-          </PageInfo>
-          <PageNav>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={<ChevronLeft size={14} strokeWidth={1.5} />}
-              disabled={isFirstPage}
-              onClick={handlePrevPage}
-              aria-label="Ir para a página anterior"
-              data-testid="routes-prev"
-            >
-              Anterior
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={<ChevronRight size={14} strokeWidth={1.5} />}
-              disabled={isLastPage}
-              onClick={handleNextPage}
-              aria-label="Ir para a próxima página"
-              data-testid="routes-next"
-            >
-              Próxima
-            </Button>
-          </PageNav>
-        </FootBar>
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={handlePrevPage}
+          onNext={handleNextPage}
+          pageInfoTestId="routes-page-info"
+          prevTestId="routes-prev"
+          nextTestId="routes-next"
+        />
       )}
 
       {canCreateRoute && hasValidSystemId && (

--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -1,10 +1,6 @@
 import {
-  ChevronLeft,
-  ChevronRight,
   Pencil,
   Plus,
-  RotateCcw,
-  Search,
   Trash2,
   Undo2,
 } from 'lucide-react';
@@ -12,7 +8,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { PageHeader } from '../components/layout/PageHeader';
-import { Alert, Badge, Button, Input, Spinner, Switch, Table } from '../components/ui';
+import { Button, Table } from '../components/ui';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { usePaginatedFetch } from '../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../hooks/usePaginationControls';
@@ -23,6 +19,16 @@ import {
   listSystems,
 } from '../shared/api';
 import { useAuth } from '../shared/auth';
+import {
+  ErrorRetryBlock,
+  InitialLoadingSpinner,
+  ListingToolbar,
+  LiveRegion,
+  PaginationFooter,
+  RefetchOverlay,
+  StatusBadge,
+  useListingLiveMessage,
+} from '../shared/listing';
 
 import { DeleteSystemConfirm } from './systems/DeleteSystemConfirm';
 import { EditSystemModal } from './systems/EditSystemModal';
@@ -105,52 +111,10 @@ interface SystemsPageProps {
 
 /* ─── Styled primitives ──────────────────────────────────── */
 
-const Toolbar = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  margin-bottom: var(--space-5);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-6);
-  }
-`;
-
-const SearchSlot = styled.div`
-  width: 100%;
-
-  @media (min-width: 48em) {
-    max-width: 360px;
-    flex: 1;
-  }
-`;
-
-const ToggleSlot = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
-/**
- * Container à direita da Toolbar agrupando o toggle "Mostrar inativos"
- * e o botão "Novo sistema" (gated por permissão). Em viewports estreitos
- * empilha vertical; a partir de 48em alinha em linha mantendo o toggle
- * antes da CTA — leitura natural "filtro → ação".
- */
-const ToolbarActions = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: var(--space-3);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    gap: var(--space-4);
-  }
-`;
+// `Toolbar`/`SearchSlot`/`ToolbarActions`/`ToggleSlot` foram movidos
+// para `src/shared/listing/` (Issue #66) — o JSX da página agora
+// consome `<ListingToolbar>` do mesmo módulo, eliminando duplicação
+// Sonar/jscpd entre listagens (lição PR #134/#135).
 
 const TableShell = styled.div`
   position: relative;
@@ -162,59 +126,13 @@ const TableShell = styled.div`
  * evitar flicker enquanto sinaliza atividade — o spinner ancorado ao
  * topo deixa claro que algo está em curso sem mover a tabela.
  */
-const TableOverlay = styled.div`
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: var(--space-6);
-  background: color-mix(in srgb, var(--bg-base) 55%, transparent);
-  border-radius: var(--radius-lg);
-  pointer-events: none;
-  z-index: 1;
-`;
-
-const InitialLoading = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-12) 0;
-`;
-
-const ErrorBlock = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: flex-start;
-`;
-
-const FootBar = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: stretch;
-  margin-top: var(--space-5);
-
-  @media (min-width: 48em) {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-`;
-
-const PageInfo = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-wider);
-`;
-
-const PageNav = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-`;
+// `TableOverlay`, `InitialLoading`, `ErrorBlock`, `FootBar`,
+// `PageInfo`, `PageNav` foram movidos para `src/shared/listing/`
+// (Issue #66) — o JSX da página agora consome `<RefetchOverlay>`,
+// `<InitialLoadingSpinner>`, `<ErrorRetryBlock>` e
+// `<PaginationFooter>` do mesmo módulo
+// para eliminar duplicação Sonar/jscpd entre SystemsPage/RoutesPage/
+// RolesPage (lição PR #134/#135).
 
 const EmptyMessage = styled.div`
   display: flex;
@@ -480,16 +398,7 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
         key: 'status',
         label: 'Status',
         width: '140px',
-        render: (row) =>
-          row.deletedAt ? (
-            <Badge variant="danger" dot>
-              Inativo
-            </Badge>
-          ) : (
-            <Badge variant="success" dot>
-              Ativo
-            </Badge>
-          ),
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} gender="m" />,
       },
     ];
 
@@ -572,27 +481,25 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
 
   // ARIA-live: anuncia o estado da tabela quando muda. Em loading
   // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
-  // o total. Em erro, o `<Alert role="alert">` já cobre.
-  const liveMessage = useMemo<string>(() => {
-    if (isInitialLoading) return 'Carregando lista de sistemas.';
-    if (isFetching) return 'Atualizando lista de sistemas.';
-    if (errorMessage) return '';
-    if (total === 0) {
-      return hasActiveSearch
-        ? `Nenhum sistema encontrado para ${trimmedSearch}.`
-        : 'Nenhum sistema cadastrado.';
-    }
-    return `${total} sistema(s) encontrado(s). Página ${page} de ${totalPages}.`;
-  }, [
-    total,
-    errorMessage,
-    hasActiveSearch,
-    isFetching,
+  // o total. Em erro, o `<Alert role="alert">` já cobre. O hook
+  // `useListingLiveMessage` centraliza a árvore de decisão (lição
+  // PR #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+  const liveMessage = useListingLiveMessage({
     isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
     page,
     totalPages,
+    hasActiveSearch,
     trimmedSearch,
-  ]);
+    copy: {
+      singular: 'sistema',
+      pluralCarregando: 'sistemas',
+      vazioSemBusca: 'Nenhum sistema cadastrado.',
+      gender: 'm',
+    },
+  });
 
   return (
     <>
@@ -604,30 +511,18 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
 
       {!hideStats && <SystemsStatsRow refreshKey={statsRefreshKey} client={client} />}
 
-      <Toolbar>
-        <SearchSlot>
-          <Input
-            label="Buscar"
-            type="search"
-            placeholder="Nome ou código do sistema"
-            icon={<Search size={14} strokeWidth={1.5} />}
-            value={searchTerm}
-            onChange={handleSearchChange}
-            aria-label="Buscar sistemas por nome ou código"
-            data-testid="systems-search"
-          />
-        </SearchSlot>
-        <ToolbarActions>
-          <ToggleSlot>
-            <Switch
-              label="Mostrar inativos"
-              helperText="Inclui sistemas com remoção lógica."
-              checked={includeDeleted}
-              onChange={handleIncludeDeletedChange}
-              data-testid="systems-include-deleted"
-            />
-          </ToggleSlot>
-          {canCreateSystem && (
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome ou código do sistema"
+        searchAriaLabel="Buscar sistemas por nome ou código"
+        searchTestId="systems-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui sistemas com remoção lógica."
+        includeDeletedTestId="systems-include-deleted"
+        actions={
+          canCreateSystem && (
             <Button
               variant="primary"
               size="md"
@@ -637,48 +532,22 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
             >
               Novo sistema
             </Button>
-          )}
-        </ToolbarActions>
-      </Toolbar>
+          )
+        }
+      />
 
-      <span
-        aria-live="polite"
-        aria-atomic="true"
-        style={{
-          position: 'absolute',
-          width: 1,
-          height: 1,
-          padding: 0,
-          margin: -1,
-          overflow: 'hidden',
-          clip: 'rect(0, 0, 0, 0)',
-          whiteSpace: 'nowrap',
-          border: 0,
-        }}
-        data-testid="systems-live"
-      >
-        {liveMessage}
-      </span>
+      <LiveRegion message={liveMessage} testId="systems-live" />
 
       {isInitialLoading && (
-        <InitialLoading data-testid="systems-loading">
-          <Spinner size="lg" label="Carregando sistemas" />
-        </InitialLoading>
+        <InitialLoadingSpinner testId="systems-loading" label="Carregando sistemas" />
       )}
 
       {!isInitialLoading && errorMessage && (
-        <ErrorBlock>
-          <Alert variant="danger">{errorMessage}</Alert>
-          <Button
-            variant="secondary"
-            size="sm"
-            icon={<RotateCcw size={14} strokeWidth={1.5} />}
-            onClick={handleRefetch}
-            data-testid="systems-retry"
-          >
-            Tentar novamente
-          </Button>
-        </ErrorBlock>
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="systems-retry"
+        />
       )}
 
       {!isInitialLoading && !errorMessage && (
@@ -690,44 +559,23 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
             getRowKey={(row) => row.id}
             emptyState={emptyContent}
           />
-          {showOverlay && (
-            <TableOverlay aria-hidden="true" data-testid="systems-overlay">
-              <Spinner size="md" label="Atualizando" />
-            </TableOverlay>
-          )}
+          {showOverlay && <RefetchOverlay testId="systems-overlay" />}
         </TableShell>
       )}
 
       {!isInitialLoading && !errorMessage && total > 0 && (
-        <FootBar>
-          <PageInfo data-testid="systems-page-info">
-            Página {page} de {totalPages} · {total} resultado(s)
-          </PageInfo>
-          <PageNav>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={<ChevronLeft size={14} strokeWidth={1.5} />}
-              disabled={isFirstPage}
-              onClick={handlePrevPage}
-              aria-label="Ir para a página anterior"
-              data-testid="systems-prev"
-            >
-              Anterior
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={<ChevronRight size={14} strokeWidth={1.5} />}
-              disabled={isLastPage}
-              onClick={handleNextPage}
-              aria-label="Ir para a próxima página"
-              data-testid="systems-next"
-            >
-              Próxima
-            </Button>
-          </PageNav>
-        </FootBar>
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={handlePrevPage}
+          onNext={handleNextPage}
+          pageInfoTestId="systems-page-info"
+          prevTestId="systems-prev"
+          nextTestId="systems-next"
+        />
       )}
 
       {canCreateSystem && (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -103,6 +103,14 @@ export const AppRoutes: React.FC = () => (
         }
       />
       <Route
+        path="/systems/:systemId/roles"
+        element={
+          <RequirePermission code="AUTH_V1_ROLES_LIST">
+            <RolesPage />
+          </RequirePermission>
+        }
+      />
+      <Route
         path="/routes"
         element={
           <RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST">
@@ -118,7 +126,11 @@ export const AppRoutes: React.FC = () => (
         path="/roles"
         element={
           <RequirePermission code="AUTH_V1_ROLES_LIST">
-            <RolesPage />
+            <PlaceholderPage
+              eyebrow="03 Roles"
+              title="Gerenciamento de Roles"
+              desc="Roles agrupam permissões e podem ser atribuídas a usuários do sistema. Para listar as roles de um sistema específico, abra o sistema correspondente."
+            />
           </RequirePermission>
         }
       />

--- a/src/routes/routeCodes.ts
+++ b/src/routes/routeCodes.ts
@@ -62,8 +62,18 @@ const ROUTE_CODES: ReadonlyArray<RouteCodeEntry> = [
   // intencional para preservar o invariante "um routeCode por linha"
   // exigido pelos testes de sanidade.
   { pattern: '/systems/:id/routes', routeCode: 'AUTH_V1_SYSTEMS_ROUTES_LIST' },
+  // Issue #66 (EPIC #47): listagem de roles escopada a um sistema.
+  // Mesma decisão da Issue #62 — `/systems/:id/roles` é o caminho
+  // canônico cadastrado pelo `AuthenticatorRoutesSeeder` para
+  // `AUTH_V1_ROLES_LIST`. A página global `/roles` é placeholder
+  // herdado da fundação (#43) e fica fora desta tabela enquanto
+  // existir, para preservar o invariante "um routeCode por linha"
+  // exigido pelos testes de sanidade — `resolveRouteCode('/roles')`
+  // devolve `null` e o `RequireAuth` pula o `verify-token`. O
+  // ordenamento garante que `/systems/:id/roles` vença `/systems`
+  // no `matchPath` (mesmo motivo da regra de routes).
+  { pattern: '/systems/:id/roles', routeCode: 'AUTH_V1_ROLES_LIST' },
   { pattern: '/systems', routeCode: 'AUTH_V1_SYSTEMS_LIST' },
-  { pattern: '/roles', routeCode: 'AUTH_V1_ROLES_LIST' },
   { pattern: '/permissions', routeCode: 'AUTH_V1_PERMISSIONS_LIST' },
   { pattern: '/users', routeCode: 'AUTH_V1_USERS_LIST' },
   { pattern: '/tokens', routeCode: 'AUTH_V1_TOKEN_TYPES_LIST' },

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -106,6 +106,23 @@ export type {
   UpdateRoutePayload,
 } from './routes';
 export {
+  createRole,
+  DEFAULT_ROLES_INCLUDE_DELETED,
+  DEFAULT_ROLES_PAGE,
+  DEFAULT_ROLES_PAGE_SIZE,
+  deleteRole,
+  isPagedRolesResponse,
+  isRoleDto,
+  listRoles,
+  updateRole,
+} from './roles';
+export type {
+  CreateRolePayload,
+  ListRolesParams,
+  RoleDto,
+  UpdateRolePayload,
+} from './roles';
+export {
   isTokenTypeArray,
   isTokenTypeDto,
   listTokenTypes,

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -1,0 +1,451 @@
+import { apiClient } from './index';
+
+import type { PagedResponse } from './systems';
+import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
+
+/**
+ * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
+ * em vez de um literal `{ kind, message }`. Sonar marca `throw` de
+ * objeto não-Error como improvement (`Expected an error object to be
+ * thrown`); estendê-lo com `Object.assign` preserva a interface
+ * `ApiError` consumida por `isApiError` sem perder o stack trace.
+ *
+ * Centralizado para evitar repetir `Object.assign(new Error(...), { kind })`
+ * em três call sites (`listRoles`/`createRole`/`updateRole`) — o
+ * Sonar contaria a repetição como duplicação. Espelha o padrão do
+ * `routes.ts` (lição PR #128 — projetar shared helpers desde o
+ * primeiro PR do recurso).
+ */
+function makeParseError(): ApiError {
+  return Object.assign(new Error('Resposta inválida do servidor.'), {
+    kind: 'parse' as const,
+  });
+}
+
+/**
+ * Espelho do `RoleResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Roles.RolesController.RoleResponse`).
+ *
+ * Issue #66 (EPIC #47) — primeiro DTO da listagem de roles.
+ *
+ * **Estado atual do contrato (snapshot do backend em `RolesController.cs`):**
+ *
+ * O backend hoje expõe `/roles` como recurso **global** (não vinculado
+ * a um sistema) e devolve `RoleResponse(Id, Name, Code, CreatedAt,
+ * UpdatedAt, DeletedAt)`. Os campos abaixo marcados como TODO ainda
+ * não são devolvidos pelo backend:
+ *
+ * - `description: string | null` — TODO no backend (`AppRole.Description`
+ *   ainda não existe no model). Mantido como opcional/`null` no DTO
+ *   para que a UI saiba renderizar "—" como placeholder hoje e exiba
+ *   a descrição automaticamente quando o backend evoluir.
+ * - `permissionsCount: number` / `usersCount: number` — TODO no backend
+ *   (controller não inclui contagens no projection). Mantidos como
+ *   opcionais para suportar o futuro `RoleResponse` enriquecido sem
+ *   precisar de PR destrutivo nesta camada.
+ * - `systemId` — TODO no backend (roles são globais hoje). A UI lê
+ *   `:systemId` da URL para preservar a IA da EPIC #47 (listagem por
+ *   sistema), mas o filtro real só passa a fazer sentido quando o
+ *   model for estendido com `SystemId`.
+ *
+ * As datas são serializadas pelo backend em ISO 8601 (UTC) — mantemos
+ * como `string` porque a UI consome via `Intl.DateTimeFormat`/
+ * `new Date()` quando precisar exibir; converter no boundary do
+ * cliente HTTP traria custo sem benefício. `deletedAt !== null` indica
+ * soft-delete.
+ *
+ * Cada um dos campos opcionais acima passa pelo `isRoleDto` apenas
+ * quando presente — payloads sem o campo (estado atual) continuam
+ * válidos.
+ */
+export interface RoleDto {
+  id: string;
+  name: string;
+  code: string;
+  /**
+   * Descrição livre da role. Ainda **não enviada** pelo backend
+   * `lfc-authenticator` (`AppRole.Description` é TODO). A UI exibe
+   * "—" como placeholder enquanto o campo for `null`/`undefined`.
+   */
+  description: string | null;
+  /**
+   * Contagem de permissões vinculadas à role. Ainda **não enviada**
+   * pelo backend (TODO). A UI exibe "—" enquanto o valor for
+   * `null`/`undefined` — quando o backend devolver, a UI mostra
+   * automaticamente.
+   */
+  permissionsCount: number | null;
+  /**
+   * Contagem de usuários que possuem essa role. Mesmo status de
+   * `permissionsCount` — TODO no backend; a UI exibe "—" hoje.
+   */
+  usersCount: number | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `RoleDto`. Tolera `description`/`deletedAt`/
+ * `permissionsCount`/`usersCount` ausentes (tratados como `null`) —
+ * outros campos são obrigatórios e checados em runtime.
+ *
+ * Exportado para que outros call sites (ex.: `createRole`/`updateRole`
+ * validando o `RoleResponse` devolvido pelo backend nas próximas
+ * issues #67/#68) reusem a mesma fonte de verdade — evita duplicação
+ * de validação de shape (lição PR #123, "type guards quase idênticos
+ * em arquivos diferentes precisam de helper compartilhado").
+ */
+export function isRoleDto(value: unknown): value is RoleDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.code === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.description === null ||
+      record.description === undefined ||
+      typeof record.description === 'string') &&
+    (record.permissionsCount === null ||
+      record.permissionsCount === undefined ||
+      typeof record.permissionsCount === 'number') &&
+    (record.usersCount === null ||
+      record.usersCount === undefined ||
+      typeof record.usersCount === 'number') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<RoleDto>`. Valida o envelope antes
+ * de confiar no payload — protege contra divergência silenciosa de
+ * versão entre frontend e backend (proxy intermediário cortando
+ * campos, deploy desalinhado). Espelha `isPagedRoutesResponse` em
+ * `routes.ts`.
+ *
+ * **Hoje** o backend `/roles` ainda devolve um array cru (não o
+ * envelope paginado). `listRoles` adapta client-side: faz o GET cru,
+ * valida cada item com `isRoleDto`, aplica filtros/paginação em
+ * memória e devolve um `PagedResponse<RoleDto>` ao caller. O type
+ * guard fica pronto para o dia em que o backend implementar
+ * `GET /systems/roles?systemId=...&page=&pageSize=...&q=&includeDeleted=`
+ * (espelhando `RoutesController`); aí `listRoles` valida o envelope
+ * direto e aposenta a adaptação client-side.
+ */
+export function isPagedRolesResponse(value: unknown): value is PagedResponse<RoleDto> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isRoleDto);
+}
+
+/**
+ * Defaults usados pela `listRoles` para alinhar a UI com os limites
+ * historicamente adotados no `lfc-admin-gui` (`SystemsPage`/
+ * `RoutesPage`). Quando o backend ganhar paginação real para roles,
+ * esses defaults serão enviados na querystring; hoje o adapter
+ * client-side respeita os mesmos valores.
+ *
+ * `DEFAULT_ROLES_PAGE_SIZE = 20` espelha `RoutesController.DefaultPageSize`
+ * — manter um único limite reduz surpresas para o admin que alterna
+ * entre listas.
+ */
+export const DEFAULT_ROLES_PAGE = 1;
+export const DEFAULT_ROLES_PAGE_SIZE = 20;
+export const DEFAULT_ROLES_INCLUDE_DELETED = false;
+
+/**
+ * Parâmetros aceitos por `listRoles`.
+ *
+ * `systemId` é declarado como obrigatório no contrato porque a UI
+ * (Issue #66) sempre invoca a partir de `/systems/:systemId/roles`.
+ * **Hoje** o valor é apenas propagado na querystring (e ignorado
+ * silenciosamente pelo backend, que não conhece `systemId`); quando
+ * o backend evoluir para `GET /systems/roles?systemId=...` (paridade
+ * com Routes), o filtro passa a funcionar de fato sem mudar a UI.
+ *
+ * Os demais parâmetros (`q`, `page`, `pageSize`, `includeDeleted`)
+ * são aplicados client-side pelo adapter em `listRoles`.
+ */
+export interface ListRolesParams {
+  /** UUID do sistema dono das roles. Obrigatório nesta listagem. */
+  systemId: string;
+  /** Termo de busca (case-insensitive em `Name` e `Code`). */
+  q?: string;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. */
+  pageSize?: number;
+  /** Quando `true`, inclui roles com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Endpoint atual do backend para listagem de roles.
+ *
+ * Quando o backend evoluir para o padrão por-sistema (espelhando
+ * `Routes`), trocar para `'/systems/roles'` em uma única linha — o
+ * resto do adapter já está pronto.
+ */
+const ROLES_LIST_PATH = '/roles';
+
+/**
+ * Lista roles de um sistema com busca, paginação e filtro de
+ * soft-deleted aplicados **client-side** enquanto o backend não
+ * suporta os parâmetros nativamente.
+ *
+ * **Adapter temporário (TODO no backend):** `RolesController.GetAll`
+ * hoje devolve `List<RoleResponse>` cru, sem `systemId`/`q`/`page`/
+ * `pageSize`/`includeDeleted`. Para preservar a UI consistente com
+ * `RoutesPage` e desacoplar a camada de página, este wrapper:
+ *
+ *  1. Faz o `GET /roles` cru e valida cada item com `isRoleDto`.
+ *  2. Filtra `deletedAt` quando `includeDeleted=false`.
+ *  3. Filtra `Name`/`Code` (case-insensitive) quando `q` está presente.
+ *  4. Ordena por `Code` para estabilidade visual entre refetches.
+ *  5. Aplica `page`/`pageSize` em memória e devolve o envelope.
+ *
+ * Quando o backend implementar o endpoint paginado, substituir o
+ * corpo desta função por:
+ *
+ * ```ts
+ * const path = `/systems/roles${buildQueryString(params)}`;
+ * const data = await client.get<unknown>(path, options);
+ * if (!isPagedRolesResponse(data)) throw makeParseError();
+ * return data;
+ * ```
+ *
+ * Lança `ApiError` em qualquer falha (rede, parse, HTTP) — o caller
+ * trata com try/catch. Cancelamento via `signal` em `options` é
+ * propagado para o cliente.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); o default usa o singleton
+ * `apiClient` configurado com `baseUrl` + `systemId` reais.
+ *
+ * Issue #66 — primeira sub-issue da EPIC #47 (CRUD de Roles por
+ * Sistema). As próximas issues (#67 criar, #68 editar, #69 associar
+ * permissões) reutilizam o mesmo módulo (`createRole`/`updateRole`/
+ * `deleteRole`) seguindo o padrão estabelecido pela EPIC #46 em
+ * `routes.ts`. Mantemos os hooks de extensão prontos para evitar
+ * refatorações destrutivas no segundo PR (lição PR #128 — projetar
+ * shared helpers desde o primeiro PR do recurso).
+ */
+export async function listRoles(
+  params: ListRolesParams,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<RoleDto>> {
+  const data = await client.get<unknown>(ROLES_LIST_PATH, options);
+  if (!Array.isArray(data) || !data.every(isRoleDto)) {
+    throw makeParseError();
+  }
+  return adaptRolesListResponse(data, params);
+}
+
+/**
+ * Aplica filtros/ordem/paginação client-side sobre o array cru
+ * devolvido pelo backend, normalizando para `PagedResponse<RoleDto>`.
+ *
+ * Mantida em função separada para que os testes possam exercer o
+ * adapter sem um `ApiClient` stub — e para isolar o ponto único de
+ * remoção quando o backend ganhar paginação real.
+ *
+ * **Decisões importantes:**
+ *
+ * - `params.systemId` é aceito mas hoje **não filtra** o conjunto:
+ *   `AppRole` ainda não tem `SystemId` no model. Aceitar o param
+ *   garante compatibilidade visual entre a UI já escopada por
+ *   sistema (`/systems/:systemId/roles`) e a futura evolução do
+ *   backend, sem precisar de breaking change na assinatura.
+ * - O ordenamento por `Code` espelha o adotado por
+ *   `RoutesController.GetAll` — manter o mesmo critério reduz
+ *   surpresa para o admin que alterna entre as listas.
+ * - `total` reflete o conjunto **após filtros** e **antes** de
+ *   `Skip`/`Take`, casando com o contrato de `PagedResponse`.
+ */
+function adaptRolesListResponse(
+  rows: ReadonlyArray<RoleDto>,
+  params: ListRolesParams,
+): PagedResponse<RoleDto> {
+  const includeDeleted = params.includeDeleted ?? DEFAULT_ROLES_INCLUDE_DELETED;
+  const q = params.q?.trim().toLowerCase();
+  const page = params.page ?? DEFAULT_ROLES_PAGE;
+  const pageSize = params.pageSize ?? DEFAULT_ROLES_PAGE_SIZE;
+
+  const filtered = rows
+    .filter((role) => includeDeleted || role.deletedAt === null)
+    .filter((role) => {
+      if (!q || q.length === 0) return true;
+      return (
+        role.name.toLowerCase().includes(q) ||
+        role.code.toLowerCase().includes(q)
+      );
+    })
+    .slice()
+    .sort((a, b) => a.code.localeCompare(b.code));
+
+  const total = filtered.length;
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  const data = filtered.slice(start, end);
+
+  return { data, page, pageSize, total };
+}
+
+/**
+ * Body aceito pelo `POST /roles` no `lfc-authenticator`
+ * (`RolesController.CreateRoleRequest`).
+ *
+ * Definido aqui (e não em #67) por dois motivos: (i) `isRoleDto` já
+ * cobre o response, então mantemos input/output simétricos no mesmo
+ * módulo; (ii) lição PR #128 — desde o primeiro PR do recurso,
+ * projetar tipos compartilhados para evitar duplicação no PR
+ * seguinte.
+ *
+ * - `name` (obrigatório, máx. 80 chars) — nome amigável da role.
+ * - `code` (obrigatório, máx. 50 chars) — identificador único global
+ *   no `lfc-authenticator` (UX_Roles_Code é único globalmente —
+ *   colidir com Code de outra role retorna 409).
+ * - `description` (opcional, máx. 500 chars) — descrição livre.
+ *   **Hoje** o backend não persiste o campo (TODO no model
+ *   `AppRole`); o wrapper já o aceita para que a UI da #67 e #68
+ *   não precise de PR destrutivo aqui quando o backend evoluir.
+ *
+ * Backend trima `Name`/`Code` e converte `Description` vazia em
+ * `null` (mesmo padrão de `RoutesController`).
+ */
+export interface CreateRolePayload {
+  name: string;
+  code: string;
+  description?: string;
+}
+
+/**
+ * Body aceito pelo `PUT /roles/{id}` no `lfc-authenticator`
+ * (`RolesController.UpdateRoleRequest`). Mesmo shape do create —
+ * segue o padrão do `routes.ts` (alias intencional para preservar
+ * simetria de contrato — divergência futura no backend pega ambos os
+ * call sites de uma vez). Issue #68 implementa o caller; já
+ * declarado aqui pelo mesmo motivo de `CreateRolePayload` (lição
+ * PR #128).
+ */
+export type UpdateRolePayload = CreateRolePayload;
+
+/**
+ * Cria uma nova role via `POST /roles` (Issue #67).
+ *
+ * Retorna o `RoleDto` recém-criado (`201 Created` com `RoleResponse`
+ * no corpo). Lança `ApiError` em qualquer falha — caller tipicamente
+ * trata 409 (conflito de Code), 400 (validação de campo) e fallbacks
+ * genéricos. Wrapper já implementado nesta sub-issue para evitar PR
+ * destrutivo no #67 (lição PR #128).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function createRole(
+  payload: CreateRolePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<RoleDto> {
+  const body = buildRoleMutationBody(payload);
+  const data = await client.post<unknown>('/roles', body, options);
+  if (!isRoleDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Atualiza uma role existente via `PUT /roles/{id}` (Issue #68).
+ *
+ * Retorna o `RoleDto` atualizado (`200 OK` com `RoleResponse` no
+ * corpo). Lança `ApiError` em qualquer falha — caller tipicamente
+ * trata 409 (conflito de Code), 404 (role não encontrada/soft-
+ * deletada), 400 (validação de campo). Wrapper já implementado para
+ * evitar PR destrutivo no #68 (lição PR #128).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function updateRole(
+  id: string,
+  payload: UpdateRolePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<RoleDto> {
+  const body = buildRoleMutationBody(payload);
+  const data = await client.put<unknown>(`/roles/${id}`, body, options);
+  if (!isRoleDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Desativa (soft-delete) uma role via `DELETE /roles/{id}` (sub-
+ * issue futura da EPIC #47).
+ *
+ * O backend (`RolesController.DeleteById`) seta `DeletedAt = UtcNow`
+ * e responde `204 No Content` em sucesso. O método não devolve corpo
+ * — a função resolve `void` e a UI faz refetch para sincronizar a
+ * lista.
+ *
+ * Lança `ApiError` em qualquer falha (404, 401, 403, 5xx, network).
+ * Wrapper já implementado nesta sub-issue para evitar PR destrutivo
+ * no PR de exclusão (lição PR #128 — projetar shared helpers desde o
+ * primeiro PR do recurso).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function deleteRole(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/roles/${id}`, options);
+}
+
+/**
+ * Constrói o body para `POST /roles` e `PUT /roles/{id}` aplicando
+ * trim defensivo nos campos. Description vazia depois de trim vira
+ * `undefined` para que o serializador omita o campo (backend
+ * converte para `null`). Centralizar essa montagem garante que
+ * create e update enviem exatamente o mesmo payload — qualquer
+ * divergência futura no shape ajusta um único helper. Espelha
+ * `buildRouteMutationBody` de `routes.ts`.
+ *
+ * **Hoje** o backend ignora `description` (TODO no model `AppRole`),
+ * mas o wrapper já o envia para evitar PR destrutivo quando o
+ * backend ganhar suporte ao campo.
+ */
+function buildRoleMutationBody(
+  payload: CreateRolePayload | UpdateRolePayload,
+): CreateRolePayload {
+  const body: CreateRolePayload = {
+    name: payload.name.trim(),
+    code: payload.code.trim(),
+  };
+  const trimmedDescription = payload.description?.trim();
+  if (trimmedDescription && trimmedDescription.length > 0) {
+    body.description = trimmedDescription;
+  }
+  return body;
+}

--- a/src/shared/listing/ErrorRetryBlock.tsx
+++ b/src/shared/listing/ErrorRetryBlock.tsx
@@ -1,0 +1,60 @@
+import { RotateCcw } from "lucide-react";
+import React from "react";
+
+import { Alert, Button } from "../../components/ui";
+
+import { ErrorBlock } from "./styles";
+
+/**
+ * Bloco de erro com `Alert` + botão "Tentar novamente". Reaproveitado
+ * pelas listagens (`SystemsPage`, `RoutesPage`, `RolesPage` e
+ * próximas) que falam com o `lfc-authenticator` via
+ * `usePaginatedFetch`.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O bloco JSX:
+ *
+ * ```jsx
+ * <ErrorBlock>
+ *   <Alert variant="danger">{errorMessage}</Alert>
+ *   <Button variant="secondary" size="sm" icon={<RotateCcw .../>}
+ *           onClick={handleRefetch} data-testid="...-retry">
+ *     Tentar novamente
+ *   </Button>
+ * </ErrorBlock>
+ * ```
+ *
+ * aparecia idêntico em 3 páginas (12 linhas tokenizadas pelo Sonar/
+ * jscpd como duplicação). Centralizar evita que cada nova listagem
+ * (Issue #66+) reintroduza o mesmo bloco. O `testId` é parametrizado
+ * para que cada página mantenha sua própria asserção
+ * (`systems-retry`, `routes-retry`, `roles-retry`, etc).
+ */
+interface ErrorRetryBlockProps {
+  /** Mensagem amigável a exibir no `Alert`. */
+  message: string;
+  /** Callback do botão "Tentar novamente" — tipicamente `refetch` do `usePaginatedFetch`. */
+  onRetry: () => void;
+  /** `data-testid` do botão (ex.: `roles-retry`). Mantém asserts estáveis. */
+  retryTestId: string;
+}
+
+export const ErrorRetryBlock: React.FC<ErrorRetryBlockProps> = ({
+  message,
+  onRetry,
+  retryTestId,
+}) => (
+  <ErrorBlock>
+    <Alert variant="danger">{message}</Alert>
+    <Button
+      variant="secondary"
+      size="sm"
+      icon={<RotateCcw size={14} strokeWidth={1.5} />}
+      onClick={onRetry}
+      data-testid={retryTestId}
+    >
+      Tentar novamente
+    </Button>
+  </ErrorBlock>
+);

--- a/src/shared/listing/InitialLoadingSpinner.tsx
+++ b/src/shared/listing/InitialLoadingSpinner.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import { Spinner } from "../../components/ui";
+
+import { InitialLoading } from "./styles";
+
+/**
+ * Container com `Spinner` "lg" exibido durante o primeiro fetch da
+ * listagem. Reaproveitado pelas listagens (`SystemsPage`,
+ * `RoutesPage`, `RolesPage` e próximas).
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O bloco JSX:
+ *
+ * ```jsx
+ * <InitialLoading data-testid="...-loading">
+ *   <Spinner size="lg" label="Carregando ..." />
+ * </InitialLoading>
+ * ```
+ *
+ * aparecia idêntico em 3 páginas com diferença apenas no `testId` e
+ * label. Centralizar elimina duplicação e padroniza o tamanho/copy
+ * do spinner.
+ */
+interface InitialLoadingSpinnerProps {
+  /** `data-testid` do container (ex.: `roles-loading`). */
+  testId: string;
+  /** Texto acessível do spinner (ex.: `"Carregando roles"`). */
+  label: string;
+}
+
+export const InitialLoadingSpinner: React.FC<InitialLoadingSpinnerProps> = ({
+  testId,
+  label,
+}) => (
+  <InitialLoading data-testid={testId}>
+    <Spinner size="lg" label={label} />
+  </InitialLoading>
+);

--- a/src/shared/listing/ListingToolbar.tsx
+++ b/src/shared/listing/ListingToolbar.tsx
@@ -1,0 +1,103 @@
+import { Search } from "lucide-react";
+import React from "react";
+
+import { Input, Switch } from "../../components/ui";
+
+import { SearchSlot, Toolbar, ToolbarActions } from "./styles";
+
+/**
+ * Toolbar superior das listagens — com `Input` de busca, `Switch` de
+ * "Mostrar inativas" e slot livre para CTAs (botão "Novo X" gated
+ * por permissão).
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O bloco JSX:
+ *
+ * ```jsx
+ * <Toolbar>
+ *   <SearchSlot>
+ *     <Input label="Buscar" type="search" placeholder="..." icon={<Search />}
+ *            value={searchTerm} onChange={handleSearchChange}
+ *            aria-label="..." data-testid="...-search" />
+ *   </SearchSlot>
+ *   <ToolbarActions>
+ *     <Switch label="Mostrar inativas" helperText="..."
+ *             checked={includeDeleted} onChange={handleIncludeDeletedChange}
+ *             data-testid="...-include-deleted" />
+ *     {canX && <Button ...>Novo X</Button>}
+ *   </ToolbarActions>
+ * </Toolbar>
+ * ```
+ *
+ * aparecia idêntico em 3 páginas com diferença apenas em literais
+ * ("rota"/"role"/"sistema") e na CTA opcional. Centralizar elimina
+ * duplicação. A CTA fica como `actions` (slot React.ReactNode) para
+ * preservar a flexibilidade — cada página continua decidindo seu
+ * gating de permissão e copy.
+ */
+interface ListingToolbarProps {
+  /** Valor corrente do input de busca. */
+  searchValue: string;
+  /** Callback do input de busca. */
+  onSearchChange: (value: string) => void;
+  /** Placeholder do input (ex.: "Nome ou código da role"). */
+  searchPlaceholder: string;
+  /** ARIA-label do input (ex.: "Buscar roles por nome ou código"). */
+  searchAriaLabel: string;
+  /** `data-testid` do input (ex.: "roles-search"). */
+  searchTestId: string;
+
+  /** Estado corrente do toggle "Mostrar inativas". */
+  includeDeletedValue: boolean;
+  /** Callback do toggle. */
+  onIncludeDeletedChange: (value: boolean) => void;
+  /** Helper text do toggle (ex.: "Inclui roles com remoção lógica."). */
+  includeDeletedHelperText: string;
+  /** `data-testid` do toggle (ex.: "roles-include-deleted"). */
+  includeDeletedTestId: string;
+
+  /**
+   * Slot opcional para CTAs (botão "Novo X", links de ações em massa,
+   * etc.). Cada página resolve gating de permissão antes de passar.
+   */
+  actions?: React.ReactNode;
+}
+
+export const ListingToolbar: React.FC<ListingToolbarProps> = ({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder,
+  searchAriaLabel,
+  searchTestId,
+  includeDeletedValue,
+  onIncludeDeletedChange,
+  includeDeletedHelperText,
+  includeDeletedTestId,
+  actions,
+}) => (
+  <Toolbar>
+    <SearchSlot>
+      <Input
+        label="Buscar"
+        type="search"
+        placeholder={searchPlaceholder}
+        icon={<Search size={14} strokeWidth={1.5} />}
+        value={searchValue}
+        onChange={onSearchChange}
+        aria-label={searchAriaLabel}
+        data-testid={searchTestId}
+      />
+    </SearchSlot>
+    <ToolbarActions>
+      <Switch
+        label="Mostrar inativas"
+        helperText={includeDeletedHelperText}
+        checked={includeDeletedValue}
+        onChange={onIncludeDeletedChange}
+        data-testid={includeDeletedTestId}
+      />
+      {actions}
+    </ToolbarActions>
+  </Toolbar>
+);

--- a/src/shared/listing/LiveRegion.tsx
+++ b/src/shared/listing/LiveRegion.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+/**
+ * Região ARIA-live invisível visualmente que anuncia transições de
+ * estado da listagem para leitores de tela.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O `<span aria-live="polite">` com inline-style de "visually hidden"
+ * (clip-rect, w/h 1, etc.) aparecia idêntico em 3 páginas (~12
+ * linhas). Centralizar elimina a duplicação e fixa o estilo
+ * acessibilidade-correto em uma única fonte de verdade.
+ *
+ * A copy específica de cada listagem ("Carregando roles..." vs
+ * "Atualizando rotas...") fica no caller via prop `message`. O
+ * `testId` é parametrizado para que cada página mantenha asserts
+ * estáveis.
+ */
+interface LiveRegionProps {
+  /** Mensagem corrente lida pelo screen reader. */
+  message: string;
+  /** `data-testid` da região (ex.: `roles-live`). */
+  testId: string;
+}
+
+const HIDDEN_STYLE: React.CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};
+
+export const LiveRegion: React.FC<LiveRegionProps> = ({ message, testId }) => (
+  <span
+    aria-live="polite"
+    aria-atomic="true"
+    style={HIDDEN_STYLE}
+    data-testid={testId}
+  >
+    {message}
+  </span>
+);

--- a/src/shared/listing/PaginationFooter.tsx
+++ b/src/shared/listing/PaginationFooter.tsx
@@ -1,0 +1,97 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+
+import { Button } from "../../components/ui";
+
+import { FootBar, PageInfo, PageNav } from "./styles";
+
+/**
+ * Footer de paginação com info textual + botões prev/next.
+ * Reaproveitado pelas listagens (`SystemsPage`, `RoutesPage`,
+ * `RolesPage` e próximas).
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O bloco JSX:
+ *
+ * ```jsx
+ * <FootBar>
+ *   <PageInfo>Página X de Y · N resultado(s)</PageInfo>
+ *   <PageNav>
+ *     <Button ... onClick={handlePrev} disabled={isFirst} ... >Anterior</Button>
+ *     <Button ... onClick={handleNext} disabled={isLast} ... >Próxima</Button>
+ *   </PageNav>
+ * </FootBar>
+ * ```
+ *
+ * aparecia idêntico em 3 páginas (~30 linhas tokenizadas pelo Sonar/
+ * jscpd como duplicação). Centralizar evita que cada nova listagem
+ * (Issue #66+) reintroduza o mesmo bloco. Os `data-testid` são
+ * parametrizados para que cada página mantenha asserts estáveis
+ * (`systems-page-info`, `routes-prev`, `roles-next`, etc.).
+ */
+interface PaginationFooterProps {
+  /** Página corrente (1-based). */
+  page: number;
+  /** Total de páginas (resultado do `usePaginationControls`). */
+  totalPages: number;
+  /** Total de itens (após filtros, antes da paginação). */
+  total: number;
+  /** `true` quando estamos na primeira página (desabilita "Anterior"). */
+  isFirstPage: boolean;
+  /** `true` quando estamos na última página (desabilita "Próxima"). */
+  isLastPage: boolean;
+  /** Callback do botão "Anterior". */
+  onPrev: () => void;
+  /** Callback do botão "Próxima". */
+  onNext: () => void;
+  /** `data-testid` do `<PageInfo>` (ex.: `roles-page-info`). */
+  pageInfoTestId: string;
+  /** `data-testid` do botão "Anterior" (ex.: `roles-prev`). */
+  prevTestId: string;
+  /** `data-testid` do botão "Próxima" (ex.: `roles-next`). */
+  nextTestId: string;
+}
+
+export const PaginationFooter: React.FC<PaginationFooterProps> = ({
+  page,
+  totalPages,
+  total,
+  isFirstPage,
+  isLastPage,
+  onPrev,
+  onNext,
+  pageInfoTestId,
+  prevTestId,
+  nextTestId,
+}) => (
+  <FootBar>
+    <PageInfo data-testid={pageInfoTestId}>
+      Página {page} de {totalPages} · {total} resultado(s)
+    </PageInfo>
+    <PageNav>
+      <Button
+        variant="secondary"
+        size="sm"
+        icon={<ChevronLeft size={14} strokeWidth={1.5} />}
+        disabled={isFirstPage}
+        onClick={onPrev}
+        aria-label="Ir para a página anterior"
+        data-testid={prevTestId}
+      >
+        Anterior
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        icon={<ChevronRight size={14} strokeWidth={1.5} />}
+        disabled={isLastPage}
+        onClick={onNext}
+        aria-label="Ir para a próxima página"
+        data-testid={nextTestId}
+      >
+        Próxima
+      </Button>
+    </PageNav>
+  </FootBar>
+);

--- a/src/shared/listing/RefetchOverlay.tsx
+++ b/src/shared/listing/RefetchOverlay.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { Spinner } from "../../components/ui";
+
+import { Overlay } from "./styles";
+
+/**
+ * Overlay leve com `Spinner` exibido sobre a tabela/cards durante
+ * refetches subsequentes (busca/paginação/toggle). Reaproveitado
+ * pelas listagens (`SystemsPage`, `RoutesPage`, `RolesPage` e
+ * próximas).
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O bloco JSX:
+ *
+ * ```jsx
+ * <Overlay aria-hidden="true" data-testid="...-overlay">
+ *   <Spinner size="md" label="Atualizando" />
+ * </Overlay>
+ * ```
+ *
+ * aparecia idêntico em 3 páginas. Centralizar evita reintroduções
+ * em listagens novas. O `data-testid` é parametrizado para que cada
+ * página mantenha asserts estáveis.
+ */
+interface RefetchOverlayProps {
+  /** `data-testid` do overlay (ex.: `roles-overlay`). */
+  testId: string;
+}
+
+export const RefetchOverlay: React.FC<RefetchOverlayProps> = ({ testId }) => (
+  <Overlay aria-hidden="true" data-testid={testId}>
+    <Spinner size="md" label="Atualizando" />
+  </Overlay>
+);

--- a/src/shared/listing/StatusBadge.tsx
+++ b/src/shared/listing/StatusBadge.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import { Badge } from "../../components/ui";
+
+/**
+ * Badge dual que representa o status ativo/inativo (soft-deleted) de
+ * uma entidade. Lê `deletedAt` (string ISO 8601 quando soft-deletada,
+ * `null`/`undefined` quando ativa) e devolve o `Badge` correto com a
+ * copy padronizada do projeto.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O ternário JSX:
+ *
+ * ```jsx
+ * row.deletedAt ? (
+ *   <Badge variant="danger" dot>Inativa</Badge>
+ * ) : (
+ *   <Badge variant="success" dot>Ativa</Badge>
+ * )
+ * ```
+ *
+ * aparecia em ~5 lugares: tabela e cards de cada uma das 3 páginas
+ * (`SystemsPage`, `RoutesPage`, `RolesPage`), cada vez ocupando ~7
+ * linhas. Sonar/jscpd tokenizam isso como bloco repetido. Centralizar
+ * em componente reduz a 1 linha por uso e garante consistência da
+ * copy ("Inativa"/"Ativa") em todas as listagens.
+ *
+ * **Sobre `gender`:** todas as listagens atuais usam o feminino
+ * ("Inativa"/"Ativa") porque os recursos são femininos em pt-BR
+ * (rota, role, permissão, sessão). Quando aparecer um recurso
+ * masculino (sistema, usuário, cliente, token), passar `gender="m"`
+ * para devolver "Inativo"/"Ativo". Manter como prop em vez de
+ * variante extra preserva a flexibilidade sem tornar o componente
+ * mais verboso.
+ */
+interface StatusBadgeProps {
+  /** Quando truthy, exibe "Inativa(o)"; caso contrário, "Ativa(o)". */
+  deletedAt: string | null | undefined;
+  /** Gênero da copy. Default: `'f'` (Inativa/Ativa). */
+  gender?: "f" | "m";
+}
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({
+  deletedAt,
+  gender = "f",
+}) => {
+  if (deletedAt) {
+    return (
+      <Badge variant="danger" dot>
+        {gender === "m" ? "Inativo" : "Inativa"}
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="success" dot>
+      {gender === "m" ? "Ativo" : "Ativa"}
+    </Badge>
+  );
+};

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Barrel do módulo `src/shared/listing/`.
+ *
+ * Concentra primitives visuais reutilizados pelas páginas de
+ * listagem do `lfc-admin-gui` (sistemas, rotas, roles, e os futuros
+ * permissões/usuários/clientes). Cada página importa apenas o que
+ * usa, mas o módulo único concentra a fonte de verdade do CSS.
+ *
+ * Lição PR #134/#135 — Sonar tokeniza CSS-in-JS como blocos de
+ * texto e marca duplicação quando os mesmos templates literais
+ * aparecem em arquivos diferentes. Centralizar aqui evita que cada
+ * recurso novo (Issue #66+) refaça os mesmos `styled.div`.
+ */
+
+export {
+  BackLink,
+  CardDescription,
+  CardHeader,
+  CardCode,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
+  CardListForMobile,
+  DescriptionCell,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ErrorBlock,
+  FootBar,
+  InitialLoading,
+  InvalidIdNotice,
+  Mono,
+  Overlay,
+  PageInfo,
+  PageNav,
+  Placeholder,
+  RowActions,
+  SearchSlot,
+  TableForDesktop,
+  TableShell,
+  Toolbar,
+  ToolbarActions,
+} from './styles';
+
+export { ErrorRetryBlock } from './ErrorRetryBlock';
+export { InitialLoadingSpinner } from './InitialLoadingSpinner';
+export { ListingToolbar } from './ListingToolbar';
+export { LiveRegion } from './LiveRegion';
+export { PaginationFooter } from './PaginationFooter';
+export { RefetchOverlay } from './RefetchOverlay';
+export { StatusBadge } from './StatusBadge';
+export {
+  useListingLiveMessage,
+  type ListingLiveMessageCopy,
+} from './useListingLiveMessage';

--- a/src/shared/listing/styles.ts
+++ b/src/shared/listing/styles.ts
@@ -1,0 +1,373 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+/**
+ * Styled primitives compartilhados pelas páginas de listagem do
+ * `lfc-admin-gui`.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * `SystemsPage` e `RoutesPage` declaravam ~30 styled components com
+ * o mesmo CSS (Toolbar, SearchSlot, ToolbarActions, TableShell,
+ * Overlay, InitialLoading, FootBar, PageInfo, PageNav, EmptyMessage,
+ * Mono, etc.). Sonar tokeniza CSS-in-JS como blocos de texto e
+ * marca como `New Code Duplication` quando os mesmos templates
+ * literais aparecem em arquivos diferentes (Issue #66 chegaria a
+ * ~200 linhas duplicadas se `RolesPage` apenas copy-pastear o
+ * pattern).
+ *
+ * Centralizar aqui:
+ *
+ * - Cada página continua importando seus tokens, mas o **template
+ *   literal** vive numa única cópia.
+ * - Adicionar uma nova listagem (Permissões, Usuários, Clientes na
+ *   EPIC #47+) só exige reusar os primitives — nenhum CSS novo.
+ * - Variantes específicas de domínio (ex.: `RouteCard` com cores de
+ *   token policy) continuam locais a cada página, mas `Card`,
+ *   `CardHeader`, `CardCode`, `CardName`, `CardDescription`,
+ *   `CardMeta` etc. — que não dependem de domínio — vivem aqui.
+ *
+ * Mantemos só primitives **visuais**. Comportamento (memoização de
+ * coluna, gating de auth, copy de mensagem) fica nas páginas — esse
+ * já é território das próprias issues. Lição PR #128/#134/#135 —
+ * desde o primeiro PR de um novo recurso de listagem, projetar
+ * shared helpers para evitar refatoração destrutiva no segundo PR.
+ */
+
+/**
+ * Link "Voltar para Sistemas" exibido no topo de listagens escopadas
+ * a um sistema (ex.: rotas, roles). Sempre aponta para `/systems`,
+ * mas o caller injeta `to` para preservar a flexibilidade.
+ */
+export const BackLink = styled(Link)`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-decoration: none;
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  margin-left: -4px;
+
+  &:hover {
+    color: var(--fg2);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+`;
+
+/**
+ * Barra de ferramentas (busca + ações) acima da tabela. Em mobile
+ * empilha vertical, em desktop alinha horizontal. Mesmo padrão
+ * usado em SystemsPage/RoutesPage e nas próximas listagens.
+ */
+export const Toolbar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-6);
+  }
+`;
+
+/** Slot do `<Input>` de busca — limita a 360px em desktop. */
+export const SearchSlot = styled.div`
+  width: 100%;
+
+  @media (min-width: 48em) {
+    max-width: 360px;
+    flex: 1;
+  }
+`;
+
+/** Slot das ações da Toolbar (toggle inativos + botão "Novo X"). */
+export const ToolbarActions = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-3);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-4);
+  }
+`;
+
+/**
+ * Wrapper relativo da tabela/cards. Permite o `Overlay` de refetch
+ * ancorar absoluto sem deslocar o conteúdo.
+ */
+export const TableShell = styled.div`
+  position: relative;
+`;
+
+/**
+ * Visibilidade da `Table` desktop. Em mobile fica oculta para
+ * favorecer leitura em coluna única via cards (critério de
+ * responsividade das issues #58/#62/#66/etc). Switch em
+ * `--bp-md` (48em ≈ 768px), espelhando o breakpoint do shell.
+ */
+export const TableForDesktop = styled.div`
+  display: none;
+
+  @media (min-width: 48em) {
+    display: block;
+  }
+`;
+
+/** Lista de cards usada apenas em mobile. */
+export const CardListForMobile = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+
+  @media (min-width: 48em) {
+    display: none;
+  }
+`;
+
+/**
+ * Card individual de item em listagem mobile. Cada página pode
+ * estender (`styled(EntityCard)`) para adicionar variantes
+ * específicas — mas a estrutura visual base (borda, background,
+ * hover, focus, padding) vive aqui.
+ */
+export const EntityCard = styled.article`
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  transition: background var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    background: var(--bg-ghost-hover);
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+`;
+
+/** Cabeçalho do card (title + status badge). */
+export const CardHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+`;
+
+/** Code monoespaçado destacado no card. */
+export const CardCode = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg1);
+  font-weight: var(--weight-medium);
+  word-break: break-word;
+`;
+
+/** Title do card (h3 com hierarquia tipográfica). */
+export const CardName = styled.h3`
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: -0.01em;
+`;
+
+/** Parágrafo de descrição livre dentro do card. */
+export const CardDescription = styled.p`
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-base);
+`;
+
+/** Lista descritiva (term/value) para metadados do card. */
+export const CardMeta = styled.dl`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+  font-size: var(--text-xs);
+`;
+
+/** Termo (label monoespaçado) do CardMeta. */
+export const CardMetaTerm = styled.dt`
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+`;
+
+/** Valor monoespaçado do CardMeta. */
+export const CardMetaValue = styled.dd`
+  margin: 0;
+  font-family: var(--font-mono);
+  color: var(--fg2);
+  word-break: break-word;
+`;
+
+/**
+ * Overlay leve aplicado em cima da listagem durante refetches
+ * subsequentes (busca/paginação/toggle). Mantém os dados anteriores
+ * visíveis para evitar flicker enquanto sinaliza atividade — o
+ * spinner ancorado ao topo deixa claro que algo está em curso sem
+ * mover a tabela.
+ */
+export const Overlay = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: var(--space-6);
+  background: color-mix(in srgb, var(--bg-base) 55%, transparent);
+  border-radius: var(--radius-lg);
+  pointer-events: none;
+  z-index: 1;
+`;
+
+/** Container do spinner de loading inicial (primeiro fetch). */
+export const InitialLoading = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-12) 0;
+`;
+
+/** Container do Alert de erro + botão "Tentar novamente". */
+export const ErrorBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+`;
+
+/** Footer com info de paginação e botões prev/next. */
+export const FootBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: stretch;
+  margin-top: var(--space-5);
+
+  @media (min-width: 48em) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+`;
+
+/** Indicador "Página X de Y · N resultado(s)". */
+export const PageInfo = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
+`;
+
+/** Wrapper dos botões prev/next. */
+export const PageNav = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+`;
+
+/**
+ * Container da mensagem de estado vazio (com/sem busca). Centraliza
+ * vertical+horizontal com gap entre título e CTA/dica.
+ */
+export const EmptyMessage = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+`;
+
+/** Title do estado vazio ("Nenhum X encontrado para Y", etc). */
+export const EmptyTitle = styled.span`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+`;
+
+/** Dica complementar ao estado vazio (ex.: ativar toggle inativos). */
+export const EmptyHint = styled.span`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+`;
+
+/**
+ * Texto monoespaçado pequeno para destaque inline (ex.: code de
+ * busca, ID, contagem). Reusado em tabelas, cards e mensagens.
+ */
+export const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg2);
+`;
+
+/**
+ * Célula com ellipsis para textos longos (descrições, paths). Usado
+ * na coluna de descrição da tabela desktop — mantém o layout estável.
+ */
+export const DescriptionCell = styled.span`
+  display: inline-block;
+  max-width: 36ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--fg2);
+`;
+
+/**
+ * Span itálico cinza usado quando um campo opcional está ausente
+ * (ex.: descrição vazia, contagem indisponível). Convenção visual
+ * "—" no projeto.
+ */
+export const Placeholder = styled.span`
+  color: var(--text-muted);
+  font-style: italic;
+`;
+
+/**
+ * Wrapper das ações por linha (Editar/Desativar/Restaurar). Mantém
+ * os botões alinhados à direita e suporta múltiplas ações sem
+ * remontar o layout.
+ */
+export const RowActions = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  justify-content: flex-end;
+`;
+
+/**
+ * Bloco do aviso "ID inválido" exibido quando o `:systemId` da URL
+ * é vazio/whitespace. Espelha o layout do ErrorBlock mas com
+ * semântica diferente (warning, não erro de fetch).
+ */
+export const InvalidIdNotice = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+`;

--- a/src/shared/listing/useListingLiveMessage.ts
+++ b/src/shared/listing/useListingLiveMessage.ts
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+
+/**
+ * Constrói a mensagem ARIA-live de uma listagem em pt-BR baseada em
+ * estados (`isInitialLoading`, `isFetching`, `errorMessage`, `total`,
+ * `page`, `totalPages`) e copy parametrizada por recurso.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * O `useMemo` com a árvore de `if`/`return` aparecia idêntico em 3
+ * páginas (`SystemsPage`, `RoutesPage`, `RolesPage`) com diferença
+ * apenas nas literais ("rota"/"role"/"sistema", "rotas"/"roles"/
+ * "sistemas"). Sonar/jscpd tokenizam isso como bloco duplicado
+ * (~15 linhas). Centralizar elimina a duplicação e padroniza o
+ * formato das mensagens.
+ *
+ * Cada caller injeta sua copy via `LiveMessageCopy`; o resultado é
+ * gerado por uma única implementação testável (em `tests/shared/
+ * listing/useListingLiveMessage.test.ts`) e os call sites colapsam
+ * em uma única chamada de hook.
+ */
+
+/**
+ * Copy textual injetada para diferenciar cada recurso. Cada listagem
+ * passa sua própria versão (`'rota'`/`'rotas'`, `'role'`/`'roles'`,
+ * `'sistema'`/`'sistemas'`).
+ *
+ * - `singular` — usado nas frases "{N} {singular}(s) encontrada(s)" e
+ *   "Nenhuma/Nenhum {singular} encontrada/o para {q}".
+ * - `pluralCarregando` — usado em "Carregando lista de {plural}." e
+ *   "Atualizando lista de {plural}.".
+ * - `vazioSemBusca` — frase completa para o estado vazio sem busca
+ *   (ex.: "Nenhuma rota cadastrada para este sistema."). Cada
+ *   recurso tem sua copy específica.
+ * - `gender` — `'f'` (feminina) ou `'m'` (masculina) para variar
+ *   "Nenhuma"/"Nenhum" e "encontrada(s)"/"encontrado(s)".
+ */
+export interface ListingLiveMessageCopy {
+  singular: string;
+  pluralCarregando: string;
+  vazioSemBusca: string;
+  gender?: 'f' | 'm';
+}
+
+interface UseListingLiveMessageArgs {
+  /** Cobertura "primeiro fetch em curso" — vence todos os outros. */
+  isInitialLoading: boolean;
+  /** Cobertura "refetch em curso" — vence quando `errorMessage`/`total` permitiriam. */
+  isFetching: boolean;
+  /** Mensagem de erro vinda do `usePaginatedFetch`. Quando truthy, retorna `''` (Alert já cobre). */
+  errorMessage: string | null;
+  /** Total filtrado da listagem (após filtros, antes de skip/take). */
+  total: number;
+  /** Página corrente (1-based). */
+  page: number;
+  /** Total de páginas (do `usePaginationControls`). */
+  totalPages: number;
+  /** `true` quando há termo de busca ativo (após trim/debounce). */
+  hasActiveSearch: boolean;
+  /** Termo de busca (após trim) para citar na frase de vazio. */
+  trimmedSearch: string;
+  /** Copy específica do recurso. */
+  copy: ListingLiveMessageCopy;
+}
+
+export function useListingLiveMessage(args: UseListingLiveMessageArgs): string {
+  const {
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy,
+  } = args;
+
+  return useMemo<string>(() => {
+    if (isInitialLoading) {
+      return `Carregando lista de ${copy.pluralCarregando}.`;
+    }
+    if (isFetching) {
+      return `Atualizando lista de ${copy.pluralCarregando}.`;
+    }
+    if (errorMessage) {
+      return '';
+    }
+    const isMasculine = copy.gender === 'm';
+    const nenhum = isMasculine ? 'Nenhum' : 'Nenhuma';
+    const encontrada = isMasculine ? 'encontrado' : 'encontrada';
+    const encontradaPlural = isMasculine ? 'encontrado(s)' : 'encontrada(s)';
+    if (total === 0) {
+      return hasActiveSearch
+        ? `${nenhum} ${copy.singular} ${encontrada} para ${trimmedSearch}.`
+        : copy.vazioSemBusca;
+    }
+    return `${total} ${copy.singular}(s) ${encontradaPlural}. Página ${page} de ${totalPages}.`;
+  }, [
+    copy.gender,
+    copy.pluralCarregando,
+    copy.singular,
+    copy.vazioSemBusca,
+    errorMessage,
+    hasActiveSearch,
+    isFetching,
+    isInitialLoading,
+    page,
+    total,
+    totalPages,
+    trimmedSearch,
+  ]);
+}

--- a/tests/pages/RolesPage.test.tsx
+++ b/tests/pages/RolesPage.test.tsx
@@ -1,0 +1,560 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  createRolesClientStub,
+  ID_ROLE_ADMIN,
+  ID_ROLE_ROOT,
+  ID_ROLE_VIEWER,
+  lastGetPath,
+  makeRole,
+  renderRolesPage,
+  waitForInitialList,
+} from './__helpers__/rolesTestHelpers';
+
+import type { ApiError, RoleDto } from '@/shared/api';
+
+import { RolesPage } from '@/pages/RolesPage';
+
+/**
+ * Suíte da `RolesPage` (Issue #66, EPIC #47 — listagem de roles por
+ * sistema). Estratégia espelha `RoutesPage.test.tsx`: stub de
+ * `ApiClient` injetado, asserts sobre estados visuais, paginação,
+ * busca debounced, toggle "incluir inativas", erros e cancelamento de
+ * request.
+ *
+ * **Diferenças em relação a `RoutesPage.test.tsx`:**
+ *
+ * - O backend `/roles` hoje devolve um array cru (sem paginação/
+ *   busca/includeDeleted nativos); o `listRoles` aplica os filtros
+ *   client-side. Por isso a suíte foca no **comportamento da UI**
+ *   (busca filtra a tabela, paginação aplica skip/take em memória,
+ *   toggle inclui/exclui inativos visualmente) em vez de inspecionar
+ *   a querystring do `client.get`.
+ * - `lastGetPath` continua existindo e é usado para garantir que o
+ *   path é sempre `/roles` (sem querystring) — quando o backend
+ *   evoluir para paginação real, esses asserts mudarão para refletir
+ *   a nova querystring.
+ * - Não há gating de auth para nova role nesta sub-issue (a CTA é
+ *   adicionada na #67); o mock `useAuth` segue sendo necessário pelo
+ *   `RequirePermission` (que não é exercitado nesta suíte porque
+ *   renderizamos a página direto, sem `AppRoutes`).
+ */
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => []));
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_ROWS: ReadonlyArray<RoleDto> = [
+  makeRole({
+    id: ID_ROLE_ROOT,
+    name: 'Root',
+    code: 'root',
+    description: 'Acesso irrestrito a todos os sistemas',
+    permissionsCount: 12,
+    usersCount: 2,
+  }),
+  makeRole({
+    id: ID_ROLE_ADMIN,
+    name: 'Admin',
+    code: 'admin',
+    description: 'Gerenciamento de usuários e permissões',
+    permissionsCount: 8,
+    usersCount: 6,
+  }),
+  makeRole({
+    id: ID_ROLE_VIEWER,
+    name: 'Viewer',
+    code: 'viewer',
+    description: null,
+    permissionsCount: null,
+    usersCount: null,
+    deletedAt: '2026-02-01T00:00:00Z',
+  }),
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('RolesPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e depois popula a tabela', async () => {
+    const client = createRolesClientStub();
+    let resolveFn: (value: unknown) => void = () => undefined;
+    const pending = new Promise<unknown>((resolve) => {
+      resolveFn = resolve;
+    });
+    client.get.mockReturnValueOnce(pending);
+
+    renderRolesPage(client);
+
+    expect(screen.getByTestId('roles-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(SAMPLE_ROWS.slice());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('roles-loading')).not.toBeInTheDocument();
+    });
+
+    // Tabela desktop e cards mobile renderizam o mesmo conteúdo lado
+    // a lado (CSS controla qual aparece). Asserir presença sem exigir
+    // unicidade — `getAllByText` cobre ambos. Apenas roles ativas
+    // (Root/Admin) aparecem por default — Viewer está soft-deletada
+    // e só aparece com o toggle "Mostrar inativas" ligado, coberto
+    // num teste dedicado abaixo.
+    expect(screen.getAllByText('Root').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Viewer')).not.toBeInTheDocument();
+  });
+
+  it('renderiza header da página com título "Roles do sistema"', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+
+    await waitForInitialList(client);
+
+    expect(screen.getByRole('heading', { name: /Roles do sistema/i })).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /roles (endpoint atual, sem paginação nativa)', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+
+    await waitForInitialList(client);
+    expect(lastGetPath(client)).toBe('/roles');
+  });
+
+  it('renderiza badge "Inativa" para roles com deletedAt e "Ativa" para as demais (com toggle ligado)', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    // Por default `includeDeleted=false` — a Viewer (deletada) é
+    // omitida. Ligamos o toggle para incluí-la e exibir o badge
+    // "Inativa".
+    fireEvent.click(screen.getByTestId('roles-include-deleted'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`roles-card-${ID_ROLE_VIEWER}`)).toBeInTheDocument();
+    });
+
+    // jsdom aplica `display: none` no `TableForDesktop` (a media
+    // query `min-width: 48em` falha em viewport zero), então a tabela
+    // desktop fica fora da accessibility tree. Asserir nas cards
+    // mobile cobre o mesmo dado.
+    const rootCard = screen.getByTestId(`roles-card-${ID_ROLE_ROOT}`);
+    const viewerCard = screen.getByTestId(`roles-card-${ID_ROLE_VIEWER}`);
+    expect(within(rootCard).getByText('Ativa')).toBeInTheDocument();
+    expect(within(viewerCard).getByText('Inativa')).toBeInTheDocument();
+  });
+
+  it('exibe placeholder "—" para description/permissionsCount/usersCount ausentes (estado atual do backend)', async () => {
+    const client = createRolesClientStub();
+    // Cenário "backend não devolve os campos opcionais" — todos `null`.
+    client.get.mockResolvedValueOnce([
+      makeRole({
+        id: ID_ROLE_ROOT,
+        name: 'Root',
+        code: 'root',
+        description: null,
+        permissionsCount: null,
+        usersCount: null,
+      }),
+    ]);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    // O placeholder "—" aparece tanto na tabela desktop quanto nos
+    // cards mobile (mesmo helper `renderDescription`/`renderCount`).
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('exibe contagens numéricas quando o backend devolve os campos (cenário futuro)', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce([
+      makeRole({
+        id: ID_ROLE_ROOT,
+        name: 'Root',
+        code: 'root',
+        description: 'Acesso irrestrito',
+        permissionsCount: 12,
+        usersCount: 2,
+      }),
+    ]);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    // Asserir presença sem exigir unicidade (tabela + cards).
+    expect(screen.getAllByText('12').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Acesso irrestrito').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza cards mobile com testId estável por role', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId(`roles-card-${ID_ROLE_ROOT}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`roles-card-${ID_ROLE_ADMIN}`)).toBeInTheDocument();
+  });
+});
+
+describe('RolesPage — busca debounced (filtro client-side)', () => {
+  it('digitar não dispara request imediato; após 300ms re-aplica o filtro client-side', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('roles-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'admin' } });
+
+    // O backend não suporta `q` nativo — o adapter aplica em memória,
+    // mas o `usePaginatedFetch` ainda dispara um refetch (a request
+    // identidade do `fetcher` mudou) para consistência com a paridade
+    // de UX entre listagens.
+    expect(client.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    // Apenas a role com nome/code "admin" deve aparecer.
+    await waitFor(() => {
+      expect(screen.getByTestId(`roles-card-${ID_ROLE_ADMIN}`)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId(`roles-card-${ID_ROLE_ROOT}`)).not.toBeInTheDocument();
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('roles-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'ad' } });
+    fireEvent.change(input, { target: { value: 'adm' } });
+    fireEvent.change(input, { target: { value: 'admin' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('RolesPage — paginação client-side', () => {
+  it('clicar "próxima" muda a página para a 2; "anterior" volta para 1', async () => {
+    const client = createRolesClientStub();
+    // 25 roles ativas garantem 2 páginas com pageSize=20.
+    const manyRows = Array.from({ length: 25 }, (_, i) =>
+      makeRole({
+        id: `id-${i}`,
+        name: `Role ${i}`,
+        code: `r${String(i).padStart(2, '0')}`,
+      }),
+    );
+    client.get.mockResolvedValue(manyRows);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    // Na página 1 vemos r00..r19.
+    expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 1 de 2/i);
+
+    fireEvent.click(screen.getByTestId('roles-next'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 2 de 2/i);
+    });
+
+    fireEvent.click(screen.getByTestId('roles-prev'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 1 de 2/i);
+    });
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createRolesClientStub();
+    const manyRows = Array.from({ length: 25 }, (_, i) =>
+      makeRole({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
+    );
+    client.get.mockResolvedValueOnce(manyRows);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('roles-prev')).toBeDisabled();
+    expect(screen.getByTestId('roles-next')).toBeEnabled();
+  });
+
+  it('botão "próxima" desabilita quando totalPages é 1', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('roles-prev')).toBeDisabled();
+    expect(screen.getByTestId('roles-next')).toBeDisabled();
+  });
+
+  it('exibe indicador "página X de Y" com total filtrado', async () => {
+    const client = createRolesClientStub();
+    const manyRows = Array.from({ length: 42 }, (_, i) =>
+      makeRole({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
+    );
+    client.get.mockResolvedValueOnce(manyRows);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    const info = screen.getByTestId('roles-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('RolesPage — filtro de inativas', () => {
+  it('liga toggle dispara request com inclusão de inativas no resultado', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    // Antes de ligar o toggle, a Viewer (deletada) não aparece.
+    expect(
+      screen.queryByTestId(`roles-card-${ID_ROLE_VIEWER}`),
+    ).not.toBeInTheDocument();
+
+    const toggle = screen.getByTestId('roles-include-deleted') as HTMLInputElement;
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    // Depois do toggle, a Viewer aparece.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`roles-card-${ID_ROLE_VIEWER}`),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe('RolesPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('roles-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Nenhuma role encontrada para/i).length).toBeGreaterThan(0);
+    });
+    // O botão "Limpar busca" aparece tanto na tabela quanto nos
+    // cards (mesmo `emptyContent` reusado).
+    expect(screen.getAllByTestId('roles-empty-clear').length).toBeGreaterThan(0);
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValueOnce([]);
+
+    renderRolesPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getAllByText(/Nenhuma role cadastrada para este sistema\./i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Roles removidas podem ser visualizadas/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('clicar em "limpar busca" reseta termo e re-popula a lista', async () => {
+    const client = createRolesClientStub();
+    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('roles-search'), {
+      target: { value: 'naoexiste' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    // Estado vazio com busca ativa.
+    await waitFor(() => {
+      expect(screen.getAllByText(/Nenhuma role encontrada para/i).length).toBeGreaterThan(0);
+    });
+
+    // O botão pode aparecer duplicado (tabela + cards). Pegamos o
+    // primeiro — clicar em qualquer um dispara o mesmo callback.
+    fireEvent.click((await screen.findAllByTestId('roles-empty-clear'))[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`roles-card-${ID_ROLE_ROOT}`),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe('RolesPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createRolesClientStub();
+    client.get
+      .mockRejectedValueOnce(apiError)
+      .mockResolvedValueOnce(SAMPLE_ROWS.slice());
+
+    renderRolesPage(client);
+
+    expect(await screen.findByText(/Falha de conexão com o servidor\./i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('roles-retry'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Root').length).toBeGreaterThan(0);
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createRolesClientStub();
+    client.get.mockRejectedValueOnce(new Error('boom'));
+
+    renderRolesPage(client);
+
+    expect(
+      await screen.findByText(/Falha ao carregar a lista de roles\. Tente novamente\./i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RolesPage — cancelamento de request', () => {
+  it('mudanças sucessivas de filtro abortam a request anterior via AbortController', async () => {
+    const client = createRolesClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (_path: string, options?: { signal?: AbortSignal }): Promise<unknown> => {
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        return Promise.resolve(SAMPLE_ROWS.slice());
+      },
+    );
+
+    renderRolesPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('roles-search'), {
+      target: { value: 'admin' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(screen.getByTestId('roles-search'), {
+      target: { value: 'admin-extra' },
+    });
+
+    expect(client.get).toHaveBeenCalledTimes(2);
+
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+
+    // O signal da request "admin" deve estar abortado: o cleanup do
+    // useEffect que rodou para "admin" foi chamado quando
+    // `debouncedSearch` mudou para "admin-extra".
+    expect(signals[1].aborted).toBe(true);
+  });
+});
+
+describe('RolesPage — systemId inválido', () => {
+  it('renderiza alerta de "ID inválido" e não chama o backend quando :systemId é vazio', async () => {
+    const client = createRolesClientStub();
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/systems/%20/roles']}>
+          <Routes>
+            <Route
+              path="/systems/:systemId/roles"
+              element={<RolesPage client={client} />}
+            />
+          </Routes>
+        </MemoryRouter>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('roles-invalid-id')).toBeInTheDocument();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -1,0 +1,328 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { expect, vi } from "vitest";
+
+import type { ApiClient, ApiError, RoleDto } from "@/shared/api";
+
+import { ToastProvider } from "@/components/ui";
+import { RolesPage } from "@/pages/RolesPage";
+
+/**
+ * Helpers de teste compartilhados pela suíte da `RolesPage` (Issue
+ * #66) e pelas próximas (#67 criar, #68 editar, #69 associar
+ * permissões) — pré-fabricados desde o primeiro PR do recurso para
+ * evitar refatoração destrutiva nos PRs seguintes (lição PR #128 —
+ * "projetar shared helpers desde o primeiro PR do recurso").
+ *
+ * Estratégia espelha `routesTestHelpers.tsx`/`systemsTestHelpers.tsx`:
+ *
+ * - `ApiClientStub` + `createRolesClientStub` para isolar a página da
+ *   camada de transporte;
+ * - `makeRole` para construir payloads do contrato `RoleDto` sem
+ *   repetir todos os campos;
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderRolesPage` envolvendo a página no `MemoryRouter` apontando
+ *   para `/systems/:systemId/roles` (a página lê `useParams`);
+ * - `waitForInitialList` colapsando o "esperar listagem" repetido em
+ *   praticamente todos os testes.
+ *
+ * **Importante (TODO no backend):** o `RoleDto` aceita
+ * `description`/`permissionsCount`/`usersCount` opcionais — o
+ * backend hoje não devolve esses campos (`AppRole` ainda não os tem;
+ * ver `src/shared/api/roles.ts`). Os helpers expõem todos eles para
+ * que os testes possam exercer ambos os caminhos: campo presente
+ * (cenário do futuro) e campo ausente (cenário atual). Assim quando
+ * o backend evoluir, os testes existentes continuam válidos sem
+ * mudanças.
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_SYS_AUTH = "11111111-1111-1111-1111-111111111111";
+export const ID_ROLE_ROOT = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+export const ID_ROLE_ADMIN = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+export const ID_ROLE_VIEWER = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+/**
+ * Stub de `ApiClient` injetado em `<RolesPage client={stub} />` —
+ * mesmo padrão de injeção usado nos testes da `SystemsPage`/
+ * `RoutesPage`. Reusa o shape de `ApiClientStub` em
+ * `routesTestHelpers.tsx`/`systemsTestHelpers.tsx`, mas declarado
+ * localmente para que cada suíte mantenha seu próprio módulo de
+ * fixtures (acoplar os três levaria à inversão "tests dependem de
+ * tests" que dificulta reorganizar).
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createRolesClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => "system-test-uuid"),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `RoleDto` com defaults — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos do contrato.
+ *
+ * Os campos opcionais (`description`/`permissionsCount`/
+ * `usersCount`) ficam `null` por default para refletir o estado
+ * **atual** do backend (TODO no model); testes que exercitam o
+ * caminho "backend devolveu o valor" sobrescrevem explicitamente.
+ */
+export function makeRole(overrides: Partial<RoleDto> = {}): RoleDto {
+  return {
+    id: ID_ROLE_ROOT,
+    name: "Root",
+    code: "root",
+    description: null,
+    permissionsCount: null,
+    usersCount: null,
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Renderiza a `RolesPage` envolvendo no `MemoryRouter` apontando
+ * para `/systems/:systemId/roles`. A página consome
+ * `useParams<{ systemId }>` — sem o roteador, `systemId` ficaria
+ * `undefined` e a página entraria no estado `InvalidIdNotice` em
+ * vez de carregar a listagem.
+ *
+ * `systemId` é parametrizável para que o teste de `:systemId`
+ * inválido possa simular a URL `/systems/ /roles` (whitespace) e
+ * cair no `InvalidIdNotice` — espelhando o comportamento real do
+ * componente.
+ *
+ * Envolvemos em `ToastProvider` desde já para que os modals das
+ * próximas issues (#67/#68) possam disparar `useToast()` sem
+ * quebrar — espelha a estratégia do `renderRoutesPage` em
+ * `routesTestHelpers.tsx` (lição PR #128 — projetar shared
+ * helpers desde o primeiro PR do recurso). Suítes de listagem
+ * que não abrem modal não pagam custo perceptível por ter o
+ * provider ativo.
+ */
+export function renderRolesPage(
+  client: ApiClientStub,
+  systemId: string = ID_SYS_AUTH,
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[`/systems/${systemId}/roles`]}>
+        <Routes>
+          <Route
+            path="/systems/:systemId/roles"
+            element={<RolesPage client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a `RolesPage` faz
+ * `listRoles` no mount). Centraliza o "esperar listagem" para que
+ * cada teste comece em estado estável sem precisar replicar
+ * `waitFor` para `client.get`. Espelha `waitForInitialList` em
+ * `routesTestHelpers.tsx`.
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId("roles-loading")).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Helper para extrair o `path` passado a `client.get` na chamada
+ * mais recente. Usado em asserts que verificam o endpoint
+ * consumido. Espelha `lastGetPath` em `routesTestHelpers.tsx`.
+ *
+ * **Hoje** o backend só expõe `GET /roles` (sem querystring); o
+ * adapter client-side em `listRoles` aplica filtros/paginação em
+ * memória. Quando o backend evoluir para `GET /systems/roles?...`,
+ * este helper continuará válido — só mudará o conteúdo retornado.
+ */
+export function lastGetPath(client: ApiClientStub): string {
+  const calls = client.get.mock.calls;
+  if (calls.length === 0) return "";
+  const path = calls[calls.length - 1][0];
+  return typeof path === "string" ? path : "";
+}
+
+/**
+ * Aceita string ou regex e devolve sempre um `RegExp` insensível a
+ * caixa, com escape de metacaracteres. Espelha
+ * `toCaseInsensitiveMatcher` em `routesTestHelpers.tsx`/
+ * `systemsTestHelpers.tsx` — pré-fabricado para que as suítes de
+ * mutação (#67/#68) consumam sem duplicar o helper (lição PR #128).
+ */
+export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
+  if (typeof text !== "string") {
+    return text;
+  }
+  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), "i");
+}
+
+/* ─── Helpers de mutação (Issues #67, #68) ─────────────────── */
+
+/**
+ * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)`
+ * das suítes de criação (#67) e edição (#68) — espelha
+ * `RoutesErrorCase` em `routesTestHelpers.tsx`. Pré-fabricado para
+ * que a próxima sub-issue não precise redeclarar o tipo (Sonar marca
+ * tipos idênticos em arquivos diferentes como duplicação — lição
+ * PR #127).
+ */
+export interface RolesErrorCase {
+  /** Descrição usada como `it.each($name)`. */
+  name: string;
+  /** Erro lançado pelo cliente HTTP no submit. */
+  error: ApiError;
+  /** Texto visível no UI após o submit (string vira regex case-insensitive). */
+  expectedText: RegExp | string;
+  /** Default `true` — quando `false`, o modal fecha após o erro (ex.: 404 no edit). */
+  modalStaysOpen?: boolean;
+}
+
+/**
+ * Constrói os 5 cenários de erro de submit que diferem **apenas** no
+ * verbo (`criar` vs `atualizar`) entre as futuras suítes de criação
+ * (#67) e edição (#68). Pré-fabrica o helper já no primeiro PR do
+ * recurso para evitar a recorrência de `New Code Duplication` no
+ * Sonar quando a #68 chegar (lição PR #128 — projetar shared
+ * helpers desde o primeiro PR).
+ */
+export function buildSharedRoleSubmitErrorCases(
+  verb: "criar" | "atualizar",
+): ReadonlyArray<RolesErrorCase> {
+  const verbAcao = verb === "criar" ? "criação" : "atualização";
+  return [
+    {
+      name: "400 com errors mapeia mensagens para os campos correspondentes",
+      error: {
+        kind: "http",
+        status: 400,
+        message: "Erro de validação.",
+        details: {
+          errors: {
+            Name: ["Name é obrigatório e não pode ser apenas espaços."],
+            Code: ["Code deve ter no máximo 50 caracteres."],
+          },
+        },
+      },
+      expectedText: "Name é obrigatório e não pode ser apenas espaços.",
+    },
+    {
+      name: "400 sem errors mapeáveis exibe Alert no topo do form",
+      error: {
+        kind: "http",
+        status: 400,
+        message: `Payload inválido para ${verbAcao} de role.`,
+      },
+      expectedText: `Payload inválido para ${verbAcao} de role.`,
+    },
+    {
+      name: "401 dispara toast vermelho com mensagem do backend",
+      error: {
+        kind: "http",
+        status: 401,
+        message: "Sessão expirada. Faça login novamente.",
+      },
+      expectedText: "Sessão expirada. Faça login novamente.",
+    },
+    {
+      name: "403 dispara toast vermelho com mensagem do backend",
+      error: {
+        kind: "http",
+        status: 403,
+        message: "Você não tem permissão para esta ação.",
+      },
+      expectedText: "Você não tem permissão para esta ação.",
+    },
+    {
+      name: "erro genérico de rede dispara toast vermelho genérico",
+      error: {
+        kind: "network",
+        message: "Falha de conexão com o servidor.",
+      },
+      expectedText: `Não foi possível ${verb} a role. Tente novamente.`,
+    },
+  ];
+}
+
+/**
+ * Constrói os 3 cenários de fechamento sem persistência (Esc,
+ * Cancelar, backdrop) usando o `cancelTestId` da suíte chamadora.
+ * Espelha `buildRoutesCloseCases` em `routesTestHelpers.tsx` —
+ * pré-fabricado já agora para a futura suíte de criação reusar com
+ * a futura suíte de edição.
+ */
+export interface RolesModalCloseCase {
+  name: string;
+  close: () => void;
+}
+
+export function buildRolesCloseCases(
+  cancelTestId: string,
+): ReadonlyArray<RolesModalCloseCase> {
+  return [
+    {
+      name: "Esc",
+      // eslint-disable-next-line no-restricted-globals
+      close: () => fireEvent.keyDown(window, { key: "Escape" }),
+    },
+    {
+      name: "botão Cancelar",
+      close: () => fireEvent.click(screen.getByTestId(cancelTestId)),
+    },
+    {
+      name: "clique no backdrop",
+      close: () => fireEvent.mouseDown(screen.getByTestId("modal-backdrop")),
+    },
+  ];
+}
+
+/**
+ * Helper que executa um submit assíncrono dentro de `act` para
+ * flushar a microtask antes do `waitFor`. Útil para futuras suítes
+ * de mutação (#67, #68) que precisarão simular submit do form
+ * — pré-fabricado para evitar duplicação entre criação/edição
+ * (lição PR #127). A suíte de listagem (#66) não consome diretamente
+ * — fica disponível no barrel.
+ */
+export async function submitFormAndAwait(
+  formTestId: string,
+  awaitOn: () => Promise<void>,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId(formTestId));
+    await Promise.resolve();
+  });
+  await awaitOn();
+}

--- a/tests/routes/routeCodes.test.ts
+++ b/tests/routes/routeCodes.test.ts
@@ -24,7 +24,13 @@ const POSITIVE_CASES: ReadonlyArray<ResolveCase> = [
     pathname: '/systems/11111111-1111-1111-1111-111111111111/routes',
     expected: 'AUTH_V1_SYSTEMS_ROUTES_LIST',
   },
-  { pathname: '/roles', expected: 'AUTH_V1_ROLES_LIST' },
+  // Issue #66: a listagem real de roles vive em `/systems/:id/roles` e
+  // resolve para `AUTH_V1_ROLES_LIST`. Mesma ordem importa — pattern
+  // mais específico vence `/systems` no `matchPath`.
+  {
+    pathname: '/systems/11111111-1111-1111-1111-111111111111/roles',
+    expected: 'AUTH_V1_ROLES_LIST',
+  },
   { pathname: '/permissions', expected: 'AUTH_V1_PERMISSIONS_LIST' },
   { pathname: '/users', expected: 'AUTH_V1_USERS_LIST' },
   { pathname: '/tokens', expected: 'AUTH_V1_TOKEN_TYPES_LIST' },
@@ -34,9 +40,10 @@ const POSITIVE_CASES: ReadonlyArray<ResolveCase> = [
  * `/settings` e `/showcase` não têm rota equivalente cadastrada no
  * `AuthenticatorRoutesSeeder` — `resolveRouteCode` devolve `null` e o
  * `RequireAuth` pula a chamada de `verify-token`. Incluímos também
- * `/routes` (Issue #62): a página global continua no `AppRoutes` como
- * placeholder gated apenas client-side, sem entrada própria nesta
- * tabela — a listagem real de rotas vive em `/systems/:id/routes`.
+ * `/routes` (Issue #62) e `/roles` (Issue #66): as páginas globais
+ * continuam no `AppRoutes` como placeholders gated apenas client-side,
+ * sem entrada própria nesta tabela — as listagens reais vivem em
+ * `/systems/:id/routes` e `/systems/:id/roles`.
  */
 const NEGATIVE_CASES: ReadonlyArray<string> = [
   '/',
@@ -47,6 +54,7 @@ const NEGATIVE_CASES: ReadonlyArray<string> = [
   '/settings',
   '/showcase',
   '/routes',
+  '/roles',
   '',
 ];
 

--- a/tests/shared/api/roles.test.ts
+++ b/tests/shared/api/roles.test.ts
@@ -1,0 +1,508 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, RoleDto } from '@/shared/api';
+
+import {
+  createRole,
+  deleteRole,
+  isPagedRolesResponse,
+  isRoleDto,
+  listRoles,
+  updateRole,
+} from '@/shared/api';
+
+/**
+ * Suíte do módulo `src/shared/api/roles.ts` (Issue #66, EPIC #47).
+ *
+ * Estratégia: stubar o `ApiClient` injetado e validar paths, body,
+ * type guards e propagação de `ApiError`. Não bate em `fetch` —
+ * cobertura de transporte HTTP é responsabilidade dos testes em
+ * `client.test.ts`.
+ *
+ * Nesta primeira sub-issue só `listRoles` é consumido pela UI; os
+ * wrappers `createRole`/`updateRole`/`deleteRole` foram declarados
+ * já agora para evitar PR destrutivo nas próximas sub-issues
+ * (lição PR #128 — projetar shared helpers desde o primeiro PR do
+ * recurso), portanto cobrimos todos com asserts mínimos.
+ *
+ * **Importante (TODO no backend):** o `RoleDto` aceita
+ * `description`/`permissionsCount`/`usersCount` opcionais — o
+ * backend hoje não devolve esses campos. Os testes exercitam ambos
+ * os caminhos (campo presente vs. ausente) para que quando o
+ * backend evoluir não seja preciso reescrever a suíte.
+ *
+ * **Adapter client-side:** como o backend `/roles` não tem
+ * paginação/busca/includeDeleted nativos, `listRoles` aplica os
+ * filtros em memória sobre o array cru devolvido pelo controller.
+ * A suíte cobre o adapter (filtragem por `q`, `includeDeleted`,
+ * paginação) — quando o backend ganhar paginação real, basta
+ * reescrever `listRoles` e ajustar dois testes do bloco "adapter".
+ */
+
+const SYS_ID = '11111111-1111-1111-1111-111111111111';
+const ROLE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+interface ClientStub {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Cria um stub mínimo de `ApiClient` — espelha o pattern usado em
+ * `tests/shared/api/routes.test.ts`/`tests/pages/__helpers__/`. O
+ * teste de API não precisa do DOM, então mantemos local em vez de
+ * importar dos helpers de página (manter independência reduz custo
+ * de boot da suíte).
+ */
+function createStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  };
+}
+
+/**
+ * Constrói um `RoleDto` válido — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos. Campos
+ * opcionais (`description`/`permissionsCount`/`usersCount`) ficam
+ * `null` por default para refletir o estado **atual** do backend.
+ */
+function makeRoleDto(overrides: Partial<RoleDto> = {}): RoleDto {
+  return {
+    id: ROLE_ID,
+    name: 'Root',
+    code: 'root',
+    description: null,
+    permissionsCount: null,
+    usersCount: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('isRoleDto', () => {
+  it('aceita payload completo do contrato (com todos os campos opcionais)', () => {
+    expect(
+      isRoleDto(
+        makeRoleDto({
+          description: 'Acesso irrestrito',
+          permissionsCount: 12,
+          usersCount: 2,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('aceita payload sem os campos opcionais (estado atual do backend)', () => {
+    expect(isRoleDto(makeRoleDto())).toBe(true);
+    const { description: _d, permissionsCount: _p, usersCount: _u, ...lean } =
+      makeRoleDto();
+    expect(isRoleDto(lean)).toBe(true);
+  });
+
+  it('aceita description ausente/null/undefined', () => {
+    expect(isRoleDto(makeRoleDto({ description: null }))).toBe(true);
+    const { description: _omit, ...withoutDescription } = makeRoleDto();
+    expect(isRoleDto(withoutDescription)).toBe(true);
+  });
+
+  it('aceita deletedAt ausente/null/undefined', () => {
+    expect(isRoleDto(makeRoleDto({ deletedAt: null }))).toBe(true);
+    const { deletedAt: _omit, ...withoutDeleted } = makeRoleDto();
+    expect(isRoleDto(withoutDeleted)).toBe(true);
+  });
+
+  it('rejeita objetos sem campos obrigatórios', () => {
+    expect(isRoleDto(null)).toBe(false);
+    expect(isRoleDto(undefined)).toBe(false);
+    expect(isRoleDto({})).toBe(false);
+    expect(isRoleDto({ id: 1, code: 'root' })).toBe(false);
+    const missingCode = makeRoleDto();
+    delete (missingCode as Partial<RoleDto>).code;
+    expect(isRoleDto(missingCode)).toBe(false);
+  });
+
+  it('rejeita campos com tipos inválidos', () => {
+    expect(
+      isRoleDto(makeRoleDto({ description: 123 as unknown as string })),
+    ).toBe(false);
+    expect(
+      isRoleDto(makeRoleDto({ deletedAt: 0 as unknown as string })),
+    ).toBe(false);
+    expect(
+      isRoleDto(
+        makeRoleDto({
+          permissionsCount: 'doze' as unknown as number,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isRoleDto(makeRoleDto({ usersCount: '12' as unknown as number })),
+    ).toBe(false);
+  });
+});
+
+describe('isPagedRolesResponse', () => {
+  it('aceita envelope válido com dados', () => {
+    const envelope = {
+      data: [makeRoleDto()],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    };
+    expect(isPagedRolesResponse(envelope)).toBe(true);
+  });
+
+  it('aceita envelope vazio', () => {
+    expect(
+      isPagedRolesResponse({ data: [], page: 1, pageSize: 20, total: 0 }),
+    ).toBe(true);
+  });
+
+  it('rejeita envelope sem campos', () => {
+    expect(isPagedRolesResponse(null)).toBe(false);
+    expect(isPagedRolesResponse({ data: [] })).toBe(false);
+    expect(
+      isPagedRolesResponse({ data: [], page: '1', pageSize: 20, total: 0 }),
+    ).toBe(false);
+  });
+
+  it('rejeita data com itens inválidos', () => {
+    expect(
+      isPagedRolesResponse({
+        data: [{ broken: true }],
+        page: 1,
+        pageSize: 20,
+        total: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', () => {
+  it('emite GET /roles e devolve envelope paginado quando backend devolve array', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([makeRoleDto()]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe('/roles');
+    expect(result.data).toHaveLength(1);
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+    expect(result.total).toBe(1);
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([makeRoleDto()]);
+    const controller = new AbortController();
+
+    await listRoles(
+      { systemId: SYS_ID },
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido (não-array)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      listRoles(
+        { systemId: SYS_ID },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    });
+  });
+
+  it('lança ApiError(parse) quando algum item do array não é RoleDto', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([makeRoleDto(), { broken: true }]);
+
+    await expect(
+      listRoles(
+        { systemId: SYS_ID },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 401, message: 'Sessão expirada.' };
+    client.get.mockRejectedValueOnce(apiError);
+
+    await expect(
+      listRoles(
+        { systemId: SYS_ID },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toEqual(apiError);
+  });
+});
+
+describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => {
+  it('filtra deletedAt quando includeDeleted=false (default)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeRoleDto({ id: 'a', code: 'aroot' }),
+      makeRoleDto({
+        id: 'b',
+        code: 'bdeleted',
+        deletedAt: '2026-02-01T00:00:00Z',
+      }),
+    ]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('a');
+    expect(result.total).toBe(1);
+  });
+
+  it('inclui deletedAt quando includeDeleted=true', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeRoleDto({ id: 'a', code: 'aroot' }),
+      makeRoleDto({
+        id: 'b',
+        code: 'bdeleted',
+        deletedAt: '2026-02-01T00:00:00Z',
+      }),
+    ]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID, includeDeleted: true },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.data).toHaveLength(2);
+    expect(result.total).toBe(2);
+  });
+
+  it('filtra por q (case-insensitive em name e code) após trim', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeRoleDto({ id: 'a', name: 'Root', code: 'root' }),
+      makeRoleDto({ id: 'b', name: 'Admin', code: 'admin' }),
+      makeRoleDto({ id: 'c', name: 'Viewer', code: 'viewer' }),
+    ]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID, q: '  ROO  ' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.data.map((r) => r.id)).toEqual(['a']);
+    expect(result.total).toBe(1);
+  });
+
+  it('q vazio após trim devolve todos os resultados', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeRoleDto({ id: 'a', code: 'a' }),
+      makeRoleDto({ id: 'b', code: 'b' }),
+    ]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID, q: '   ' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.total).toBe(2);
+  });
+
+  it('ordena por code (estabilidade visual entre refetches)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeRoleDto({ id: 'c', code: 'charlie' }),
+      makeRoleDto({ id: 'a', code: 'alpha' }),
+      makeRoleDto({ id: 'b', code: 'bravo' }),
+    ]);
+
+    const result = await listRoles(
+      { systemId: SYS_ID },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.data.map((r) => r.code)).toEqual(['alpha', 'bravo', 'charlie']);
+  });
+
+  it('aplica page/pageSize em memória; total reflete o conjunto após filtros', async () => {
+    const client = createStub();
+    const rows = Array.from({ length: 25 }, (_, i) =>
+      makeRoleDto({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
+    );
+    client.get.mockResolvedValueOnce(rows);
+
+    const result = await listRoles(
+      { systemId: SYS_ID, page: 2, pageSize: 10 },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(10);
+    expect(result.total).toBe(25);
+    expect(result.data).toHaveLength(10);
+    expect(result.data[0].code).toBe('r10');
+  });
+});
+
+describe('createRole', () => {
+  it('emite POST /roles com body trimado e devolve RoleDto', async () => {
+    const client = createStub();
+    const created = makeRoleDto();
+    client.post.mockResolvedValueOnce(created);
+
+    const result = await createRole(
+      {
+        name: '  Root  ',
+        code: ' root ',
+        description: '  desc  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    const [path, body] = client.post.mock.calls[0];
+    expect(path).toBe('/roles');
+    expect(body).toEqual({
+      name: 'Root',
+      code: 'root',
+      description: 'desc',
+    });
+    expect(result).toEqual(created);
+  });
+
+  it('omite description quando string vazia/whitespace após trim', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeRoleDto());
+
+    await createRole(
+      { name: 'Root', code: 'root', description: '   ' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][1]).toEqual({
+      name: 'Root',
+      code: 'root',
+    });
+  });
+
+  it('lança ApiError(parse) quando resposta não é RoleDto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      createRole(
+        { name: 'X', code: 'X' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('updateRole', () => {
+  it('emite PUT /roles/{id} com body trimado e devolve RoleDto', async () => {
+    const client = createStub();
+    const updated = makeRoleDto({ name: 'Root (atualizado)' });
+    client.put.mockResolvedValueOnce(updated);
+
+    const result = await updateRole(
+      ROLE_ID,
+      {
+        name: '  Root (atualizado)  ',
+        code: 'root',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    const [path, body] = client.put.mock.calls[0];
+    expect(path).toBe(`/roles/${ROLE_ID}`);
+    expect(body).toEqual({
+      name: 'Root (atualizado)',
+      code: 'root',
+    });
+    expect(result).toEqual(updated);
+  });
+
+  it('lança ApiError(parse) quando resposta não é RoleDto', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(null);
+
+    await expect(
+      updateRole(
+        ROLE_ID,
+        { name: 'X', code: 'X' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('deleteRole', () => {
+  it('emite DELETE /roles/{id} e resolve void', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    await expect(
+      deleteRole(ROLE_ID, undefined, client as unknown as ApiClient),
+    ).resolves.toBeUndefined();
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete.mock.calls[0][0]).toBe(`/roles/${ROLE_ID}`);
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 404, message: 'Role não encontrada.' };
+    client.delete.mockRejectedValueOnce(apiError);
+
+    await expect(
+      deleteRole(ROLE_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+});


### PR DESCRIPTION
## Contexto

Primeira sub-issue da EPIC #47 (CRUD de Roles por Sistema). A página `/systems/:systemId/roles` espelha a estrutura de `RoutesPage` (EPIC #46): tabela desktop, cards mobile, busca debounced, paginação, toggle "Mostrar inativas", estados de loading/empty/error e ARIA-live para mudanças de estado.

## Closes

Closes #66

## Backend — investigação obrigatória

`AuthService/Controllers/Roles/RolesController.cs` foi inspecionado antes da implementação. O contrato atual:

- `GET /roles` devolve `List<RoleResponse>` cru — **sem** `systemId`/`q`/`page`/`pageSize`/`includeDeleted`.
- `RoleResponse(Id, Name, Code, CreatedAt, UpdatedAt, DeletedAt)` — **sem** `description`, `permissionsCount`, `usersCount`.
- `AppRole` model — **sem** `SystemId` (roles são globais hoje).
- Codes de permissão: `AUTH_V1_ROLES_LIST/CREATE/UPDATE/DELETE/RESTORE` (não `AUTH_V1_SYSTEMS_ROLES_*`). Confirmado em `AuthenticatorRoutesSeeder.cs` (linhas 75–90).

### Decisão

**Opção A do prompt** (TODO documentado, sem bloquear o merge):

- O DTO `RoleDto` aceita `description`/`permissionsCount`/`usersCount` opcionais (`null`/`undefined` = "ainda não enviado pelo backend"). A UI exibe `—` em itálico hoje e exibe o valor automaticamente quando o backend evoluir, sem mudar código.
- `listRoles` aplica `q`/`page`/`pageSize`/`includeDeleted` **client-side** sobre o array cru de `GET /roles`, normalizando para `PagedResponse<RoleDto>`. Esse adapter é claramente marcado como temporário no JSDoc — quando o backend implementar `GET /systems/roles?...` paginado (espelhando `RoutesController`), substituir o corpo da função por 3 linhas de fetch direto + type guard.
- `systemId` é declarado obrigatório no contrato da função (a UI sempre invoca de `/systems/:systemId/roles`) mas hoje não filtra: aceitar o param garante que a UI escopada por sistema continue válida quando o backend ganhar `SystemId` no `AppRole`.

## Wrappers já declarados (lição PR #128)

Para evitar PR destrutivo nas próximas sub-issues, `roles.ts` já exporta `createRole/updateRole/deleteRole` com testes — todos consumidos pelas issues #67/#68 e pela exclusão futura. Tudo segue o padrão de `routes.ts`.

## Refactor compartilhado em `src/shared/listing/` (lição PR #134/#135)

Replicar `RolesPage` linha-a-linha quebraria o threshold do Sonar/jscpd. Para mantê-lo abaixo de 3% mesmo com a nova listagem, primitives visuais comuns das 3 páginas (Systems/Routes/Roles) foram centralizados:

- `<ListingToolbar>` — busca + toggle inativos + slot de CTAs.
- `<PaginationFooter>` — info textual + botões prev/next.
- `<ErrorRetryBlock>` — Alert + botão "Tentar novamente".
- `<RefetchOverlay>` — overlay com Spinner para refetches.
- `<InitialLoadingSpinner>` — Spinner do primeiro fetch.
- `<LiveRegion>` — `<span aria-live>` invisível.
- `<StatusBadge>` — Badge ativo/inativo (parametrizada por gênero).
- `useListingLiveMessage` — árvore de decisão das mensagens ARIA-live.
- Styled primitives (`BackLink`/`Toolbar`/`SearchSlot`/`TableShell`/`EntityCard`/`CardHeader`/`CardCode`/`CardName`/`CardDescription`/`CardMeta`/`Mono`/`Placeholder`/`DescriptionCell`/`RowActions`/`InvalidIdNotice`/etc.) em `src/shared/listing/styles.ts`.

`SystemsPage`/`RoutesPage` foram refatoradas para consumir todos os componentes acima — diff líquido **-806 / +647 linhas** (redução de código apesar da página nova).

## Roteamento e mapping

- `src/routes/index.tsx`: nova rota `/systems/:systemId/roles → RolesPage` gated por `AUTH_V1_ROLES_LIST`. A rota global `/roles` virou `<PlaceholderPage>` (espelhando o que foi feito com `/routes` na EPIC #46).
- `src/routes/routeCodes.ts`: adicionado `/systems/:id/roles → AUTH_V1_ROLES_LIST` antes de `/systems` (matchPath prefix-match precisa do mais específico primeiro). `/roles` global agora é negative case (placeholder, sem verify-token).
- `src/layouts/AppLayout.tsx`: adicionado título "Roles" para `/systems/:systemId/roles` antes de `/systems`.
- `tests/routes/routeCodes.test.ts`: positive case `'/systems/:id/roles' → 'AUTH_V1_ROLES_LIST'`; `/roles` global movido para negative cases.

## Arquivos impactados

**Novos**:
- `src/shared/api/roles.ts` (DTO + type guards + listRoles/createRole/updateRole/deleteRole)
- `src/shared/listing/{styles.ts,index.ts,ErrorRetryBlock.tsx,InitialLoadingSpinner.tsx,ListingToolbar.tsx,LiveRegion.tsx,PaginationFooter.tsx,RefetchOverlay.tsx,StatusBadge.tsx,useListingLiveMessage.ts}`
- `tests/pages/RolesPage.test.tsx` (21 testes — render, busca, paginação, toggle, vazio, erro, cancelamento, systemId inválido)
- `tests/pages/__helpers__/rolesTestHelpers.tsx` (fixtures + helpers para #67/#68)
- `tests/shared/api/roles.test.ts` (29 testes — DTOs, type guards, listRoles/adapter, createRole, updateRole, deleteRole)

**Modificados**:
- `src/pages/RolesPage.tsx` (substitui o placeholder por implementação real)
- `src/pages/RoutesPage.tsx` (refatora para usar `src/shared/listing`)
- `src/pages/SystemsPage.tsx` (refatora para usar `src/shared/listing`)
- `src/routes/index.tsx`, `src/routes/routeCodes.ts`, `src/layouts/AppLayout.tsx`, `src/shared/api/index.ts`, `tests/routes/routeCodes.test.ts`, `.gitignore`

## Gate pré-PR (Issue #137) — todos verdes ✅

```
docker compose run --rm web npm run lint        → OK (sem erros, 0 warnings)
docker compose run --rm web npm run typecheck   → OK
docker compose run --rm web npm test            → 621 passed (45 test files)
docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10
   → Total: 690 (2.87%) | TypeScript: 2.67% | TSX: 1.04%  ✅ abaixo do 3%
```

Baseline em `development` era 2.97% — esta PR **reduz** a duplicação geral mesmo adicionando uma página nova, graças ao refactor de `src/shared/listing/`.

## Visual

- Pixel-perfection herdado do design system (mesmos tokens de Systems/Routes — nenhum hardcode de cor).
- Hover/focus/disabled tratados em todos os interativos (`BackLink`, `EntityCard`, botões via design system).
- Loading: `Spinner` "lg" no primeiro fetch; overlay leve com `Spinner` "md" em refetches subsequentes (mantém dados anteriores visíveis).
- Empty: 2 variantes (com/sem busca ativa) com CTA "Limpar busca" e dica sobre toggle inativos.
- Error: `Alert variant="danger"` + botão "Tentar novamente" via `<ErrorRetryBlock>`.
- Responsivo: tabela desktop ≥ 48em; cards mobile abaixo. Hover/focus em cada card.
- Acessibilidade: `role="list"`/`role="listitem"`, `aria-live` para mudanças, ARIA-labels em todos os interativos. `<LiveRegion>` aplica clip-rect padrão.

## Segurança

- Sem `dangerouslySetInnerHTML`.
- Inputs do usuário (busca/path) não são renderizados sem escape — passam por `<Input>` controlado e `useParams`. UUID inválido cai em alerta dedicado sem tocar o backend.
- Sem logs/console com dados sensíveis.
- Sem novas dependências.

## Riscos / pendências

- **Backend não evoluído**: paginação, busca, includeDeleted e descrição/contagens são adaptados client-side. Isso é aceitável para datasets pequenos (poucas dezenas de roles) e está claramente sinalizado in-code como TODO. Quando o backend ganhar `GET /systems/roles?...` paginado e os campos faltantes, a UI absorve sem mudança.
- **Roles globais**: o filtro por `:systemId` é apenas decorativo hoje (backend não conhece o conceito). Coberto pela mesma decisão acima — UI já está pronta para o dia em que `AppRole` ganhar `SystemId`.

## Issue relacionada

EPIC #47 — CRUD de Roles por Sistema.