### PR TITLE
chore(security): .snyk policy + sanitizar audit-guard

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,52 @@
+# Snyk (https://snyk.io) policy file
+# Documenta exceções intencionais detectadas pelo Snyk Code (SAST).
+# Cada entrada exige justificativa, criação e expiração — exceções
+# expiradas voltam automaticamente para o painel e precisam de revisão.
+
+version: v1.0.0
+
+ignore:
+  # FP: TOKEN_KEY é o NOME da chave em localStorage onde o JWT vivo é
+  # persistido em runtime, não um segredo embutido. O JWT real vem do
+  # lfc-authenticator via /auth/login. Documentado em src/shared/auth/storage.ts.
+  'javascript/HardcodedNonCryptoSecret':
+    - 'src/shared/auth/storage.ts':
+        reason: >-
+          Constant TOKEN_KEY is the localStorage key name, not a secret value.
+          The actual token is a runtime JWT received from lfc-authenticator.
+        expires: '2027-05-01T00:00:00.000Z'
+        created: '2026-05-01T00:00:00.000Z'
+
+  # FP: senhas em arquivos de teste são fixtures usadas em mocks de
+  # cliente HTTP — nenhuma credencial real. Aplicado a todo o diretório
+  # tests/ via glob.
+  'javascript/NoHardcodedPasswords/test':
+    - 'tests/**/*.test.tsx':
+        reason: >-
+          Test fixture passwords used as mocked input to HTTP client stubs.
+          No real credentials. Snyk's own rule suffix '/test' acknowledges
+          this is test code.
+        expires: '2027-05-01T00:00:00.000Z'
+        created: '2026-05-01T00:00:00.000Z'
+    - 'tests/**/*.test.ts':
+        reason: >-
+          Test fixture passwords used as mocked input to HTTP client stubs.
+          No real credentials.
+        expires: '2027-05-01T00:00:00.000Z'
+        created: '2026-05-01T00:00:00.000Z'
+
+  # Mitigado: scripts/audit-guard.cjs valida o caminho via
+  # resolveInsideRepo() antes de fs.readFileSync, recusando paths fora
+  # de process.cwd(). Snyk Code taint analyzer não reconhece o
+  # sanitizer customizado, por isso a anotação é necessária.
+  'javascript/PT':
+    - 'scripts/audit-guard.cjs':
+        reason: >-
+          Path validated by resolveInsideRepo() (path.resolve + cwd prefix
+          check) before reaching fs.readFileSync. Custom sanitizer not
+          recognized by Snyk Code taint analyzer. Script runs only in CI
+          with hardcoded paths from .github/workflows/ci.yml.
+        expires: '2027-05-01T00:00:00.000Z'
+        created: '2026-05-01T00:00:00.000Z'
+
+patch: {}

--- a/scripts/audit-guard.cjs
+++ b/scripts/audit-guard.cjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 const args = process.argv.slice(2);
+const repoRoot = process.cwd();
 
 function getArg(flag, fallback) {
   const idx = args.indexOf(flag);
@@ -16,8 +18,17 @@ const reportPath = getArg('--report', 'audit-report.json');
 const exceptionsPath = getArg('--exceptions', 'security/audit-exceptions.json');
 const now = new Date();
 
-function readJson(path) {
-  return JSON.parse(fs.readFileSync(path, 'utf8'));
+function resolveInsideRepo(filePath) {
+  const resolved = path.resolve(repoRoot, filePath);
+  const rootWithSep = repoRoot.endsWith(path.sep) ? repoRoot : repoRoot + path.sep;
+  if (resolved !== repoRoot && !resolved.startsWith(rootWithSep)) {
+    throw new Error(`Caminho fora do repositório recusado: ${filePath}`);
+  }
+  return resolved;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(resolveInsideRepo(filePath), 'utf8'));
 }
 
 const report = readJson(reportPath);


### PR DESCRIPTION
## Contexto

Após importar o repo no Snyk (Open Source + Code), o scan inicial apontou **4 issues no Snyk Code (SAST)** — 1 HIGH, 1 MEDIUM, 2 LOW. Snyk Open Source retornou **0 vulnerabilidades** (deps limpas).

Esta PR materializa a baseline da decisão sobre cada issue, sem alterar comportamento de runtime.

## Análise das 4 issues

| # | Severity | Arquivo | Regra | Veredito |
|---|---|---|---|---|
| 1 | HIGH | `src/shared/auth/storage.ts:10` | `HardcodedNonCryptoSecret` | Falso positivo |
| 2 | LOW | `tests/pages/LoginPage.test.tsx:272` | `NoHardcodedPasswords/test` | Falso positivo |
| 3 | LOW | `tests/pages/LoginPage.test.tsx:319` | `NoHardcodedPasswords/test` | Falso positivo |
| 4 | MEDIUM | `scripts/audit-guard.cjs:20` | `PT` (Path Traversal) | Mitigado com sanitizer |

### #1 — `storage.ts:10` (FP)
`const TOKEN_KEY = 'lfc-admin-auth-token'` é o **nome da chave** do `localStorage`, não um segredo embutido. O JWT real vem do `lfc-authenticator` em runtime via `/auth/login`.

### #2 e #3 — `LoginPage.test.tsx` (FP)
Strings `password: 'segredo'` em assertions de mock do cliente HTTP. A própria regra do Snyk usa o sufixo `/test` — ele reconhece que é teste, mas reporta como `note` mesmo assim. São fixtures, não credenciais.

### #4 — `audit-guard.cjs:20` (Mitigado)
Argumento de CLI fluindo para `fs.readFileSync` sem sanitização. Risco efetivo zero porque o script roda apenas em `ci.yml` com paths hardcoded, mas adicionei `resolveInsideRepo()` que usa `path.resolve` + checagem de prefix com `process.cwd()` para recusar qualquer caminho fora do repo.

## Mudanças

### 1. `.snyk` (novo)
Policy file Snyk versionado documentando os 3 FPs + a mitigação do PT. Cada entrada inclui:
- `reason` — justificativa por escrito
- `created` / `expires` — janela de 1 ano para revisão automática

### 2. `scripts/audit-guard.cjs`
Adicionado `resolveInsideRepo(filePath)`:
- `path.resolve(repoRoot, filePath)` para normalizar
- Recusa caminhos fora de `process.cwd()` antes de chegar em `fs.readFileSync`
- Lança erro descritivo se path inválido

## Validação local (container Docker)

| Etapa | Resultado |
|---|---|
| `npm ci` | OK |
| `npm run lint --max-warnings 0` | sem warnings |
| `npm run typecheck` | sem erros |
| `npm test` | **621/621** passing |
| `node scripts/audit-guard.cjs --report ... --exceptions ...` | `Audit policy OK` |

## Notas operacionais

- **Snyk Code CLI Free não aplica `.snyk` ignores localmente** — limitação conhecida. Após merge, o painel Snyk online deve reconhecer via GitHub App. Se ainda mostrar issues abertas, basta marcar como **Ignored** na UI com referência a este arquivo.
- **Snyk Open Source = 0 vulnerabilidades** — já temos `npm audit` + `audit-guard.cjs` rodando como gate; mantemos os dois rodando como camadas independentes.
- **PR Checks do Snyk não estão ativos** ainda — ativar é decisão pós-baseline.

## Riscos

- Baixo. Zero alteração em código de runtime de produção. Mudança no `audit-guard.cjs` é defensiva e validada com gate completo.