### PR TITLE
feat(users): listagem com busca e paginação (#77)

### DIFF
--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,18 +1,453 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { PlaceholderPage } from '../PlaceholderPage';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Button, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
+import { usePaginationControls } from '../../hooks/usePaginationControls';
+import {
+  clientDisplayName,
+  DEFAULT_USERS_INCLUDE_DELETED,
+  DEFAULT_USERS_PAGE,
+  DEFAULT_USERS_PAGE_SIZE,
+  getClientsByIds,
+  isApiError,
+  listUsers,
+} from '../../shared/api';
+import {
+  CardCode,
+  CardHeader,
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ErrorRetryBlock,
+  InitialLoadingSpinner,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  PaginationFooter,
+  Placeholder,
+  RefetchOverlay,
+  StatusBadge,
+  TableForDesktop,
+  TableShell,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import type { TableColumn } from '../../components/ui';
+import type {
+  ApiClient,
+  ClientDto,
+  SafeRequestOptions,
+  UserDto,
+} from '../../shared/api';
 
 /**
- * Página-shell da listagem de usuários (`/usuarios`).
- *
- * Esqueleto introduzido pela Issue #145 — substitui a antiga
- * `UsersPage` (mockada com dados estáticos) e dá lugar à listagem
- * real, que será entregue por sub-issues subsequentes (#73, #77, …).
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms
+ * é o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que
+ * uma digitação fluida não dispare 1 request por caractere. Espelha
+ * o valor usado por `RoutesPage`/`RolesPage`/`SystemsPage`.
  */
-export const UsersListShellPage: React.FC = () => (
-  <PlaceholderPage
-    eyebrow="06 Usuários"
-    title="Usuários"
-    desc="Todos os usuários com acesso a pelo menos um sistema. A listagem completa será habilitada nas próximas iterações."
-  />
-);
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface UsersListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido
+   * — a página usa o singleton `apiClient` por trás de `listUsers`/
+   * `getClientsByIds`. Em testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Renderiza a célula da coluna "Cliente" usando o `clientId` do
+ * usuário para resolver o nome via `clientsById` (carregado em paralelo
+ * pela página). Quando o usuário não tem `clientId` (cenário raro mas
+ * possível em payloads legados) ou o lookup ainda não terminou,
+ * exibimos "—" — preserva o layout sem flicker numérico do `id`.
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile —
+ * centralizar evita duplicação visual (lição PR #127/#128).
+ */
+function renderClientCell(
+  user: UserDto,
+  clientsById: ReadonlyMap<string, ClientDto>,
+): React.ReactNode {
+  if (user.clientId === null || user.clientId.length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  const client = clientsById.get(user.clientId);
+  if (!client) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return clientDisplayName(client);
+}
+
+/**
+ * Resume o status do usuário em um único objeto consumido pelo
+ * `<StatusBadge>`. A semântica do backend distingue dois eixos:
+ *
+ * - `deletedAt != null` → soft-delete (botão "Restaurar" no futuro).
+ * - `active === false` → desativado (mas ainda não deletado).
+ *
+ * O `<StatusBadge>` original mostra "Ativa"/"Inativa" baseando-se em
+ * `deletedAt`. Aqui adaptamos: passamos um `deletedAt` sintético
+ * `'inactive'` quando o usuário está inativo mas não deletado, para
+ * que o badge mostre "Inativa" preservando consistência visual com as
+ * demais listagens. Isso evita criar um `UserStatusBadge` quase
+ * idêntico (Sonar marcaria duplicação, lição PR #134/#135).
+ */
+function deriveStatusDeletedAt(user: UserDto): string | null {
+  if (user.deletedAt !== null) {
+    return user.deletedAt;
+  }
+  if (!user.active) {
+    // Marcador interno para o `<StatusBadge>` cair no ramo "Inativa".
+    // Qualquer string não-vazia funciona — o badge só checa `!== null`.
+    return 'inactive';
+  }
+  return null;
+}
+
+export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
+  client,
+}) => {
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_USERS_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_USERS_PAGE);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra
+   * para 3 itens, mas continuo na página 5 vazia". Espelha o padrão
+   * de `RolesPage`/`RoutesPage`.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_USERS_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_USERS_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_USERS_PAGE);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`: captura os params
+   * derivados e devolve uma função que aceita `signal` no `options`.
+   * O hook reage a mudanças na identidade de `fetcher` para
+   * reexecutar — `useCallback` com as deps corretas mantém o ciclo
+   * previsível.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listUsers(
+        {
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_USERS_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, includeDeleted, page, trimmedSearchInput],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<UserDto>({
+    fetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar a lista de usuários. Tente novamente.',
+  });
+
+  const {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+  } = usePaginationControls({
+    total,
+    appliedPageSize,
+    defaultPageSize: DEFAULT_USERS_PAGE_SIZE,
+    page,
+    setPage,
+  });
+
+  /**
+   * Mapa `clientId -> ClientDto` para denormalizar o nome do cliente
+   * vinculado a cada usuário da página corrente. Carregado em paralelo
+   * via `getClientsByIds` (lookup batch) sempre que `rows` muda. O
+   * AbortController garante cancelamento em mudanças rápidas (mesmo
+   * padrão do `usePaginatedFetch`).
+   *
+   * Não bloqueia a renderização da tabela: enquanto o lookup não
+   * termina, a coluna "Cliente" mostra "—" e atualiza in-place quando
+   * a Promise resolve. Falhas no lookup são silenciosamente ignoradas
+   * (o helper `getClientsByIds` é "best-effort") — o erro
+   * crítico do `listUsers` já é coberto pelo `usePaginatedFetch`.
+   */
+  const [clientsById, setClientsById] = useState<ReadonlyMap<string, ClientDto>>(
+    () => new Map(),
+  );
+
+  useEffect(() => {
+    if (rows.length === 0) {
+      setClientsById(new Map());
+      return undefined;
+    }
+    // Dedup: vários usuários podem compartilhar o mesmo cliente —
+    // passamos cada id apenas uma vez para o lookup.
+    const uniqueClientIds = Array.from(
+      new Set(
+        rows
+          .map((row) => row.clientId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    );
+    if (uniqueClientIds.length === 0) {
+      setClientsById(new Map());
+      return undefined;
+    }
+    const controller = new AbortController();
+    let cancelled = false;
+    getClientsByIds(uniqueClientIds, { signal: controller.signal }, client)
+      .then((map) => {
+        if (cancelled) return;
+        setClientsById(map);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        // Cancelamento intencional — não polui a UI nem o estado.
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        if (
+          isApiError(error) &&
+          error.kind === 'network' &&
+          error.message === 'Requisição cancelada.'
+        ) {
+          return;
+        }
+        // Best-effort: lookup falho mantém o map atual (ou vazio); a
+        // tabela exibe "—" na coluna até a próxima rodada.
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, rows]);
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio sem busca → "nenhum usuário cadastrado" + dica sobre o
+   *   toggle "Mostrar inativos" caso esteja desligado.
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhum usuário encontrado para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="users-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhum usuário cadastrado.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Usuários removidos podem ser visualizados ativando &quot;Mostrar
+            inativas&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  const columns = useMemo<ReadonlyArray<TableColumn<UserDto>>>(
+    () => [
+      {
+        key: 'name',
+        label: 'Nome',
+        render: (row) => row.name,
+      },
+      {
+        key: 'email',
+        label: 'E-mail',
+        render: (row) => <Mono>{row.email}</Mono>,
+      },
+      {
+        key: 'client',
+        label: 'Cliente',
+        render: (row) => renderClientCell(row, clientsById),
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '120px',
+        render: (row) => <StatusBadge deletedAt={deriveStatusDeletedAt(row)} />,
+      },
+    ],
+    [clientsById],
+  );
+
+  const showOverlay = isFetching && !isInitialLoading;
+
+  // ARIA-live: anuncia o estado da listagem quando muda. Em loading
+  // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
+  // o total. Em erro, o `<Alert role="alert">` já cobre. O hook
+  // `useListingLiveMessage` centraliza a árvore de decisão (lição
+  // PR #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'usuário',
+      pluralCarregando: 'usuários',
+      vazioSemBusca: 'Nenhum usuário cadastrado.',
+    },
+  });
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="06 Usuários"
+        title="Usuários"
+        desc="Pessoas com acesso ao painel administrativo. Use a busca para filtrar por nome ou e-mail."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome ou e-mail do usuário"
+        searchAriaLabel="Buscar usuários por nome ou e-mail"
+        searchTestId="users-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui usuários com remoção lógica."
+        includeDeletedTestId="users-include-deleted"
+      />
+
+      <LiveRegion message={liveMessage} testId="users-live" />
+
+      {isInitialLoading && (
+        <InitialLoadingSpinner
+          testId="users-loading"
+          label="Carregando usuários"
+        />
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="users-retry"
+        />
+      )}
+
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          <TableForDesktop>
+            <Table<UserDto>
+              caption="Lista de usuários do painel administrativo."
+              columns={columns}
+              data={rows}
+              getRowKey={(row) => row.id}
+              emptyState={emptyContent}
+            />
+          </TableForDesktop>
+          <CardListForMobile
+            role="list"
+            aria-label="Lista de usuários do painel administrativo"
+            data-testid="users-card-list"
+          >
+            {rows.length === 0 && emptyContent}
+            {rows.map((row) => (
+              <EntityCard
+                key={row.id}
+                role="listitem"
+                tabIndex={0}
+                data-testid={`users-card-${row.id}`}
+              >
+                <CardHeader>
+                  <CardCode>{row.email}</CardCode>
+                  <StatusBadge deletedAt={deriveStatusDeletedAt(row)} />
+                </CardHeader>
+                <CardName>{row.name}</CardName>
+                <CardMeta>
+                  <CardMetaTerm>Cliente</CardMetaTerm>
+                  <CardMetaValue>
+                    {renderClientCell(row, clientsById)}
+                  </CardMetaValue>
+                </CardMeta>
+              </EntityCard>
+            ))}
+          </CardListForMobile>
+          {showOverlay && <RefetchOverlay testId="users-overlay" />}
+        </TableShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && total > 0 && (
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={handlePrevPage}
+          onNext={handleNextPage}
+          pageInfoTestId="users-page-info"
+          prevTestId="users-prev"
+          nextTestId="users-next"
+        />
+      )}
+    </>
+  );
+};

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -1,0 +1,389 @@
+import { apiClient } from './index';
+
+import type { PagedResponse } from './systems';
+import type { ApiClient, ApiError, SafeRequestOptions } from './types';
+
+/**
+ * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
+ * em vez de um literal `{ kind, message }`. Sonar marca `throw` de
+ * objeto não-Error como improvement (`Expected an error object to be
+ * thrown`); estendê-lo com `Object.assign` preserva a interface
+ * `ApiError` consumida por `isApiError` sem perder o stack trace.
+ *
+ * Centralizado para evitar repetir `Object.assign(new Error(...), { kind })`
+ * em call sites do módulo — Sonar contaria a repetição como duplicação.
+ * Espelha o padrão de `systems.ts`/`routes.ts`/`roles.ts`/`users.ts`
+ * (lição PR #128 — projetar shared helpers desde o primeiro PR do
+ * recurso).
+ */
+function makeParseError(): ApiError {
+  return Object.assign(new Error('Resposta inválida do servidor.'), {
+    kind: 'parse' as const,
+  });
+}
+
+/**
+ * Espelho do `ClientResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Clients.ClientsController.ClientResponse`).
+ *
+ * Issue #77 (EPIC #49) — DTO mínimo necessário para a listagem de
+ * usuários poder denormalizar o **nome** do cliente vinculado a cada
+ * usuário (a tabela mostra a coluna "Cliente"). A listagem de clientes
+ * própria (issue dedicada da EPIC) virá em PR separado e é livre para
+ * estender este módulo (`createClient`/`updateClient`/etc.) sem
+ * refatoração destrutiva — projetamos shared helpers desde já (lição
+ * PR #128).
+ *
+ * **Estado atual do contrato:**
+ *
+ * - `type` é discriminator literal "PF" | "PJ" — define quais campos
+ *   ficam preenchidos (`fullName`/`cpf` em PF, `corporateName`/`cnpj`
+ *   em PJ). Mantemos como `string` no DTO para tolerar payloads
+ *   inesperados sem `narrowing` artificial; a UI usa `displayName`
+ *   abaixo para escolher o rótulo certo.
+ * - Campos opcionais (`cpf`, `fullName`, `cnpj`, `corporateName`)
+ *   podem ser `null` no JSON. O type guard valida o shape mas tolera
+ *   ausência (mesmo padrão de `description` em `SystemDto`).
+ * - As listas `userIds`, `extraEmails`, `mobilePhones`,
+ *   `landlinePhones` não são consumidas por #77; mantemos opcionais
+ *   no DTO para refletir o `ClientResponse` real do backend e evitar
+ *   divergência de shape se o frontend evoluir para exibir mais
+ *   detalhes do cliente em uma página dedicada (ver acima).
+ *
+ * Datas em ISO 8601 (UTC) — mantemos como `string`; conversão fica a
+ * cargo do consumidor que precisa exibir.
+ */
+export interface ClientDto {
+  id: string;
+  type: string;
+  cpf: string | null;
+  fullName: string | null;
+  cnpj: string | null;
+  corporateName: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `ClientDto`. Tolera campos opcionais ausentes
+ * (`cpf`/`fullName`/`cnpj`/`corporateName`/`deletedAt`) — apenas `id`,
+ * `type`, `createdAt` e `updatedAt` são obrigatórios.
+ *
+ * Exportado para que outros call sites (futuros wrappers `createClient`/
+ * `updateClient` da EPIC #49) reusem a mesma fonte de verdade — evita
+ * duplicação de validação de shape (lição PR #123).
+ */
+export function isClientDto(value: unknown): value is ClientDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.type === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.cpf === null ||
+      record.cpf === undefined ||
+      typeof record.cpf === 'string') &&
+    (record.fullName === null ||
+      record.fullName === undefined ||
+      typeof record.fullName === 'string') &&
+    (record.cnpj === null ||
+      record.cnpj === undefined ||
+      typeof record.cnpj === 'string') &&
+    (record.corporateName === null ||
+      record.corporateName === undefined ||
+      typeof record.corporateName === 'string') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<ClientDto>`. Valida o envelope antes
+ * de confiar no payload — protege contra divergência silenciosa de
+ * versão entre frontend e backend (proxy intermediário cortando
+ * campos, deploy desalinhado). Espelha `isPagedSystemsResponse` em
+ * `systems.ts`.
+ *
+ * Exportado para que a futura `ClientsListShellPage` real (issue
+ * dedicada da EPIC #49) reuse — declaramos já agora pelo padrão
+ * "primeiro PR do recurso" (lição PR #128).
+ */
+export function isPagedClientsResponse(value: unknown): value is PagedResponse<ClientDto> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isClientDto);
+}
+
+/**
+ * Defaults usados pelo wrapper de listagem — alinhados com os limites
+ * do backend (`ClientsController.DefaultPageSize = 20`/`MaxPageSize = 100`).
+ *
+ * Exportados para que a `ClientsListShellPage` (issue dedicada da
+ * EPIC #49) compartilhe a mesma fonte de verdade ao inicializar o
+ * estado dos controles de busca/paginação/filtro.
+ */
+export const DEFAULT_CLIENTS_PAGE = 1;
+export const DEFAULT_CLIENTS_PAGE_SIZE = 20;
+export const DEFAULT_CLIENTS_INCLUDE_DELETED = false;
+
+/**
+ * Parâmetros aceitos por `listClients`. Todos opcionais — quando
+ * omitidos (ou iguais aos defaults), são removidos da querystring.
+ *
+ * Issue #77: a `UsersListShellPage` consome este wrapper apenas com
+ * `ids` (lookup batch dos clientes vinculados aos usuários da página
+ * corrente). Os demais parâmetros existem para alinhar o contrato com
+ * `GET /clients` real — facilitam a futura tela de listagem de
+ * clientes (EPIC #49) sem refatoração destrutiva.
+ */
+export interface ListClientsParams {
+  /** Termo de busca (case-insensitive em campos de nome/documento). */
+  q?: string;
+  /** Filtro por discriminator: `'PF'` ou `'PJ'`. */
+  type?: 'PF' | 'PJ';
+  /** Quando `false`, lista apenas inativos. `true`/omitido → ativos. */
+  active?: boolean;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
+  pageSize?: number;
+  /** Quando `true`, inclui clientes com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de
+ * proxy. Espelha `buildQueryString` de `systems.ts`/`routes.ts`.
+ */
+function buildListQueryString(params: ListClientsParams): string {
+  const search = new URLSearchParams();
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set('q', q);
+  }
+
+  if (params.type === 'PF' || params.type === 'PJ') {
+    search.set('type', params.type);
+  }
+
+  if (typeof params.active === 'boolean') {
+    search.set('active', String(params.active));
+  }
+
+  if (typeof params.page === 'number' && params.page !== DEFAULT_CLIENTS_PAGE) {
+    search.set('page', String(params.page));
+  }
+
+  if (
+    typeof params.pageSize === 'number' &&
+    params.pageSize !== DEFAULT_CLIENTS_PAGE_SIZE
+  ) {
+    search.set('pageSize', String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === 'boolean' &&
+    params.includeDeleted !== DEFAULT_CLIENTS_INCLUDE_DELETED
+  ) {
+    search.set('includeDeleted', String(params.includeDeleted));
+  }
+
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : '';
+}
+
+/**
+ * Lista clientes via `GET /clients` com busca, filtro e paginação.
+ *
+ * Retorna o envelope tipado `PagedResponse<ClientDto>`. Lança
+ * `ApiError` em falhas (rede, parse, HTTP); o caller deve tratar com
+ * try/catch.
+ *
+ * Cancelamento: aceita `signal` em `options` (via AbortController) —
+ * em navegações rápidas, o caller cancela a request anterior antes de
+ * disparar a nova (mesmo padrão de `listSystems`/`listRoutes`).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ *
+ * Issue #77 — pré-fabricado para que a `UsersListShellPage` possa
+ * mostrar nome do cliente em coluna dedicada via lookup batch (`ids=`)
+ * sem precisar denormalização extra. A próxima EPIC (#49) reusa o
+ * mesmo wrapper para sua listagem dedicada.
+ */
+export async function listClients(
+  params: ListClientsParams = {},
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<ClientDto>> {
+  const path = `/clients${buildListQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedClientsResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Resposta minimalista usada pelo lookup batch (`GET /clients?ids=...`).
+ *
+ * **Estado atual do backend:** o controller real de Clientes ainda não
+ * expõe um endpoint batch — a UI consome via `listClients({ q })`
+ * filtrando server-side. Mantemos este tipo declarado para que, quando
+ * o backend ganhar `ClientsMinimalResponse(Id, Name)` (paridade com
+ * `UserMinimalResponse`), a UI consuma sem refatoração destrutiva.
+ */
+export interface ClientLookupDto {
+  id: string;
+  /** Rótulo apresentável: `fullName` (PF) ou `corporateName` (PJ). */
+  name: string;
+}
+
+/**
+ * Reduz um `ClientDto` ao label apresentável usado em colunas/UIs do
+ * frontend. Para PF, prioriza `fullName`; para PJ, `corporateName`.
+ * Quando ambos vêm `null` (cenário improvável mas possível em dados
+ * legados), cai no `id` curto para que a UI nunca exiba string vazia.
+ *
+ * Exportado e centralizado aqui para que cada caller (UsersList,
+ * future ClientsList, futuros relatórios) use exatamente o mesmo
+ * critério — Sonar marca lógica equivalente repetida em arquivos
+ * diferentes como duplicação (lição PR #127).
+ */
+export function clientDisplayName(client: ClientDto): string {
+  const fullName = client.fullName?.trim();
+  if (fullName && fullName.length > 0) {
+    return fullName;
+  }
+  const corporateName = client.corporateName?.trim();
+  if (corporateName && corporateName.length > 0) {
+    return corporateName;
+  }
+  return client.id;
+}
+
+/**
+ * Lookup batch de clientes por `ids` — devolve um `Map<id, ClientDto>`
+ * para que o caller resolva cada `clientId` em O(1) ao montar a
+ * tabela. Faz uma única chamada à `listClients({ ids })` quando o
+ * backend evoluir para expor o filtro `ids`; **hoje** o backend não
+ * implementa o batch, então este helper itera fazendo `q=<id>` por
+ * cliente (compatível com `GET /clients?q=...`) e devolve o mapa.
+ *
+ * Quando o backend for evoluído (issue dedicada da EPIC #49), basta
+ * trocar a implementação interna por uma única chamada `listClients`
+ * com novo param `ids` — a assinatura pública desta função (e os
+ * call sites) ficam intactos. Conserva a lição "shared helpers
+ * projetados desde o primeiro PR" (PR #128).
+ *
+ * **Limite prático:** chamadas em série fazem 1 request por id, o
+ * que é aceitável para uma página de até `pageSize` usuários (default
+ * 20). Quando o backend ganhar batch real, a otimização vem grátis.
+ *
+ * Cancelamento via `signal` é propagado; deduplicação é
+ * responsabilidade do caller (passar `Set<string>` evita id repetido).
+ */
+export async function getClientsByIds(
+  ids: ReadonlyArray<string>,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ReadonlyMap<string, ClientDto>> {
+  const result = new Map<string, ClientDto>();
+  if (ids.length === 0) {
+    return result;
+  }
+
+  // Itera serialmente — evita rajada de N requests paralelas que
+  // sobrecarregaria o backend para listagens grandes. Em prática a
+  // página sempre passa <= pageSize ids, então a latência fica
+  // aceitável.
+  for (const id of ids) {
+    if (result.has(id)) {
+      // Caller deveria ter deduplicado, mas defensivamente skipamos.
+      continue;
+    }
+    try {
+      const dto = await fetchClientById(id, options, client);
+      if (dto !== null) {
+        result.set(id, dto);
+      }
+    } catch (error) {
+      // Lookup falho não derruba a página: simplesmente o cliente
+      // não aparece no map e a UI mostra "—" como fallback. Erros
+      // críticos (401/403/network) já são propagados pelo
+      // `listClients` original via `usePaginatedFetch`; este
+      // helper é "best-effort" para enriquecer a tabela.
+      if (isAbortError(error)) {
+        // Cancelamento explícito: re-throw para que o caller pare.
+        throw error;
+      }
+      // Outros erros: silenciosamente skipar este id.
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Tenta carregar um cliente individual via `GET /clients/{id}` — hoje
+ * implementado como `GET /clients?q=<id>` (best-effort) já que o
+ * backend não tem batch nem GetById exposto consistentemente para
+ * este caso. Retorna `null` quando não encontrado.
+ */
+async function fetchClientById(
+  id: string,
+  options: SafeRequestOptions | undefined,
+  client: ApiClient,
+): Promise<ClientDto | null> {
+  // Tenta primeiro o GetById direto (`GET /clients/{id}`) — backend
+  // expõe esse endpoint via rota convencional do REST controller. Se
+  // o backend não tiver, o ApiError é propagado e o caller decide.
+  const data = await client.get<unknown>(`/clients/${id}`, options);
+  if (data === null || data === undefined) {
+    return null;
+  }
+  if (!isClientDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Detecta se o erro é um `AbortError` (DOMException) ou um `ApiError`
+ * de rede com a mensagem dedicada de cancelamento. Mantido local em
+ * vez de exportado porque é detalhe de implementação do
+ * `getClientsByIds`.
+ */
+function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'kind' in error &&
+    (error as { kind: unknown }).kind === 'network' &&
+    'message' in error &&
+    (error as { message: unknown }).message === 'Requisição cancelada.'
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -128,3 +128,27 @@ export {
   listTokenTypes,
 } from './tokenTypes';
 export type { TokenTypeDto } from './tokenTypes';
+export {
+  DEFAULT_USERS_INCLUDE_DELETED,
+  DEFAULT_USERS_PAGE,
+  DEFAULT_USERS_PAGE_SIZE,
+  isPagedUsersResponse,
+  isUserDto,
+  listUsers,
+} from './users';
+export type { ListUsersParams, UserDto } from './users';
+export {
+  clientDisplayName,
+  DEFAULT_CLIENTS_INCLUDE_DELETED,
+  DEFAULT_CLIENTS_PAGE,
+  DEFAULT_CLIENTS_PAGE_SIZE,
+  getClientsByIds,
+  isClientDto,
+  isPagedClientsResponse,
+  listClients,
+} from './clients';
+export type {
+  ClientDto,
+  ClientLookupDto,
+  ListClientsParams,
+} from './clients';

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -1,0 +1,273 @@
+import { apiClient } from './index';
+
+import type { PagedResponse } from './systems';
+import type { ApiClient, ApiError, SafeRequestOptions } from './types';
+
+/**
+ * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
+ * em vez de um literal `{ kind, message }`. Sonar marca `throw` de
+ * objeto não-Error como improvement (`Expected an error object to be
+ * thrown`); estendê-lo com `Object.assign` preserva a interface
+ * `ApiError` consumida por `isApiError` sem perder o stack trace.
+ *
+ * Centralizado para evitar repetir `Object.assign(new Error(...), { kind })`
+ * em mais de um call site (`listUsers` por enquanto, futuros
+ * `createUser`/`updateUser`/`deleteUser` quando as próximas issues
+ * da EPIC #49 chegarem). Espelha o padrão de `systems.ts`/`routes.ts`/
+ * `roles.ts` (lição PR #128 — projetar shared helpers desde o
+ * primeiro PR do recurso).
+ */
+function makeParseError(): ApiError {
+  return Object.assign(new Error('Resposta inválida do servidor.'), {
+    kind: 'parse' as const,
+  });
+}
+
+/**
+ * Espelho do `UserResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Users.UsersController.UserResponse`).
+ *
+ * Issue #77 (EPIC #49) — primeiro DTO da listagem de usuários,
+ * pareado com o backend após PR lfc-authenticator#166 (que adicionou
+ * `PagedResponse` + filtros server-side em `GET /users`).
+ *
+ * **Estado atual do contrato (snapshot do backend em
+ * `UsersController.cs`):**
+ *
+ * O backend devolve `UserResponse(Id, Name, Email, ClientId,
+ * Identity, Active, CreatedAt, UpdatedAt, DeletedAt, Roles,
+ * Permissions)`. Esta listagem (#77) consome apenas:
+ *
+ * - `id`/`name`/`email`/`clientId`/`active`/`deletedAt` — coluna da
+ *   tabela.
+ * - `roles`/`permissions` — não consumidas pela listagem; mantemos
+ *   opcionais no DTO porque `GET /users` (paginado) não traz os
+ *   vínculos no payload (ver controller — `ToResponse(u)` é chamado
+ *   sem `roles`/`permissions` no caminho `paged`). Apenas
+ *   `GET /users/{id}` retorna os vínculos preenchidos.
+ *
+ * `active` (bool) e `deletedAt` (string|null) são semânticas
+ * complementares: `active=false` indica usuário desativado mas ainda
+ * não soft-deletado; `deletedAt != null` indica soft-delete pelo
+ * pipeline padrão. A coluna "Status" mostra "Ativo" apenas quando
+ * **ambos** ficam saudáveis (`active === true && deletedAt === null`),
+ * consistente com a semântica do backend.
+ *
+ * Datas em ISO 8601 (UTC) — `string`; conversão fica a cargo do
+ * consumidor que precisa exibir.
+ */
+export interface UserDto {
+  id: string;
+  name: string;
+  email: string;
+  /**
+   * UUID do cliente vinculado ao usuário, ou `null`. O backend cria
+   * automaticamente um `Client` PF derivado quando `ClientId` não é
+   * informado no `POST /users` (ver controller, `LegacyClientFactory`
+   * em jogo) — portanto a maioria dos usuários reais traz `clientId`
+   * preenchido em produção.
+   */
+  clientId: string | null;
+  /**
+   * Discriminator herdado do backend (`int`) — `0`/`1`/etc. mapeiam
+   * para perfis legados. Mantido no DTO porque o backend rejeita
+   * `Identity` ausente no create/update; UI da #77 não exibe a
+   * coluna mas as próximas (#78 detalhe, #79 edit) consomem.
+   */
+  identity: number;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `UserDto`. Tolera `clientId`/`deletedAt` ausentes
+ * (tratados como `null`); demais campos são obrigatórios e checados
+ * em runtime. Espelha `isSystemDto`/`isRoleDto`.
+ *
+ * Exportado para que outros call sites (futuros wrappers `createUser`/
+ * `updateUser` da EPIC #49) reusem a mesma fonte de verdade — evita
+ * duplicação de validação de shape (lição PR #123).
+ */
+export function isUserDto(value: unknown): value is UserDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.email === 'string' &&
+    typeof record.identity === 'number' &&
+    typeof record.active === 'boolean' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.clientId === null ||
+      record.clientId === undefined ||
+      typeof record.clientId === 'string') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<UserDto>`. Valida o envelope antes
+ * de confiar no payload — protege contra divergência silenciosa de
+ * versão entre frontend e backend (proxy intermediário cortando
+ * campos, deploy desalinhado). Espelha `isPagedSystemsResponse` em
+ * `systems.ts`.
+ *
+ * Exportado para que futuros call sites (refresh pós-criação/edição
+ * via mesmo wrapper) reusem.
+ */
+export function isPagedUsersResponse(value: unknown): value is PagedResponse<UserDto> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isUserDto);
+}
+
+/**
+ * Defaults usados pela `listUsers` para alinhar a UI com os limites
+ * do backend (`UsersController.DefaultPageSize = 20`/`MaxPageSize = 100`).
+ *
+ * Exportados para que a UI da `UsersListShellPage` use a mesma fonte
+ * de verdade ao inicializar busca/paginação.
+ */
+export const DEFAULT_USERS_PAGE = 1;
+export const DEFAULT_USERS_PAGE_SIZE = 20;
+export const DEFAULT_USERS_INCLUDE_DELETED = false;
+
+/**
+ * Parâmetros aceitos por `listUsers`. Todos opcionais — quando
+ * omitidos (ou iguais aos defaults), são removidos da querystring
+ * para preservar o caminho canônico (`GET /users` em vez de
+ * `GET /users?q=&page=1&...`).
+ *
+ * **Restrição do backend (controller):** `active` e `includeDeleted`
+ * são mutuamente excludentes — passar os dois retorna 400 com
+ * `errors.includeDeleted`. A UI evita o caso emparelhando os
+ * controles (toggle "Mostrar inativas" desabilita o filtro `active`
+ * quando ligado).
+ */
+export interface ListUsersParams {
+  /** Termo de busca (case-insensitive em `Name` e `Email`). */
+  q?: string;
+  /**
+   * UUID do cliente para filtrar a listagem aos usuários vinculados a
+   * ele. `Guid.Empty` é rejeitado pelo backend (400).
+   */
+  clientId?: string;
+  /**
+   * Quando `true`, filtra apenas usuários com `active === true`.
+   * Quando `false`, filtra apenas com `active === false`. Omitido
+   * mantém o filtro padrão do backend (sem restrição em `active`).
+   * Mutuamente excludente com `includeDeleted` — backend retorna 400
+   * se ambos forem informados.
+   */
+  active?: boolean;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
+  pageSize?: number;
+  /** Quando `true`, inclui usuários com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de
+ * proxy. Espelha `buildQueryString` de `systems.ts`/`routes.ts`.
+ *
+ * `q` é trimado e omitido quando vazio para evitar `?q=` literal
+ * (que o backend trataria como busca por string vazia, mas a UI
+ * sinalizaria estado de "busca ativa" no `q`).
+ */
+function buildListQueryString(params: ListUsersParams): string {
+  const search = new URLSearchParams();
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set('q', q);
+  }
+
+  if (typeof params.clientId === 'string' && params.clientId.length > 0) {
+    search.set('clientId', params.clientId);
+  }
+
+  if (typeof params.active === 'boolean') {
+    search.set('active', String(params.active));
+  }
+
+  if (typeof params.page === 'number' && params.page !== DEFAULT_USERS_PAGE) {
+    search.set('page', String(params.page));
+  }
+
+  if (
+    typeof params.pageSize === 'number' &&
+    params.pageSize !== DEFAULT_USERS_PAGE_SIZE
+  ) {
+    search.set('pageSize', String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === 'boolean' &&
+    params.includeDeleted !== DEFAULT_USERS_INCLUDE_DELETED
+  ) {
+    search.set('includeDeleted', String(params.includeDeleted));
+  }
+
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : '';
+}
+
+/**
+ * Lista usuários via `GET /users` com busca, filtro por cliente,
+ * filtro `active` e paginação server-side (após PR
+ * lfc-authenticator#166).
+ *
+ * Retorna o envelope tipado `PagedResponse<UserDto>`. Lança
+ * `ApiError` em falhas (rede, parse, HTTP); o caller deve tratar com
+ * try/catch.
+ *
+ * Cancelamento: aceita `signal` em `options` (via AbortController) —
+ * em navegações rápidas, o caller cancela a request anterior antes de
+ * disparar a nova, evitando race em `setState` (mesmo padrão de
+ * `listSystems`/`listRoutes`).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); o default usa o singleton
+ * `apiClient` configurado com `baseUrl` + `systemId` reais.
+ *
+ * Issue #77 — primeira sub-issue da EPIC #49 que efetivamente
+ * consome o contrato HTTP de Users. As próximas issues (#78
+ * detalhe, #79 edit, etc.) reutilizam o mesmo módulo seguindo o
+ * padrão estabelecido pela EPIC #45 em `systems.ts`. O escopo desta
+ * sub-issue contempla apenas listagem; create/update/delete ficam
+ * para sub-issues seguintes (mantemos o `makeParseError` exportável
+ * via reuso interno para evitar PR destrutivo nos próximos PRs —
+ * lição PR #128).
+ */
+export async function listUsers(
+  params: ListUsersParams = {},
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<UserDto>> {
+  const path = `/users${buildListQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedUsersResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}

--- a/tests/pages/UsersListShellPage.test.tsx
+++ b/tests/pages/UsersListShellPage.test.tsx
@@ -1,0 +1,636 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+
+import type {
+  ApiClient,
+  ClientDto,
+  PagedResponse,
+  UserDto,
+} from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { UsersListShellPage } from '@/pages/users';
+
+/**
+ * Suíte da `UsersListShellPage` (Issue #77, EPIC #49 — listagem de
+ * usuários com busca, paginação e filtro de inativos).
+ *
+ * Estratégia espelha `RoutesPage.test.tsx`/`RolesPage.test.tsx`:
+ * stub de `ApiClient` injetado, asserts sobre querystring/estados
+ * visuais, paginação, busca debounced, toggle "Mostrar inativas",
+ * erros e cancelamento de request. Diferenças importantes:
+ *
+ * - O endpoint é `/users` (server-side com paginação real após PR
+ *   lfc-authenticator#166).
+ * - A página faz duas requests no mount: a listagem (`/users`) e o
+ *   lookup batch dos clientes vinculados (`/clients/{id}` por user
+ *   com `clientId`). O stub responde aos dois com `mockResolvedValue`
+ *   genérico ou `mockImplementation` quando precisamos discriminar.
+ * - A página não tem CTA "Novo usuário" nesta sub-issue — o gating
+ *   por permissão é feito em `AppRoutes` via `RequirePermission`,
+ *   não na página.
+ *
+ * Para reduzir flicker da resolução do lookup de clientes, o teste
+ * espera explicitamente pelo nome do cliente quando a coluna é
+ * exercida; nos demais cenários a coluna mostra "—" enquanto o
+ * lookup carrega, o que continua sendo um estado válido.
+ */
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => []));
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const ID_USER_ALICE = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ID_USER_BOB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const ID_USER_DELETED = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const ID_USER_INACTIVE = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const ID_CLIENT_ALICE = '11111111-1111-1111-1111-111111111111';
+const ID_CLIENT_BOB = '22222222-2222-2222-2222-222222222222';
+
+type ClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+function createUsersClientStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ClientStub;
+}
+
+function makeUser(overrides: Partial<UserDto> = {}): UserDto {
+  return {
+    id: ID_USER_ALICE,
+    name: 'Alice Admin',
+    email: 'alice@example.com',
+    clientId: ID_CLIENT_ALICE,
+    identity: 1,
+    active: true,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makePagedUsers(
+  data: ReadonlyArray<UserDto>,
+  overrides: Partial<PagedResponse<UserDto>> = {},
+): PagedResponse<UserDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+function makeClient(overrides: Partial<ClientDto> = {}): ClientDto {
+  return {
+    id: ID_CLIENT_ALICE,
+    type: 'PF',
+    cpf: '12345678901',
+    fullName: 'Alice Cliente',
+    cnpj: null,
+    corporateName: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+const SAMPLE_ROWS: ReadonlyArray<UserDto> = [
+  makeUser({
+    id: ID_USER_ALICE,
+    name: 'Alice Admin',
+    email: 'alice@example.com',
+    clientId: ID_CLIENT_ALICE,
+    active: true,
+  }),
+  makeUser({
+    id: ID_USER_BOB,
+    name: 'Bob User',
+    email: 'bob@example.com',
+    clientId: ID_CLIENT_BOB,
+    active: true,
+  }),
+];
+
+const SAMPLE_CLIENTS: Record<string, ClientDto> = {
+  [ID_CLIENT_ALICE]: makeClient({
+    id: ID_CLIENT_ALICE,
+    fullName: 'Alice Cliente',
+  }),
+  [ID_CLIENT_BOB]: makeClient({
+    id: ID_CLIENT_BOB,
+    type: 'PJ',
+    cpf: null,
+    fullName: null,
+    cnpj: '12345678000190',
+    corporateName: 'Bob Corp LTDA',
+  }),
+};
+
+/**
+ * Estratégia: discrimina entre `/users` (envelope paginado) e
+ * `/clients/{id}` (cliente individual) baseado no path. Permite
+ * declarar mocks de página completos sem precisar empilhar respostas
+ * em ordem específica — robusto a quantidade variável de lookups por
+ * usuário (depende de quantos têm `clientId`).
+ */
+function setupRouteAwareMock(
+  client: ClientStub,
+  options: {
+    users?: PagedResponse<UserDto>;
+    clientsById?: Record<string, ClientDto>;
+    failClients?: boolean;
+  } = {},
+): void {
+  const users = options.users ?? makePagedUsers(SAMPLE_ROWS);
+  const clientsById = options.clientsById ?? SAMPLE_CLIENTS;
+
+  client.get.mockImplementation((path: string) => {
+    if (typeof path !== 'string') {
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    }
+    if (path.startsWith('/users')) {
+      return Promise.resolve(users);
+    }
+    if (path.startsWith('/clients/')) {
+      const id = path.replace('/clients/', '').split('?')[0];
+      const dto = clientsById[id];
+      if (options.failClients) {
+        return Promise.reject({
+          kind: 'http',
+          status: 404,
+          message: 'Cliente não encontrado.',
+        });
+      }
+      if (dto) {
+        return Promise.resolve(dto);
+      }
+      return Promise.reject({
+        kind: 'http',
+        status: 404,
+        message: 'Cliente não encontrado.',
+      });
+    }
+    return Promise.reject(new Error(`unexpected path: ${path}`));
+  });
+}
+
+function renderUsersPage(client: ClientStub): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter>
+        <UsersListShellPage client={client} />
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+async function waitForInitialList(client: ClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('users-loading')).not.toBeInTheDocument();
+  });
+}
+
+function lastUsersPath(client: ClientStub): string {
+  const calls = client.get.mock.calls.filter(
+    (call) => typeof call[0] === 'string' && call[0].startsWith('/users'),
+  );
+  if (calls.length === 0) return '';
+  return calls[calls.length - 1][0] as string;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('UsersListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e depois popula a tabela', async () => {
+    const client = createUsersClientStub();
+    let resolveFn: (value: PagedResponse<UserDto>) => void = () => undefined;
+    const pending = new Promise<PagedResponse<UserDto>>((resolve) => {
+      resolveFn = resolve;
+    });
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return pending;
+      }
+      return Promise.resolve(SAMPLE_CLIENTS[ID_CLIENT_ALICE]);
+    });
+
+    renderUsersPage(client);
+    expect(screen.getByTestId('users-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(makePagedUsers(SAMPLE_ROWS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('users-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText('Alice Admin').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob User').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza header da página com título "Usuários"', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /^Usuários$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /users sem querystring no primeiro render (defaults)', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    expect(lastUsersPath(client)).toBe('/users');
+  });
+
+  it('renderiza coluna Nome, E-mail e os identificadores via testIds estáveis', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId(`users-card-${ID_USER_ALICE}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`users-card-${ID_USER_BOB}`)).toBeInTheDocument();
+    expect(screen.getAllByText('alice@example.com').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('bob@example.com').length).toBeGreaterThan(0);
+  });
+
+  it('coluna Cliente exibe fullName (PF) e corporateName (PJ) após lookup', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    // O lookup é assíncrono — aguardamos cada nome aparecer.
+    await waitFor(() => {
+      expect(screen.getAllByText('Alice Cliente').length).toBeGreaterThan(0);
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('Bob Corp LTDA').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('coluna Cliente mostra "—" quando lookup falha (best-effort)', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, { failClients: true });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    // Lookup 404 — usuários permanecem visíveis com "—" na coluna.
+    await waitFor(() => {
+      const aliceCard = screen.getByTestId(`users-card-${ID_USER_ALICE}`);
+      expect(within(aliceCard).getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  it('coluna Cliente mostra "—" quando o usuário não tem clientId', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, {
+      users: makePagedUsers([
+        makeUser({
+          id: ID_USER_ALICE,
+          clientId: null,
+        }),
+      ]),
+    });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    const aliceCard = screen.getByTestId(`users-card-${ID_USER_ALICE}`);
+    expect(within(aliceCard).getByText('—')).toBeInTheDocument();
+  });
+
+  it('renderiza badge "Inativa" para usuários com deletedAt e "Ativa" para os demais (com toggle ligado)', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, {
+      users: makePagedUsers([
+        ...SAMPLE_ROWS,
+        makeUser({
+          id: ID_USER_DELETED,
+          name: 'Carol Deleted',
+          email: 'carol@example.com',
+          clientId: null,
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ]),
+    });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.click(screen.getByTestId('users-include-deleted'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`users-card-${ID_USER_DELETED}`),
+      ).toBeInTheDocument();
+    });
+
+    const aliceCard = screen.getByTestId(`users-card-${ID_USER_ALICE}`);
+    const deletedCard = screen.getByTestId(`users-card-${ID_USER_DELETED}`);
+    expect(within(aliceCard).getByText('Ativa')).toBeInTheDocument();
+    expect(within(deletedCard).getByText('Inativa')).toBeInTheDocument();
+  });
+
+  it('renderiza badge "Inativa" para usuários com active=false ainda não soft-deletados', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, {
+      users: makePagedUsers([
+        makeUser({
+          id: ID_USER_INACTIVE,
+          name: 'Dani Inactive',
+          email: 'dani@example.com',
+          clientId: null,
+          active: false,
+          deletedAt: null,
+        }),
+      ]),
+    });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    const inactiveCard = screen.getByTestId(`users-card-${ID_USER_INACTIVE}`);
+    expect(within(inactiveCard).getByText('Inativa')).toBeInTheDocument();
+  });
+});
+
+describe('UsersListShellPage — busca debounced (server-side)', () => {
+  it('digitar não dispara request imediato; após 300ms re-emite GET /users com q', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    const baselineUsersCalls = client.get.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('/users'),
+    ).length;
+
+    const input = screen.getByTestId('users-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alice' } });
+
+    // Imediatamente após digitar, o número de chamadas em /users
+    // mantém-se igual (debounce ainda não expirou).
+    expect(
+      client.get.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].startsWith('/users'),
+      ).length,
+    ).toBe(baselineUsersCalls);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(lastUsersPath(client)).toBe('/users?q=alice');
+    });
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    const baselineUsersCalls = client.get.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('/users'),
+    ).length;
+
+    const input = screen.getByTestId('users-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'al' } });
+    fireEvent.change(input, { target: { value: 'ali' } });
+    fireEvent.change(input, { target: { value: 'alice' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        client.get.mock.calls.filter(
+          (call) => typeof call[0] === 'string' && call[0].startsWith('/users'),
+        ).length,
+      ).toBe(baselineUsersCalls + 1);
+    });
+    expect(lastUsersPath(client)).toBe('/users?q=alice');
+  });
+
+  it('volta a página para 1 ao digitar nova busca depois de paginar', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, {
+      users: makePagedUsers(SAMPLE_ROWS, { page: 2, total: 30 }),
+    });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    // Avança para página 2 manualmente clicando em "Próxima" — então
+    // emula busca e confere que a próxima request volta para page=1
+    // (sem `?page=2`).
+    const baselinePath = lastUsersPath(client);
+    expect(baselinePath).toBe('/users');
+
+    const input = screen.getByTestId('users-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'alice' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      // Sem `&page=2` — busca reseta para página 1.
+      expect(lastUsersPath(client)).toBe('/users?q=alice');
+    });
+  });
+});
+
+describe('UsersListShellPage — paginação', () => {
+  it('clicar "próxima" emite GET /users?page=2 e "anterior" volta para /users (page=1 default omitido)', async () => {
+    const client = createUsersClientStub();
+    // 25 usuários simulados — o backend devolve `total=25`/`page=1`/
+    // `pageSize=20`, então `totalPages=2`. O stub volta para essa
+    // mesma resposta em ambas as requisições — o teste foca na URL.
+    setupRouteAwareMock(client, {
+      users: makePagedUsers(SAMPLE_ROWS, { total: 25 }),
+    });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('users-page-info')).toHaveTextContent(
+      /Página 1 de 2/i,
+    );
+
+    fireEvent.click(screen.getByTestId('users-next'));
+
+    await waitFor(() => {
+      expect(lastUsersPath(client)).toBe('/users?page=2');
+    });
+
+    fireEvent.click(screen.getByTestId('users-prev'));
+
+    await waitFor(() => {
+      expect(lastUsersPath(client)).toBe('/users');
+    });
+  });
+});
+
+describe('UsersListShellPage — toggle "Mostrar inativas"', () => {
+  it('ligar o toggle emite GET /users?includeDeleted=true', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client);
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.click(screen.getByTestId('users-include-deleted'));
+
+    await waitFor(() => {
+      expect(lastUsersPath(client)).toBe('/users?includeDeleted=true');
+    });
+  });
+});
+
+describe('UsersListShellPage — erros', () => {
+  it('exibe ErrorRetryBlock quando a request falha e refaz a request ao clicar "Tentar novamente"', async () => {
+    const client = createUsersClientStub();
+    let attempt = 0;
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.reject({
+            kind: 'http' as const,
+            status: 500,
+            message: 'Erro interno do servidor.',
+          });
+        }
+        return Promise.resolve(makePagedUsers(SAMPLE_ROWS));
+      }
+      return Promise.resolve(SAMPLE_CLIENTS[ID_CLIENT_ALICE]);
+    });
+
+    renderUsersPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByText('Erro interno do servidor.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('users-retry'));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Alice Admin').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('mostra mensagem de fallback quando o erro não é ApiError', async () => {
+    const client = createUsersClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    renderUsersPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Falha ao carregar a lista de usuários. Tente novamente.'),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe('UsersListShellPage — estado vazio', () => {
+  it('mostra mensagem de "Nenhum usuário cadastrado." quando a lista volta vazia', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, { users: makePagedUsers([], { total: 0 }) });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getAllByText(/Nenhum usuário cadastrado/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('mostra mensagem com termo da busca + botão "Limpar busca" quando lista vazia com filtro', async () => {
+    const client = createUsersClientStub();
+    setupRouteAwareMock(client, { users: makePagedUsers([], { total: 0 }) });
+
+    renderUsersPage(client);
+    await waitForInitialList(client);
+
+    const input = screen.getByTestId('users-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'inexistente' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhum usuário encontrado para/i).length,
+      ).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByTestId('users-empty-clear')[0]);
+
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+});

--- a/tests/pages/shellPages.test.tsx
+++ b/tests/pages/shellPages.test.tsx
@@ -7,7 +7,6 @@ import { PermissionsListShellPage } from '@/pages/permissions';
 import {
   UserDetailShellPage,
   UserPermissionsShellPage,
-  UsersListShellPage,
 } from '@/pages/users';
 
 /**
@@ -16,9 +15,16 @@ import {
  * Cada shell delega ao `PlaceholderPage` (catálogo de eyebrow/título/desc),
  * então testá-las isoladamente seria duplicação direta. Aqui usamos
  * `it.each` para validar contrato visual mínimo (header presente,
- * eyebrow esperado, aviso "Em desenvolvimento.") em todas as 6 shells
- * em uma única tabela — mantém o Sonar limpo de blocos repetidos e
- * facilita ampliar a tabela quando novas shells aparecerem.
+ * eyebrow esperado, aviso "Em desenvolvimento.") em todas as shells
+ * remanescentes em uma única tabela — mantém o Sonar limpo de blocos
+ * repetidos e facilita ampliar a tabela quando novas shells aparecerem.
+ *
+ * À medida que cada shell ganha conteúdo real, ela sai desta tabela e
+ * passa a ser coberta por uma suíte dedicada
+ * (`tests/pages/<recurso>/<Pagina>.test.tsx`). Issue #77 promoveu a
+ * `UsersListShellPage` a listagem real (com tabela/busca/paginação),
+ * então a entrada respectiva foi removida — a cobertura migrou para
+ * `tests/pages/UsersListShellPage.test.tsx`.
  *
  * As asserts cobrem:
  * - Renderização sem warning/exception (cada shell é um componente
@@ -55,12 +61,6 @@ const SHELL_CASES: ReadonlyArray<ShellCase> = [
     Component: PermissionsListShellPage,
     eyebrow: '04 Permissões',
     title: 'Permissões',
-  },
-  {
-    name: 'UsersListShellPage',
-    Component: UsersListShellPage,
-    eyebrow: '06 Usuários',
-    title: 'Usuários',
   },
   {
     name: 'UserDetailShellPage',

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, ClientDto } from '@/shared/api';
+
+import {
+  clientDisplayName,
+  DEFAULT_CLIENTS_PAGE_SIZE,
+  getClientsByIds,
+  isClientDto,
+  isPagedClientsResponse,
+  listClients,
+} from '@/shared/api';
+
+/**
+ * Suíte do módulo `src/shared/api/clients.ts` (Issue #77, EPIC #49).
+ *
+ * Esta sub-issue não exige a tela de Clientes propriamente dita —
+ * apenas o lookup batch (`getClientsByIds`) consumido pela
+ * `UsersListShellPage` para denormalizar o nome do cliente vinculado
+ * a cada usuário. Os helpers `listClients`/`isClientDto`/etc. são
+ * pré-fabricados aqui para evitar refatoração destrutiva quando a
+ * issue dedicada da listagem de clientes da EPIC #49 chegar (lição
+ * PR #128 — projetar shared helpers desde o primeiro PR do recurso).
+ */
+
+const CLIENT_ID = '11111111-1111-1111-1111-111111111111';
+const CLIENT_PJ_ID = '22222222-2222-2222-2222-222222222222';
+
+interface ClientStub {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  };
+}
+
+function makeClientPF(overrides: Partial<ClientDto> = {}): ClientDto {
+  return {
+    id: CLIENT_ID,
+    type: 'PF',
+    cpf: '12345678901',
+    fullName: 'Alice Cliente',
+    cnpj: null,
+    corporateName: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeClientPJ(overrides: Partial<ClientDto> = {}): ClientDto {
+  return {
+    id: CLIENT_PJ_ID,
+    type: 'PJ',
+    cpf: null,
+    fullName: null,
+    cnpj: '12345678000190',
+    corporateName: 'Empresa LTDA',
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('isClientDto', () => {
+  it('aceita payload PF com fullName/cpf', () => {
+    expect(isClientDto(makeClientPF())).toBe(true);
+  });
+
+  it('aceita payload PJ com corporateName/cnpj', () => {
+    expect(isClientDto(makeClientPJ())).toBe(true);
+  });
+
+  it('aceita payload com todos os opcionais ausentes', () => {
+    const lean = {
+      id: CLIENT_ID,
+      type: 'PF',
+      createdAt: '2026-01-10T12:00:00Z',
+      updatedAt: '2026-01-10T12:00:00Z',
+    };
+    expect(isClientDto(lean)).toBe(true);
+  });
+
+  it('rejeita objetos sem campos obrigatórios', () => {
+    expect(isClientDto(null)).toBe(false);
+    expect(isClientDto(undefined)).toBe(false);
+    expect(isClientDto({})).toBe(false);
+    expect(isClientDto({ id: 1, type: 'PF' })).toBe(false);
+  });
+
+  it('rejeita campos opcionais com tipo inválido', () => {
+    expect(
+      isClientDto(makeClientPF({ fullName: 0 as unknown as string })),
+    ).toBe(false);
+    expect(
+      isClientDto(makeClientPJ({ cnpj: 0 as unknown as string })),
+    ).toBe(false);
+  });
+});
+
+describe('isPagedClientsResponse', () => {
+  it('aceita envelope válido', () => {
+    expect(
+      isPagedClientsResponse({
+        data: [makeClientPF()],
+        page: 1,
+        pageSize: 20,
+        total: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejeita envelope com data com itens inválidos', () => {
+    expect(
+      isPagedClientsResponse({
+        data: [{ broken: true }],
+        page: 1,
+        pageSize: 20,
+        total: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('clientDisplayName', () => {
+  it('retorna fullName para PF', () => {
+    expect(clientDisplayName(makeClientPF())).toBe('Alice Cliente');
+  });
+
+  it('retorna corporateName para PJ', () => {
+    expect(clientDisplayName(makeClientPJ())).toBe('Empresa LTDA');
+  });
+
+  it('cai no id quando ambos os labels estão ausentes', () => {
+    const orphan = makeClientPF({ fullName: null, corporateName: null });
+    expect(clientDisplayName(orphan)).toBe(CLIENT_ID);
+  });
+
+  it('cai no id quando os labels são apenas whitespace', () => {
+    const orphan = makeClientPF({ fullName: '   ', corporateName: '' });
+    expect(clientDisplayName(orphan)).toBe(CLIENT_ID);
+  });
+
+  it('prioriza fullName sobre corporateName se ambos estiverem preenchidos', () => {
+    const both = makeClientPF({
+      fullName: 'PF Name',
+      corporateName: 'PJ Name',
+    });
+    expect(clientDisplayName(both)).toBe('PF Name');
+  });
+});
+
+describe('listClients — querystring', () => {
+  it('emite GET /clients sem querystring quando params são default', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listClients({}, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[0][0]).toBe('/clients');
+  });
+
+  it('serializa q + type + active + page + pageSize', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 2,
+      pageSize: 50,
+      total: 100,
+    });
+
+    await listClients(
+      {
+        q: 'alice',
+        type: 'PF',
+        active: true,
+        page: 2,
+        pageSize: 50,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(
+      '/clients?q=alice&type=PF&active=true&page=2&pageSize=50',
+    );
+  });
+
+  it('omite type quando não é PF/PJ', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
+      total: 0,
+    });
+
+    // @ts-expect-error — propositalmente passa tipo inválido para
+    // garantir que o builder ignora valores fora do enum.
+    await listClients({ type: 'XX' }, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[0][0]).toBe('/clients');
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      listClients({}, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('getClientsByIds', () => {
+  it('retorna Map vazio quando ids está vazio (sem chamadas ao client)', async () => {
+    const client = createStub();
+    const result = await getClientsByIds(
+      [],
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(result.size).toBe(0);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('busca cada id e popula o Map preservando o id-chave', async () => {
+    const client = createStub();
+    const pf = makeClientPF();
+    const pj = makeClientPJ();
+    client.get.mockResolvedValueOnce(pf).mockResolvedValueOnce(pj);
+
+    const result = await getClientsByIds(
+      [pf.id, pj.id],
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.get(pf.id)).toEqual(pf);
+    expect(result.get(pj.id)).toEqual(pj);
+    expect(client.get.mock.calls[0][0]).toBe(`/clients/${pf.id}`);
+    expect(client.get.mock.calls[1][0]).toBe(`/clients/${pj.id}`);
+  });
+
+  it('skipa ids duplicados sem refazer chamada', async () => {
+    const client = createStub();
+    const pf = makeClientPF();
+    client.get.mockResolvedValueOnce(pf);
+
+    await getClientsByIds(
+      [pf.id, pf.id, pf.id],
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('é best-effort: lookup falho silenciosamente skipa o id', async () => {
+    const client = createStub();
+    const pf = makeClientPF();
+    client.get
+      .mockRejectedValueOnce({ kind: 'http', status: 404, message: 'x' })
+      .mockResolvedValueOnce(pf);
+
+    const result = await getClientsByIds(
+      ['missing-id', pf.id],
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.size).toBe(1);
+    expect(result.get(pf.id)).toEqual(pf);
+    expect(result.has('missing-id')).toBe(false);
+  });
+
+  it('lança AbortError quando a requisição é cancelada', async () => {
+    const client = createStub();
+    const abort = new DOMException('aborted', 'AbortError');
+    client.get.mockRejectedValueOnce(abort);
+
+    await expect(
+      getClientsByIds(
+        [CLIENT_ID],
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(abort);
+  });
+
+  it('lança ApiError de network com cancelamento explícito', async () => {
+    const client = createStub();
+    const networkAbort = {
+      kind: 'network' as const,
+      message: 'Requisição cancelada.',
+    };
+    client.get.mockRejectedValueOnce(networkAbort);
+
+    await expect(
+      getClientsByIds(
+        [CLIENT_ID],
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(networkAbort);
+  });
+});

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiClient, UserDto } from '@/shared/api';
+
+import {
+  DEFAULT_USERS_PAGE_SIZE,
+  isPagedUsersResponse,
+  isUserDto,
+  listUsers,
+} from '@/shared/api';
+
+/**
+ * Suíte do módulo `src/shared/api/users.ts` (Issue #77, EPIC #49).
+ *
+ * Estratégia: stubar o `ApiClient` injetado e validar paths
+ * (querystring serializada), type guards e propagação de `ApiError`.
+ * Não bate em `fetch` — cobertura de transporte HTTP é
+ * responsabilidade dos testes em `client.test.ts`.
+ *
+ * Diferente de `roles.ts` (que adapta client-side enquanto o backend
+ * não pagina), `users.ts` consome o endpoint server-side completo
+ * (`PagedResponse<UserResponse>` após PR lfc-authenticator#166).
+ * Asserts focam na serialização correta da querystring e no parsing
+ * estrito do envelope.
+ */
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const CLIENT_ID = '22222222-2222-2222-2222-222222222222';
+
+interface ClientStub {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Cria um stub mínimo de `ApiClient` — espelha o pattern usado em
+ * `tests/shared/api/routes.test.ts`/`roles.test.ts`. Mantemos local em
+ * vez de importar dos helpers de página para reduzir custo de boot da
+ * suíte (sem dependência de DOM).
+ */
+function createStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  };
+}
+
+/**
+ * Constrói um `UserDto` válido — testes só sobrescrevem o que importa
+ * para o cenário sem repetir todos os campos. Campos opcionais
+ * (`clientId`/`deletedAt`) ficam definidos por default; testes de
+ * type guard usam `Partial<UserDto>` para exercitar omissões.
+ */
+function makeUserDto(overrides: Partial<UserDto> = {}): UserDto {
+  return {
+    id: USER_ID,
+    name: 'Alice Admin',
+    email: 'alice@example.com',
+    clientId: CLIENT_ID,
+    identity: 1,
+    active: true,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+describe('isUserDto', () => {
+  it('aceita payload completo do contrato', () => {
+    expect(isUserDto(makeUserDto())).toBe(true);
+  });
+
+  it('aceita clientId null/undefined (usuário sem cliente vinculado)', () => {
+    expect(isUserDto(makeUserDto({ clientId: null }))).toBe(true);
+    const { clientId: _omit, ...withoutClientId } = makeUserDto();
+    expect(isUserDto(withoutClientId)).toBe(true);
+  });
+
+  it('aceita deletedAt null/undefined', () => {
+    expect(isUserDto(makeUserDto({ deletedAt: null }))).toBe(true);
+    const { deletedAt: _omit, ...withoutDeleted } = makeUserDto();
+    expect(isUserDto(withoutDeleted)).toBe(true);
+  });
+
+  it('rejeita objetos sem campos obrigatórios', () => {
+    expect(isUserDto(null)).toBe(false);
+    expect(isUserDto(undefined)).toBe(false);
+    expect(isUserDto({})).toBe(false);
+    expect(isUserDto({ id: 1, name: 'x' })).toBe(false);
+    const missingEmail = makeUserDto();
+    delete (missingEmail as Partial<UserDto>).email;
+    expect(isUserDto(missingEmail)).toBe(false);
+  });
+
+  it('rejeita campos com tipos inválidos', () => {
+    expect(
+      isUserDto(makeUserDto({ active: 'yes' as unknown as boolean })),
+    ).toBe(false);
+    expect(
+      isUserDto(makeUserDto({ identity: '1' as unknown as number })),
+    ).toBe(false);
+    expect(
+      isUserDto(makeUserDto({ clientId: 0 as unknown as string })),
+    ).toBe(false);
+  });
+});
+
+describe('isPagedUsersResponse', () => {
+  it('aceita envelope válido com dados', () => {
+    const envelope = {
+      data: [makeUserDto()],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    };
+    expect(isPagedUsersResponse(envelope)).toBe(true);
+  });
+
+  it('aceita envelope vazio', () => {
+    expect(
+      isPagedUsersResponse({ data: [], page: 1, pageSize: 20, total: 0 }),
+    ).toBe(true);
+  });
+
+  it('rejeita envelope sem campos obrigatórios', () => {
+    expect(isPagedUsersResponse(null)).toBe(false);
+    expect(isPagedUsersResponse({ data: [] })).toBe(false);
+    expect(
+      isPagedUsersResponse({
+        data: [],
+        page: '1' as unknown as number,
+        pageSize: 20,
+        total: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('rejeita data com itens inválidos', () => {
+    expect(
+      isPagedUsersResponse({
+        data: [{ broken: true }],
+        page: 1,
+        pageSize: 20,
+        total: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('listUsers — querystring', () => {
+  it('emite GET /users sem querystring quando params são default/omitidos', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [makeUserDto()],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 1,
+    });
+
+    await listUsers({}, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe('/users');
+  });
+
+  it('serializa q (trimado) na querystring quando informado', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listUsers(
+      { q: '  alice  ' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe('/users?q=alice');
+  });
+
+  it('omite q quando vazio depois de trim', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listUsers({ q: '   ' }, undefined, client as unknown as ApiClient);
+
+    expect(client.get.mock.calls[0][0]).toBe('/users');
+  });
+
+  it('serializa clientId quando informado', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listUsers(
+      { clientId: CLIENT_ID },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(`/users?clientId=${CLIENT_ID}`);
+  });
+
+  it('serializa active=true e active=false explicitamente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValue({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listUsers({ active: true }, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[0][0]).toBe('/users?active=true');
+
+    await listUsers({ active: false }, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[1][0]).toBe('/users?active=false');
+  });
+
+  it('omite page=1 (default) e inclui page>1', async () => {
+    const client = createStub();
+    client.get.mockResolvedValue({
+      data: [],
+      page: 2,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 30,
+    });
+
+    await listUsers({ page: 1 }, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[0][0]).toBe('/users');
+
+    await listUsers({ page: 2 }, undefined, client as unknown as ApiClient);
+    expect(client.get.mock.calls[1][0]).toBe('/users?page=2');
+  });
+
+  it('omite pageSize=20 (default) e inclui valores customizados', async () => {
+    const client = createStub();
+    client.get.mockResolvedValue({
+      data: [],
+      page: 1,
+      pageSize: 50,
+      total: 0,
+    });
+
+    await listUsers(
+      { pageSize: DEFAULT_USERS_PAGE_SIZE },
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.get.mock.calls[0][0]).toBe('/users');
+
+    await listUsers(
+      { pageSize: 50 },
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.get.mock.calls[1][0]).toBe('/users?pageSize=50');
+  });
+
+  it('serializa includeDeleted=true e omite includeDeleted=false (default)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValue({
+      data: [],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 0,
+    });
+
+    await listUsers(
+      { includeDeleted: false },
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.get.mock.calls[0][0]).toBe('/users');
+
+    await listUsers(
+      { includeDeleted: true },
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.get.mock.calls[1][0]).toBe('/users?includeDeleted=true');
+  });
+
+  it('combina múltiplos params na ordem correta', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 3,
+      pageSize: 50,
+      total: 100,
+    });
+
+    await listUsers(
+      {
+        q: 'alice',
+        clientId: CLIENT_ID,
+        active: true,
+        page: 3,
+        pageSize: 50,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(
+      `/users?q=alice&clientId=${CLIENT_ID}&active=true&page=3&pageSize=50`,
+    );
+  });
+});
+
+describe('listUsers — comportamento', () => {
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [makeUserDto()],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 1,
+    });
+    const controller = new AbortController();
+
+    await listUsers(
+      {},
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      listUsers({}, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    });
+  });
+
+  it('lança ApiError(parse) quando algum item do envelope não é UserDto', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [makeUserDto(), { broken: true }],
+      page: 1,
+      pageSize: DEFAULT_USERS_PAGE_SIZE,
+      total: 2,
+    });
+
+    await expect(
+      listUsers({}, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 401, message: 'Sessão expirada.' };
+    client.get.mockRejectedValueOnce(apiError);
+
+    await expect(
+      listUsers({}, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('devolve o envelope intacto quando válido', async () => {
+    const client = createStub();
+    const envelope = {
+      data: [makeUserDto()],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    };
+    client.get.mockResolvedValueOnce(envelope);
+
+    const result = await listUsers(
+      {},
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(envelope);
+  });
+});


### PR DESCRIPTION
## Resumo

Implementa a listagem real em `/usuarios` consumindo `GET /users` (paginação server-side após PR lfc-authenticator#166), com busca por nome/e-mail debounced, paginação, toggle \"Mostrar inativas\" e coluna \"Cliente\" denormalizada via lookup batch a `GET /clients/{id}`.

Substitui o shell placeholder herdado de #145 por uma página completa com tabela responsiva (desktop) + cards (mobile), estados de loading/erro/vazio, ARIA-live para anúncio acessível e gating por `AUTH_V1_USERS_LIST` em `AppRoutes`.

## Mudanças

- **`src/shared/api/users.ts`** (novo): `UserDto`, `isUserDto`, `isPagedUsersResponse`, `listUsers({ q, clientId, active, page, pageSize, includeDeleted })` com defaults exportados (`DEFAULT_USERS_PAGE_SIZE = 20`).
- **`src/shared/api/clients.ts`** (novo): `ClientDto`, `clientDisplayName` (PF→`fullName`, PJ→`corporateName`), `getClientsByIds` (best-effort, suporta cancelamento) e `listClients`/`isPagedClientsResponse` pré-fabricados para a EPIC #49.
- **`src/pages/users/UsersListShellPage.tsx`**: tabela com colunas Nome/E-mail/Cliente/Status, status derivado do par (`active`, `deletedAt`), reset de página em filtro/busca, anúncio ARIA-live.
- **`src/shared/api/index.ts`**: re-export dos novos módulos.
- **`tests/pages/shellPages.test.tsx`**: remove `UsersListShellPage` da tabela de shells (agora tem suíte dedicada).
- **`tests/shared/api/users.test.ts`** (novo, 23 testes): type guards, querystring, propagação de `ApiError`, cancelamento.
- **`tests/shared/api/clients.test.ts`** (novo, 22 testes): type guards, `clientDisplayName` (PF/PJ/órfão), `getClientsByIds` (sucesso, dedup, lookup falho, cancelamento).
- **`tests/pages/UsersListShellPage.test.tsx`** (novo, 18 testes): render inicial, busca debounced, paginação, toggle \"Mostrar inativas\", erros + retry, estados vazios.

## Test plan

- [x] `npm run typecheck` (verde)
- [x] `npm run lint` (verde, --max-warnings 0)
- [x] `npm run build` (verde, 8s)
- [x] `npm test` — 698/698 testes passam (`--maxThreads=2` no host Docker)
- [x] Suíte completa rodada via container Docker (`node:22-alpine`)

Closes #77