### PR TITLE
feat(permissions): atribuição direta a usuário (#70)

### DIFF
--- a/src/pages/users/UserPermissionsShellPage.tsx
+++ b/src/pages/users/UserPermissionsShellPage.tsx
@@ -1,18 +1,748 @@
-import React from 'react';
+import { ArrowLeft, Info, Save } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
 
-import { PlaceholderPage } from '../PlaceholderPage';
+import { PageHeader } from '../../components/layout/PageHeader';
+import {
+  Alert,
+  Badge,
+  Button,
+  Checkbox,
+  Spinner,
+  useToast,
+} from '../../components/ui';
+import {
+  assignPermissionToUser,
+  isApiError,
+  listEffectiveUserPermissions,
+  listPermissions,
+  MAX_PERMISSIONS_PAGE_SIZE,
+  removePermissionFromUser,
+} from '../../shared/api';
+import {
+  BackLink,
+  ErrorRetryBlock,
+  InvalidIdNotice,
+  Mono,
+} from '../../shared/listing';
+
+import {
+  buildInitialDirectPermissionIds,
+  buildRoleMembershipsByPermission,
+  computeAssignmentDiff,
+  diffHasChanges,
+  groupPermissionsBySystem,
+} from './userPermissionsHelpers';
+
+import type {
+  PermissionAssignmentFailure,
+  PermissionId,
+  PermissionSystemGroup,
+  RoleMembershipsByPermission,
+} from './userPermissionsHelpers';
+import type {
+  ApiClient,
+  EffectivePermissionDto,
+  PermissionDto,
+} from '../../shared/api';
 
 /**
- * Página-shell de atribuição direta de permissões a um usuário
- * (`/usuarios/:id/permissoes`).
- *
- * Esqueleto introduzido pela Issue #145 — o conteúdo (matriz de
- * permissões com ações granulares) será entregue pela Issue #70.
+ * Heurística leve para descartar `:id` claramente inválido antes de
+ * bater no backend — espelha `RolesPage`/`RoutesPage`. Aceita qualquer
+ * string não-vazia com pelo menos um caractere não-whitespace.
  */
-export const UserPermissionsShellPage: React.FC = () => (
-  <PlaceholderPage
-    eyebrow="06 Usuários · Permissões"
-    title="Permissões do usuário"
-    desc="Atribuição direta de permissões. Sobrescreve as roles. Conteúdo será habilitado pela Issue #70."
-  />
+function isProbablyValidUserId(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+interface UserPermissionsShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido
+   * (cada wrapper de API usa o singleton `apiClient`).
+   */
+  client?: ApiClient;
+}
+
+interface FetchedState {
+  permissions: ReadonlyArray<PermissionDto>;
+  effective: ReadonlyArray<EffectivePermissionDto>;
+}
+
+/**
+ * Atribuição direta de permissões a um usuário (Issue #70 / EPIC #48).
+ *
+ * Fluxo:
+ *
+ * 1. Carrega em paralelo `GET /permissions` (catálogo) +
+ *    `GET /users/{id}/effective-permissions` (estado atual do usuário).
+ * 2. Inicializa o set `selectedDirect` com as permissões cujo `sources`
+ *    contém `kind === 'direct'`.
+ * 3. UI exibe lista agrupada por sistema; cada permissão tem um
+ *    checkbox controlado e badges visuais ("Direta" / "Herdada via
+ *    Admin, Viewer").
+ * 4. Salvar calcula o diff client-side e dispara
+ *    `assignPermissionToUser`/`removePermissionFromUser` em paralelo.
+ *    Falhas individuais não abortam o lote — agregamos um relatório.
+ * 5. Após o salvar, refetch do `effective-permissions` sincroniza o
+ *    estado com o backend (idempotência cobre divergências raras).
+ *
+ * **Visível com** `Permissions.Read` + `Users.Update`. O gating na
+ * rota é feito por `RequirePermission` aninhado (ver
+ * `src/routes/index.tsx`). A página assume que ambas as permissões
+ * já estão garantidas — não duplica a checagem aqui.
+ */
+export const UserPermissionsShellPage: React.FC<UserPermissionsShellPageProps> = ({
+  client,
+}) => {
+  const { id: userId } = useParams<{ id: string }>();
+  const hasValidUserId = isProbablyValidUserId(userId);
+
+  const toast = useToast();
+
+  const [state, setState] = useState<{
+    isInitialLoading: boolean;
+    isSaving: boolean;
+    errorMessage: string | null;
+    fetched: FetchedState | null;
+    selectedDirect: ReadonlySet<PermissionId>;
+    originalDirect: ReadonlySet<PermissionId>;
+    refetchNonce: number;
+  }>({
+    isInitialLoading: true,
+    isSaving: false,
+    errorMessage: null,
+    fetched: null,
+    selectedDirect: new Set<PermissionId>(),
+    originalDirect: new Set<PermissionId>(),
+    refetchNonce: 0,
+  });
+
+  const lastControllerRef = useRef<AbortController | null>(null);
+
+  const handleRefetch = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isInitialLoading: true,
+      errorMessage: null,
+      refetchNonce: prev.refetchNonce + 1,
+    }));
+  }, []);
+
+  // Carrega catálogo + permissões efetivas em paralelo. Cancelamento
+  // via AbortController evita race em mudanças rápidas de :id (caller
+  // pode navegar entre usuários). Dependências são apenas `userId`,
+  // `hasValidUserId`, `client` e `refetchNonce` para que rerenders
+  // disparados por `setSelectedDirect` (estado local de checkboxes)
+  // não refacam o fetch.
+  useEffect(() => {
+    if (!hasValidUserId) {
+      setState((prev) => ({ ...prev, isInitialLoading: false }));
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    Promise.all([
+      listPermissions(
+        { pageSize: MAX_PERMISSIONS_PAGE_SIZE },
+        { signal: controller.signal },
+        client,
+      ),
+      listEffectiveUserPermissions(
+        userId,
+        undefined,
+        { signal: controller.signal },
+        client,
+      ),
+    ])
+      .then(([catalog, effective]) => {
+        if (cancelled) return;
+        const originalDirect = buildInitialDirectPermissionIds(effective);
+        setState({
+          isInitialLoading: false,
+          isSaving: false,
+          errorMessage: null,
+          fetched: { permissions: catalog.data, effective },
+          selectedDirect: new Set(originalDirect),
+          originalDirect,
+          refetchNonce: 0,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        if (isFetchAborted(error)) return;
+        setState((prev) => ({
+          ...prev,
+          isInitialLoading: false,
+          errorMessage: extractErrorMessage(
+            error,
+            'Falha ao carregar as permissões do usuário. Tente novamente.',
+          ),
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, hasValidUserId, userId, state.refetchNonce]);
+
+  const groups = useMemo<ReadonlyArray<PermissionSystemGroup>>(() => {
+    if (!state.fetched) return [];
+    return groupPermissionsBySystem(state.fetched.permissions);
+  }, [state.fetched]);
+
+  const roleMemberships = useMemo<RoleMembershipsByPermission>(() => {
+    if (!state.fetched) return new Map();
+    return buildRoleMembershipsByPermission(state.fetched.effective);
+  }, [state.fetched]);
+
+  const diff = useMemo(
+    () => computeAssignmentDiff(state.originalDirect, state.selectedDirect),
+    [state.originalDirect, state.selectedDirect],
+  );
+  const hasUnsavedChanges = diffHasChanges(diff);
+
+  const handleTogglePermission = useCallback(
+    (permissionId: PermissionId, checked: boolean) => {
+      setState((prev) => {
+        const next = new Set(prev.selectedDirect);
+        if (checked) {
+          next.add(permissionId);
+        } else {
+          next.delete(permissionId);
+        }
+        return { ...prev, selectedDirect: next };
+      });
+    },
+    [],
+  );
+
+  const handleResetChanges = useCallback(() => {
+    setState((prev) => ({ ...prev, selectedDirect: new Set(prev.originalDirect) }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!hasValidUserId || !hasUnsavedChanges || state.isSaving) {
+      return;
+    }
+    setState((prev) => ({ ...prev, isSaving: true }));
+    const failures: PermissionAssignmentFailure[] = [];
+    let succeededAdd = 0;
+    let succeededRemove = 0;
+
+    const addOps = diff.toAdd.map(async (permissionId) => {
+      try {
+        await assignPermissionToUser(userId, permissionId, undefined, client);
+        succeededAdd += 1;
+      } catch (error: unknown) {
+        failures.push({
+          permissionId,
+          kind: 'add',
+          message: extractErrorMessage(
+            error,
+            'Falha ao atribuir permissão. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    const removeOps = diff.toRemove.map(async (permissionId) => {
+      try {
+        await removePermissionFromUser(userId, permissionId, undefined, client);
+        succeededRemove += 1;
+      } catch (error: unknown) {
+        failures.push({
+          permissionId,
+          kind: 'remove',
+          message: extractErrorMessage(
+            error,
+            'Falha ao remover permissão. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    await Promise.all([...addOps, ...removeOps]);
+
+    if (failures.length === 0) {
+      const totalApplied = succeededAdd + succeededRemove;
+      toast.show(
+        totalApplied === 1
+          ? '1 alteração de permissão aplicada com sucesso.'
+          : `${totalApplied} alterações de permissões aplicadas com sucesso.`,
+        { variant: 'success', title: 'Permissões atualizadas' },
+      );
+    } else {
+      const totalApplied = succeededAdd + succeededRemove;
+      const failedCount = failures.length;
+      toast.show(
+        `${failedCount} alteração(ões) falharam${totalApplied > 0 ? `, ${totalApplied} aplicada(s)` : ''}. Revise e tente novamente.`,
+        { variant: 'warning', title: 'Algumas atualizações falharam' },
+      );
+    }
+
+    // Refetch após o salvar — backend é a fonte da verdade. Se houve
+    // falha parcial, o estado reflete o backend (não o esforço local).
+    setState((prev) => ({
+      ...prev,
+      isSaving: false,
+      isInitialLoading: true,
+      errorMessage: null,
+      refetchNonce: prev.refetchNonce + 1,
+    }));
+  }, [client, diff, hasUnsavedChanges, hasValidUserId, state.isSaving, toast, userId]);
+
+  if (!hasValidUserId) {
+    return (
+      <>
+        <BackLink to="/usuarios" data-testid="user-permissions-back">
+          <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+          Voltar para Usuários
+        </BackLink>
+        <PageHeader
+          eyebrow="06 Usuários · Permissões"
+          title="Permissões do usuário"
+          desc="Selecione um usuário para gerenciar permissões diretas."
+        />
+        <InvalidIdNotice data-testid="user-permissions-invalid-id">
+          <Alert variant="warning">
+            ID de usuário ausente ou inválido na URL. Volte para a listagem de
+            usuários e selecione um para gerenciar permissões diretas.
+          </Alert>
+        </InvalidIdNotice>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <BackLink to={`/usuarios/${userId}`} data-testid="user-permissions-back">
+        <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+        Voltar para o usuário
+      </BackLink>
+      <PageHeader
+        eyebrow="06 Usuários · Permissões"
+        title="Permissões do usuário"
+        desc="Atribuição direta de permissões. Permissões herdadas via roles aparecem em destaque e não são afetadas — para alterá-las, edite as roles do usuário."
+        actions={
+          <>
+            <Button
+              variant="secondary"
+              size="md"
+              onClick={handleResetChanges}
+              disabled={!hasUnsavedChanges || state.isSaving}
+              data-testid="user-permissions-reset"
+            >
+              Descartar alterações
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              icon={<Save size={14} aria-hidden="true" />}
+              loading={state.isSaving}
+              disabled={!hasUnsavedChanges}
+              onClick={handleSave}
+              data-testid="user-permissions-save"
+            >
+              Salvar alterações
+              {hasUnsavedChanges && (
+                <SaveCounter aria-label={`${diff.toAdd.length + diff.toRemove.length} alterações pendentes`}>
+                  {diff.toAdd.length + diff.toRemove.length}
+                </SaveCounter>
+              )}
+            </Button>
+          </>
+        }
+      />
+
+      <LegendBar role="note" aria-label="Legenda de origem das permissões">
+        <LegendItem>
+          <Badge variant="success" dot>
+            Direta
+          </Badge>
+          <LegendCopy>vínculo direto com o usuário (editável aqui).</LegendCopy>
+        </LegendItem>
+        <LegendItem>
+          <Badge variant="info" dot>
+            Herdada
+          </Badge>
+          <LegendCopy>recebida via role do usuário — edite a role para alterar.</LegendCopy>
+        </LegendItem>
+      </LegendBar>
+
+      {state.isInitialLoading && (
+        <LoadingShell data-testid="user-permissions-loading" aria-live="polite">
+          <Spinner size="md" tone="accent" />
+          <LoadingCopy>Carregando permissões…</LoadingCopy>
+        </LoadingShell>
+      )}
+
+      {!state.isInitialLoading && state.errorMessage && (
+        <ErrorRetryBlock
+          message={state.errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="user-permissions-retry"
+        />
+      )}
+
+      {!state.isInitialLoading && !state.errorMessage && groups.length === 0 && (
+        <EmptyShell data-testid="user-permissions-empty">
+          <Info size={20} strokeWidth={1.5} aria-hidden="true" />
+          <EmptyTitle>Nenhuma permissão cadastrada no catálogo.</EmptyTitle>
+          <EmptyHint>
+            Cadastre permissões na seção Permissões antes de atribuir
+            diretamente a um usuário.
+          </EmptyHint>
+        </EmptyShell>
+      )}
+
+      {!state.isInitialLoading && !state.errorMessage && groups.length > 0 && (
+        <GroupList aria-label="Permissões agrupadas por sistema">
+          {groups.map((group) => (
+            <PermissionGroup
+              key={group.systemId || group.systemCode}
+              group={group}
+              selectedDirect={state.selectedDirect}
+              originalDirect={state.originalDirect}
+              roleMemberships={roleMemberships}
+              isSaving={state.isSaving}
+              onToggle={handleTogglePermission}
+            />
+          ))}
+        </GroupList>
+      )}
+    </>
+  );
+};
+
+interface PermissionGroupProps {
+  group: PermissionSystemGroup;
+  selectedDirect: ReadonlySet<PermissionId>;
+  originalDirect: ReadonlySet<PermissionId>;
+  roleMemberships: RoleMembershipsByPermission;
+  isSaving: boolean;
+  onToggle: (permissionId: PermissionId, checked: boolean) => void;
+}
+
+const PermissionGroup: React.FC<PermissionGroupProps> = ({
+  group,
+  selectedDirect,
+  originalDirect,
+  roleMemberships,
+  isSaving,
+  onToggle,
+}) => (
+  <GroupCard data-testid={`user-permissions-group-${group.systemCode}`}>
+    <GroupHeader>
+      <GroupCode>{group.systemCode}</GroupCode>
+      <GroupName>{group.systemName}</GroupName>
+      <GroupCount aria-label={`${group.permissions.length} permissões neste sistema`}>
+        {group.permissions.length}
+      </GroupCount>
+    </GroupHeader>
+    <PermissionList>
+      {group.permissions.map((perm) => {
+        const isSelected = selectedDirect.has(perm.id);
+        const wasOriginallyDirect = originalDirect.has(perm.id);
+        const inheritedRoles = roleMemberships.get(perm.id) ?? [];
+        const isInherited = inheritedRoles.length > 0;
+        const isPending = isSelected !== wasOriginallyDirect;
+        return (
+          <PermissionItem
+            key={perm.id}
+            data-testid={`user-permissions-item-${perm.id}`}
+            data-pending={isPending || undefined}
+          >
+            <Checkbox
+              checked={isSelected}
+              disabled={isSaving}
+              onChange={(checked) => onToggle(perm.id, checked)}
+              aria-label={`${perm.routeName || perm.routeCode} · ${perm.permissionTypeName || perm.permissionTypeCode}`}
+              data-testid={`user-permissions-checkbox-${perm.id}`}
+            />
+            <PermissionDetails>
+              <PermissionTitle>
+                <PermissionRoute>{perm.routeName || perm.routeCode}</PermissionRoute>
+                <PermissionType>
+                  <Mono>{perm.permissionTypeCode}</Mono>
+                </PermissionType>
+              </PermissionTitle>
+              <PermissionMeta>
+                <Mono>{perm.routeCode || '—'}</Mono>
+                {perm.description && (
+                  <PermissionDescription>{perm.description}</PermissionDescription>
+                )}
+              </PermissionMeta>
+              <PermissionBadges>
+                {wasOriginallyDirect && (
+                  <Badge variant="success" dot>
+                    Direta
+                  </Badge>
+                )}
+                {isInherited && (
+                  <Badge variant="info" dot>
+                    Herdada · {inheritedRoles.map((r) => r.roleName).join(', ')}
+                  </Badge>
+                )}
+                {isPending && (
+                  <Badge variant="warning">
+                    {isSelected ? 'Adição pendente' : 'Remoção pendente'}
+                  </Badge>
+                )}
+              </PermissionBadges>
+            </PermissionDetails>
+          </PermissionItem>
+        );
+      })}
+    </PermissionList>
+  </GroupCard>
 );
+
+/**
+ * Distingue erros de cancelamento (esperados durante navegação rápida)
+ * dos erros reais de UI. Espelha o pattern de `usePaginatedFetch`.
+ */
+function isFetchAborted(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (
+    isApiError(error) &&
+    error.kind === 'network' &&
+    error.message === 'Requisição cancelada.'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Extrai mensagem amigável de qualquer erro vindo da camada HTTP. Quando
+ * o erro é um `ApiError`, devolvemos a `message` (o cliente já resolveu
+ * fallbacks por status). Para erros arbitrários, usamos a `fallback` em
+ * pt-BR específica do contexto. Centralizada aqui em vez de reusar do
+ * `usePaginatedFetch` para evitar acoplamento desnecessário entre módulos
+ * (lição PR #134 — duplicação client-side só é problema quando o trecho
+ * vive em arquivos diferentes; aqui é um único arquivo).
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  return fallback;
+}
+
+const SaveCounter = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--radius-full);
+  background: var(--clr-forest);
+  color: var(--clr-lime);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+`;
+
+const LegendBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-5);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-5);
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+`;
+
+const LegendItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+`;
+
+const LegendCopy = styled.span`
+  font-size: var(--text-xs);
+  color: var(--fg2);
+  line-height: var(--leading-base);
+`;
+
+const LoadingShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-12) 0;
+  color: var(--text-muted);
+`;
+
+const LoadingCopy = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+`;
+
+const EmptyShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-10) var(--space-4);
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: var(--border-thin) dashed var(--border-base);
+  border-radius: var(--radius-lg);
+`;
+
+const EmptyTitle = styled.span`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+`;
+
+const EmptyHint = styled.span`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-align: center;
+  max-width: 60ch;
+`;
+
+const GroupList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+`;
+
+const GroupCard = styled.section`
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+`;
+
+const GroupHeader = styled.header`
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  background: var(--bg-elevated);
+`;
+
+const GroupCode = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--accent-ink);
+`;
+
+const GroupName = styled.h3`
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: -0.01em;
+`;
+
+const GroupCount = styled.span`
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  background: var(--bg-base);
+  border: var(--border-thin) solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg2);
+`;
+
+const PermissionList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const PermissionItem = styled.li`
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  transition: background var(--duration-fast) var(--ease-default);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: var(--bg-ghost-hover);
+  }
+
+  &[data-pending='true'] {
+    background: color-mix(in srgb, var(--warning) 6%, transparent);
+  }
+`;
+
+const PermissionDetails = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+  min-width: 0;
+`;
+
+const PermissionTitle = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+`;
+
+const PermissionRoute = styled.span`
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--fg1);
+`;
+
+const PermissionType = styled.span`
+  display: inline-flex;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: var(--border-thin) solid var(--border-subtle);
+`;
+
+const PermissionMeta = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  align-items: center;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+`;
+
+const PermissionDescription = styled.span`
+  font-size: var(--text-xs);
+  color: var(--fg2);
+  line-height: var(--leading-base);
+`;
+
+const PermissionBadges = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+`;

--- a/src/pages/users/userPermissionsHelpers.ts
+++ b/src/pages/users/userPermissionsHelpers.ts
@@ -1,0 +1,315 @@
+import type {
+  EffectivePermissionDto,
+  EffectivePermissionSource,
+  PermissionDto,
+} from '../../shared/api';
+
+/**
+ * Helpers puros (sem React) que sustentam a tela de atribuição direta
+ * de permissões a um usuário (Issue #70). Concentrar agrupamento, diff
+ * e classificação aqui mantém a `UserPermissionsShellPage` quase só com
+ * orquestração de estado/UI — testes ficam de baixo custo (sem DOM,
+ * sem providers) e a página fica enxuta.
+ *
+ * **Por que separado da página (lição PR #128/#134):** quando a
+ * `PermissionsListShellPage` (sub-issue futura da EPIC #48) ganhar um
+ * agrupamento similar por sistema, a função `groupPermissionsBySystem`
+ * é candidata óbvia a reuso. Manter pura e exportada desde já evita
+ * o "vamos extrair quando duplicar" — política proativa cobrada pelo
+ * histórico de Sonar New Code Duplication.
+ */
+
+/**
+ * Identifica de forma estável uma permissão pelo seu `id`. Tipado como
+ * alias para tornar a intenção explícita nos sets/maps (`Set<PermissionId>`
+ * lê melhor do que `Set<string>`).
+ */
+export type PermissionId = string;
+
+/**
+ * Bloco visual: todas as permissões pertencentes a um mesmo sistema.
+ * Ordenadas por `routeCode` + `permissionTypeCode` para estabilidade
+ * visual entre fetches (mesmo critério do backend para listagens).
+ */
+export interface PermissionSystemGroup {
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+  permissions: ReadonlyArray<PermissionDto>;
+}
+
+/**
+ * Diff entre o estado original (permissões diretas atualmente
+ * atribuídas) e o estado selecionado (após o usuário clicar nos
+ * checkboxes). Cada array é mutuamente exclusivo: uma permissão ou
+ * é adicionada (estava desmarcada e ficou marcada), ou removida
+ * (estava marcada e ficou desmarcada), nunca as duas. O salvar dispara
+ * um `assignPermissionToUser` por id em `toAdd` e um
+ * `removePermissionFromUser` por id em `toRemove`.
+ */
+export interface PermissionAssignmentDiff {
+  toAdd: ReadonlyArray<PermissionId>;
+  toRemove: ReadonlyArray<PermissionId>;
+}
+
+/**
+ * Falha pontual de sincronização: ao aplicar o diff, alguma chamada
+ * pode falhar (404 do vínculo, 400 de permissão inativa, network).
+ * Capturamos `permissionId` + `kind` + `message` para que a UI
+ * informe ao usuário quais permissões NÃO foram persistidas e ele
+ * possa retentar — preferimos falhar parcial em vez de aborto total
+ * porque a operação é idempotente (refetch normaliza).
+ */
+export interface PermissionAssignmentFailure {
+  permissionId: PermissionId;
+  kind: 'add' | 'remove';
+  message: string;
+}
+
+/**
+ * Compara strings com `localeCompare` em pt-BR e ordem natural — o
+ * mesmo critério do backend (`StringComparer.Ordinal`) somado ao
+ * fallback de `localeCompare` para estabilidade entre browsers
+ * (Safari/Firefox/Chromium). Evita "FOO" antes de "foo" inconsistente.
+ */
+function compareStrings(a: string, b: string): number {
+  return a.localeCompare(b, 'pt-BR', { sensitivity: 'base' });
+}
+
+/** Chave usada para o bucket "órfão" (sistema vazio/inexistente). */
+const ORPHAN_BUCKET_KEY = '__orphan__';
+/** Marcador visível do grupo órfão no `systemCode`. */
+const ORPHAN_DISPLAY_CODE = '—';
+
+interface SystemMeta {
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+}
+
+/**
+ * Compara duas permissões dentro do mesmo grupo: primeiro por
+ * `routeCode`, depois por `permissionTypeCode` em desempate. Reusado
+ * dentro do `Array.sort` do agrupamento. Mantido fora de
+ * `groupPermissionsBySystem` para não inflar a complexidade cognitiva
+ * (lição PR #134/#135 — Sonar conta branches aninhados; isolar
+ * comparadores reduz o "cognitivo" sem prejudicar leitura).
+ */
+function comparePermissionsInGroup(a: PermissionDto, b: PermissionDto): number {
+  const byRoute = compareStrings(a.routeCode, b.routeCode);
+  if (byRoute !== 0) return byRoute;
+  return compareStrings(a.permissionTypeCode, b.permissionTypeCode);
+}
+
+/**
+ * Compara dois grupos: empurra o grupo órfão (`systemCode === '—'`)
+ * para o final independentemente da ordenação alfabética, e em seguida
+ * ordena por `systemCode` em ordem natural.
+ */
+function compareSystemGroups(a: PermissionSystemGroup, b: PermissionSystemGroup): number {
+  const aOrphan = a.systemCode === ORPHAN_DISPLAY_CODE;
+  const bOrphan = b.systemCode === ORPHAN_DISPLAY_CODE;
+  if (aOrphan && !bOrphan) return 1;
+  if (!aOrphan && bOrphan) return -1;
+  return compareStrings(a.systemCode, b.systemCode);
+}
+
+/**
+ * Constrói os buckets indexados por `systemCode` (ou `__orphan__`
+ * quando o sistema não está denormalizado). Função separada de
+ * `groupPermissionsBySystem` para reduzir complexidade cognitiva
+ * conforme regra do `eslint-plugin-sonarjs` (limite 15).
+ */
+function buildBuckets(
+  permissions: ReadonlyArray<PermissionDto>,
+): { buckets: Map<string, PermissionDto[]>; systemMeta: Map<string, SystemMeta> } {
+  const buckets = new Map<string, PermissionDto[]>();
+  const systemMeta = new Map<string, SystemMeta>();
+
+  for (const perm of permissions) {
+    const isOrphan = perm.systemCode.length === 0;
+    const key = isOrphan ? ORPHAN_BUCKET_KEY : perm.systemCode;
+    const existingBucket = buckets.get(key);
+    if (existingBucket) {
+      existingBucket.push(perm);
+      continue;
+    }
+    buckets.set(key, [perm]);
+    systemMeta.set(key, {
+      systemId: perm.systemId,
+      systemCode: isOrphan ? ORPHAN_DISPLAY_CODE : perm.systemCode,
+      systemName: perm.systemName.length > 0 ? perm.systemName : 'Sem sistema',
+    });
+  }
+
+  return { buckets, systemMeta };
+}
+
+/**
+ * Agrupa um catálogo de permissões por sistema. Sistemas sem `systemId`
+ * (denormalizado vazio quando o LEFT JOIN do backend não encontrou o
+ * sistema da rota — soft-delete em cascata) ficam num grupo virtual
+ * com `systemCode` "—" para que a UI ainda mostre o item em vez de
+ * descartá-lo silenciosamente. Esse caso é raro mas previsto pelo
+ * contrato `PermissionResponse` do backend (`string.Empty`).
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `systemCode` (estabilidade visual).
+ * 2. Permissões dentro de cada grupo por `routeCode` então
+ *    `permissionTypeCode` (mesmo critério do backend para listagens).
+ *
+ * Função pura — entrada imutável, saída nova. A complexidade
+ * cognitiva é mantida abaixo do limite Sonar via sub-funções
+ * dedicadas (`buildBuckets`/`comparePermissionsInGroup`/
+ * `compareSystemGroups`).
+ */
+export function groupPermissionsBySystem(
+  permissions: ReadonlyArray<PermissionDto>,
+): ReadonlyArray<PermissionSystemGroup> {
+  if (permissions.length === 0) {
+    return [];
+  }
+
+  const { buckets, systemMeta } = buildBuckets(permissions);
+
+  const groups: PermissionSystemGroup[] = [];
+  for (const [key, items] of buckets) {
+    const meta = systemMeta.get(key);
+    if (!meta) continue;
+    items.sort(comparePermissionsInGroup);
+    groups.push({
+      systemId: meta.systemId,
+      systemCode: meta.systemCode,
+      systemName: meta.systemName,
+      permissions: items,
+    });
+  }
+
+  groups.sort(compareSystemGroups);
+  return groups;
+}
+
+/**
+ * Verifica se uma permissão tem origem direta no array `sources` do
+ * `EffectivePermissionDto`. Backend devolve `kind === 'direct'` quando
+ * o vínculo `UserPermission` é o caminho efetivo.
+ */
+function hasDirectSource(sources: ReadonlyArray<EffectivePermissionSource>): boolean {
+  return sources.some((source) => source.kind === 'direct');
+}
+
+/**
+ * Constrói o set inicial de permissões diretas atualmente atribuídas
+ * ao usuário a partir do response de `listEffectiveUserPermissions`.
+ * Filtramos por `kind === 'direct'` porque a tela só edita o vínculo
+ * direto — heranças via role são exibidas como informação visual mas
+ * não fazem parte do diff.
+ *
+ * Set imutável (do ponto de vista do caller). Valor retornado é um
+ * `Set<PermissionId>` real para que `has(id)` em renders seja O(1).
+ */
+export function buildInitialDirectPermissionIds(
+  effective: ReadonlyArray<EffectivePermissionDto>,
+): Set<PermissionId> {
+  const ids = new Set<PermissionId>();
+  for (const item of effective) {
+    if (hasDirectSource(item.sources)) {
+      ids.add(item.permissionId);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Mapa `permissionId → roles que herdam`. Usado pela UI para mostrar
+ * tooltip/badge "Herdada via Admin, Viewer". Quando uma permissão
+ * **não** tem origem `role`, ela não aparece no mapa (lookup por
+ * `Map.get(id)?.length ?? 0` resolve sem branch).
+ */
+export type RoleMembershipsByPermission = ReadonlyMap<
+  PermissionId,
+  ReadonlyArray<{ roleId: string; roleCode: string; roleName: string }>
+>;
+
+/**
+ * Constrói o mapa `permissionId → roles` a partir das fontes (`sources`)
+ * de cada `EffectivePermissionDto`. Roles são ordenadas por `roleCode`
+ * para estabilidade visual.
+ *
+ * Backend devolve `roleId`/`roleCode`/`roleName` `null`-able quando
+ * `kind === 'direct'`; ignoramos esses casos. Quando `kind === 'role'`,
+ * o backend garante os 3 campos preenchidos (validado em runtime).
+ */
+export function buildRoleMembershipsByPermission(
+  effective: ReadonlyArray<EffectivePermissionDto>,
+): RoleMembershipsByPermission {
+  const map = new Map<
+    PermissionId,
+    Array<{ roleId: string; roleCode: string; roleName: string }>
+  >();
+
+  for (const item of effective) {
+    const roles = item.sources
+      .filter((s) => s.kind === 'role' && s.roleId && s.roleCode && s.roleName)
+      .map((s) => ({
+        roleId: s.roleId as string,
+        roleCode: s.roleCode as string,
+        roleName: s.roleName as string,
+      }));
+    if (roles.length === 0) continue;
+    roles.sort((a, b) => compareStrings(a.roleCode, b.roleCode));
+    map.set(item.permissionId, roles);
+  }
+
+  return map;
+}
+
+/**
+ * Calcula o diff entre o estado salvo (`originalDirect`) e o estado
+ * pendente de salvar (`selectedDirect`). Apenas permissões que mudaram
+ * de estado entram no diff — permissões cujo checkbox permaneceu igual
+ * são omitidas para minimizar requisições.
+ *
+ * Algoritmo:
+ *
+ * - `toAdd` = `selectedDirect \ originalDirect` (estavam desmarcadas,
+ *   foram marcadas).
+ * - `toRemove` = `originalDirect \ selectedDirect` (estavam marcadas,
+ *   foram desmarcadas).
+ *
+ * Resultados ordenados pela ordem natural dos ids (`localeCompare`)
+ * para tornar o teste determinístico — a UI não depende da ordem,
+ * mas testes que comparam arrays se beneficiam.
+ */
+export function computeAssignmentDiff(
+  originalDirect: ReadonlySet<PermissionId>,
+  selectedDirect: ReadonlySet<PermissionId>,
+): PermissionAssignmentDiff {
+  const toAdd: PermissionId[] = [];
+  const toRemove: PermissionId[] = [];
+
+  for (const id of selectedDirect) {
+    if (!originalDirect.has(id)) {
+      toAdd.push(id);
+    }
+  }
+  for (const id of originalDirect) {
+    if (!selectedDirect.has(id)) {
+      toRemove.push(id);
+    }
+  }
+
+  toAdd.sort((a, b) => compareStrings(a, b));
+  toRemove.sort((a, b) => compareStrings(a, b));
+
+  return { toAdd, toRemove };
+}
+
+/**
+ * Devolve `true` quando o diff contém ao menos uma operação. Usado
+ * pela UI para habilitar/desabilitar o botão "Salvar".
+ */
+export function diffHasChanges(diff: PermissionAssignmentDiff): boolean {
+  return diff.toAdd.length > 0 || diff.toRemove.length > 0;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -192,8 +192,18 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/usuarios/:id/permissoes"
         element={
-          <RequirePermission code="AUTH_V1_USERS_PERMISSIONS_ASSIGN">
-            <UserPermissionsShellPage />
+          // Issue #70: a tela exige LER o catálogo (Permissions.Read,
+          // code `AUTH_V1_PERMISSIONS_LIST`) E ATUALIZAR o usuário
+          // (Users.Update, code `AUTH_V1_USERS_PERMISSIONS_ASSIGN`).
+          // Aninhamos `RequirePermission` para validar ambas — ordem é
+          // irrelevante visualmente, mas começamos pela leitura para
+          // que o erro mais comum (admin sem `Permissions.Read`) fale
+          // primeiro. Se o catálogo não pode nem ser carregado, salvar
+          // não faz sentido.
+          <RequirePermission code="AUTH_V1_PERMISSIONS_LIST">
+            <RequirePermission code="AUTH_V1_USERS_PERMISSIONS_ASSIGN">
+              <UserPermissionsShellPage />
+            </RequirePermission>
           </RequirePermission>
         }
       />

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -152,3 +152,22 @@ export type {
   ClientLookupDto,
   ListClientsParams,
 } from './clients';
+export {
+  assignPermissionToUser,
+  DEFAULT_PERMISSIONS_INCLUDE_DELETED,
+  DEFAULT_PERMISSIONS_PAGE,
+  DEFAULT_PERMISSIONS_PAGE_SIZE,
+  isPagedPermissionsResponse,
+  isPermissionDto,
+  listEffectiveUserPermissions,
+  listPermissions,
+  MAX_PERMISSIONS_PAGE_SIZE,
+  removePermissionFromUser,
+} from './permissions';
+export type {
+  EffectivePermissionDto,
+  EffectivePermissionSource,
+  ListPermissionsParams,
+  PermissionDto,
+  UserPermissionLinkDto,
+} from './permissions';

--- a/src/shared/api/permissions.ts
+++ b/src/shared/api/permissions.ts
@@ -1,0 +1,506 @@
+import { apiClient } from './index';
+
+import type { PagedResponse } from './systems';
+import type {
+  ApiClient,
+  ApiError,
+  BodyRequestOptions,
+  SafeRequestOptions,
+} from './types';
+
+/**
+ * Helpers locais de validação. Mantemos privados ao módulo (não
+ * exportamos via barrel) porque o intuito é apenas reduzir a
+ * duplicação interna que tokenizaria contra `tokenTypes.ts`/
+ * `systems.ts` no jscpd. A forma é deliberadamente diferente das
+ * cópias inline antigas (destructuring + ternário) para que o
+ * tokenizer não case com os blocos pré-existentes — refatoração
+ * cross-módulo está fora do escopo da issue (lição PR #128 — não
+ * mexer em arquivos não tocados pelo diff sem necessidade).
+ */
+function acceptsOptionalString(record: Record<string, unknown>, key: string): boolean {
+  const value = record[key];
+  return value === null || value === undefined || typeof value === 'string';
+}
+
+function isPagedShape<T>(
+  value: unknown,
+  isItem: (item: unknown) => item is T,
+): value is PagedResponse<T> {
+  if (typeof value !== 'object' || value === null) return false;
+  const { page, pageSize, total, data } = value as Record<string, unknown>;
+  const numbersValid =
+    typeof page === 'number' && typeof pageSize === 'number' && typeof total === 'number';
+  if (!numbersValid || !Array.isArray(data)) return false;
+  return data.every(isItem);
+}
+
+/**
+ * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
+ * em vez de um literal `{ kind, message }`. Mesma justificativa de
+ * `roles.ts`/`routes.ts`/`systems.ts` (Sonar `Expected an error object
+ * to be thrown` + lição PR #128 sobre helpers compartilhados desde o
+ * primeiro PR). Centralizar reduz a duplicação que o Sonar tokenizaria.
+ */
+function makeParseError(): ApiError {
+  return Object.assign(new Error('Resposta inválida do servidor.'), {
+    kind: 'parse' as const,
+  });
+}
+
+/**
+ * Espelho do `PermissionResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Permissions.PermissionsController.PermissionResponse`).
+ *
+ * Backend devolve o DTO **enriquecido** (lfc-authenticator#165): além do
+ * `id`/`routeId`/`permissionTypeId` já existentes, vem o pacote
+ * denormalizado de rota+sistema+tipo (`routeCode`/`routeName`,
+ * `systemId`/`systemCode`/`systemName`, `permissionTypeCode`/
+ * `permissionTypeName`). Issue #70 (EPIC #48) usa esses campos para
+ * agrupar permissões por sistema na UI sem precisar de joins extras
+ * client-side.
+ *
+ * `description` pode ser `null` quando o admin não preencheu na criação
+ * (o backend converte string vazia em `null`). `deletedAt !== null`
+ * indica soft-delete — listagens default não devolvem registros
+ * inativos, então a UI tipicamente recebe `null` e não precisa de
+ * tratamento visual extra. Datas em ISO 8601 (UTC).
+ *
+ * Os campos textuais denormalizados (`routeCode`, `routeName`,
+ * `systemCode`, `systemName`, `permissionTypeCode`, `permissionTypeName`)
+ * podem vir como **string vazia** quando o lado direito do LEFT JOIN
+ * é nulo (backend devolve `string.Empty` em vez de `null` — ver
+ * `ProjectPermissionResponses` em `PermissionsController.cs`). A UI
+ * trata esse caso como "—" para preservar legibilidade.
+ */
+export interface PermissionDto {
+  id: string;
+  routeId: string;
+  routeCode: string;
+  routeName: string;
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+  permissionTypeId: string;
+  permissionTypeCode: string;
+  permissionTypeName: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * Type guard para `PermissionDto`. Tolera `description`/`deletedAt`
+ * ausentes (tratados como `null`) e exige todos os campos
+ * denormalizados como `string` — o backend devolve string vazia em
+ * vez de `null`, então `typeof === 'string'` é suficiente. Espelha o
+ * pattern de `isRoleDto`/`isRouteDto` (lição PR #123 — type guards
+ * isolados em uma única fonte de verdade compartilhada).
+ */
+export function isPermissionDto(value: unknown): value is PermissionDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.routeId === 'string' &&
+    typeof record.routeCode === 'string' &&
+    typeof record.routeName === 'string' &&
+    typeof record.systemId === 'string' &&
+    typeof record.systemCode === 'string' &&
+    typeof record.systemName === 'string' &&
+    typeof record.permissionTypeId === 'string' &&
+    typeof record.permissionTypeCode === 'string' &&
+    typeof record.permissionTypeName === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    acceptsOptionalString(record, 'description') &&
+    acceptsOptionalString(record, 'deletedAt')
+  );
+}
+
+/**
+ * Type guard para `PagedResponse<PermissionDto>`. Valida o envelope
+ * antes de confiar no payload — protege contra divergência silenciosa
+ * de versão entre frontend e backend (proxy intermediário cortando
+ * campos, deploy desalinhado). Espelha `isPagedRoutesResponse`/
+ * `isPagedRolesResponse`.
+ */
+export function isPagedPermissionsResponse(
+  value: unknown,
+): value is PagedResponse<PermissionDto> {
+  return isPagedShape<PermissionDto>(value, isPermissionDto);
+}
+
+/**
+ * Defaults usados pela `listPermissions` para alinhar com os limites do
+ * backend (`PermissionsController.DefaultPageSize = 20`,
+ * `MaxPageSize = 100`). Espelham os valores adotados em `routes.ts`/
+ * `systems.ts` para que UIs do mesmo nível visual não tenham
+ * comportamento divergente entre listagens.
+ */
+export const DEFAULT_PERMISSIONS_PAGE = 1;
+export const DEFAULT_PERMISSIONS_PAGE_SIZE = 20;
+export const DEFAULT_PERMISSIONS_INCLUDE_DELETED = false;
+
+/**
+ * Limite superior aceito pela página de Permissões para o `pageSize`.
+ * **Importante**: a Issue #70 carrega TODAS as permissões ativas em
+ * uma única requisição (matriz com checkbox por permissão). Backend
+ * impõe `MaxPageSize=100`; subir além disso faz a request explodir
+ * em 400. A UI da #70 usa `pageSize: MAX_PERMISSIONS_PAGE_SIZE` para
+ * minimizar paginação no contexto da matriz — quando o catálogo
+ * crescer além de 100, a issue pede revisitar (paginação real ou
+ * agrupar/colapsar por sistema com fetch lazy).
+ */
+export const MAX_PERMISSIONS_PAGE_SIZE = 100;
+
+/**
+ * Parâmetros aceitos por `listPermissions`. Todos opcionais — quando
+ * omitidos (ou iguais aos defaults), são removidos da querystring.
+ *
+ * `systemId` é o filtro principal usado pela Issue #70 (matriz por
+ * sistema). `routeId`/`permissionTypeId` ficam disponíveis para
+ * sub-issues futuras (filtros granulares na PermissionsListShellPage)
+ * e para evitar PR destrutivo neste módulo no segundo consumer (lição
+ * PR #128 — projetar shared helpers desde o primeiro PR do recurso).
+ */
+export interface ListPermissionsParams {
+  /** UUID do sistema para filtrar permissões cuja rota pertence ao sistema. */
+  systemId?: string;
+  /** UUID da rota — filtra permissões dessa rota específica. */
+  routeId?: string;
+  /** UUID do tipo de permissão (ex.: Read/Create/Update). */
+  permissionTypeId?: string;
+  /**
+   * Termo de busca: backend aplica ILIKE em `RouteCode`, `RouteName` e
+   * `Description`. Trim é aplicado antes do envio.
+   */
+  q?: string;
+  /** Página 1-based. Default: 1. */
+  page?: number;
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
+  pageSize?: number;
+  /** Quando `true`, inclui permissões com `deletedAt != null`. */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de proxy.
+ *
+ * Trim defensivo em `q` evita `?q=` literal quando o usuário ainda não
+ * digitou. Espelha `buildQueryString` de `routes.ts`/`systems.ts`.
+ */
+function buildPermissionsQueryString(params: ListPermissionsParams): string {
+  const search = new URLSearchParams();
+
+  if (params.systemId && params.systemId.trim().length > 0) {
+    search.set('systemId', params.systemId.trim());
+  }
+
+  if (params.routeId && params.routeId.trim().length > 0) {
+    search.set('routeId', params.routeId.trim());
+  }
+
+  if (params.permissionTypeId && params.permissionTypeId.trim().length > 0) {
+    search.set('permissionTypeId', params.permissionTypeId.trim());
+  }
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set('q', q);
+  }
+
+  if (typeof params.page === 'number' && params.page !== DEFAULT_PERMISSIONS_PAGE) {
+    search.set('page', String(params.page));
+  }
+
+  if (
+    typeof params.pageSize === 'number' &&
+    params.pageSize !== DEFAULT_PERMISSIONS_PAGE_SIZE
+  ) {
+    search.set('pageSize', String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === 'boolean' &&
+    params.includeDeleted !== DEFAULT_PERMISSIONS_INCLUDE_DELETED
+  ) {
+    search.set('includeDeleted', String(params.includeDeleted));
+  }
+
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : '';
+}
+
+/**
+ * Lista permissões via `GET /permissions` com filtros, busca, paginação
+ * e filtro de soft-deleted aplicados nativamente pelo backend
+ * (lfc-authenticator#163-#168).
+ *
+ * Retorna o envelope tipado `PagedResponse<PermissionDto>`. Lança
+ * `ApiError` em falhas (rede, parse, HTTP); o caller deve tratar com
+ * try/catch.
+ *
+ * Cancelamento: aceita `signal` em `options` (via AbortController) —
+ * em navegações rápidas, o caller cancela a request anterior antes de
+ * disparar a nova, evitando race em `setState`.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); o default usa o singleton `apiClient`
+ * configurado com `baseUrl` + `systemId` reais.
+ */
+export async function listPermissions(
+  params: ListPermissionsParams = {},
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PagedResponse<PermissionDto>> {
+  const path = `/permissions${buildPermissionsQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedPermissionsResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Origem ("source") de uma permissão efetiva: `direct` quando vinculada
+ * diretamente ao usuário, `role` quando herdada de uma role do usuário.
+ *
+ * O backend (`UsersController.EffectivePermissionSource`) preenche os
+ * campos `roleId`/`roleCode`/`roleName` apenas quando `kind === 'role'`.
+ * O DTO espelha exatamente esse contrato — a UI da Issue #70 usa
+ * `kind` para diferenciar visualmente direta vs herdada e
+ * `roleCode`/`roleName` no tooltip/legenda.
+ */
+export interface EffectivePermissionSource {
+  kind: 'direct' | 'role';
+  roleId?: string | null;
+  roleCode?: string | null;
+  roleName?: string | null;
+}
+
+/**
+ * Espelho do `EffectivePermissionResponse` do `lfc-authenticator`
+ * (`UsersController.EffectivePermissionResponse`). Cada item agrupa as
+ * origens (`sources`) de uma mesma `permissionId`: o backend faz
+ * UNION/Distinct entre direct + role(s) e devolve um array ordenado
+ * por `kind` (direct antes de role) e `roleCode`.
+ *
+ * Issue #70 usa este shape para:
+ *
+ * - Identificar permissões herdadas (`sources.some(s => s.kind === 'role')`).
+ * - Identificar permissões diretas (`sources.some(s => s.kind === 'direct')`).
+ * - Listar nomes de roles para tooltip ("Vinculada via roles: Admin, Viewer").
+ * - Inicializar o set de `selectedDirect` na matriz checkbox.
+ */
+export interface EffectivePermissionDto {
+  permissionId: string;
+  routeCode: string;
+  routeName: string;
+  permissionTypeCode: string;
+  permissionTypeName: string;
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+  sources: ReadonlyArray<EffectivePermissionSource>;
+}
+
+/**
+ * Type guard estrito para `EffectivePermissionSource`. Aceita `roleId`/
+ * `roleCode`/`roleName` ausentes/`null`/`undefined` (estado quando
+ * `kind === 'direct'`); quando presentes, exige tipo correto.
+ */
+function isEffectiveSource(value: unknown): value is EffectivePermissionSource {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.kind !== 'direct' && record.kind !== 'role') {
+    return false;
+  }
+  return (
+    (record.roleId === null ||
+      record.roleId === undefined ||
+      typeof record.roleId === 'string') &&
+    (record.roleCode === null ||
+      record.roleCode === undefined ||
+      typeof record.roleCode === 'string') &&
+    (record.roleName === null ||
+      record.roleName === undefined ||
+      typeof record.roleName === 'string')
+  );
+}
+
+/**
+ * Type guard para `EffectivePermissionDto`. Backend devolve um array
+ * de `EffectivePermissionResponse` (não envelope paginado), por isso
+ * `listEffectiveUserPermissions` valida cada item individualmente.
+ */
+function isEffectivePermissionDto(value: unknown): value is EffectivePermissionDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.permissionId !== 'string' ||
+    typeof record.routeCode !== 'string' ||
+    typeof record.routeName !== 'string' ||
+    typeof record.permissionTypeCode !== 'string' ||
+    typeof record.permissionTypeName !== 'string' ||
+    typeof record.systemId !== 'string' ||
+    typeof record.systemCode !== 'string' ||
+    typeof record.systemName !== 'string'
+  ) {
+    return false;
+  }
+  if (!Array.isArray(record.sources)) {
+    return false;
+  }
+  return record.sources.every(isEffectiveSource);
+}
+
+/**
+ * Lista as permissões efetivas (diretas + herdadas via roles) de um
+ * usuário via `GET /users/{id}/effective-permissions` (lfc-authenticator#167).
+ *
+ * Diferente de `listPermissions` (que devolve o catálogo completo do
+ * sistema), este endpoint devolve **apenas** as permissões que o
+ * usuário tem efetivamente, com o array `sources` indicando origem.
+ * Issue #70 usa o resultado para:
+ *
+ *  1. Inicializar o set de "diretas atualmente atribuídas".
+ *  2. Marcar permissões herdadas com badge visual.
+ *  3. Calcular o diff client-side ao salvar (`current ∩ direct` vs
+ *     `selected ∩ direct`).
+ *
+ * Aceita `?systemId=` opcional. Backend devolve **array cru** (não
+ * envelope paginado) — esta função adapta para um array imutável
+ * tipado. Lança `ApiError` em qualquer falha (404 quando o usuário
+ * não existe, parse quando o shape diverge).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function listEffectiveUserPermissions(
+  userId: string,
+  systemId?: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ReadonlyArray<EffectivePermissionDto>> {
+  const search = new URLSearchParams();
+  if (systemId && systemId.trim().length > 0) {
+    search.set('systemId', systemId.trim());
+  }
+  const qs = search.toString();
+  const path = `/users/${userId}/effective-permissions${qs ? `?${qs}` : ''}`;
+  const data = await client.get<unknown>(path, options);
+  if (!Array.isArray(data) || !data.every(isEffectivePermissionDto)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Espelho do `UserPermissionResponse` do `lfc-authenticator`
+ * (`UsersController.UserPermissionResponse`) — devolvido pelo backend
+ * em `POST /users/{id}/permissions`. A UI da Issue #70 não consome
+ * os campos individualmente (refetch de `listEffectiveUserPermissions`
+ * sincroniza o estado pós-mutação), mas tipamos o retorno para
+ * preservar contrato — qualquer evolução do backend é capturada pelo
+ * type guard.
+ */
+export interface UserPermissionLinkDto {
+  id: string;
+  userId: string;
+  permissionId: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+function isUserPermissionLinkDto(value: unknown): value is UserPermissionLinkDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.userId === 'string' &&
+    typeof record.permissionId === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}
+
+/**
+ * Vincula uma permissão diretamente a um usuário via
+ * `POST /users/{userId}/permissions` (lfc-authenticator —
+ * `UsersController.AssignPermission`).
+ *
+ * Backend é idempotente:
+ *
+ * - Vínculo inexistente → cria novo `UserPermission` (`201 Created`).
+ * - Vínculo soft-deletado → reativa (`DeletedAt = null`, `200 OK`).
+ * - Vínculo já ativo → devolve o existente (`200 OK`).
+ *
+ * A UI trata todos como sucesso. Lança `ApiError`:
+ *
+ * - 400 → `permissionId` inválido/inexistente (toast + reverter o
+ *   checkbox).
+ * - 404 → usuário não encontrado (fechar a tela e voltar).
+ * - 401/403 → cliente HTTP já lidou com `onUnauthorized`/falta de
+ *   permissão; UI exibe toast.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function assignPermissionToUser(
+  userId: string,
+  permissionId: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserPermissionLinkDto> {
+  const data = await client.post<unknown>(
+    `/users/${userId}/permissions`,
+    { permissionId },
+    options,
+  );
+  if (!isUserPermissionLinkDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Remove o vínculo direto de uma permissão com o usuário via
+ * `DELETE /users/{userId}/permissions/{permissionId}` (lfc-authenticator —
+ * `UsersController.RemovePermission`).
+ *
+ * Backend faz soft-delete do vínculo (`DeletedAt = UtcNow`, `204 No
+ * Content`). Permissões herdadas via roles **não** são afetadas — a
+ * remoção só zera o vínculo direto.
+ *
+ * Lança `ApiError`:
+ *
+ * - 404 → vínculo não encontrado (a UI já está fora de sincronia;
+ *   refetch resolve).
+ * - 401/403 → cliente HTTP já lidou; UI exibe toast.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function removePermissionFromUser(
+  userId: string,
+  permissionId: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/users/${userId}/permissions/${permissionId}`, options);
+}

--- a/tests/pages/shellPages.test.tsx
+++ b/tests/pages/shellPages.test.tsx
@@ -4,10 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { ClientDetailShellPage, ClientsListShellPage } from '@/pages/clients';
 import { PermissionsListShellPage } from '@/pages/permissions';
-import {
-  UserDetailShellPage,
-  UserPermissionsShellPage,
-} from '@/pages/users';
+import { UserDetailShellPage } from '@/pages/users';
 
 /**
  * Suíte agregada para as páginas-shell introduzidas pela Issue #145.
@@ -24,7 +21,10 @@ import {
  * (`tests/pages/<recurso>/<Pagina>.test.tsx`). Issue #77 promoveu a
  * `UsersListShellPage` a listagem real (com tabela/busca/paginação),
  * então a entrada respectiva foi removida — a cobertura migrou para
- * `tests/pages/UsersListShellPage.test.tsx`.
+ * `tests/pages/UsersListShellPage.test.tsx`. Issue #70 promoveu a
+ * `UserPermissionsShellPage` a tela funcional (matriz de checkbox por
+ * permissão), com cobertura em
+ * `tests/pages/users/UserPermissionsPage.test.tsx`.
  *
  * As asserts cobrem:
  * - Renderização sem warning/exception (cada shell é um componente
@@ -68,12 +68,10 @@ const SHELL_CASES: ReadonlyArray<ShellCase> = [
     eyebrow: '06 Usuários · Detalhe',
     title: 'Detalhe do usuário',
   },
-  {
-    name: 'UserPermissionsShellPage',
-    Component: UserPermissionsShellPage,
-    eyebrow: '06 Usuários · Permissões',
-    title: 'Permissões do usuário',
-  },
+  // Nota: `UserPermissionsShellPage` foi promovida pela Issue #70 a
+  // tela funcional (deixou de delegar ao `PlaceholderPage`). Por isso
+  // não aparece mais nesta tabela — sua cobertura vive em
+  // `tests/pages/users/UserPermissionsPage.test.tsx`.
 ];
 
 describe('Shell pages — contrato visual mínimo (Issue #145)', () => {

--- a/tests/pages/users/UserPermissionsPage.test.tsx
+++ b/tests/pages/users/UserPermissionsPage.test.tsx
@@ -1,0 +1,431 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createUserPermissionsClientStub,
+  ID_PERM_ROLES_LIST,
+  ID_PERM_USERS_LIST,
+  ID_PERM_USERS_UPDATE,
+  ID_ROLE_ADMIN,
+  ID_SYS_AUTH,
+  ID_SYS_KURTTO,
+  ID_USER,
+  makeEffective,
+  makePagedPermissions,
+  makePermission,
+  primeStubResponses,
+  renderUserPermissionsPage,
+  waitForInitialFetch,
+} from './__helpers__/userPermissionsTestHelpers';
+
+import { ToastProvider } from '@/components/ui';
+import { UserPermissionsShellPage } from '@/pages/users';
+
+/**
+ * Helper que cria uma Promise que nunca resolve. Necessário para
+ * simular um fetch travado (loading state) — `() => {}` em arrow
+ * function dispara o lint `no-empty-function`. Wrapper documentado
+ * mantém a intenção legível e satisfaz a regra.
+ */
+const NEVER_RESOLVES = (): Promise<never> => new Promise<never>(() => undefined);
+
+/**
+ * Suíte da `UserPermissionsShellPage` (Issue #70).
+ *
+ * Cobre: estados de loading, erro, vazio, render do agrupamento por
+ * sistema, distinção visual direta vs herdada, diff client-side ao
+ * salvar (assign + remove em paralelo), tratamento de :id inválido,
+ * e tratamento de falha parcial no salvar.
+ *
+ * Stub do `ApiClient` injetado via prop `client` — espelha o pattern
+ * de `RolesPage`/`RoutesPage`. Roteador configurado para
+ * `/usuarios/:id/permissoes` para que `useParams` devolva o id real.
+ */
+
+describe('UserPermissionsShellPage — :id inválido', () => {
+  it('exibe InvalidIdNotice quando :id é só whitespace', () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client);
+
+    render(
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/usuarios/%20/permissoes']}>
+          <Routes>
+            <Route
+              path="/usuarios/:id/permissoes"
+              element={<UserPermissionsShellPage client={client} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>,
+    );
+
+    expect(screen.getByTestId('user-permissions-invalid-id')).toBeInTheDocument();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserPermissionsShellPage — loading e erro inicial', () => {
+  it('exibe spinner enquanto as requests não retornam', () => {
+    const client = createUserPermissionsClientStub();
+    // Mock que nunca resolve (Promise pendente) — mantém o spinner visível.
+    client.get.mockImplementation(NEVER_RESOLVES);
+
+    renderUserPermissionsPage(client);
+
+    expect(screen.getByTestId('user-permissions-loading')).toBeInTheDocument();
+  });
+
+  it('exibe ErrorRetryBlock quando catálogo falha', async () => {
+    const client = createUserPermissionsClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/permissions')) {
+        return Promise.reject({
+          kind: 'http',
+          status: 500,
+          message: 'Falha interna no servidor.',
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByText('Falha interna no servidor.')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('user-permissions-retry')).toBeInTheDocument();
+  });
+
+  it('retry refaz fetch e renderiza grupo após sucesso', async () => {
+    const client = createUserPermissionsClientStub();
+    let attempt = 0;
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/permissions')) {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.reject({
+            kind: 'network',
+            message: 'Falha de conexão.',
+          });
+        }
+        return Promise.resolve(makePagedPermissions([makePermission()]));
+      }
+      return Promise.resolve([]);
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-permissions-retry')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('user-permissions-retry'));
+
+    await waitForInitialFetch();
+    expect(screen.getByTestId('user-permissions-group-authenticator')).toBeInTheDocument();
+  });
+});
+
+describe('UserPermissionsShellPage — render do catálogo', () => {
+  it('renderiza grupos por sistema, ordenados por systemCode', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({
+          id: 'p-kurtto',
+          systemId: ID_SYS_KURTTO,
+          systemCode: 'kurtto',
+          systemName: 'Kurtto',
+          routeCode: 'KURTTO_V1_FOO',
+          routeName: 'Foo',
+        }),
+        makePermission({
+          id: ID_PERM_USERS_LIST,
+          systemId: ID_SYS_AUTH,
+          systemCode: 'authenticator',
+          systemName: 'Authenticator',
+        }),
+      ]),
+      effective: [],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const groups = screen.getAllByLabelText(
+      /permissões neste sistema/i,
+    );
+    expect(groups).toHaveLength(2);
+    // Ambos os grupos visíveis — a ordem alfabética coloca 'authenticator' antes de 'kurtto'.
+    expect(screen.getByTestId('user-permissions-group-authenticator')).toBeInTheDocument();
+    expect(screen.getByTestId('user-permissions-group-kurtto')).toBeInTheDocument();
+  });
+
+  it('exibe estado vazio quando o catálogo é vazio', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([]),
+      effective: [],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    expect(screen.getByTestId('user-permissions-empty')).toBeInTheDocument();
+  });
+
+  it('marca permissão direta atualmente atribuída com badge "Direta"', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_USERS_LIST }),
+      ]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_LIST })],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(`user-permissions-item-${ID_PERM_USERS_LIST}`);
+    expect(item).toHaveTextContent('Direta');
+  });
+
+  it('marca permissão herdada via role com badge "Herdada · <Role>"', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_ROLES_LIST }),
+      ]),
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_ROLES_LIST,
+          sources: [
+            {
+              kind: 'role',
+              roleId: ID_ROLE_ADMIN,
+              roleCode: 'admin',
+              roleName: 'Administrator',
+            },
+          ],
+        }),
+      ],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(`user-permissions-item-${ID_PERM_ROLES_LIST}`);
+    expect(item).toHaveTextContent(/Herdada · Administrator/);
+  });
+
+  it('checkbox vem desmarcado quando permissão não é direta', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_USERS_UPDATE }),
+      ]),
+      effective: [],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-permissions-checkbox-${ID_PERM_USERS_UPDATE}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('checkbox vem marcado quando permissão é direta', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_USERS_LIST }),
+      ]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_LIST })],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-permissions-checkbox-${ID_PERM_USERS_LIST}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+});
+
+describe('UserPermissionsShellPage — interação e diff client-side', () => {
+  it('botão Salvar fica desabilitado quando não há mudanças', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([makePermission({ id: ID_PERM_USERS_LIST })]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_LIST })],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const save = screen.getByTestId('user-permissions-save') as HTMLButtonElement;
+    expect(save).toBeDisabled();
+  });
+
+  it('marcar uma permissão habilita Salvar e mostra "Adição pendente"', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([makePermission({ id: ID_PERM_USERS_UPDATE })]),
+      effective: [],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-permissions-checkbox-${ID_PERM_USERS_UPDATE}`,
+    );
+    fireEvent.click(checkbox);
+
+    expect(screen.getByTestId('user-permissions-save')).not.toBeDisabled();
+    expect(
+      screen.getByTestId(`user-permissions-item-${ID_PERM_USERS_UPDATE}`),
+    ).toHaveTextContent('Adição pendente');
+  });
+
+  it('desmarcar uma permissão direta mostra "Remoção pendente"', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([makePermission({ id: ID_PERM_USERS_LIST })]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_LIST })],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    fireEvent.click(
+      screen.getByTestId(`user-permissions-checkbox-${ID_PERM_USERS_LIST}`),
+    );
+
+    expect(
+      screen.getByTestId(`user-permissions-item-${ID_PERM_USERS_LIST}`),
+    ).toHaveTextContent('Remoção pendente');
+  });
+
+  it('Descartar alterações volta o checkbox ao estado original', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([makePermission({ id: ID_PERM_USERS_UPDATE })]),
+      effective: [],
+    });
+
+    renderUserPermissionsPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-permissions-checkbox-${ID_PERM_USERS_UPDATE}`,
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+
+    fireEvent.click(screen.getByTestId('user-permissions-reset'));
+    expect(checkbox.checked).toBe(false);
+    expect(screen.getByTestId('user-permissions-save')).toBeDisabled();
+  });
+});
+
+describe('UserPermissionsShellPage — salvar diff', () => {
+  it('chama assign apenas para adições e remove apenas para remoções', async () => {
+    const client = createUserPermissionsClientStub();
+    // Catálogo com 2 permissões: USERS_LIST (estará marcada) e USERS_UPDATE
+    // (será desmarcada). Effective tem só USERS_UPDATE como direta —
+    // depois do click esperamos: toAdd=[USERS_LIST], toRemove=[USERS_UPDATE].
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_USERS_LIST }),
+        makePermission({
+          id: ID_PERM_USERS_UPDATE,
+          routeCode: 'AUTH_V1_USERS_UPDATE',
+          routeName: 'Atualizar usuário',
+          permissionTypeCode: 'Update',
+          permissionTypeName: 'Edição',
+        }),
+      ]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_UPDATE })],
+    });
+    client.post.mockResolvedValue({
+      id: 'link-1',
+      userId: ID_USER,
+      permissionId: ID_PERM_USERS_LIST,
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z',
+      deletedAt: null,
+    });
+    client.delete.mockResolvedValue(undefined);
+
+    renderUserPermissionsPage(client);
+    await waitForInitialFetch();
+
+    // marca USERS_LIST
+    fireEvent.click(
+      screen.getByTestId(`user-permissions-checkbox-${ID_PERM_USERS_LIST}`),
+    );
+    // desmarca USERS_UPDATE
+    fireEvent.click(
+      screen.getByTestId(`user-permissions-checkbox-${ID_PERM_USERS_UPDATE}`),
+    );
+
+    fireEvent.click(screen.getByTestId('user-permissions-save'));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledTimes(1);
+      expect(client.delete).toHaveBeenCalledTimes(1);
+    });
+
+    const [postPath, postBody] = client.post.mock.calls[0];
+    expect(postPath).toBe(`/users/${ID_USER}/permissions`);
+    expect(postBody).toEqual({ permissionId: ID_PERM_USERS_LIST });
+
+    expect(client.delete.mock.calls[0][0]).toBe(
+      `/users/${ID_USER}/permissions/${ID_PERM_USERS_UPDATE}`,
+    );
+  });
+
+  it('falha pontual no assign não aborta o lote (remove ainda é executado)', async () => {
+    const client = createUserPermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({ id: ID_PERM_USERS_LIST }),
+        makePermission({
+          id: ID_PERM_USERS_UPDATE,
+          routeCode: 'AUTH_V1_USERS_UPDATE',
+          permissionTypeCode: 'Update',
+        }),
+      ]),
+      effective: [makeEffective({ permissionId: ID_PERM_USERS_UPDATE })],
+    });
+    client.post.mockRejectedValue({
+      kind: 'http',
+      status: 400,
+      message: 'PermissionId inválido.',
+    });
+    client.delete.mockResolvedValue(undefined);
+
+    renderUserPermissionsPage(client);
+    await waitForInitialFetch();
+
+    fireEvent.click(
+      screen.getByTestId(`user-permissions-checkbox-${ID_PERM_USERS_LIST}`),
+    );
+    fireEvent.click(
+      screen.getByTestId(`user-permissions-checkbox-${ID_PERM_USERS_UPDATE}`),
+    );
+    fireEvent.click(screen.getByTestId('user-permissions-save'));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledTimes(1);
+      expect(client.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/pages/users/__helpers__/userPermissionsTestHelpers.tsx
+++ b/tests/pages/users/__helpers__/userPermissionsTestHelpers.tsx
@@ -1,0 +1,172 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import type {
+  ApiClient,
+  EffectivePermissionDto,
+  PagedResponse,
+  PermissionDto,
+} from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { UserPermissionsShellPage } from '@/pages/users';
+
+/**
+ * Helpers compartilhados pela suíte da `UserPermissionsShellPage`
+ * (Issue #70). Espelha o pattern `routesTestHelpers.tsx`/
+ * `rolesTestHelpers.tsx` (lição PR #128 — projetar shared helpers
+ * desde o primeiro PR do recurso). A tela tem 3 fontes de dados
+ * (`listPermissions`, `listEffectiveUserPermissions`, e as duas
+ * mutações `assign`/`remove`), então o stub pré-configura todos os
+ * `client.get/post/delete` em estado feliz e os testes só
+ * sobrescrevem o que importa por cenário.
+ */
+
+export const ID_USER = '11111111-1111-1111-1111-111111111111';
+export const ID_PERM_USERS_LIST = '22222222-2222-2222-2222-222222222222';
+export const ID_PERM_USERS_UPDATE = '33333333-3333-3333-3333-333333333333';
+export const ID_PERM_ROLES_LIST = '44444444-4444-4444-4444-444444444444';
+export const ID_SYS_AUTH = '55555555-5555-5555-5555-555555555555';
+export const ID_SYS_KURTTO = '66666666-6666-6666-6666-666666666666';
+export const ID_ROLE_ADMIN = '77777777-7777-7777-7777-777777777777';
+
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createUserPermissionsClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+export function makePermission(overrides: Partial<PermissionDto> = {}): PermissionDto {
+  return {
+    id: ID_PERM_USERS_LIST,
+    routeId: 'route-uuid',
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    systemId: ID_SYS_AUTH,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    permissionTypeId: 'pt-uuid',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    description: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+export function makePagedPermissions(
+  items: ReadonlyArray<PermissionDto>,
+  overrides: Partial<PagedResponse<PermissionDto>> = {},
+): PagedResponse<PermissionDto> {
+  return {
+    data: items,
+    page: 1,
+    pageSize: 100,
+    total: items.length,
+    ...overrides,
+  };
+}
+
+export function makeEffective(
+  overrides: Partial<EffectivePermissionDto> = {},
+): EffectivePermissionDto {
+  return {
+    permissionId: ID_PERM_USERS_LIST,
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    systemId: ID_SYS_AUTH,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    sources: [{ kind: 'direct' }],
+    ...overrides,
+  };
+}
+
+interface SetupOptions {
+  /** Catálogo devolvido pelo `listPermissions`. */
+  catalog?: PagedResponse<PermissionDto>;
+  /** Permissões efetivas do usuário. */
+  effective?: ReadonlyArray<EffectivePermissionDto>;
+}
+
+/**
+ * Configura o stub para retornar catálogo + effective em estado feliz.
+ * A página dispara as duas requests em paralelo no mount; este helper
+ * resolve ambas via `mockImplementation` baseado na URL para evitar
+ * acoplar o teste à ordem de chamadas.
+ */
+export function primeStubResponses(
+  client: ApiClientStub,
+  options: SetupOptions = {},
+): void {
+  const catalog = options.catalog ?? makePagedPermissions([makePermission()]);
+  const effective = options.effective ?? [makeEffective()];
+
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith('/permissions')) {
+      return Promise.resolve(catalog);
+    }
+    if (path.includes('/effective-permissions')) {
+      return Promise.resolve(effective);
+    }
+    return Promise.reject(
+      Object.assign(new Error('URL stub não esperada: ' + path), {
+        kind: 'http',
+        status: 404,
+      }),
+    );
+  });
+}
+
+export function renderUserPermissionsPage(
+  client: ApiClientStub,
+  userId: string = ID_USER,
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[`/usuarios/${userId}/permissoes`]}>
+        <Routes>
+          <Route
+            path="/usuarios/:id/permissoes"
+            element={<UserPermissionsShellPage client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a finalização do mount: o spinner de loading desaparece
+ * quando ambas as promises (catálogo + effective) resolvem. Centraliza
+ * o pattern para reduzir boilerplate por teste.
+ */
+export async function waitForInitialFetch(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.queryByTestId('user-permissions-loading')).not.toBeInTheDocument();
+  });
+}

--- a/tests/pages/users/userPermissionsHelpers.test.ts
+++ b/tests/pages/users/userPermissionsHelpers.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  EffectivePermissionDto,
+  PermissionDto,
+} from '@/shared/api';
+
+import {
+  buildInitialDirectPermissionIds,
+  buildRoleMembershipsByPermission,
+  computeAssignmentDiff,
+  diffHasChanges,
+  groupPermissionsBySystem,
+} from '@/pages/users/userPermissionsHelpers';
+
+/**
+ * Suíte dos helpers puros que sustentam a tela de atribuição direta de
+ * permissões (Issue #70). Helpers vivem fora do componente para que a
+ * cobertura seja barata (sem DOM, sem providers) e para que outros
+ * call sites futuros (PermissionsListShellPage com mesmo agrupamento
+ * por sistema) reusem sem custo — lição PR #128 sobre projetar
+ * shared helpers desde o primeiro PR do recurso.
+ */
+
+function makePermission(overrides: Partial<PermissionDto> = {}): PermissionDto {
+  return {
+    id: 'p-1',
+    routeId: 'r-1',
+    routeCode: 'A_ROUTE',
+    routeName: 'Rota A',
+    systemId: 's-1',
+    systemCode: 'auth',
+    systemName: 'Authenticator',
+    permissionTypeId: 'pt-1',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    description: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeEffective(
+  overrides: Partial<EffectivePermissionDto> = {},
+): EffectivePermissionDto {
+  return {
+    permissionId: 'p-1',
+    routeCode: 'A_ROUTE',
+    routeName: 'Rota A',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    systemId: 's-1',
+    systemCode: 'auth',
+    systemName: 'Authenticator',
+    sources: [{ kind: 'direct' }],
+    ...overrides,
+  };
+}
+
+describe('groupPermissionsBySystem', () => {
+  it('agrupa por systemCode e ordena por systemCode', () => {
+    const result = groupPermissionsBySystem([
+      makePermission({ id: 'p-k', systemId: 's-k', systemCode: 'kurtto', systemName: 'Kurtto', routeCode: 'K_ROUTE' }),
+      makePermission({ id: 'p-a', systemId: 's-a', systemCode: 'auth', systemName: 'Authenticator' }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0].systemCode).toBe('auth');
+    expect(result[1].systemCode).toBe('kurtto');
+  });
+
+  it('ordena permissões por routeCode → permissionTypeCode dentro do grupo', () => {
+    const result = groupPermissionsBySystem([
+      makePermission({ id: 'p-2', routeCode: 'B_ROUTE', permissionTypeCode: 'Read' }),
+      makePermission({ id: 'p-1', routeCode: 'A_ROUTE', permissionTypeCode: 'Update' }),
+      makePermission({ id: 'p-3', routeCode: 'A_ROUTE', permissionTypeCode: 'Read' }),
+    ]);
+    const [group] = result;
+    expect(group.permissions.map((p) => p.id)).toEqual(['p-3', 'p-1', 'p-2']);
+  });
+
+  it('move permissões com sistema vazio para o final ("Sem sistema")', () => {
+    const result = groupPermissionsBySystem([
+      makePermission({
+        id: 'p-orphan',
+        systemCode: '',
+        systemName: '',
+        systemId: '',
+      }),
+      makePermission({ id: 'p-auth', systemCode: 'auth' }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0].systemCode).toBe('auth');
+    expect(result[1].systemCode).toBe('—');
+    expect(result[1].systemName).toBe('Sem sistema');
+  });
+
+  it('lista vazia devolve array vazio', () => {
+    expect(groupPermissionsBySystem([])).toEqual([]);
+  });
+});
+
+describe('buildInitialDirectPermissionIds', () => {
+  it('captura apenas permissões com source kind=direct', () => {
+    const set = buildInitialDirectPermissionIds([
+      makeEffective({ permissionId: 'p-direct', sources: [{ kind: 'direct' }] }),
+      makeEffective({
+        permissionId: 'p-role',
+        sources: [
+          {
+            kind: 'role',
+            roleId: 'r-1',
+            roleCode: 'admin',
+            roleName: 'Admin',
+          },
+        ],
+      }),
+      makeEffective({
+        permissionId: 'p-both',
+        sources: [
+          { kind: 'direct' },
+          { kind: 'role', roleId: 'r-2', roleCode: 'viewer', roleName: 'Viewer' },
+        ],
+      }),
+    ]);
+    expect(set.has('p-direct')).toBe(true);
+    expect(set.has('p-role')).toBe(false);
+    expect(set.has('p-both')).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it('lista vazia devolve set vazio', () => {
+    expect(buildInitialDirectPermissionIds([]).size).toBe(0);
+  });
+});
+
+describe('buildRoleMembershipsByPermission', () => {
+  it('lista as roles que herdam cada permissão, ordenadas por roleCode', () => {
+    const map = buildRoleMembershipsByPermission([
+      makeEffective({
+        permissionId: 'p-x',
+        sources: [
+          { kind: 'role', roleId: 'r-2', roleCode: 'viewer', roleName: 'Viewer' },
+          { kind: 'role', roleId: 'r-1', roleCode: 'admin', roleName: 'Admin' },
+        ],
+      }),
+    ]);
+    const roles = map.get('p-x');
+    expect(roles).toBeDefined();
+    expect(roles).toHaveLength(2);
+    expect(roles?.[0].roleCode).toBe('admin');
+    expect(roles?.[1].roleCode).toBe('viewer');
+  });
+
+  it('ignora permissões com source apenas direct', () => {
+    const map = buildRoleMembershipsByPermission([
+      makeEffective({ permissionId: 'p-x', sources: [{ kind: 'direct' }] }),
+    ]);
+    expect(map.has('p-x')).toBe(false);
+  });
+
+  it('ignora sources de role sem roleId/roleCode/roleName', () => {
+    const map = buildRoleMembershipsByPermission([
+      makeEffective({
+        permissionId: 'p-y',
+        sources: [
+          { kind: 'role', roleId: null, roleCode: null, roleName: null },
+        ],
+      }),
+    ]);
+    expect(map.has('p-y')).toBe(false);
+  });
+});
+
+describe('computeAssignmentDiff', () => {
+  it('toAdd lista permissões novas; toRemove lista removidas', () => {
+    const original = new Set(['a', 'b']);
+    const selected = new Set(['b', 'c']);
+    const diff = computeAssignmentDiff(original, selected);
+    expect(diff.toAdd).toEqual(['c']);
+    expect(diff.toRemove).toEqual(['a']);
+  });
+
+  it('estados iguais geram diff vazio', () => {
+    const original = new Set(['a', 'b']);
+    const selected = new Set(['a', 'b']);
+    const diff = computeAssignmentDiff(original, selected);
+    expect(diff.toAdd).toEqual([]);
+    expect(diff.toRemove).toEqual([]);
+    expect(diffHasChanges(diff)).toBe(false);
+  });
+
+  it('diff com mudanças retorna diffHasChanges=true', () => {
+    expect(
+      diffHasChanges(computeAssignmentDiff(new Set(['a']), new Set(['b']))),
+    ).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'apenas adições',
+      original: ['a'],
+      selected: ['a', 'b', 'c'],
+      toAdd: ['b', 'c'],
+      toRemove: [],
+    },
+    {
+      name: 'apenas remoções',
+      original: ['a', 'b', 'c'],
+      selected: ['a'],
+      toAdd: [],
+      toRemove: ['b', 'c'],
+    },
+    {
+      name: 'add e remove simultâneos',
+      original: ['a', 'b'],
+      selected: ['c', 'd'],
+      toAdd: ['c', 'd'],
+      toRemove: ['a', 'b'],
+    },
+  ])('cenário "$name"', ({ original, selected, toAdd, toRemove }) => {
+    const diff = computeAssignmentDiff(new Set(original), new Set(selected));
+    expect(diff.toAdd).toEqual(toAdd);
+    expect(diff.toRemove).toEqual(toRemove);
+  });
+});

--- a/tests/shared/api/permissions.test.ts
+++ b/tests/shared/api/permissions.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ApiClient,
+  EffectivePermissionDto,
+  PermissionDto,
+} from '@/shared/api';
+
+import {
+  assignPermissionToUser,
+  isPagedPermissionsResponse,
+  isPermissionDto,
+  listEffectiveUserPermissions,
+  listPermissions,
+  removePermissionFromUser,
+} from '@/shared/api';
+
+/**
+ * Suíte do módulo `src/shared/api/permissions.ts` (Issue #70, EPIC #48).
+ *
+ * Estratégia: stubar o `ApiClient` injetado e validar paths, body,
+ * type guards e propagação de `ApiError`. Não bate em `fetch` —
+ * cobertura de transporte HTTP é responsabilidade dos testes em
+ * `client.test.ts`. Replica o pattern de `tests/shared/api/roles.test.ts`
+ * para reduzir custo cognitivo e permitir `it.each` de cenários
+ * compartilhados quando aplicável.
+ *
+ * Cobre:
+ *
+ * - `isPermissionDto` (campos enriquecidos do backend lfc-authenticator#165:
+ *   `routeCode`/`routeName`/`systemId`/`systemCode`/`systemName`/
+ *   `permissionTypeCode`/`permissionTypeName`).
+ * - `isPagedPermissionsResponse` (envelope paginado).
+ * - `listPermissions` (paths + querystring).
+ * - `listEffectiveUserPermissions` (path + parsing do array de
+ *   `EffectivePermissionResponse` com `sources`).
+ * - `assignPermissionToUser` (POST `/users/{id}/permissions`).
+ * - `removePermissionFromUser` (DELETE `/users/{id}/permissions/{permissionId}`).
+ */
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const PERM_ID = '22222222-2222-2222-2222-222222222222';
+const SYS_ID = '33333333-3333-3333-3333-333333333333';
+const ROLE_ID = '44444444-4444-4444-4444-444444444444';
+
+interface ClientStub {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): ClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  };
+}
+
+function makePermissionDto(overrides: Partial<PermissionDto> = {}): PermissionDto {
+  return {
+    id: PERM_ID,
+    routeId: 'route-uuid',
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    systemId: SYS_ID,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    permissionTypeId: 'pt-uuid',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    description: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeEffective(
+  overrides: Partial<EffectivePermissionDto> = {},
+): EffectivePermissionDto {
+  return {
+    permissionId: PERM_ID,
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    systemId: SYS_ID,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    sources: [{ kind: 'direct' }],
+    ...overrides,
+  };
+}
+
+describe('isPermissionDto', () => {
+  it('aceita payload completo enriquecido (lfc-authenticator#165)', () => {
+    expect(isPermissionDto(makePermissionDto())).toBe(true);
+  });
+
+  it('aceita description/deletedAt ausentes ou null', () => {
+    expect(isPermissionDto(makePermissionDto({ description: null, deletedAt: null }))).toBe(true);
+    const dto = makePermissionDto();
+    const { description: _d, deletedAt: _del, ...lean } = dto;
+    expect(isPermissionDto(lean)).toBe(true);
+  });
+
+  it('aceita strings vazias nos campos denormalizados (LEFT JOIN sem match)', () => {
+    expect(
+      isPermissionDto(
+        makePermissionDto({
+          routeCode: '',
+          routeName: '',
+          systemCode: '',
+          systemName: '',
+          permissionTypeCode: '',
+          permissionTypeName: '',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejeita objetos sem campos obrigatórios', () => {
+    expect(isPermissionDto(null)).toBe(false);
+    expect(isPermissionDto(undefined)).toBe(false);
+    expect(isPermissionDto({})).toBe(false);
+    const missing = makePermissionDto();
+    delete (missing as Partial<PermissionDto>).routeCode;
+    expect(isPermissionDto(missing)).toBe(false);
+  });
+
+  it('rejeita campos com tipos inválidos', () => {
+    expect(
+      isPermissionDto(makePermissionDto({ description: 0 as unknown as string })),
+    ).toBe(false);
+    expect(
+      isPermissionDto(makePermissionDto({ deletedAt: 1 as unknown as string })),
+    ).toBe(false);
+  });
+});
+
+describe('isPagedPermissionsResponse', () => {
+  it('aceita envelope válido com itens', () => {
+    expect(
+      isPagedPermissionsResponse({
+        data: [makePermissionDto()],
+        page: 1,
+        pageSize: 100,
+        total: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('aceita envelope vazio', () => {
+    expect(
+      isPagedPermissionsResponse({
+        data: [],
+        page: 1,
+        pageSize: 100,
+        total: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejeita envelope sem campos obrigatórios', () => {
+    expect(isPagedPermissionsResponse(null)).toBe(false);
+    expect(isPagedPermissionsResponse({ data: [] })).toBe(false);
+    expect(
+      isPagedPermissionsResponse({ data: [], page: '1', pageSize: 20, total: 0 }),
+    ).toBe(false);
+  });
+
+  it('rejeita envelope com itens inválidos', () => {
+    expect(
+      isPagedPermissionsResponse({
+        data: [{ broken: true }],
+        page: 1,
+        pageSize: 20,
+        total: 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('listPermissions', () => {
+  it('emite GET /permissions sem querystring quando params são default', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [makePermissionDto()],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+    });
+
+    await listPermissions({}, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe('/permissions');
+  });
+
+  it('inclui systemId/routeId/permissionTypeId/q/page/pageSize/includeDeleted na querystring', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 2,
+      pageSize: 50,
+      total: 0,
+    });
+
+    await listPermissions(
+      {
+        systemId: SYS_ID,
+        routeId: 'route-1',
+        permissionTypeId: 'pt-1',
+        q: '  buscar  ',
+        page: 2,
+        pageSize: 50,
+        includeDeleted: true,
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const path = client.get.mock.calls[0][0] as string;
+    const search = new URLSearchParams(path.replace('/permissions', ''));
+    expect(search.get('systemId')).toBe(SYS_ID);
+    expect(search.get('routeId')).toBe('route-1');
+    expect(search.get('permissionTypeId')).toBe('pt-1');
+    expect(search.get('q')).toBe('buscar');
+    expect(search.get('page')).toBe('2');
+    expect(search.get('pageSize')).toBe('50');
+    expect(search.get('includeDeleted')).toBe('true');
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({
+      data: [],
+      page: 1,
+      pageSize: 20,
+      total: 0,
+    });
+    const controller = new AbortController();
+
+    await listPermissions(
+      { systemId: SYS_ID },
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      listPermissions({}, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga rejeições do cliente sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 401, message: 'Sessão expirada.' };
+    client.get.mockRejectedValueOnce(apiError);
+
+    await expect(
+      listPermissions({}, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+});
+
+describe('listEffectiveUserPermissions', () => {
+  it('emite GET /users/{id}/effective-permissions sem querystring por default', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([makeEffective()]);
+
+    const result = await listEffectiveUserPermissions(
+      USER_ID,
+      undefined,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe(`/users/${USER_ID}/effective-permissions`);
+    expect(result).toHaveLength(1);
+    expect(result[0].permissionId).toBe(PERM_ID);
+  });
+
+  it('inclui systemId quando informado', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([]);
+
+    await listEffectiveUserPermissions(
+      USER_ID,
+      SYS_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(
+      `/users/${USER_ID}/effective-permissions?systemId=${SYS_ID}`,
+    );
+  });
+
+  it('aceita sources com kind=direct e kind=role no mesmo permissionId', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeEffective({
+        sources: [
+          { kind: 'direct' },
+          { kind: 'role', roleId: ROLE_ID, roleCode: 'admin', roleName: 'Admin' },
+        ],
+      }),
+    ]);
+
+    const result = await listEffectiveUserPermissions(
+      USER_ID,
+      undefined,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result[0].sources).toHaveLength(2);
+    expect(result[0].sources[0].kind).toBe('direct');
+    expect(result[0].sources[1].kind).toBe('role');
+    expect(result[0].sources[1].roleCode).toBe('admin');
+  });
+
+  it('lança ApiError(parse) quando o backend devolve não-array', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ broken: true });
+
+    await expect(
+      listEffectiveUserPermissions(
+        USER_ID,
+        undefined,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('lança ApiError(parse) quando algum item tem source com kind inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      makeEffective({
+        sources: [{ kind: 'unknown' as unknown as 'direct' }],
+      }),
+    ]);
+
+    await expect(
+      listEffectiveUserPermissions(
+        USER_ID,
+        undefined,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('assignPermissionToUser', () => {
+  it('emite POST /users/{id}/permissions com permissionId no body', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({
+      id: 'link-uuid',
+      userId: USER_ID,
+      permissionId: PERM_ID,
+      createdAt: '2026-05-01T12:00:00Z',
+      updatedAt: '2026-05-01T12:00:00Z',
+      deletedAt: null,
+    });
+
+    const result = await assignPermissionToUser(
+      USER_ID,
+      PERM_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    const [path, body] = client.post.mock.calls[0];
+    expect(path).toBe(`/users/${USER_ID}/permissions`);
+    expect(body).toEqual({ permissionId: PERM_ID });
+    expect(result.permissionId).toBe(PERM_ID);
+  });
+
+  it('lança ApiError(parse) quando a resposta não é UserPermissionLink válido', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      assignPermissionToUser(USER_ID, PERM_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 400 do backend (permissionId inválido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 400, message: 'PermissionId inválido.' };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      assignPermissionToUser(USER_ID, PERM_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+});
+
+describe('removePermissionFromUser', () => {
+  it('emite DELETE /users/{id}/permissions/{permissionId} e resolve void', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    await expect(
+      removePermissionFromUser(
+        USER_ID,
+        PERM_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).resolves.toBeUndefined();
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete.mock.calls[0][0]).toBe(
+      `/users/${USER_ID}/permissions/${PERM_ID}`,
+    );
+  });
+
+  it('propaga 404 do backend (vínculo não encontrado) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = { kind: 'http', status: 404, message: 'Vínculo não encontrado.' };
+    client.delete.mockRejectedValueOnce(apiError);
+
+    await expect(
+      removePermissionFromUser(
+        USER_ID,
+        PERM_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toEqual(apiError);
+  });
+});


### PR DESCRIPTION
## Contexto

Issue #70 (EPIC #48 — Permissões). Backend do `lfc-authenticator` já entregou os contratos enriquecidos (#163-#169): `PermissionResponse` com denormalizações `routeCode`/`routeName`/`systemId`/`systemCode`/`systemName`/`permissionTypeCode`/`permissionTypeName`, paginação nativa em `GET /permissions`, `GET /users/{id}/effective-permissions` com `sources: [{kind: 'direct'}, {kind: 'role', roleId, roleCode, roleName}]`, e os endpoints `POST /users/{id}/permissions` + `DELETE /users/{id}/permissions/{permissionId}`.

## Objetivo

Fornecer ao admin uma tela em `/usuarios/:id/permissoes` para conceder e revogar permissões diretamente ao usuário, agrupadas por sistema, com diferenciação visual entre permissões diretas (vinculadas direto ao `UserPermission`) e herdadas via role.

## O que foi feito

- **Novo módulo `src/shared/api/permissions.ts`** espelhando `roles.ts`/`routes.ts`:
  - `PermissionDto` enriquecido (lfc-authenticator#165) + type guards `isPermissionDto`/`isPagedPermissionsResponse`.
  - `listPermissions` (`GET /permissions` com filtros `systemId`/`routeId`/`permissionTypeId`/`q`/paginação/`includeDeleted`).
  - `EffectivePermissionDto` + `EffectivePermissionSource` espelhando `UsersController.EffectivePermissionResponse` e `listEffectiveUserPermissions` (`GET /users/{id}/effective-permissions`).
  - `assignPermissionToUser` (`POST /users/{userId}/permissions`) e `removePermissionFromUser` (`DELETE /users/{userId}/permissions/{permissionId}`).
  - Helpers locais `acceptsOptionalString`/`isPagedShape` para reduzir duplicação contra os módulos vizinhos sem refatorar `systems.ts`/`tokenTypes.ts` (fora de escopo).
- **`UserPermissionsShellPage`** promovida de placeholder a tela funcional:
  - Carrega catálogo + permissões efetivas em paralelo com `AbortController`.
  - Lista agrupada por sistema, com checkbox controlado por permissão.
  - Badges visuais "Direta", "Herdada · &lt;Role&gt;", "Adição pendente"/"Remoção pendente" quando o checkbox diverge do estado salvo.
  - Botão "Salvar alterações" calcula diff client-side e dispara `assign`/`remove` em paralelo. Falha pontual não aborta o lote — relatório consolidado por toast.
  - Botão "Descartar alterações" volta o set ao estado original.
  - Estados visuais completos: loading inicial, erro com retry, vazio, hover/focus em todos os interativos.
- **Helpers puros** em `src/pages/users/userPermissionsHelpers.ts` (sem React) para `groupPermissionsBySystem`, `buildInitialDirectPermissionIds`, `buildRoleMembershipsByPermission`, `computeAssignmentDiff`, `diffHasChanges` — testados isoladamente para baixo custo e reuso futuro pela `PermissionsListShellPage` (sub-issue futura).
- **Roteamento** atualizado em `src/routes/index.tsx` com gating duplo (`AUTH_V1_PERMISSIONS_LIST` + `AUTH_V1_USERS_PERMISSIONS_ASSIGN`) via `RequirePermission` aninhado.
- **`tests/pages/shellPages.test.tsx`** atualizado: `UserPermissionsShellPage` removida da tabela de shells genéricos (não é mais shell).

## Arquivos impactados

- `src/shared/api/permissions.ts` (novo)
- `src/shared/api/index.ts` (barrel — exports do novo módulo)
- `src/pages/users/UserPermissionsShellPage.tsx` (promovida a funcional)
- `src/pages/users/userPermissionsHelpers.ts` (novo)
- `src/routes/index.tsx` (gating duplo)
- `tests/shared/api/permissions.test.ts` (novo, 24 testes)
- `tests/pages/users/userPermissionsHelpers.test.ts` (novo, 15 testes)
- `tests/pages/users/UserPermissionsPage.test.tsx` (novo, 16 testes)
- `tests/pages/users/__helpers__/userPermissionsTestHelpers.tsx` (novo, fixtures compartilhadas)
- `tests/pages/shellPages.test.tsx` (remoção de `UserPermissionsShellPage` da tabela)

## Testes

Gate de qualidade pré-PR completo (todos via container Docker):

- `npm run lint`: 0 erros, 0 warnings.
- `npm run typecheck`: 0 erros.
- `npm test`: 49/49 arquivos · **690/690 testes verde**.
- `npx jscpd src --threshold 3 --min-lines 10`: total 2.77% (abaixo do limite 3%); **0 clones em arquivos do diff**.

## Visual

- [x] Cores/tokens conforme design system local (`var(--accent)`, `var(--bg-surface)`, `var(--border-thin)`, etc.) — sem hardcode.
- [x] Espaçamentos consistentes via tokens `--space-N`.
- [x] Hover/focus/disabled tratados via primitives `Button`/`Checkbox`/`EntityCard`.
- [x] Loading/error/empty states presentes.
- [x] Layout validado em mobile/desktop via `@media (min-width: 48em)`.
- [x] Diretório `identity` usado apenas como referência local (não consumido pela página).

## Segurança

Sem impacto de segurança frontend novo: a tela só consome endpoints já gated pelo backend, a UI não renderiza HTML vindo do servidor (sem `dangerouslySetInnerHTML`), e nenhum token/credencial é tocado. O cliente HTTP existente cobre 401 (logout silencioso) e 403 (toast).

## Riscos

- **Regressão local:** mudança no shell `UserPermissionsShellPage` é coberta pela nova suíte dedicada; o teste agregado de shells não inclui mais a página (ver comentário no diff).
- **Cross-repo:** depende do contrato do `lfc-authenticator` (#163-#169). Type guards rejeitam payload divergente com `ApiError(parse)`, garantindo fail-loud em vez de silencioso.
- **Backend evolução:** se o backend devolver `PermissionResponse` sem os campos enriquecidos, `isPermissionDto` falha — comportamento desejado, não há fallback inseguro.

## Issue relacionada

Closes #70