### PR TITLE
feat(roles): editar role com modal pré-populado (#68)

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -1,13 +1,9 @@
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Pencil } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { PageHeader } from "../components/layout/PageHeader";
-import {
-  Alert,
-  Button,
-  Table,
-} from "../components/ui";
+import { Alert, Button, Table } from "../components/ui";
 import { useDebouncedValue } from "../hooks/useDebouncedValue";
 import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
 import { usePaginationControls } from "../hooks/usePaginationControls";
@@ -17,6 +13,7 @@ import {
   DEFAULT_ROLES_PAGE_SIZE,
   listRoles,
 } from "../shared/api";
+import { useAuth } from "../shared/auth";
 import {
   BackLink,
   CardCode,
@@ -41,11 +38,14 @@ import {
   PaginationFooter,
   Placeholder,
   RefetchOverlay,
+  RowActions,
   StatusBadge,
   TableForDesktop,
   TableShell,
   useListingLiveMessage,
 } from "../shared/listing";
+
+import { EditRoleModal } from "./roles/EditRoleModal";
 
 import type { TableColumn } from "../components/ui";
 import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
@@ -58,6 +58,17 @@ import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
  * usado pela `RoutesPage`/`SystemsPage`.
  */
 const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Code de permissão exigido para o botão "Editar" por linha (Issue
+ * #68). Espelha o `AUTH_V1_ROLES_UPDATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`PUT /roles/{id}` valida via
+ * `[Authorize(Policy = PermissionPolicies.RolesUpdate)]`); o gating
+ * client-side é apenas UX — esconder ações que o usuário não pode
+ * executar.
+ */
+const ROLES_UPDATE_PERMISSION = "AUTH_V1_ROLES_UPDATE";
 
 interface RolesPageProps {
   /**
@@ -127,6 +138,9 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   const { systemId } = useParams<{ systemId: string }>();
   const hasValidSystemId = isProbablyValidSystemId(systemId);
 
+  const { hasPermission } = useAuth();
+  const canUpdateRole = hasPermission(ROLES_UPDATE_PERMISSION);
+
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>("");
   const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
@@ -135,6 +149,13 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
     DEFAULT_ROLES_INCLUDE_DELETED,
   );
   const [page, setPage] = useState<number>(DEFAULT_ROLES_PAGE);
+
+  // Role selecionada para edição (Issue #68). Quando definida, abre
+  // o `EditRoleModal` pré-populado com seus dados; `null` mantém o
+  // modal fechado. Manter a role completa (em vez de só o id) evita
+  // round-trip extra para refazer fetch no modal — a tabela já tem
+  // o payload pronto.
+  const [editingRole, setEditingRole] = useState<RoleDto | null>(null);
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -154,6 +175,14 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   const handleIncludeDeletedChange = useCallback((value: boolean) => {
     setIncludeDeleted(value);
     setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleOpenEditModal = useCallback((row: RoleDto) => {
+    setEditingRole(row);
+  }, []);
+
+  const handleCloseEditModal = useCallback(() => {
+    setEditingRole(null);
   }, []);
 
   /**
@@ -256,8 +285,8 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
     );
   }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
 
-  const columns = useMemo<ReadonlyArray<TableColumn<RoleDto>>>(
-    () => [
+  const columns = useMemo<ReadonlyArray<TableColumn<RoleDto>>>(() => {
+    const base: Array<TableColumn<RoleDto>> = [
       {
         key: "name",
         label: "Nome",
@@ -286,9 +315,45 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
         width: "120px",
         render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
       },
-    ],
-    [],
-  );
+    ];
+
+    // Coluna "Ações" só aparece quando o usuário tem alguma ação
+    // disponível. Hoje "Editar" (Issue #68); a paridade total com
+    // Sistemas/Rotas (criar via toolbar, desativar/restaurar) fica
+    // para issues futuras da EPIC #47. Espelha a estratégia do
+    // `RoutesPage`/`SystemsPage`.
+    if (canUpdateRole) {
+      base.push({
+        key: "actions",
+        label: "Ações",
+        isActions: true,
+        render: (row) => (
+          <RowActions>
+            {row.deletedAt === null && (
+              // "Editar" só faz sentido em roles ativas. O backend
+              // devolve 404 ao tentar PUT em role soft-deletada
+              // (`Roles.FirstOrDefaultAsync` cai no query filter
+              // global), mas esconder no UI alinha com a coluna
+              // Status. Espelha a estratégia de `RoutesPage`/
+              // `SystemsPage`.
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Pencil size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenEditModal(row)}
+                aria-label={`Editar role ${row.name}`}
+                data-testid={`roles-edit-${row.id}`}
+              >
+                Editar
+              </Button>
+            )}
+          </RowActions>
+        ),
+      });
+    }
+
+    return base;
+  }, [canUpdateRole, handleOpenEditModal]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -362,7 +427,10 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
       <LiveRegion message={liveMessage} testId="roles-live" />
 
       {isInitialLoading && (
-        <InitialLoadingSpinner testId="roles-loading" label="Carregando roles" />
+        <InitialLoadingSpinner
+          testId="roles-loading"
+          label="Carregando roles"
+        />
       )}
 
       {!isInitialLoading && errorMessage && (
@@ -409,10 +477,30 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
                   )}
                 <CardMeta>
                   <CardMetaTerm>Permissões</CardMetaTerm>
-                  <CardMetaValue>{renderCount(row.permissionsCount)}</CardMetaValue>
+                  <CardMetaValue>
+                    {renderCount(row.permissionsCount)}
+                  </CardMetaValue>
                   <CardMetaTerm>Usuários</CardMetaTerm>
                   <CardMetaValue>{renderCount(row.usersCount)}</CardMetaValue>
                 </CardMeta>
+                {canUpdateRole && row.deletedAt === null && (
+                  // Ações na versão mobile espelham a coluna "Ações"
+                  // do desktop. Só aparecem quando o usuário tem
+                  // permissão e a linha é ativa — coerente com o
+                  // gating da tabela.
+                  <RowActions>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={<Pencil size={14} strokeWidth={1.5} />}
+                      onClick={() => handleOpenEditModal(row)}
+                      aria-label={`Editar role ${row.name}`}
+                      data-testid={`roles-card-edit-${row.id}`}
+                    >
+                      Editar
+                    </Button>
+                  </RowActions>
+                )}
               </EntityCard>
             ))}
           </CardListForMobile>
@@ -432,6 +520,17 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
           pageInfoTestId="roles-page-info"
           prevTestId="roles-prev"
           nextTestId="roles-next"
+        />
+      )}
+
+      {canUpdateRole && hasValidSystemId && (
+        <EditRoleModal
+          open={editingRole !== null}
+          role={editingRole}
+          systemId={systemId}
+          onClose={handleCloseEditModal}
+          onUpdated={handleRefetch}
+          client={client}
         />
       )}
     </>

--- a/src/pages/roles/EditRoleModal.tsx
+++ b/src/pages/roles/EditRoleModal.tsx
@@ -1,0 +1,308 @@
+import React, { useCallback, useEffect, useMemo } from "react";
+
+import { Modal, useToast } from "../../components/ui";
+import { updateRole } from "../../shared/api";
+import {
+  useEditEntitySubmit,
+  type EditEntitySubmitCopy,
+  type EditSubmitActionCopy,
+} from "../../shared/forms";
+
+import { RoleFormBody } from "./RoleFormFields";
+import {
+  type RoleFieldErrors,
+  type RoleFormState,
+  type RoleSubmitErrorCopy,
+} from "./rolesFormShared";
+import { useRoleForm } from "./useRoleForm";
+
+import type { ApiClient, RoleDto } from "../../shared/api";
+
+/**
+ * Copy injetada em `classifyRoleSubmitError` para o caminho de
+ * edição. Os literais aqui são os únicos pontos onde "atualizar"/
+ * "outra role" diferem do "criar"/"uma role" do futuro
+ * `NewRoleModal` — o resto da lógica de classificação é
+ * compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: RoleSubmitErrorCopy = {
+  conflictDefault: "Já existe outra role com este código.",
+  forbiddenTitle: "Falha ao atualizar role",
+  genericFallback: "Não foi possível atualizar a role. Tente novamente.",
+};
+
+/** Texto exibido inline no campo `code` quando o backend devolve 409. */
+const CONFLICT_INLINE_MESSAGE =
+  "Já existe outra role com este código neste sistema.";
+
+/** Texto exibido em toast quando a role some entre abertura e submit (404). */
+const NOT_FOUND_MESSAGE =
+  "Role não encontrada ou foi removida. Atualize a lista.";
+
+/**
+ * Cópia textual injetada em `applyEditSubmitAction`. Concentra os
+ * literais que diferem entre `EditRoleModal` e os demais modals de
+ * edição (`EditSystemModal`/`EditRouteModal`) sem duplicar o switch
+ * de dispatch — lição PR #128/#134/#135 reforçada.
+ */
+const EDIT_SUBMIT_ACTION_COPY: EditSubmitActionCopy = {
+  conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+  notFoundMessage: NOT_FOUND_MESSAGE,
+  forbiddenTitle: SUBMIT_ERROR_COPY.forbiddenTitle,
+};
+
+interface EditRoleModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Role sendo editada. Pré-popula o form e fornece o `id` usado no
+   * `PUT /roles/{id}`. Quando `null`, o modal não renderiza —
+   * caller é responsável por só passar `role` quando `open=true`.
+   *
+   * Os campos visíveis (`Name`/`Code`/`Description`) vêm do
+   * `RoleResponse` enriquecido em `lfc-authenticator#163`/`#164`.
+   * Para roles que ainda não receberam `Description` no backend
+   * (cenário transitório), o valor `null`/`undefined` vira string
+   * vazia no form (mesma estratégia do `EditSystemModal`/
+   * `EditRouteModal`).
+   */
+  role: RoleDto | null;
+  /**
+   * UUID do sistema dono da role — vem da URL
+   * `/systems/:systemId/roles`. Repassado ao
+   * `prepareSubmit(systemId)` para construir o body do PUT
+   * (`UpdateRoleRequest.SystemId` é `[Required]` no backend após
+   * o enriquecimento; tentar omitir devolve 400). O backend rejeita
+   * tentativas de mudar o `SystemId` (imutável após criação) com
+   * 400 "SystemId é imutável após a criação do role." — daí a UI
+   * **nunca** expõe o campo no form e sempre repassa o valor
+   * imutável.
+   */
+  systemId: string;
+  /** Fecha o modal sem persistir. Chamada também após sucesso ou 404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após atualização bem-sucedida ou após
+   * detecção de 404 (role já removida) — em ambos casos a UI quer
+   * refetch para sincronizar a tabela com o estado real do backend.
+   */
+  onUpdated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção,
+   * omitido, `updateRole` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Constrói o estado inicial do form a partir de uma `RoleDto`.
+ * `description: null` (do backend quando vazio) vira string vazia
+ * para que o input controlado nunca receba `null`/`undefined` —
+ * preserva paridade com o `INITIAL_ROLE_FORM_STATE` do create.
+ */
+function stateFromRole(role: RoleDto): RoleFormState {
+  return {
+    name: role.name,
+    code: role.code,
+    description: role.description ?? "",
+  };
+}
+
+const EMPTY_INITIAL_STATE: RoleFormState = {
+  name: "",
+  code: "",
+  description: "",
+};
+
+/* ─── Component ──────────────────────────────────────────── */
+
+/**
+ * Modal de edição de role (Issue #68).
+ *
+ * Espelha a forma de `EditSystemModal`/`EditRouteModal` (mesma
+ * estrutura visual, validação, mapeamento de erros) com três
+ * diferenças funcionais relevantes:
+ *
+ * 1. Pré-popula `formState` com `Name`/`Code`/`Description` da
+ *    `role` recebida por prop (atende o critério de aceite
+ *    "pré-popula campos"). `Description` veio do enriquecimento do
+ *    backend em `lfc-authenticator#163`/`#164`.
+ * 2. Submit chama `updateRole(id, payload)` com `systemId` injetado
+ *    (vem da URL — `RoleRequestBase.SystemId` é `[Required]` no
+ *    backend; tentar mudar devolve 400 "SystemId é imutável após
+ *    a criação do role.").
+ * 3. Trata 404 fechando o modal + toast vermelho + refetch (role
+ *    removida concorrentemente entre abertura e submit). Os outros
+ *    códigos (409/400/401/403/network) seguem o mesmo mapeamento
+ *    da criação, com copy adaptado para "atualizada" e mensagem
+ *    de conflito citando "outra role neste sistema".
+ *
+ * Toda a lógica de validação client-side e parsing de
+ * `ValidationProblemDetails` vem de `rolesFormShared.ts`, os campos
+ * vivem em `RoleFormFields`, o estado/handlers do form vêm de
+ * `useRoleForm` e o ciclo de submit vem de `useEditEntitySubmit`
+ * — evita duplicação ≥10 linhas com os outros modals de edição
+ * (BLOCKER de duplicação Sonar, lição PR #134/#135).
+ */
+export const EditRoleModal: React.FC<EditRoleModalProps> = ({
+  open,
+  role,
+  systemId,
+  onClose,
+  onUpdated,
+  client,
+}) => {
+  const { show } = useToast();
+
+  // Inicialização defensiva: quando `role` é `null` na primeira
+  // render, usamos um estado vazio até o pai entregar a role. O
+  // `useEffect` abaixo sincroniza sempre que `role` muda.
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleNameChange,
+    handleCodeChange,
+    handleDescriptionChange,
+    prepareSubmit,
+    applyBadRequest,
+  } = useRoleForm(role ? stateFromRole(role) : EMPTY_INITIAL_STATE);
+
+  /**
+   * Sincroniza o form sempre que: (a) o modal abre, ou (b) a `role`
+   * selecionada muda. Limpa erros pendentes para evitar resíduo
+   * entre aberturas (mesmo padrão do `EditSystemModal`/
+   * `EditRouteModal`).
+   */
+  useEffect(() => {
+    if (!open || !role) return;
+    setFormState(stateFromRole(role));
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [open, role, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reseta erros ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar
+   * durante submissão é bloqueado para evitar request órfã. Não
+   * resetamos o `formState` aqui (diferente de um modal de
+   * criação) porque o efeito de sincronização re-popula a partir
+   * da `role` quando o modal reabre.
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareSubmit` que injeta o `systemId` (vem da
+   * URL via prop) e reprova quando o gate de `isSubmitting`/`!role`
+   * falhar — preserva o dedupe original ao mover a lógica para
+   * dentro de `useEditEntitySubmit` (lição PR #135, 6ª recorrência
+   * de Sonar).
+   */
+  const prepareSubmitSafe = useCallback((): unknown | null => {
+    if (isSubmitting || !role) return null;
+    return prepareSubmit(systemId);
+  }, [isSubmitting, prepareSubmit, role, systemId]);
+
+  /**
+   * Closure sobre `role.id` + `client`. Quando `role` é `null` o
+   * `prepareSubmitSafe` já reprova antes do `mutationFn` rodar — a
+   * checagem inline aqui é defensiva (preserva o tipo sem `!`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> => {
+      if (!role) {
+        return Promise.reject(new Error("Role unavailable."));
+      }
+      return updateRole(
+        role.id,
+        payload as Parameters<typeof updateRole>[1],
+        undefined,
+        client,
+      );
+    },
+    [client, role],
+  );
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<EditEntitySubmitCopy>(
+    () => ({
+      successMessage: "Role atualizada.",
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+      editSubmitActionCopy: EDIT_SUBMIT_ACTION_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * `handleSubmit` orquestrado pelo hook compartilhado — encapsula
+   * o `try/catch/finally` + `classifyApiSubmitError` +
+   * `applyEditSubmitAction` que vivia inline. O bloco extraído
+   * tinha ~33 linhas idênticas com os demais modals de edição
+   * (lição PR #134/#135).
+   */
+  const handleSubmit = useEditEntitySubmit<keyof RoleFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onUpdated,
+      onClose,
+    },
+    conflictField: "code",
+  });
+
+  // Não renderiza nada quando não houver `role` selecionada — o
+  // pai controla `open` em conjunto com a `role`, mas cobrimos o
+  // caso defensivo de `open=true && role=null` para não quebrar o
+  // submit.
+  if (!role) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Editar role"
+      description="Atualize os dados da role selecionada."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <RoleFormBody
+        idPrefix="edit-role"
+        submitError={submitError}
+        values={formState}
+        errors={fieldErrors}
+        onChangeName={handleNameChange}
+        onChangeCode={handleCodeChange}
+        onChangeDescription={handleDescriptionChange}
+        onSubmit={handleSubmit}
+        onCancel={handleClose}
+        isSubmitting={isSubmitting}
+        submitLabel="Salvar alterações"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/roles/RoleFormFields.tsx
+++ b/src/pages/roles/RoleFormFields.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import {
+  NameCodeDescriptionFormBody,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormCopy,
+  type NameCodeDescriptionFormState,
+} from "../../shared/forms";
+
+/**
+ * Wrapper fino do `NameCodeDescriptionFormBody` parametrizado com
+ * placeholders/copy do recurso "roles".
+ *
+ * Antes da Issue #68 cada recurso (sistemas, roles) declarava seu
+ * próprio `<Recurso>FormFields.tsx` com 100+ linhas de campos +
+ * shell + footer — gatilho garantido de BLOCKER de duplicação Sonar
+ * (lição PR #128/#134/#135 — Sonar tokenizou >100 linhas
+ * idênticas). Centralizamos no helper genérico
+ * `src/shared/forms/NameCodeDescriptionForm.tsx`; cada recurso
+ * mantém apenas as cópias textuais e tipos locais.
+ *
+ * **Por que manter o wrapper?** Para preservar a API local
+ * (`RoleFormBody` continua sendo importado de `./RoleFormFields`)
+ * e os tipos específicos do recurso (`RoleFieldErrors` /
+ * `RoleFormState`) ficarem acoplados ao módulo `rolesFormShared.ts`
+ * em vez de vazar o nome genérico no callsite — o `EditRoleModal`
+ * (e o futuro `NewRoleModal`) consomem o tipo do recurso, não o
+ * tipo genérico.
+ */
+
+/* ─── Cópia textual (placeholders) específica de roles ─── */
+
+const ROLE_FORM_COPY: NameCodeDescriptionFormCopy = {
+  namePlaceholder: "ex.: Administrador",
+  codePlaceholder: "ex.: admin",
+  descriptionPlaceholder: "Descrição opcional da role.",
+};
+
+/* ─── Form body ──────────────────────────────────────────── */
+
+interface RoleFormBodyProps {
+  /**
+   * Prefixo dos `data-testid` do form e dos campos. Em produção,
+   * `new-role` ou `edit-role`; preserva os testIds estáveis das
+   * suítes (`RolesPage.edit.test.tsx`, futura `.create.test.tsx`).
+   */
+  idPrefix: string;
+  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
+  submitError: string | null;
+  /** Estado controlado dos campos. Tipos vêm do `rolesFormShared.ts`. */
+  values: NameCodeDescriptionFormState;
+  /** Erros inline por campo. */
+  errors: NameCodeDescriptionFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeCode: (value: string) => void;
+  onChangeDescription: (value: string) => void;
+  /** Handler do submit do form. */
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  /** Handler do botão Cancelar (bloqueado durante submit). */
+  onCancel: () => void;
+  /** Flag de submissão em andamento. */
+  isSubmitting: boolean;
+  /** Texto do botão de envio (ex.: "Criar role", "Salvar alterações"). */
+  submitLabel: string;
+}
+
+export const RoleFormBody: React.FC<RoleFormBodyProps> = (props) => (
+  <NameCodeDescriptionFormBody {...props} copy={ROLE_FORM_COPY} />
+);

--- a/src/pages/roles/rolesFormShared.ts
+++ b/src/pages/roles/rolesFormShared.ts
@@ -1,0 +1,159 @@
+import {
+  classifyApiSubmitError,
+  decideNameCodeDescriptionBadRequestHandling,
+  extractNameCodeDescriptionValidationErrors,
+  NAME_CODE_DESCRIPTION_CODE_MAX,
+  NAME_CODE_DESCRIPTION_DESCRIPTION_MAX,
+  NAME_CODE_DESCRIPTION_NAME_MAX,
+  validateNameCodeDescriptionForm,
+  type ApiSubmitErrorAction,
+  type ApiSubmitErrorCopy,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormState,
+  type NameCodeDescriptionSubmitDecision,
+} from "../../shared/forms";
+
+/**
+ * Helpers compartilhados pelos formulários de criação e edição de
+ * roles.
+ *
+ * O `lfc-authenticator` (`RolesController.cs`) trata
+ * `UpdateRoleRequest === CreateRoleRequest` (mesmos campos), seguindo
+ * o padrão já adotado em `systems`/`routes`. Por isso centralizamos
+ * tipos, validação client-side e parsing de
+ * `ValidationProblemDetails` neste módulo desde o **primeiro PR de
+ * mutação do recurso** (Issue #68 — editar) — quando a sub-issue de
+ * criação chegar, ela herda todo este boilerplate sem copiar uma
+ * linha sequer (lição PR #128 — projetar shared helpers desde o
+ * primeiro PR do recurso).
+ *
+ * **Após o PR #68 (lição PR #134/#135 reforçada):** este módulo
+ * passou a ser uma **camada fina** que delega para
+ * `src/shared/forms/NameCodeDescriptionForm.ts` — Sonar tokenizou
+ * ~80 linhas idênticas entre `systemFormShared.ts` e
+ * `rolesFormShared.ts` (validate/extract/decide). Centralizar no
+ * helper genérico evitou a 7ª recorrência de New Code Duplication.
+ *
+ * Mantemos os exports locais (`RoleFormState`, `RoleFieldErrors`,
+ * `validateRoleForm`, etc.) como aliases por **um motivo prático**:
+ * o `EditRoleModal` e o futuro `NewRoleModal` importam de
+ * `./rolesFormShared` para preservar acoplamento de domínio
+ * (mudanças no contrato do backend de roles ficam visíveis aqui;
+ * mudanças genéricas ficam em `shared/forms`).
+ */
+
+/** Tamanho máximo do campo `Name` (espelha `RoleRequestBase.Name`). */
+export const NAME_MAX = NAME_CODE_DESCRIPTION_NAME_MAX;
+/** Tamanho máximo do campo `Code` (espelha `RoleRequestBase.Code`). */
+export const CODE_MAX = NAME_CODE_DESCRIPTION_CODE_MAX;
+/** Tamanho máximo do campo `Description` (espelha `RoleRequestBase.Description`). */
+export const DESCRIPTION_MAX = NAME_CODE_DESCRIPTION_DESCRIPTION_MAX;
+
+/**
+ * Estado controlado dos campos do form de role. Alias estrutural de
+ * `NameCodeDescriptionFormState` (3 campos compartilhados com
+ * sistemas). O `systemId` **não** vive no estado porque é imutável
+ * após criação (ver `RolesController.UpdateById`: tentativa de
+ * alterar devolve 400 com "SystemId é imutável após a criação do
+ * role.") — o caller injeta o valor já validado via
+ * `prepareSubmit(systemId)` no momento do envio.
+ */
+export type RoleFormState = NameCodeDescriptionFormState;
+
+/**
+ * Mensagens de erro inline por campo. Cada chave é opcional —
+ * `undefined` indica "campo válido" (ou ainda não validado).
+ * Alias estrutural de `NameCodeDescriptionFieldErrors`.
+ */
+export type RoleFieldErrors = NameCodeDescriptionFieldErrors;
+
+/** Estado inicial vazio reutilizado pelo futuro modal de criação. */
+export const INITIAL_ROLE_FORM_STATE: RoleFormState = {
+  name: "",
+  code: "",
+  description: "",
+};
+
+/**
+ * Valida o estado do form contra as mesmas regras do backend
+ * (`CreateRoleRequest`/`UpdateRoleRequest`). Delegação direta para
+ * `validateNameCodeDescriptionForm` — todos os limites/mensagens
+ * coincidem com sistemas (lição PR #134/#135).
+ */
+export function validateRoleForm(state: RoleFormState): RoleFieldErrors | null {
+  return validateNameCodeDescriptionForm(state);
+}
+
+/**
+ * Extrai erros por campo do payload de `ValidationProblemDetails` do
+ * ASP.NET. Delegação direta para
+ * `extractNameCodeDescriptionValidationErrors` — o backend de roles
+ * envia `Name`/`Code`/`Description` (mesma lista de sistemas);
+ * chaves não-mapeáveis (ex.: `SystemId` em "SystemId é imutável...")
+ * caem para o caller via `submitError` no Alert do topo, evitando
+ * exibir inline um erro que o usuário não controla.
+ */
+export function extractRoleValidationErrors(
+  details: unknown,
+): RoleFieldErrors | null {
+  return extractNameCodeDescriptionValidationErrors(details);
+}
+
+/**
+ * Resultado do mapeamento de uma `ApiError` 400 do backend. Alias
+ * estrutural de `NameCodeDescriptionSubmitDecision`.
+ */
+export type RoleSubmitDecision = NameCodeDescriptionSubmitDecision;
+
+/**
+ * Decide o tratamento de uma resposta 400 do backend para o form de
+ * role. Delegação direta para
+ * `decideNameCodeDescriptionBadRequestHandling`.
+ */
+export function decideRoleBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): RoleSubmitDecision {
+  return decideNameCodeDescriptionBadRequestHandling(details, fallbackMessage);
+}
+
+/**
+ * Copy textual usado por `classifyRoleSubmitError` para diferenciar
+ * create de edit sem duplicar a lógica de classificação. Cada modal
+ * injeta sua versão (`'uma role'` vs `'outra role'`, `'criar'` vs
+ * `'atualizar'`).
+ */
+export type RoleSubmitErrorCopy = ApiSubmitErrorCopy;
+
+/**
+ * Resultado da classificação de um erro lançado por
+ * `createRole`/`updateRole`. Discriminada (`kind`) para o caller
+ * usar num `switch` curto.
+ */
+export type RoleSubmitErrorAction = ApiSubmitErrorAction<keyof RoleFieldErrors>;
+
+/**
+ * Classifica um erro lançado por `createRole`/`updateRole` em uma
+ * `RoleSubmitErrorAction` discriminada. Delegação de uma linha para
+ * o helper genérico — preserva a assinatura pública usada pelo
+ * modal de role e pelos testes unitários.
+ *
+ * - `409` → `conflict` no campo `code` com mensagem do backend (ou
+ *   `copy.conflictDefault`). Caller exibe inline. O backend devolve
+ *   "Já existe outro role com este Code neste sistema." em update;
+ *   a unicidade é por (SystemId, Code), não global.
+ * - `400` → `bad-request` com `details` cru.
+ * - `404` → `not-found` (só relevante no `EditRoleModal` — role
+ *   removida concorrentemente entre abertura e submit).
+ * - `401`/`403` → `toast` vermelho.
+ * - Outros → `unhandled`.
+ *
+ * O `conflictField` é fixo em `'code'` — campo único de unicidade
+ * do contrato `CreateRoleRequest`/`UpdateRoleRequest`.
+ */
+export function classifyRoleSubmitError(
+  error: unknown,
+  copy: RoleSubmitErrorCopy,
+): RoleSubmitErrorAction {
+  return classifyApiSubmitError<keyof RoleFieldErrors>(error, copy, "code");
+}

--- a/src/pages/roles/useRoleForm.ts
+++ b/src/pages/roles/useRoleForm.ts
@@ -1,0 +1,75 @@
+import { useCallback } from "react";
+
+import {
+  useNameCodeDescriptionForm,
+  type UseNameCodeDescriptionFormReturn,
+} from "../../shared/forms";
+
+import { type RoleFormState } from "./rolesFormShared";
+
+import type { CreateRolePayload } from "../../shared/api";
+
+/**
+ * Hook compartilhado pelo modal de edição (`EditRoleModal` — Issue
+ * #68) e pelo futuro modal de criação (`NewRoleModal`) de roles.
+ *
+ * **Após o PR #68 (lição PR #134/#135 reforçada):** delega para o
+ * helper genérico `useNameCodeDescriptionForm` em
+ * `src/shared/forms/`, decorando apenas o `prepareSubmit` para
+ * injetar o `systemId` no payload (campo exigido pelo backend
+ * `lfc-authenticator` após o enriquecimento do contrato em #163/
+ * #164). Centralizar evita ~50 linhas de boilerplate idênticas
+ * entre `useSystemForm.ts` e `useRoleForm.ts` (interface
+ * `Use<Recurso>FormReturn`, `useState`, `prepareSubmit`,
+ * `applyBadRequest`).
+ *
+ * Recebe `systemId` como parâmetro do `prepareSubmit` porque o
+ * `:systemId` vive na URL da `RolesPage` (não no form) — o caller
+ * passa o valor já validado quando vai construir o
+ * `CreateRolePayload`. Espelha o desenho de `useRouteForm` (#63/
+ * #64), onde o `systemId` também vem da URL e não é editável pelo
+ * usuário (no caso de roles, o backend rejeita até tentativas de
+ * mudar com 400 "SystemId é imutável após a criação do role.").
+ */
+
+/**
+ * Tipo de retorno do hook — espelha o do helper genérico, mas
+ * sobrescreve `prepareSubmit` para refletir a assinatura específica
+ * de roles (recebe `systemId` e devolve `CreateRolePayload`).
+ */
+export type UseRoleFormReturn = Omit<
+  UseNameCodeDescriptionFormReturn,
+  "prepareSubmit"
+> & {
+  /**
+   * Roda a validação client-side e, se passar, prepara o
+   * `CreateRolePayload` trimado. `systemId` é injetado pelo caller
+   * (vem da URL `/systems/:systemId/roles`) — manter fora do estado
+   * do form preserva a separação "form = inputs do usuário" e evita
+   * race quando o usuário troca de sistema com o modal aberto.
+   */
+  prepareSubmit: (systemId: string) => CreateRolePayload | null;
+};
+
+export function useRoleForm(initialState: RoleFormState): UseRoleFormReturn {
+  const inner = useNameCodeDescriptionForm(initialState);
+
+  const prepareSubmit = useCallback(
+    (systemId: string): CreateRolePayload | null => {
+      const trimmed = inner.prepareSubmit();
+      if (trimmed === null) return null;
+      return {
+        systemId,
+        name: trimmed.name,
+        code: trimmed.code,
+        description: trimmed.description,
+      };
+    },
+    [inner],
+  );
+
+  return {
+    ...inner,
+    prepareSubmit,
+  };
+}

--- a/src/pages/systems/SystemFormFields.tsx
+++ b/src/pages/systems/SystemFormFields.tsx
@@ -1,172 +1,51 @@
-import React, { useMemo } from 'react';
-import styled from 'styled-components';
-
-import { Alert, Button, Input, Textarea } from '../../components/ui';
+import React from "react";
 
 import {
-  CODE_MAX,
-  DESCRIPTION_MAX,
-  NAME_MAX,
+  NameCodeDescriptionFormBody,
+  type NameCodeDescriptionFormCopy,
+} from "../../shared/forms";
+
+import {
   type SystemFieldErrors,
   type SystemFormState,
-} from './systemFormShared';
-
-/* ─── Styled primitives compartilhados pelos dois modals ─── */
+} from "./systemFormShared";
 
 /**
- * Wrapper do `<form>` dos modals de sistema. Extraído porque ambos
- * `NewSystemModal` e `EditSystemModal` declaravam a mesma `styled.form`
- * (~5 linhas idênticas) — somando aos demais styled wrappers, a
- * duplicação cumulativa atingia o threshold do Sonar (lição PR #127).
- */
-const SystemFormShell = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-`;
-
-/** Footer com botões alinhados à direita, separados pelo gap padrão. */
-const SystemFormFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
-`;
-
-/** Linha de hint "campos com * são obrigatórios" no rodapé do form. */
-const SystemFormHelperRow = styled.div`
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-tight);
-`;
-
-/**
- * Campos comuns dos formulários `NewSystemModal` e `EditSystemModal`.
+ * Wrapper fino do `NameCodeDescriptionFormBody` parametrizado com
+ * placeholders/copy do recurso "systems".
  *
- * Cada modal pré-popula valores diferentes (vazio para criação, dados
- * atuais para edição), mas a estrutura visual (Name/Code/Description) e
- * a validação são idênticas. Antes de extrair, o `EditSystemModal`
- * espelhava ~80 linhas do `NewSystemModal` — gatilho garantido de BLOCKER
- * de duplicação Sonar (lição PR #123/#127 — qualquer trecho de 10+
- * linhas em 2+ arquivos é `New Code Duplication` independente da
- * intenção).
+ * Antes da Issue #68 este arquivo carregava ~250 linhas de campos +
+ * shell + footer + helpers — duplicadas integralmente pelo `roles`
+ * (#68) e quase integralmente pelo `routes` (sem o `<Select>` de
+ * token type). Sonar tokenizou >100 linhas idênticas entre
+ * `SystemFormFields.tsx` e `RoleFormFields.tsx` (lição PR
+ * #128/#134/#135 — 7ª recorrência potencial de New Code
+ * Duplication).
  *
- * O componente é deliberadamente "burro": cada modal continua dono do
- * `formState`/`fieldErrors`/handlers e do submit. Aqui só renderizamos os
- * inputs e centralizamos `aria`, `maxLength`, helper text de contagem e
- * o `data-modal-initial-focus` no campo Name.
- *
- * Os `data-testid` recebem um `idPrefix` para que cada modal preserve os
- * IDs estáveis usados pelos seus testes (`new-system-name`,
- * `edit-system-name`, etc.) — assim refator do shared não invalida
- * suítes existentes.
+ * Centralizamos em `src/shared/forms/NameCodeDescriptionForm.tsx`;
+ * este arquivo agora é só um wrapper que injeta as cópias
+ * específicas de "sistema". Preserva a API local
+ * (`SystemFormBody` continua sendo importado de
+ * `./SystemFormFields`) para que `NewSystemModal`/`EditSystemModal`
+ * não precisem mudar.
  */
 
-interface SystemFormFieldsProps {
-  /**
-   * Prefixo dos `data-testid` de cada input. Default `system` cobre
-   * ambientes ad-hoc; o caller deve passar `new-system`/`edit-system` em
-   * produção para casar com os helpers de teste.
-   */
-  idPrefix?: string;
-  /** Estado controlado dos campos. */
-  values: SystemFormState;
-  /** Erros inline por campo (vindos da validação client-side ou do backend). */
-  errors: SystemFieldErrors;
-  onChangeName: (value: string) => void;
-  onChangeCode: (value: string) => void;
-  onChangeDescription: (value: string) => void;
-  /**
-   * Quando `true`, todos os inputs ficam desabilitados (durante submit).
-   * Default `false` mantém o comportamento padrão de form interativo.
-   */
-  disabled?: boolean;
-  /**
-   * Quando `true`, o campo Name recebe `data-modal-initial-focus` para
-   * que o `Modal` foque automaticamente nele ao abrir. Permite que o
-   * `EditSystemModal` desligue o auto-foco se quiser focar outro campo
-   * no futuro — hoje os dois modals usam `true`.
-   */
-  autoFocusName?: boolean;
-}
+/* ─── Cópia textual (placeholders) específica de sistemas ─── */
 
-const FieldStack = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-`;
-
-const SystemFormFields: React.FC<SystemFormFieldsProps> = ({
-  idPrefix = 'system',
-  values,
-  errors,
-  onChangeName,
-  onChangeCode,
-  onChangeDescription,
-  disabled = false,
-  autoFocusName = true,
-}) => {
-  // `data-modal-initial-focus` no campo Name garante que o foco vá para
-  // o primeiro input independente da ordem dos `querySelector`. Útil em
-  // jsdom (testes) e em qualquer mudança futura de layout. Memoizado
-  // para preservar referência do objeto passado como spread.
-  const nameFocusAttr = useMemo(
-    () => (autoFocusName ? ({ 'data-modal-initial-focus': true } as const) : ({} as const)),
-    [autoFocusName],
-  );
-
-  return (
-    <FieldStack>
-      <Input
-        label="Nome"
-        placeholder="ex.: lfc-authenticator"
-        value={values.name}
-        onChange={onChangeName}
-        error={errors.name}
-        maxLength={NAME_MAX}
-        autoComplete="off"
-        required
-        disabled={disabled}
-        data-testid={`${idPrefix}-name`}
-        {...nameFocusAttr}
-      />
-      <Input
-        label="Código"
-        placeholder="ex.: AUTH"
-        value={values.code}
-        onChange={onChangeCode}
-        error={errors.code}
-        maxLength={CODE_MAX}
-        autoComplete="off"
-        required
-        disabled={disabled}
-        data-testid={`${idPrefix}-code`}
-      />
-      <Textarea
-        label="Descrição"
-        placeholder="Descrição opcional do sistema."
-        value={values.description}
-        onChange={onChangeDescription}
-        error={errors.description}
-        helperText={
-          errors.description ? undefined : `${values.description.length}/${DESCRIPTION_MAX} caracteres`
-        }
-        maxLength={DESCRIPTION_MAX}
-        rows={3}
-        disabled={disabled}
-        data-testid={`${idPrefix}-description`}
-      />
-    </FieldStack>
-  );
+const SYSTEM_FORM_COPY: NameCodeDescriptionFormCopy = {
+  namePlaceholder: "ex.: lfc-authenticator",
+  codePlaceholder: "ex.: AUTH",
+  descriptionPlaceholder: "Descrição opcional do sistema.",
 };
 
-/* ─── Form body completo ─────────────────────────────────── */
+/* ─── Form body ──────────────────────────────────────────── */
 
 interface SystemFormBodyProps {
   /**
    * Prefixo dos `data-testid` do form e dos campos. Em produção,
-   * `new-system` ou `edit-system`; usar prefixo curto para combinar com
-   * os testIds estáveis das suítes existentes.
+   * `new-system` ou `edit-system` — preserva os testIds estáveis
+   * das suítes `SystemsPage.create.test.tsx` (#58/#127) e
+   * `SystemsPage.edit.test.tsx` (#59).
    */
   idPrefix: string;
   /** Erro genérico de submissão exibido em `Alert` no topo do form. */
@@ -188,71 +67,6 @@ interface SystemFormBodyProps {
   submitLabel: string;
 }
 
-/**
- * Body completo dos modals de criação/edição: shell `<form>` + Alert do
- * erro genérico + campos (Nome/Código/Descrição) + linha de hint
- * obrigatórios + footer (Cancelar/Submit).
- *
- * Antes de extrair, ambos os modals declaravam ~38 linhas de JSX com a
- * mesma estrutura, diferindo só em `data-testid`/labels — alvo certo do
- * Sonar para `New Code Duplication` (lição PR #127). Centralizando aqui,
- * cada modal importa um único componente e passa os pontos de variação
- * por prop.
- *
- * Os `data-testid` ficam estáveis porque cada modal passa `idPrefix`
- * diferente — preserva os testIds esperados pelas suítes
- * `SystemsPage.create.test.tsx` (#58/#127) e `SystemsPage.edit.test.tsx`
- * (#59).
- */
-export const SystemFormBody: React.FC<SystemFormBodyProps> = ({
-  idPrefix,
-  submitError,
-  values,
-  errors,
-  onChangeName,
-  onChangeCode,
-  onChangeDescription,
-  onSubmit,
-  onCancel,
-  isSubmitting,
-  submitLabel,
-}) => (
-  <SystemFormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
-    {submitError && (
-      <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
-        {submitError}
-      </Alert>
-    )}
-    <SystemFormFields
-      idPrefix={idPrefix}
-      values={values}
-      errors={errors}
-      onChangeName={onChangeName}
-      onChangeCode={onChangeCode}
-      onChangeDescription={onChangeDescription}
-      disabled={isSubmitting}
-    />
-    <SystemFormHelperRow>Campos com * são obrigatórios.</SystemFormHelperRow>
-    <SystemFormFooter>
-      <Button
-        type="button"
-        variant="ghost"
-        size="md"
-        onClick={onCancel}
-        disabled={isSubmitting}
-        data-testid={`${idPrefix}-cancel`}
-      >
-        Cancelar
-      </Button>
-      <Button
-        type="submit"
-        variant="primary"
-        size="md"
-        loading={isSubmitting}
-        data-testid={`${idPrefix}-submit`}
-      >
-        {submitLabel}
-      </Button>
-    </SystemFormFooter>
-  </SystemFormShell>
+export const SystemFormBody: React.FC<SystemFormBodyProps> = (props) => (
+  <NameCodeDescriptionFormBody {...props} copy={SYSTEM_FORM_COPY} />
 );

--- a/src/pages/systems/systemFormShared.ts
+++ b/src/pages/systems/systemFormShared.ts
@@ -1,9 +1,18 @@
-import { isApiError } from '../../shared/api';
+import { isApiError } from "../../shared/api";
 import {
   classifyApiSubmitError,
+  decideNameCodeDescriptionBadRequestHandling,
+  extractNameCodeDescriptionValidationErrors,
+  NAME_CODE_DESCRIPTION_CODE_MAX,
+  NAME_CODE_DESCRIPTION_DESCRIPTION_MAX,
+  NAME_CODE_DESCRIPTION_NAME_MAX,
+  validateNameCodeDescriptionForm,
   type ApiSubmitErrorAction,
   type ApiSubmitErrorCopy,
-} from '../../shared/forms';
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormState,
+  type NameCodeDescriptionSubmitDecision,
+} from "../../shared/forms";
 
 /**
  * Helpers compartilhados pelos formulários de criação e edição de sistemas.
@@ -16,169 +25,97 @@ import {
  * BLOCKER de duplicação no Sonar (lição PR #123/#127 — qualquer trecho
  * de 10+ linhas em 2+ arquivos vira `New Code Duplication`).
  *
- * Este módulo concentra:
+ * Após o PR #68 (lição PR #134/#135 reforçada): os helpers de
+ * validação/parsing migraram para
+ * `src/shared/forms/NameCodeDescriptionForm.ts` — Sonar tokenizou
+ * ~80 linhas idênticas entre `systemFormShared.ts` e
+ * `rolesFormShared.ts` (validate/extract/decide). Os exports locais
+ * agora são alias finos (delegam para os genéricos) para preservar
+ * a API pública dos consumidores existentes.
  *
- * - Limites de tamanho de cada campo (espelham `CreateSystemRequest`
- *   no `SystemsController.cs`).
- * - Tipos `SystemFormState`/`SystemFieldErrors` consumidos pelos modals
- *   e pelo componente compartilhado `SystemFormFields`.
- * - `validateSystemForm` — replica as regras `Required`/`MaxLength` do
- *   backend para feedback imediato sem round-trip.
- * - `extractSystemValidationErrors` — mapeia `ValidationProblemDetails`
- *   do ASP.NET (`{ errors: { Name: ['msg'] } }`) para
- *   `SystemFieldErrors`.
- * - `classifySubmitError` — converte um `unknown` lançado por
- *   `createSystem`/`updateSystem` em uma `SubmitErrorAction` discriminada,
- *   eliminando a cadeia de `if (apiError.status === ...)` duplicada entre
- *   `NewSystemModal.handleSubmit` e `EditSystemModal.handleSubmit` (lição
- *   PR #128 — 4ª recorrência de BLOCKER de duplicação Sonar).
+ * Este módulo segue concentrando o que é específico de "sistemas":
+ *
+ * - Tipos `SystemFormState`/`SystemFieldErrors` (alias estruturais).
+ * - `classifySubmitError` (classificação de erros de submit, herdada
+ *   do helper genérico em `shared/forms`).
+ * - `MutationErrorCopy`/`classifyMutationError` para os modals de
+ *   confirmação simples (delete/restore — cenário sem corpo de form,
+ *   exclusivo de sistemas hoje).
  *
  * Mantemos a lógica em TS puro (sem React) para que os testes unitários
  * possam consumir diretamente sem precisar de provider/render.
  */
 
 /** Tamanho máximo do campo `Name` (espelha `CreateSystemRequest.Name`). */
-export const NAME_MAX = 80;
+export const NAME_MAX = NAME_CODE_DESCRIPTION_NAME_MAX;
 /** Tamanho máximo do campo `Code` (espelha `CreateSystemRequest.Code`). */
-export const CODE_MAX = 50;
+export const CODE_MAX = NAME_CODE_DESCRIPTION_CODE_MAX;
 /** Tamanho máximo do campo `Description` (espelha `CreateSystemRequest.Description`). */
-export const DESCRIPTION_MAX = 500;
+export const DESCRIPTION_MAX = NAME_CODE_DESCRIPTION_DESCRIPTION_MAX;
 
 /**
- * Estado controlado dos campos do form de sistema. Usamos `string` em
- * todos os campos para que o React lide com inputs vazios sem `null`/
- * `undefined` — o trim é responsabilidade do submit.
+ * Estado controlado dos campos do form de sistema. Alias estrutural
+ * de `NameCodeDescriptionFormState` (mesmo shape de roles após o
+ * extract de PR #68). Usamos `string` em todos os campos para que o
+ * React lide com inputs vazios sem `null`/`undefined` — o trim é
+ * responsabilidade do submit.
  */
-export interface SystemFormState {
-  name: string;
-  code: string;
-  description: string;
-}
+export type SystemFormState = NameCodeDescriptionFormState;
 
 /**
- * Mensagens de erro inline por campo. Cada chave é opcional — `undefined`
- * indica "campo válido" (ou ainda não validado).
+ * Mensagens de erro inline por campo. Cada chave é opcional —
+ * `undefined` indica "campo válido" (ou ainda não validado). Alias
+ * estrutural de `NameCodeDescriptionFieldErrors`.
  */
-export interface SystemFieldErrors {
-  name?: string;
-  code?: string;
-  description?: string;
-}
+export type SystemFieldErrors = NameCodeDescriptionFieldErrors;
 
 /** Estado inicial vazio reutilizado no modal de criação. */
 export const INITIAL_SYSTEM_FORM_STATE: SystemFormState = {
-  name: '',
-  code: '',
-  description: '',
+  name: "",
+  code: "",
+  description: "",
 };
 
 /**
  * Valida o estado do form contra as mesmas regras do backend
- * (`CreateSystemRequest`/`UpdateSystemRequest`). Retorna `null` quando
- * válido, ou um objeto com mensagens por campo. Usamos pt-BR e textos
- * próximos aos do backend para que a UX seja coerente entre validação
- * client e server.
+ * (`CreateSystemRequest`/`UpdateSystemRequest`). Delegação direta
+ * para `validateNameCodeDescriptionForm` — todos os limites/mensagens
+ * coincidem com roles (lição PR #134/#135).
  */
-export function validateSystemForm(state: SystemFormState): SystemFieldErrors | null {
-  const errors: SystemFieldErrors = {};
-  const name = state.name.trim();
-  const code = state.code.trim();
-  const description = state.description.trim();
-
-  if (name.length === 0) {
-    errors.name = 'Nome é obrigatório.';
-  } else if (name.length > NAME_MAX) {
-    errors.name = `Nome deve ter no máximo ${NAME_MAX} caracteres.`;
-  }
-
-  if (code.length === 0) {
-    errors.code = 'Código é obrigatório.';
-  } else if (code.length > CODE_MAX) {
-    errors.code = `Código deve ter no máximo ${CODE_MAX} caracteres.`;
-  }
-
-  if (description.length > DESCRIPTION_MAX) {
-    errors.description = `Descrição deve ter no máximo ${DESCRIPTION_MAX} caracteres.`;
-  }
-
-  return Object.keys(errors).length > 0 ? errors : null;
-}
-
-/**
- * Normaliza o nome de campo do backend (PascalCase) para o nome usado
- * no estado do form (camelCase). Mantém a função interna estática
- * porque a lista é fechada (3 campos do contrato).
- */
-function normalizeSystemFieldName(serverField: string): keyof SystemFieldErrors | null {
-  const lower = serverField.toLowerCase();
-  if (lower === 'name') return 'name';
-  if (lower === 'code') return 'code';
-  if (lower === 'description') return 'description';
-  return null;
+export function validateSystemForm(
+  state: SystemFormState,
+): SystemFieldErrors | null {
+  return validateNameCodeDescriptionForm(state);
 }
 
 /**
  * Extrai erros por campo do payload de `ValidationProblemDetails` do
- * ASP.NET (`{ errors: { Name: ['msg'], ... } }`). Tolerante: se o
- * payload não bate com o shape esperado, devolve `null` para que o
- * caller caia no fallback genérico.
+ * ASP.NET. Delegação direta para
+ * `extractNameCodeDescriptionValidationErrors` — backend de sistemas
+ * envia exatamente as 3 chaves esperadas (Name/Code/Description).
  */
-export function extractSystemValidationErrors(details: unknown): SystemFieldErrors | null {
-  if (!details || typeof details !== 'object') {
-    return null;
-  }
-  const errors = (details as Record<string, unknown>).errors;
-  if (!errors || typeof errors !== 'object') {
-    return null;
-  }
-  const result: SystemFieldErrors = {};
-  for (const [serverField, raw] of Object.entries(errors)) {
-    const field = normalizeSystemFieldName(serverField);
-    if (!field) continue;
-    if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
-      result[field] = raw[0];
-    } else if (typeof raw === 'string') {
-      result[field] = raw;
-    }
-  }
-  return Object.keys(result).length > 0 ? result : null;
+export function extractSystemValidationErrors(
+  details: unknown,
+): SystemFieldErrors | null {
+  return extractNameCodeDescriptionValidationErrors(details);
 }
 
 /**
- * Resultado do mapeamento de uma `ApiError` 400 do backend. O caller
- * usa essa decisão para chamar `setFieldErrors` (campos mapeados) ou
- * `setSubmitError` (mensagem genérica para Alert) — separar a decisão
- * do efeito colateral mantém o helper testável e idêntico entre os
- * dois modals.
+ * Resultado do mapeamento de uma `ApiError` 400 do backend. Alias
+ * estrutural de `NameCodeDescriptionSubmitDecision`.
  */
-export type SystemSubmitDecision =
-  | { kind: 'field-errors'; errors: SystemFieldErrors }
-  | { kind: 'submit-error'; message: string };
+export type SystemSubmitDecision = NameCodeDescriptionSubmitDecision;
 
 /**
  * Decide o tratamento de uma resposta 400 do backend para o form de
- * sistema:
- *
- * - Se o payload bate com `ValidationProblemDetails` e o backend
- *   identificou ao menos um campo, devolve `field-errors` com as
- *   mensagens mapeadas → caller exibe inline.
- * - Caso contrário, devolve `submit-error` com a mensagem do backend
- *   → caller exibe `Alert` no topo do form.
- *
- * Centralizar essa decisão evita o bloco `if (validation) { ... } else {
- *   setSubmitError(...) }` duplicado entre `NewSystemModal` e
- * `EditSystemModal` (lição PR #123/#127 — qualquer trecho de 10+
- * linhas em 2+ arquivos é `New Code Duplication` no Sonar).
+ * sistema. Delegação direta para
+ * `decideNameCodeDescriptionBadRequestHandling`.
  */
 export function decideBadRequestHandling(
   details: unknown,
   fallbackMessage: string,
 ): SystemSubmitDecision {
-  const validation = extractSystemValidationErrors(details);
-  if (validation) {
-    return { kind: 'field-errors', errors: validation };
-  }
-  return { kind: 'submit-error', message: fallbackMessage };
+  return decideNameCodeDescriptionBadRequestHandling(details, fallbackMessage);
 }
 
 /**
@@ -227,7 +164,7 @@ export function classifySubmitError(
   error: unknown,
   copy: SubmitErrorCopy,
 ): SubmitErrorAction {
-  return classifyApiSubmitError<keyof SystemFieldErrors>(error, copy, 'code');
+  return classifyApiSubmitError<keyof SystemFieldErrors>(error, copy, "code");
 }
 
 /**
@@ -282,10 +219,10 @@ export interface MutationErrorCopy {
  * correto (toast + close + refetch).
  */
 export type MutationErrorAction =
-  | { kind: 'not-found'; message: string; title: string }
-  | { kind: 'conflict'; message: string; title: string }
-  | { kind: 'toast'; message: string; title: string }
-  | { kind: 'unhandled'; title: string; fallback: string };
+  | { kind: "not-found"; message: string; title: string }
+  | { kind: "conflict"; message: string; title: string }
+  | { kind: "toast"; message: string; title: string }
+  | { kind: "unhandled"; title: string; fallback: string };
 
 /**
  * Classifica um erro lançado por uma mutação simples sem corpo
@@ -309,30 +246,38 @@ export function classifyMutationError(
   error: unknown,
   copy: MutationErrorCopy,
 ): MutationErrorAction {
-  if (!isApiError(error) || error.kind !== 'http') {
-    return { kind: 'unhandled', title: copy.forbiddenTitle, fallback: copy.genericFallback };
+  if (!isApiError(error) || error.kind !== "http") {
+    return {
+      kind: "unhandled",
+      title: copy.forbiddenTitle,
+      fallback: copy.genericFallback,
+    };
   }
   const status = error.status;
   if (status === 404) {
     return {
-      kind: 'not-found',
+      kind: "not-found",
       message: copy.notFoundMessage,
       title: copy.forbiddenTitle,
     };
   }
-  if (status === 409 && typeof copy.conflictMessage === 'string') {
+  if (status === 409 && typeof copy.conflictMessage === "string") {
     return {
-      kind: 'conflict',
+      kind: "conflict",
       message: error.message ?? copy.conflictMessage,
       title: copy.forbiddenTitle,
     };
   }
   if (status === 401 || status === 403) {
     return {
-      kind: 'toast',
-      message: error.message ?? 'Você não tem permissão para esta ação.',
+      kind: "toast",
+      message: error.message ?? "Você não tem permissão para esta ação.",
       title: copy.forbiddenTitle,
     };
   }
-  return { kind: 'unhandled', title: copy.forbiddenTitle, fallback: copy.genericFallback };
+  return {
+    kind: "unhandled",
+    title: copy.forbiddenTitle,
+    fallback: copy.genericFallback,
+  };
 }

--- a/src/pages/systems/useSystemForm.ts
+++ b/src/pages/systems/useSystemForm.ts
@@ -1,143 +1,70 @@
-import { useCallback, useState } from 'react';
-
-import { useFieldChangeHandlers } from '../../shared/forms';
+import { useCallback } from "react";
 
 import {
-  decideBadRequestHandling,
-  validateSystemForm,
-  type SystemFieldErrors,
-  type SystemFormState,
-} from './systemFormShared';
+  useNameCodeDescriptionForm,
+  type UseNameCodeDescriptionFormReturn,
+} from "../../shared/forms";
 
-import type { CreateSystemPayload } from '../../shared/api';
+import { type SystemFormState } from "./systemFormShared";
 
-/**
- * Lista fixa dos campos do form de sistema, usada por
- * `useFieldChangeHandlers` para gerar os handlers `name`/`code`/
- * `description` em uma única linha. `as const` preserva os literais
- * para o helper genérico inferir as chaves do `SystemFormState`.
- */
-const SYSTEM_FORM_FIELDS = ['name', 'code', 'description'] as const;
+import type { CreateSystemPayload } from "../../shared/api";
 
 /**
- * Hook compartilhado pelos formulários de criação (`NewSystemModal`) e
- * edição (`EditSystemModal`) de sistemas.
+ * Hook compartilhado pelos formulários de criação (`NewSystemModal`)
+ * e edição (`EditSystemModal`) de sistemas.
  *
- * Encapsula:
+ * **Após o PR #68 (lição PR #134/#135 reforçada):** delega para o
+ * helper genérico `useNameCodeDescriptionForm` em
+ * `src/shared/forms/`. O `prepareSubmit` original retornava direto
+ * `{name, code, description}` — o helper genérico devolve o mesmo
+ * shape (`NameCodeDescriptionFormState`), que é estruturalmente
+ * compatível com `CreateSystemPayload` (description é optional no
+ * payload, mas string trimada é aceita).
  *
- * - O estado do form (`SystemFormState`) e dos erros inline por campo.
- * - O estado do `Alert` no topo (erro genérico de submissão).
- * - A flag `isSubmitting`.
- * - Os handlers `onChangeName`/`onChangeCode`/`onChangeDescription` que
- *   atualizam o campo correspondente e limpam o erro inline associado.
- *
- * Os handlers eram literalmente idênticos entre os dois modals (~14
+ * Os handlers eram literalmente idênticos entre os modals (~14
  * linhas cada bloco × 2 arquivos = 28 linhas duplicadas) — cenário
- * clássico de BLOCKER de duplicação Sonar (lição PR #123/#127 — Sonar
- * conta blocos de 10+ linhas como `New Code Duplication` independente
- * da intenção). Centralizamos aqui para que o BLOCKER nunca volte.
+ * clássico de BLOCKER de duplicação Sonar (lição PR #123/#127 —
+ * Sonar conta blocos de 10+ linhas como `New Code Duplication`
+ * independente da intenção). Centralizamos no helper compartilhado
+ * para que o BLOCKER nunca volte.
  *
  * O caller é dono da lógica de submit (que precisa do contexto de
  * `createSystem` vs `updateSystem`), do reset entre aberturas e do
- * mapping de erros — o hook só cuida do que é genuinamente compartilhado.
+ * mapping de erros — o hook só cuida do que é genuinamente
+ * compartilhado.
  */
 
-interface UseSystemFormReturn {
-  formState: SystemFormState;
-  fieldErrors: SystemFieldErrors;
-  submitError: string | null;
-  isSubmitting: boolean;
-  setFormState: React.Dispatch<React.SetStateAction<SystemFormState>>;
-  setFieldErrors: React.Dispatch<React.SetStateAction<SystemFieldErrors>>;
-  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
-  setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
-  handleNameChange: (value: string) => void;
-  handleCodeChange: (value: string) => void;
-  handleDescriptionChange: (value: string) => void;
+export type UseSystemFormReturn = Omit<
+  UseNameCodeDescriptionFormReturn,
+  "prepareSubmit"
+> & {
   /**
-   * Roda a validação client-side e, se passar, prepara o payload trimado
-   * + zera erros + marca `isSubmitting`. Devolve o payload pronto para
-   * envio quando válido, ou `null` quando não (já tendo populado
-   * `fieldErrors`). Centralizar essa rotina elimina ~14 linhas de
-   * boilerplate idênticas entre `NewSystemModal` e `EditSystemModal`
-   * (lição PR #127 — Sonar conta 10+ linhas em 2+ arquivos como
-   * duplicação independente da intenção).
+   * Roda a validação client-side e, se passar, prepara o
+   * `CreateSystemPayload` trimado. Diferente do `useRoleForm` (que
+   * exige `systemId` injetado pelo caller), `useSystemForm`
+   * devolve o payload sem `systemId` — o backend de sistemas usa o
+   * próprio token JWT como contexto, não precisa do campo no body.
    */
   prepareSubmit: () => CreateSystemPayload | null;
-  /**
-   * Aplica o tratamento de uma resposta 400 do backend: distribui erros
-   * por campo quando `ValidationProblemDetails` é mapeável, ou popula
-   * `submitError` com a mensagem do backend quando não. Centraliza ~10
-   * linhas de side-effect idênticas que apareciam nos dois modals
-   * (lição PR #127).
-   */
-  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
-}
+};
 
-export function useSystemForm(initialState: SystemFormState): UseSystemFormReturn {
-  const [formState, setFormState] = useState<SystemFormState>(initialState);
-  const [fieldErrors, setFieldErrors] = useState<SystemFieldErrors>({});
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-
-  // Handlers `name`/`code`/`description` gerados pelo helper genérico
-  // (lição PR #134 — Sonar tokenizou ~19 linhas idênticas entre
-  // `useSystemForm` e `useRouteForm`). Cada handler atualiza o campo
-  // correspondente e limpa o erro inline associado.
-  const {
-    name: handleNameChange,
-    code: handleCodeChange,
-    description: handleDescriptionChange,
-  } = useFieldChangeHandlers<SystemFormState, SystemFieldErrors>(
-    SYSTEM_FORM_FIELDS,
-    setFormState,
-    setFieldErrors,
-  );
+export function useSystemForm(
+  initialState: SystemFormState,
+): UseSystemFormReturn {
+  const inner = useNameCodeDescriptionForm(initialState);
 
   const prepareSubmit = useCallback((): CreateSystemPayload | null => {
-    const clientErrors = validateSystemForm(formState);
-    if (clientErrors) {
-      setFieldErrors(clientErrors);
-      setSubmitError(null);
-      return null;
-    }
-    setFieldErrors({});
-    setSubmitError(null);
-    setIsSubmitting(true);
-    // `description: ''` é trimado para `''` aqui; a camada HTTP
-    // (`buildSystemMutationBody`) omite o campo quando vazio para que o
-    // backend grave `null`. Trim duplicado é defensivo — preserva o
-    // contrato mesmo se um caller futuro pular a camada HTTP.
+    const trimmed = inner.prepareSubmit();
+    if (trimmed === null) return null;
     return {
-      name: formState.name.trim(),
-      code: formState.code.trim(),
-      description: formState.description.trim(),
+      name: trimmed.name,
+      code: trimmed.code,
+      description: trimmed.description,
     };
-  }, [formState]);
-
-  const applyBadRequest = useCallback((details: unknown, fallbackMessage: string): void => {
-    const decision = decideBadRequestHandling(details, fallbackMessage);
-    if (decision.kind === 'field-errors') {
-      setFieldErrors(decision.errors);
-      setSubmitError(null);
-    } else {
-      setSubmitError(decision.message);
-    }
-  }, []);
+  }, [inner]);
 
   return {
-    formState,
-    fieldErrors,
-    submitError,
-    isSubmitting,
-    setFormState,
-    setFieldErrors,
-    setSubmitError,
-    setIsSubmitting,
-    handleNameChange,
-    handleCodeChange,
-    handleDescriptionChange,
+    ...inner,
     prepareSubmit,
-    applyBadRequest,
   };
 }

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -1,7 +1,12 @@
-import { apiClient } from './index';
+import { apiClient } from "./index";
 
-import type { PagedResponse } from './systems';
-import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
+import type { PagedResponse } from "./systems";
+import type {
+  ApiClient,
+  ApiError,
+  BodyRequestOptions,
+  SafeRequestOptions,
+} from "./types";
 
 /**
  * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
@@ -17,8 +22,8 @@ import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from
  * primeiro PR do recurso).
  */
 function makeParseError(): ApiError {
-  return Object.assign(new Error('Resposta inválida do servidor.'), {
-    kind: 'parse' as const,
+  return Object.assign(new Error("Resposta inválida do servidor."), {
+    kind: "parse" as const,
   });
 }
 
@@ -97,28 +102,28 @@ export interface RoleDto {
  * em arquivos diferentes precisam de helper compartilhado").
  */
 export function isRoleDto(value: unknown): value is RoleDto {
-  if (!value || typeof value !== 'object') {
+  if (!value || typeof value !== "object") {
     return false;
   }
   const record = value as Record<string, unknown>;
   return (
-    typeof record.id === 'string' &&
-    typeof record.name === 'string' &&
-    typeof record.code === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string' &&
+    typeof record.id === "string" &&
+    typeof record.name === "string" &&
+    typeof record.code === "string" &&
+    typeof record.createdAt === "string" &&
+    typeof record.updatedAt === "string" &&
     (record.description === null ||
       record.description === undefined ||
-      typeof record.description === 'string') &&
+      typeof record.description === "string") &&
     (record.permissionsCount === null ||
       record.permissionsCount === undefined ||
-      typeof record.permissionsCount === 'number') &&
+      typeof record.permissionsCount === "number") &&
     (record.usersCount === null ||
       record.usersCount === undefined ||
-      typeof record.usersCount === 'number') &&
+      typeof record.usersCount === "number") &&
     (record.deletedAt === null ||
       record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
+      typeof record.deletedAt === "string")
   );
 }
 
@@ -138,15 +143,17 @@ export function isRoleDto(value: unknown): value is RoleDto {
  * (espelhando `RoutesController`); aí `listRoles` valida o envelope
  * direto e aposenta a adaptação client-side.
  */
-export function isPagedRolesResponse(value: unknown): value is PagedResponse<RoleDto> {
-  if (!value || typeof value !== 'object') {
+export function isPagedRolesResponse(
+  value: unknown,
+): value is PagedResponse<RoleDto> {
+  if (!value || typeof value !== "object") {
     return false;
   }
   const record = value as Record<string, unknown>;
   if (
-    typeof record.page !== 'number' ||
-    typeof record.pageSize !== 'number' ||
-    typeof record.total !== 'number' ||
+    typeof record.page !== "number" ||
+    typeof record.pageSize !== "number" ||
+    typeof record.total !== "number" ||
     !Array.isArray(record.data)
   ) {
     return false;
@@ -202,7 +209,7 @@ export interface ListRolesParams {
  * `Routes`), trocar para `'/systems/roles'` em uma única linha — o
  * resto do adapter já está pronto.
  */
-const ROLES_LIST_PATH = '/roles';
+const ROLES_LIST_PATH = "/roles";
 
 /**
  * Lista roles de um sistema com busca, paginação e filtro de
@@ -318,19 +325,25 @@ function adaptRolesListResponse(
  * projetar tipos compartilhados para evitar duplicação no PR
  * seguinte.
  *
+ * - `systemId` (obrigatório, UUID) — sistema dono da role. O backend
+ *   marca `RoleRequestBase.SystemId` como `[Required]` e rejeita
+ *   payloads sem este campo com 400. A UI sempre injeta o valor lido
+ *   da URL `/systems/:systemId/roles` (após enriquecimento do
+ *   contrato em `lfc-authenticator#163`/`#164`).
  * - `name` (obrigatório, máx. 80 chars) — nome amigável da role.
- * - `code` (obrigatório, máx. 50 chars) — identificador único global
- *   no `lfc-authenticator` (UX_Roles_Code é único globalmente —
- *   colidir com Code de outra role retorna 409).
- * - `description` (opcional, máx. 500 chars) — descrição livre.
- *   **Hoje** o backend não persiste o campo (TODO no model
- *   `AppRole`); o wrapper já o aceita para que a UI da #67 e #68
- *   não precise de PR destrutivo aqui quando o backend evoluir.
+ * - `code` (obrigatório, máx. 50 chars) — identificador da role.
+ *   Único por `(SystemId, Code)` no `lfc-authenticator` — colidir
+ *   com Code de outra role no mesmo sistema retorna 409 com
+ *   `"Já existe outro role com este Code neste sistema."`.
+ * - `description` (opcional, máx. 500 chars) — descrição livre. O
+ *   backend converte string vazia em `null` (mesmo padrão de
+ *   `RoutesController`).
  *
  * Backend trima `Name`/`Code` e converte `Description` vazia em
- * `null` (mesmo padrão de `RoutesController`).
+ * `null`.
  */
 export interface CreateRolePayload {
+  systemId: string;
   name: string;
   code: string;
   description?: string;
@@ -365,7 +378,7 @@ export async function createRole(
   client: ApiClient = apiClient,
 ): Promise<RoleDto> {
   const body = buildRoleMutationBody(payload);
-  const data = await client.post<unknown>('/roles', body, options);
+  const data = await client.post<unknown>("/roles", body, options);
   if (!isRoleDto(data)) {
     throw makeParseError();
   }
@@ -432,14 +445,17 @@ export async function deleteRole(
  * divergência futura no shape ajusta um único helper. Espelha
  * `buildRouteMutationBody` de `routes.ts`.
  *
- * **Hoje** o backend ignora `description` (TODO no model `AppRole`),
- * mas o wrapper já o envia para evitar PR destrutivo quando o
- * backend ganhar suporte ao campo.
+ * Após o enriquecimento do contrato em `lfc-authenticator#163`/
+ * `#164`, o backend exige `SystemId` e persiste `Description`. O
+ * wrapper propaga ambos: `systemId` é repassado sem trim (vem da URL
+ * já normalizada pelo router), e `description` é trimada e omitida
+ * se vier vazia para que o backend grave `null`.
  */
 function buildRoleMutationBody(
   payload: CreateRolePayload | UpdateRolePayload,
 ): CreateRolePayload {
   const body: CreateRolePayload = {
+    systemId: payload.systemId,
     name: payload.name.trim(),
     code: payload.code.trim(),
   };

--- a/src/shared/forms/NameCodeDescriptionForm.tsx
+++ b/src/shared/forms/NameCodeDescriptionForm.tsx
@@ -1,0 +1,431 @@
+import React, { useMemo } from "react";
+import styled from "styled-components";
+
+import { Alert, Button, Input, Textarea } from "../../components/ui";
+
+/**
+ * Form body genérico para entidades cujo CRUD expõe exatamente os
+ * mesmos 3 campos: `Name` (obrigatório, máx. 80), `Code` (obrigatório,
+ * máx. 50), `Description` (opcional, máx. 500). Hoje aplica-se a
+ * `systems` (#58/#59) e `roles` (#67/#68) — duas entidades cuja UI de
+ * mutação coincide totalmente em estrutura, mudando apenas placeholders
+ * e copy do submitLabel/título.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar):**
+ *
+ * Antes da Issue #68 cada recurso (sistemas/roles) tinha seu próprio
+ * `<Recurso>FormFields.tsx` com ~30 linhas de campos + `<Recurso>FormBody`
+ * com ~50 linhas de shell/footer/Alert. Sonar tokenizou ~102 linhas
+ * idênticas entre `SystemFormFields.tsx` e `RoleFormFields.tsx`,
+ * dispararia BLOCKER de duplicação (>3% de New Code Duplication —
+ * 7ª recorrência seguindo o mesmo padrão das PRs #119/#123/#127/#128/
+ * #134/#135).
+ *
+ * Centralizando aqui:
+ *
+ * - Cada `<recurso>` consome `NameCodeDescriptionFormBody` direto e
+ *   passa só o que diverge (placeholders, copy de submit/cancel,
+ *   `idPrefix`, callbacks de mudança).
+ * - `systems` e `roles` mantêm seus próprios `<Recurso>FormFields.tsx`
+ *   apenas como wrapper fino quando precisam de controle adicional;
+ *   por padrão consomem o helper diretamente.
+ * - Adicionar um recurso futuro com mesmo shape (3 campos
+ *   Name/Code/Description) só exige importar este módulo — nenhum
+ *   código novo de campos.
+ *
+ * **Por que não unificar com `RouteFormFields`?** Rotas têm 4 campos
+ * (extra `systemTokenTypeId` num `<Select>` com regras próprias —
+ * carregamento async, opção sintética para token type inativo, etc.).
+ * Forçar abstração que cubra ambos exigiria parametrização excessiva
+ * do tipo de campo (Input/Textarea/Select) — o custo cognitivo
+ * supera o benefício. Mantemos `RouteFormFields` separado e este
+ * módulo focado no shape compartilhado de 2 recursos.
+ */
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+const FormShell = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const FormFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+`;
+
+const FormHelperRow = styled.div`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const FieldStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+/* ─── Tipos públicos ─────────────────────────────────────── */
+
+/** Estado controlado dos 3 campos. Usado por todos os recursos com este shape. */
+export interface NameCodeDescriptionFormState {
+  name: string;
+  code: string;
+  description: string;
+}
+
+/** Erros inline por campo. Cada chave é opcional (undefined = válido). */
+export interface NameCodeDescriptionFieldErrors {
+  name?: string;
+  code?: string;
+  description?: string;
+}
+
+/**
+ * Cópia textual injetada por cada recurso para diferenciar
+ * placeholders e helper text sem duplicar JSX. Cada slot existe
+ * porque divergiu em pelo menos um recurso real (sistemas vs roles).
+ */
+export interface NameCodeDescriptionFormCopy {
+  /** Placeholder do campo Nome (ex.: "ex.: lfc-authenticator", "ex.: Administrador"). */
+  namePlaceholder: string;
+  /** Placeholder do campo Código (ex.: "ex.: AUTH", "ex.: admin"). */
+  codePlaceholder: string;
+  /** Placeholder do Textarea de Descrição. */
+  descriptionPlaceholder: string;
+}
+
+/* ─── Constantes do contrato (espelham o backend) ────────── */
+
+/** Tamanho máximo do campo `Name` — espelha `MaxLength(80)` no backend. */
+export const NAME_CODE_DESCRIPTION_NAME_MAX = 80;
+/** Tamanho máximo do campo `Code` — espelha `MaxLength(50)` no backend. */
+export const NAME_CODE_DESCRIPTION_CODE_MAX = 50;
+/** Tamanho máximo do campo `Description` — espelha `MaxLength(500)` no backend. */
+export const NAME_CODE_DESCRIPTION_DESCRIPTION_MAX = 500;
+
+/* ─── Componente: campos (Input/Input/Textarea) ──────────── */
+
+interface NameCodeDescriptionFieldsProps {
+  /**
+   * Prefixo dos `data-testid` de cada input. Cada recurso usa o seu
+   * (`new-system`, `edit-role`, etc.) para preservar IDs estáveis nos
+   * testes existentes.
+   */
+  idPrefix: string;
+  /** Estado controlado dos campos. */
+  values: NameCodeDescriptionFormState;
+  /** Erros inline por campo. */
+  errors: NameCodeDescriptionFieldErrors;
+  /** Cópia textual (placeholders) específica do recurso. */
+  copy: NameCodeDescriptionFormCopy;
+  onChangeName: (value: string) => void;
+  onChangeCode: (value: string) => void;
+  onChangeDescription: (value: string) => void;
+  /**
+   * Quando `true`, todos os inputs ficam desabilitados (durante
+   * submit). Default `false`.
+   */
+  disabled?: boolean;
+  /**
+   * Quando `true`, o campo Name recebe `data-modal-initial-focus`
+   * para o `Modal` focar nele ao abrir. Default `true` — o caller
+   * desliga apenas em fluxos atípicos.
+   */
+  autoFocusName?: boolean;
+}
+
+const NameCodeDescriptionFields: React.FC<NameCodeDescriptionFieldsProps> = ({
+  idPrefix,
+  values,
+  errors,
+  copy,
+  onChangeName,
+  onChangeCode,
+  onChangeDescription,
+  disabled = false,
+  autoFocusName = true,
+}) => {
+  // `data-modal-initial-focus` no campo Name garante que o foco vá
+  // para o primeiro input independente da ordem do `querySelector`
+  // do `Modal`. Memoizado para preservar referência do objeto
+  // passado como spread.
+  const nameFocusAttr = useMemo(
+    () =>
+      autoFocusName
+        ? ({ "data-modal-initial-focus": true } as const)
+        : ({} as const),
+    [autoFocusName],
+  );
+
+  return (
+    <FieldStack>
+      <Input
+        label="Nome"
+        placeholder={copy.namePlaceholder}
+        value={values.name}
+        onChange={onChangeName}
+        error={errors.name}
+        maxLength={NAME_CODE_DESCRIPTION_NAME_MAX}
+        autoComplete="off"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-name`}
+        {...nameFocusAttr}
+      />
+      <Input
+        label="Código"
+        placeholder={copy.codePlaceholder}
+        value={values.code}
+        onChange={onChangeCode}
+        error={errors.code}
+        maxLength={NAME_CODE_DESCRIPTION_CODE_MAX}
+        autoComplete="off"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-code`}
+      />
+      <Textarea
+        label="Descrição"
+        placeholder={copy.descriptionPlaceholder}
+        value={values.description}
+        onChange={onChangeDescription}
+        error={errors.description}
+        helperText={
+          errors.description
+            ? undefined
+            : `${values.description.length}/${NAME_CODE_DESCRIPTION_DESCRIPTION_MAX} caracteres`
+        }
+        maxLength={NAME_CODE_DESCRIPTION_DESCRIPTION_MAX}
+        rows={3}
+        disabled={disabled}
+        data-testid={`${idPrefix}-description`}
+      />
+    </FieldStack>
+  );
+};
+
+/* ─── Componente: form body completo (shell + Alert + footer) ─── */
+
+interface NameCodeDescriptionFormBodyProps {
+  /** Prefixo dos `data-testid` do form e dos campos. */
+  idPrefix: string;
+  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
+  submitError: string | null;
+  /** Estado controlado dos campos. */
+  values: NameCodeDescriptionFormState;
+  /** Erros inline por campo. */
+  errors: NameCodeDescriptionFieldErrors;
+  /** Cópia textual (placeholders) específica do recurso. */
+  copy: NameCodeDescriptionFormCopy;
+  onChangeName: (value: string) => void;
+  onChangeCode: (value: string) => void;
+  onChangeDescription: (value: string) => void;
+  /** Handler do submit do form. */
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  /** Handler do botão Cancelar (bloqueado durante submit). */
+  onCancel: () => void;
+  /** Flag de submissão em andamento. */
+  isSubmitting: boolean;
+  /** Texto do botão de envio (ex.: "Criar sistema", "Salvar alterações"). */
+  submitLabel: string;
+}
+
+/**
+ * Form body completo para entidades com shape Name/Code/Description:
+ * shell `<form>` + Alert do erro genérico + campos + linha de hint
+ * obrigatórios + footer (Cancelar/Submit).
+ *
+ * Cada recurso (`systems`, `roles`) passa `idPrefix` próprio para
+ * preservar os testIds estáveis das suítes existentes
+ * (`new-system-form`, `edit-role-form`, etc.).
+ */
+export const NameCodeDescriptionFormBody: React.FC<
+  NameCodeDescriptionFormBodyProps
+> = ({
+  idPrefix,
+  submitError,
+  values,
+  errors,
+  copy,
+  onChangeName,
+  onChangeCode,
+  onChangeDescription,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  submitLabel,
+}) => (
+  <FormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
+    {submitError && (
+      <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
+        {submitError}
+      </Alert>
+    )}
+    <NameCodeDescriptionFields
+      idPrefix={idPrefix}
+      values={values}
+      errors={errors}
+      copy={copy}
+      onChangeName={onChangeName}
+      onChangeCode={onChangeCode}
+      onChangeDescription={onChangeDescription}
+      disabled={isSubmitting}
+    />
+    <FormHelperRow>Campos com * são obrigatórios.</FormHelperRow>
+    <FormFooter>
+      <Button
+        type="button"
+        variant="ghost"
+        size="md"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        data-testid={`${idPrefix}-cancel`}
+      >
+        Cancelar
+      </Button>
+      <Button
+        type="submit"
+        variant="primary"
+        size="md"
+        loading={isSubmitting}
+        data-testid={`${idPrefix}-submit`}
+      >
+        {submitLabel}
+      </Button>
+    </FormFooter>
+  </FormShell>
+);
+
+/* ─── Helpers de validação client-side ───────────────────── */
+
+/**
+ * Valida o estado do form genérico contra as mesmas regras do
+ * backend (`Required`/`MaxLength` em `Name`/`Code`/`Description`).
+ * Retorna `null` quando válido, ou um objeto com mensagens por campo.
+ *
+ * Cada recurso pode usar diretamente ou compor com regras adicionais
+ * (nenhum dos consumidores atuais — `systems`/`roles` — precisa
+ * estender, então a função é exportada como única fonte de verdade).
+ *
+ * Centralizar aqui evita ~30 linhas duplicadas entre
+ * `validateSystemForm` e `validateRoleForm` (lição PR #128 —
+ * mensagens diferem só em literais; lógica é idêntica).
+ */
+export function validateNameCodeDescriptionForm(
+  state: NameCodeDescriptionFormState,
+): NameCodeDescriptionFieldErrors | null {
+  const errors: NameCodeDescriptionFieldErrors = {};
+  const name = state.name.trim();
+  const code = state.code.trim();
+  const description = state.description.trim();
+
+  if (name.length === 0) {
+    errors.name = "Nome é obrigatório.";
+  } else if (name.length > NAME_CODE_DESCRIPTION_NAME_MAX) {
+    errors.name = `Nome deve ter no máximo ${NAME_CODE_DESCRIPTION_NAME_MAX} caracteres.`;
+  }
+
+  if (code.length === 0) {
+    errors.code = "Código é obrigatório.";
+  } else if (code.length > NAME_CODE_DESCRIPTION_CODE_MAX) {
+    errors.code = `Código deve ter no máximo ${NAME_CODE_DESCRIPTION_CODE_MAX} caracteres.`;
+  }
+
+  if (description.length > NAME_CODE_DESCRIPTION_DESCRIPTION_MAX) {
+    errors.description = `Descrição deve ter no máximo ${NAME_CODE_DESCRIPTION_DESCRIPTION_MAX} caracteres.`;
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+}
+
+/**
+ * Normaliza o nome de campo do backend (PascalCase) para o nome
+ * usado no estado do form (camelCase). Lista fechada nos 3 campos
+ * compartilhados — qualquer outra chave (ex.: `SystemId` em roles)
+ * é ignorada para que o caller não exiba inline um erro que o
+ * usuário não controla; tais erros caem no fallback genérico
+ * (`submitError`).
+ */
+function normalizeNameCodeDescriptionFieldName(
+  serverField: string,
+): keyof NameCodeDescriptionFieldErrors | null {
+  const lower = serverField.toLowerCase();
+  if (lower === "name") return "name";
+  if (lower === "code") return "code";
+  if (lower === "description") return "description";
+  return null;
+}
+
+/**
+ * Extrai erros por campo do payload de `ValidationProblemDetails`
+ * do ASP.NET (`{ errors: { Name: ['msg'], ... } }`). Tolerante: se
+ * o payload não bate com o shape esperado, devolve `null` para que
+ * o caller caia no fallback genérico.
+ *
+ * Centralizar aqui evita ~20 linhas duplicadas entre
+ * `extractSystemValidationErrors` e `extractRoleValidationErrors`
+ * — apenas a lista de campos aceitos diferia (ambos têm Name/
+ * Code/Description; `route` adicionaria SystemTokenTypeId, daí
+ * por que `routeFormShared.ts` não consome este helper).
+ */
+export function extractNameCodeDescriptionValidationErrors(
+  details: unknown,
+): NameCodeDescriptionFieldErrors | null {
+  if (!details || typeof details !== "object") {
+    return null;
+  }
+  const errors = (details as Record<string, unknown>).errors;
+  if (!errors || typeof errors !== "object") {
+    return null;
+  }
+  const result: NameCodeDescriptionFieldErrors = {};
+  for (const [serverField, raw] of Object.entries(errors)) {
+    const field = normalizeNameCodeDescriptionFieldName(serverField);
+    if (!field) continue;
+    if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === "string") {
+      result[field] = raw[0];
+    } else if (typeof raw === "string") {
+      result[field] = raw;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Resultado do mapeamento de uma `ApiError` 400 do backend para
+ * forms NameCodeDescription. O caller usa essa decisão para chamar
+ * `setFieldErrors` (campos mapeados) ou `setSubmitError` (mensagem
+ * genérica).
+ */
+export type NameCodeDescriptionSubmitDecision =
+  | { kind: "field-errors"; errors: NameCodeDescriptionFieldErrors }
+  | { kind: "submit-error"; message: string };
+
+/**
+ * Decide o tratamento de uma resposta 400 do backend:
+ *
+ * - Se o payload bate com `ValidationProblemDetails` e o backend
+ *   identificou ao menos um campo, devolve `field-errors` com as
+ *   mensagens mapeadas.
+ * - Caso contrário, devolve `submit-error` com a mensagem do
+ *   backend (caller exibe `Alert` no topo do form).
+ *
+ * Centralizar aqui evita ~10 linhas duplicadas entre
+ * `decideBadRequestHandling` (sistemas) e
+ * `decideRoleBadRequestHandling` (roles).
+ */
+export function decideNameCodeDescriptionBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): NameCodeDescriptionSubmitDecision {
+  const validation = extractNameCodeDescriptionValidationErrors(details);
+  if (validation) {
+    return { kind: "field-errors", errors: validation };
+  }
+  return { kind: "submit-error", message: fallbackMessage };
+}

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -19,17 +19,37 @@ export {
   classifyApiSubmitError,
   type ApiSubmitErrorAction,
   type ApiSubmitErrorCopy,
-} from './classifySubmitError';
-export { useFieldChangeHandlers, type FieldChangeHandlers } from './createFieldChangeHandler';
+} from "./classifySubmitError";
+export {
+  useFieldChangeHandlers,
+  type FieldChangeHandlers,
+} from "./createFieldChangeHandler";
 export {
   applyEditSubmitAction,
   type EditSubmitActionCopy,
   type EditSubmitActionDispatchers,
-} from './applyEditSubmitAction';
+} from "./applyEditSubmitAction";
 export {
   useEditEntitySubmit,
   type EditEntitySubmitCallbacks,
   type EditEntitySubmitCopy,
   type EditEntitySubmitDispatchers,
   type UseEditEntitySubmitArgs,
-} from './useEditEntitySubmit';
+} from "./useEditEntitySubmit";
+export {
+  NameCodeDescriptionFormBody,
+  NAME_CODE_DESCRIPTION_NAME_MAX,
+  NAME_CODE_DESCRIPTION_CODE_MAX,
+  NAME_CODE_DESCRIPTION_DESCRIPTION_MAX,
+  decideNameCodeDescriptionBadRequestHandling,
+  extractNameCodeDescriptionValidationErrors,
+  validateNameCodeDescriptionForm,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormCopy,
+  type NameCodeDescriptionFormState,
+  type NameCodeDescriptionSubmitDecision,
+} from "./NameCodeDescriptionForm";
+export {
+  useNameCodeDescriptionForm,
+  type UseNameCodeDescriptionFormReturn,
+} from "./useNameCodeDescriptionForm";

--- a/src/shared/forms/useNameCodeDescriptionForm.ts
+++ b/src/shared/forms/useNameCodeDescriptionForm.ts
@@ -1,0 +1,152 @@
+import { useCallback, useState } from "react";
+
+import { useFieldChangeHandlers } from "./createFieldChangeHandler";
+import {
+  decideNameCodeDescriptionBadRequestHandling,
+  validateNameCodeDescriptionForm,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormState,
+} from "./NameCodeDescriptionForm";
+
+/**
+ * Hook genérico que encapsula o ciclo completo de form para
+ * recursos com shape `Name`/`Code`/`Description` (sistemas hoje;
+ * roles a partir do PR #68; potencialmente outros recursos
+ * futuros).
+ *
+ * **Por que existe (lição PR #134/#135 reforçada):**
+ *
+ * Sonar tokenizou ~50 linhas idênticas entre `useSystemForm`,
+ * `useRouteForm` e `useRoleForm` (interface
+ * `Use<Recurso>FormReturn`, declaração de `useState`, handlers
+ * `prepareSubmit`/`applyBadRequest`). Centralizando aqui:
+ *
+ * - Cada `use<Recurso>Form` consome este hook e devolve o resultado
+ *   praticamente as-is (apenas decora o `prepareSubmit` quando
+ *   precisa do `systemId`).
+ * - Os tipos de retorno passam a ser alias estruturais (em vez de
+ *   interfaces declaradas independentemente).
+ * - Adicionar um recurso futuro com mesmo shape só exige um wrapper
+ *   de 5–10 linhas no domínio do recurso.
+ *
+ * **Não cobre rotas porque** `useRouteForm` tem 4 campos (extra
+ * `systemTokenTypeId`) — manter o hook genérico no shape de 3
+ * campos preserva o tipo estreito; o caller de rotas continua com
+ * sua versão adaptada (a duplicação remanescente entre
+ * `useRouteForm` e `useSystemForm` sobre os 3 campos em comum é
+ * pré-existente ao PR #68 e fica para uma refatoração isolada).
+ */
+
+export interface UseNameCodeDescriptionFormReturn {
+  formState: NameCodeDescriptionFormState;
+  fieldErrors: NameCodeDescriptionFieldErrors;
+  submitError: string | null;
+  isSubmitting: boolean;
+  setFormState: React.Dispatch<
+    React.SetStateAction<NameCodeDescriptionFormState>
+  >;
+  setFieldErrors: React.Dispatch<
+    React.SetStateAction<NameCodeDescriptionFieldErrors>
+  >;
+  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
+  setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  handleNameChange: (value: string) => void;
+  handleCodeChange: (value: string) => void;
+  handleDescriptionChange: (value: string) => void;
+  /**
+   * Roda a validação client-side e, se passar, prepara o payload
+   * trimado + zera erros + marca `isSubmitting`. Devolve o objeto
+   * `{ name, code, description }` com trim aplicado e `description`
+   * podendo ser string vazia (caller decide como tratar — sistemas
+   * envia inline; roles trima e omite quando vazio na camada HTTP).
+   *
+   * Devolve `null` quando há erros client-side (que já foram
+   * propagados via `setFieldErrors`).
+   *
+   * O caller compõe o payload final adicionando outros campos
+   * (`systemId` para roles/rotas) por cima do retorno.
+   */
+  prepareSubmit: () => NameCodeDescriptionFormState | null;
+  /**
+   * Aplica o tratamento de uma resposta 400 do backend: distribui
+   * erros por campo quando `ValidationProblemDetails` é mapeável,
+   * ou popula `submitError` com a mensagem do backend quando não.
+   */
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+}
+
+/**
+ * Lista fixa dos campos do form genérico. `as const` preserva os
+ * literais para o helper `useFieldChangeHandlers` inferir as chaves
+ * do `NameCodeDescriptionFormState`.
+ */
+const NAME_CODE_DESCRIPTION_FIELDS = ["name", "code", "description"] as const;
+
+export function useNameCodeDescriptionForm(
+  initialState: NameCodeDescriptionFormState,
+): UseNameCodeDescriptionFormReturn {
+  const [formState, setFormState] =
+    useState<NameCodeDescriptionFormState>(initialState);
+  const [fieldErrors, setFieldErrors] =
+    useState<NameCodeDescriptionFieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const {
+    name: handleNameChange,
+    code: handleCodeChange,
+    description: handleDescriptionChange,
+  } = useFieldChangeHandlers<
+    NameCodeDescriptionFormState,
+    NameCodeDescriptionFieldErrors
+  >(NAME_CODE_DESCRIPTION_FIELDS, setFormState, setFieldErrors);
+
+  const prepareSubmit = useCallback((): NameCodeDescriptionFormState | null => {
+    const clientErrors = validateNameCodeDescriptionForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+    return {
+      name: formState.name.trim(),
+      code: formState.code.trim(),
+      description: formState.description.trim(),
+    };
+  }, [formState]);
+
+  const applyBadRequest = useCallback(
+    (details: unknown, fallbackMessage: string): void => {
+      const decision = decideNameCodeDescriptionBadRequestHandling(
+        details,
+        fallbackMessage,
+      );
+      if (decision.kind === "field-errors") {
+        setFieldErrors(decision.errors);
+        setSubmitError(null);
+      } else {
+        setSubmitError(decision.message);
+      }
+    },
+    [],
+  );
+
+  return {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleNameChange,
+    handleCodeChange,
+    handleDescriptionChange,
+    prepareSubmit,
+    applyBadRequest,
+  };
+}

--- a/tests/pages/RolesPage.edit.test.tsx
+++ b/tests/pages/RolesPage.edit.test.tsx
@@ -1,0 +1,397 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildAuthMock } from "./__helpers__/mockUseAuth";
+import {
+  buildRolesCloseCases,
+  buildSharedRoleSubmitErrorCases,
+  createRolesClientStub,
+  fillEditRoleForm,
+  ID_ROLE_ROOT,
+  ID_SYS_AUTH,
+  makeRole,
+  openEditRoleModal,
+  renderRolesPage,
+  submitEditRoleForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from "./__helpers__/rolesTestHelpers";
+
+import type { RolesErrorCase } from "./__helpers__/rolesTestHelpers";
+import type { ApiError } from "@/shared/api";
+
+/**
+ * Suíte da `RolesPage` — caminho de edição (Issue #68, EPIC #47).
+ *
+ * Espelha a estratégia de `RoutesPage.edit.test.tsx`/
+ * `SystemsPage.edit.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory para que `vi.mock` capture o valor atual a cada
+ *   `useAuth()`).
+ * - Stub de `ApiClient` injetado em `<RolesPage client={stub} />`
+ *   isolando a página da camada de transporte real.
+ * - Helpers compartilhados em `rolesTestHelpers.tsx` para colapsar
+ *   o boilerplate "abrir modal → preencher → submeter" e evitar
+ *   `New Code Duplication` no Sonar (lição PR #134).
+ *
+ * Diferenças relativas à suíte de edição de Rotas:
+ *
+ * - O modal de role não tem dependência de `<Select>` externo (sem
+ *   token types) — o fluxo de abertura é simples: GET inicial →
+ *   click no botão "Editar" → form pré-populado.
+ * - O backend exige `SystemId` no body do PUT (após enriquecimento
+ *   do contrato em `lfc-authenticator#163`/`#164`); a UI sempre
+ *   propaga o valor lido da URL `/systems/:systemId/roles` — testes
+ *   asseguram que o body inclui `systemId`.
+ * - 409 cita "outra role neste sistema" (unicidade `(SystemId, Code)`
+ *   no backend; mensagem do controller é
+ *   `"Já existe outro role com este Code neste sistema."`).
+ * - 404 fecha o modal e dispara refetch (role removida
+ *   concorrentemente entre abertura e submit).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock("@/shared/auth", () => buildAuthMock(() => permissionsMock));
+
+const ROLES_UPDATE_PERMISSION = "AUTH_V1_ROLES_UPDATE";
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = "";
+});
+
+describe("RolesPage — edição (Issue #68)", () => {
+  describe('gating do botão "Editar" por linha', () => {
+    it('não exibe botões "Editar" quando o usuário não possui AUTH_V1_ROLES_UPDATE', async () => {
+      permissionsMock = [];
+      const client = createRolesClientStub();
+      client.get.mockResolvedValueOnce([makeRole()]);
+
+      // Renderização explícita aqui (sem helper de open) porque o
+      // teste valida apenas a ausência do botão antes de abrir
+      // qualquer modal.
+      renderRolesPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`roles-edit-${ID_ROLE_ROOT}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Editar" para linhas ativas quando o usuário possui AUTH_V1_ROLES_UPDATE', async () => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+      const client = createRolesClientStub();
+      client.get.mockResolvedValueOnce([makeRole()]);
+
+      renderRolesPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`roles-edit-${ID_ROLE_ROOT}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute("aria-label", "Editar role Root");
+    });
+
+    it('não exibe botão "Editar" em linhas soft-deletadas mesmo com permissão', async () => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+      const client = createRolesClientStub();
+      // O `listRoles` adapter filtra `deletedAt !== null` quando
+      // `includeDeleted=false` (default). Para que a role
+      // soft-deletada apareça na tabela e possamos verificar a
+      // ausência do botão "Editar", ligamos o toggle "Mostrar
+      // inativas" — assim o gating exercitado é o `row.deletedAt`
+      // dentro da render da coluna "Ações", não o filtro do
+      // adapter. Backend devolve a mesma role nas duas requests
+      // (toggle só muda o filtro client-side).
+      const deletedRole = makeRole({ deletedAt: "2026-02-01T00:00:00Z" });
+      client.get
+        .mockResolvedValueOnce([deletedRole])
+        .mockResolvedValueOnce([deletedRole]);
+
+      renderRolesPage(client);
+      await waitForInitialList(client);
+      // Liga o toggle "Mostrar inativas" para a role aparecer na
+      // listagem; o gating é por `row.deletedAt`, não pela
+      // visibilidade.
+      fireEvent.click(screen.getByTestId("roles-include-deleted"));
+      await waitFor(() => {
+        expect(screen.queryByTestId("roles-loading")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByTestId(`roles-edit-${ID_ROLE_ROOT}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("abertura e pré-preenchimento do modal", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+    });
+
+    it('clicar em "Editar" abre o diálogo pré-populado com os dados da role', async () => {
+      const role = makeRole({
+        id: ID_ROLE_ROOT,
+        name: "Root",
+        code: "root",
+        description: "Acesso irrestrito a todos os sistemas",
+      });
+      const client = createRolesClientStub();
+      await openEditRoleModal(client, { role });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("edit-role-name")).toHaveValue("Root");
+      expect(screen.getByTestId("edit-role-code")).toHaveValue("root");
+      expect(screen.getByTestId("edit-role-description")).toHaveValue(
+        "Acesso irrestrito a todos os sistemas",
+      );
+    });
+
+    it("aceita role sem description (description=null vira string vazia)", async () => {
+      const role = makeRole({ description: null });
+      const client = createRolesClientStub();
+      await openEditRoleModal(client, { role });
+
+      expect(screen.getByTestId("edit-role-description")).toHaveValue("");
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — colapsados em `it.each`
+     * via `buildRolesCloseCases` para evitar BLOCKER de duplicação
+     * Sonar (lição PR #123/#127). Reusa o mesmo helper de fechamento
+     * pré-fabricado em `rolesTestHelpers` desde o PR #143.
+     */
+    const CLOSE_CASES = buildRolesCloseCases("edit-role-cancel");
+
+    it.each(CLOSE_CASES)(
+      "fechar via $name não dispara PUT",
+      async ({ close }) => {
+        const client = createRolesClientStub();
+        await openEditRoleModal(client);
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        });
+        expect(client.put).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe("validação client-side", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+    });
+
+    it("apagar campos obrigatórios mostra erros inline e não chama PUT", async () => {
+      const client = createRolesClientStub();
+      await openEditRoleModal(client);
+
+      fillEditRoleForm({ name: "", code: "" });
+      fireEvent.submit(screen.getByTestId("edit-role-form"));
+
+      expect(screen.getByText("Nome é obrigatório.")).toBeInTheDocument();
+      expect(screen.getByText("Código é obrigatório.")).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it("campos com apenas espaços também são tratados como vazios", async () => {
+      const client = createRolesClientStub();
+      await openEditRoleModal(client);
+
+      fillEditRoleForm({ name: "   ", code: "  " });
+      fireEvent.submit(screen.getByTestId("edit-role-form"));
+
+      expect(screen.getByText("Nome é obrigatório.")).toBeInTheDocument();
+      expect(screen.getByText("Código é obrigatório.")).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it("descrição maior que 500 caracteres mostra erro inline", async () => {
+      const client = createRolesClientStub();
+      await openEditRoleModal(client);
+
+      // `fireEvent.change` ignora `maxLength` do input — a validação
+      // client-side roda no submit, então o erro aparece mesmo se o
+      // usuário colar texto bypassing o `maxLength`.
+      const longDesc = "x".repeat(501);
+      fillEditRoleForm({ description: longDesc });
+      fireEvent.submit(screen.getByTestId("edit-role-form"));
+
+      expect(
+        screen.getByText("Descrição deve ter no máximo 500 caracteres."),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submissão bem-sucedida", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+    });
+
+    it("envia PUT /roles/{id} com body trimado (incluindo systemId), fecha modal, exibe toast e refaz listRoles", async () => {
+      const original = makeRole({
+        id: ID_ROLE_ROOT,
+        name: "Root",
+        code: "root",
+        description: null,
+      });
+      const updated = makeRole({
+        id: ID_ROLE_ROOT,
+        name: "Root v2",
+        code: "root_v2",
+        description: "Versão atualizada.",
+      });
+      const client = createRolesClientStub();
+      // Fila: GET inicial → GET refetch → PUT.
+      client.get
+        .mockResolvedValueOnce([original])
+        .mockResolvedValueOnce([updated]);
+      client.put.mockResolvedValueOnce(updated);
+
+      await openEditRoleModal(client, { role: original });
+
+      fillEditRoleForm({
+        name: "  Root v2  ",
+        code: "  root_v2  ",
+        description: "  Versão atualizada.  ",
+      });
+      await submitEditRoleForm(client);
+
+      expect(client.put).toHaveBeenCalledWith(
+        `/roles/${ID_ROLE_ROOT}`,
+        {
+          systemId: ID_SYS_AUTH,
+          name: "Root v2",
+          code: "root_v2",
+          description: "Versão atualizada.",
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Role atualizada.".
+      expect(await screen.findByText("Role atualizada.")).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez (inicial
+      // + refetch).
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("envia body sem description quando o usuário apaga o conteúdo", async () => {
+      const original = makeRole({
+        id: ID_ROLE_ROOT,
+        description: "algo",
+      });
+      const updated = makeRole({ id: ID_ROLE_ROOT, description: null });
+      const client = createRolesClientStub();
+      client.put.mockResolvedValueOnce(updated);
+
+      await openEditRoleModal(client, { role: original });
+
+      fillEditRoleForm({ description: "" });
+      await submitEditRoleForm(client);
+
+      const [, body] = client.put.mock.calls[0];
+      expect(body).toEqual({
+        systemId: ID_SYS_AUTH,
+        name: "Root",
+        code: "root",
+      });
+      expect(body).not.toHaveProperty("description");
+    });
+  });
+
+  describe("tratamento de erros do backend", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_UPDATE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127) — testes
+     * com a mesma estrutura mudando 1-2 mocks viram tabela. Caso
+     * específico do edit: 409 com mensagem citando "outra role neste
+     * sistema" + 404 (role removida concorrentemente). Os 5 cenários
+     * comuns (400 com/sem errors, 401, 403, network) vêm de
+     * `buildSharedRoleSubmitErrorCases('atualizar')`, pré-fabricado
+     * desde o PR #143.
+     */
+    const ERROR_CASES: ReadonlyArray<RolesErrorCase> = [
+      {
+        name: "409 (code duplicado no sistema) exibe mensagem inline no campo code",
+        error: {
+          kind: "http",
+          status: 409,
+          message: "Já existe outro role com este Code neste sistema.",
+        },
+        expectedText: "Já existe outra role com este código neste sistema.",
+      },
+      ...buildSharedRoleSubmitErrorCases("atualizar"),
+      {
+        name: "404 (role removida) fecha modal, exibe toast e dispara refetch",
+        error: {
+          kind: "http",
+          status: 404,
+          message: "Role não encontrado.",
+        },
+        expectedText: "Role não encontrada ou foi removida. Atualize a lista.",
+        modalStaysOpen: false,
+      },
+    ];
+
+    it.each(ERROR_CASES)(
+      "mapeia $name",
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createRolesClientStub();
+        client.put.mockRejectedValueOnce(error);
+
+        await openEditRoleModal(client);
+        await submitEditRoleForm(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole("dialog")).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it("404 dispara refetch (onUpdated chamado mesmo em erro)", async () => {
+      const client = createRolesClientStub();
+      // Fila: GET inicial → PUT (404) → GET refetch.
+      client.get.mockResolvedValueOnce([makeRole()]).mockResolvedValueOnce([]);
+      client.put.mockRejectedValueOnce({
+        kind: "http",
+        status: 404,
+        message: "Role não encontrado.",
+      } satisfies ApiError);
+
+      await openEditRoleModal(client);
+      await submitEditRoleForm(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -326,3 +326,111 @@ export async function submitFormAndAwait(
   });
   await awaitOn();
 }
+
+/* ─── Helpers para suíte de edição (Issue #68) ──────────────── */
+
+/**
+ * Empilha respostas no stub do cliente para simular a sequência
+ * típica da `RolesPage` ao abrir o modal de edição:
+ *
+ *  1. `GET /roles` (listagem inicial da página, com a role-alvo).
+ *  2. (opcional) `GET /roles` (refetch após atualização).
+ *
+ * Diferente de `mockOpenEditModalResponses` em
+ * `routesTestHelpers.tsx` (que precisa empilhar token types), o
+ * fluxo de edit de role só requer o GET inicial — não há
+ * dependências externas no modal. Centraliza para que cada teste
+ * da suíte de edição não duplique o mesmo `client.get
+ * .mockResolvedValueOnce` (lição PR #127 — trechos de 5+ linhas em
+ * 2+ testes são `New Code Duplication`).
+ */
+export function mockOpenEditModalResponses(
+  client: ApiClientStub,
+  options: { role?: RoleDto } = {},
+): void {
+  const role = options.role ?? makeRole();
+  client.get.mockResolvedValueOnce([role]);
+}
+
+/**
+ * Mocka a resposta inicial (listagem com a role-alvo), renderiza a
+ * `RolesPage`, espera a lista carregar e clica no botão "Editar"
+ * da linha da role informada. Aguarda a presença do form do modal
+ * (`edit-role-form`) para garantir que o efeito de sincronização
+ * já populou os campos.
+ *
+ * Espelha `openEditRouteModal`/`openEditModal` (sistemas) — pré-
+ * fabricado para evitar duplicação entre as suítes de edição
+ * (lição PR #128). Quem precisar de mocks diferentes pode chamar
+ * `client.get.mockXxx` antes para sobrescrever a fila — a
+ * detecção de mocks pré-existentes preserva o caso "fila
+ * customizada de respostas" (ex.: cenários de erro 404 com
+ * refetch).
+ */
+export async function openEditRoleModal(
+  client: ApiClientStub,
+  options: { role?: RoleDto } = {},
+): Promise<void> {
+  const role = options.role ?? makeRole();
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    mockOpenEditModalResponses(client, { role });
+  }
+  renderRolesPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`roles-edit-${role.id}`));
+  // Garante que o efeito do modal terminou — a presença do form
+  // indica que o `useEffect` de sincronização já rodou.
+  await waitFor(() => {
+    expect(screen.getByTestId("edit-role-form")).toBeInTheDocument();
+  });
+}
+
+/**
+ * Preenche os campos do form do `EditRoleModal`. Cada chave é
+ * opcional — testes que validam só `name` e `code` deixam
+ * `description` ausente. Espelha `fillEditRouteForm` mas com
+ * testIds `edit-role-*`.
+ */
+export function fillEditRoleForm(values: {
+  name?: string;
+  code?: string;
+  description?: string;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId("edit-role-name"), {
+      target: { value: values.name },
+    });
+  }
+  if (values.code !== undefined) {
+    fireEvent.change(screen.getByTestId("edit-role-code"), {
+      target: { value: values.code },
+    });
+  }
+  if (values.description !== undefined) {
+    fireEvent.change(screen.getByTestId("edit-role-description"), {
+      target: { value: values.description },
+    });
+  }
+}
+
+/**
+ * Submete o form do `EditRoleModal` e aguarda o `client.put` ser
+ * chamado pelo menos `expectedPutCalls` vezes (default `1`).
+ * Espelha `submitEditRouteForm`/`submitEditSystemForm` — `act` +
+ * `waitFor` para flushar a microtask do submit antes do assert.
+ */
+export async function submitEditRoleForm(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId("edit-role-form"));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.put).toHaveBeenCalledTimes(expectedPutCalls),
+  );
+}

--- a/tests/shared/api/roles.test.ts
+++ b/tests/shared/api/roles.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from "vitest";
 
-import type { ApiClient, RoleDto } from '@/shared/api';
+import type { ApiClient, RoleDto } from "@/shared/api";
 
 import {
   createRole,
@@ -9,7 +9,7 @@ import {
   isRoleDto,
   listRoles,
   updateRole,
-} from '@/shared/api';
+} from "@/shared/api";
 
 /**
  * Suíte do módulo `src/shared/api/roles.ts` (Issue #66, EPIC #47).
@@ -39,8 +39,8 @@ import {
  * reescrever `listRoles` e ajustar dois testes do bloco "adapter".
  */
 
-const SYS_ID = '11111111-1111-1111-1111-111111111111';
-const ROLE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const SYS_ID = "11111111-1111-1111-1111-111111111111";
+const ROLE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 
 interface ClientStub {
   get: ReturnType<typeof vi.fn>;
@@ -69,7 +69,7 @@ function createStub(): ClientStub {
     patch: vi.fn(),
     delete: vi.fn(),
     setAuth: vi.fn(),
-    getSystemId: vi.fn(() => 'system-test-uuid'),
+    getSystemId: vi.fn(() => "system-test-uuid"),
   };
 }
 
@@ -82,24 +82,24 @@ function createStub(): ClientStub {
 function makeRoleDto(overrides: Partial<RoleDto> = {}): RoleDto {
   return {
     id: ROLE_ID,
-    name: 'Root',
-    code: 'root',
+    name: "Root",
+    code: "root",
     description: null,
     permissionsCount: null,
     usersCount: null,
-    createdAt: '2026-01-10T12:00:00Z',
-    updatedAt: '2026-01-10T12:00:00Z',
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
     deletedAt: null,
     ...overrides,
   };
 }
 
-describe('isRoleDto', () => {
-  it('aceita payload completo do contrato (com todos os campos opcionais)', () => {
+describe("isRoleDto", () => {
+  it("aceita payload completo do contrato (com todos os campos opcionais)", () => {
     expect(
       isRoleDto(
         makeRoleDto({
-          description: 'Acesso irrestrito',
+          description: "Acesso irrestrito",
           permissionsCount: 12,
           usersCount: 2,
         }),
@@ -107,57 +107,61 @@ describe('isRoleDto', () => {
     ).toBe(true);
   });
 
-  it('aceita payload sem os campos opcionais (estado atual do backend)', () => {
+  it("aceita payload sem os campos opcionais (estado atual do backend)", () => {
     expect(isRoleDto(makeRoleDto())).toBe(true);
-    const { description: _d, permissionsCount: _p, usersCount: _u, ...lean } =
-      makeRoleDto();
+    const {
+      description: _d,
+      permissionsCount: _p,
+      usersCount: _u,
+      ...lean
+    } = makeRoleDto();
     expect(isRoleDto(lean)).toBe(true);
   });
 
-  it('aceita description ausente/null/undefined', () => {
+  it("aceita description ausente/null/undefined", () => {
     expect(isRoleDto(makeRoleDto({ description: null }))).toBe(true);
     const { description: _omit, ...withoutDescription } = makeRoleDto();
     expect(isRoleDto(withoutDescription)).toBe(true);
   });
 
-  it('aceita deletedAt ausente/null/undefined', () => {
+  it("aceita deletedAt ausente/null/undefined", () => {
     expect(isRoleDto(makeRoleDto({ deletedAt: null }))).toBe(true);
     const { deletedAt: _omit, ...withoutDeleted } = makeRoleDto();
     expect(isRoleDto(withoutDeleted)).toBe(true);
   });
 
-  it('rejeita objetos sem campos obrigatórios', () => {
+  it("rejeita objetos sem campos obrigatórios", () => {
     expect(isRoleDto(null)).toBe(false);
     expect(isRoleDto(undefined)).toBe(false);
     expect(isRoleDto({})).toBe(false);
-    expect(isRoleDto({ id: 1, code: 'root' })).toBe(false);
+    expect(isRoleDto({ id: 1, code: "root" })).toBe(false);
     const missingCode = makeRoleDto();
     delete (missingCode as Partial<RoleDto>).code;
     expect(isRoleDto(missingCode)).toBe(false);
   });
 
-  it('rejeita campos com tipos inválidos', () => {
+  it("rejeita campos com tipos inválidos", () => {
     expect(
       isRoleDto(makeRoleDto({ description: 123 as unknown as string })),
     ).toBe(false);
-    expect(
-      isRoleDto(makeRoleDto({ deletedAt: 0 as unknown as string })),
-    ).toBe(false);
+    expect(isRoleDto(makeRoleDto({ deletedAt: 0 as unknown as string }))).toBe(
+      false,
+    );
     expect(
       isRoleDto(
         makeRoleDto({
-          permissionsCount: 'doze' as unknown as number,
+          permissionsCount: "doze" as unknown as number,
         }),
       ),
     ).toBe(false);
     expect(
-      isRoleDto(makeRoleDto({ usersCount: '12' as unknown as number })),
+      isRoleDto(makeRoleDto({ usersCount: "12" as unknown as number })),
     ).toBe(false);
   });
 });
 
-describe('isPagedRolesResponse', () => {
-  it('aceita envelope válido com dados', () => {
+describe("isPagedRolesResponse", () => {
+  it("aceita envelope válido com dados", () => {
     const envelope = {
       data: [makeRoleDto()],
       page: 1,
@@ -167,21 +171,21 @@ describe('isPagedRolesResponse', () => {
     expect(isPagedRolesResponse(envelope)).toBe(true);
   });
 
-  it('aceita envelope vazio', () => {
+  it("aceita envelope vazio", () => {
     expect(
       isPagedRolesResponse({ data: [], page: 1, pageSize: 20, total: 0 }),
     ).toBe(true);
   });
 
-  it('rejeita envelope sem campos', () => {
+  it("rejeita envelope sem campos", () => {
     expect(isPagedRolesResponse(null)).toBe(false);
     expect(isPagedRolesResponse({ data: [] })).toBe(false);
     expect(
-      isPagedRolesResponse({ data: [], page: '1', pageSize: 20, total: 0 }),
+      isPagedRolesResponse({ data: [], page: "1", pageSize: 20, total: 0 }),
     ).toBe(false);
   });
 
-  it('rejeita data com itens inválidos', () => {
+  it("rejeita data com itens inválidos", () => {
     expect(
       isPagedRolesResponse({
         data: [{ broken: true }],
@@ -193,8 +197,8 @@ describe('isPagedRolesResponse', () => {
   });
 });
 
-describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', () => {
-  it('emite GET /roles e devolve envelope paginado quando backend devolve array', async () => {
+describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", () => {
+  it("emite GET /roles e devolve envelope paginado quando backend devolve array", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([makeRoleDto()]);
 
@@ -205,14 +209,14 @@ describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', (
     );
 
     expect(client.get).toHaveBeenCalledTimes(1);
-    expect(client.get.mock.calls[0][0]).toBe('/roles');
+    expect(client.get.mock.calls[0][0]).toBe("/roles");
     expect(result.data).toHaveLength(1);
     expect(result.page).toBe(1);
     expect(result.pageSize).toBe(20);
     expect(result.total).toBe(1);
   });
 
-  it('passa signal/options adiante para o cliente', async () => {
+  it("passa signal/options adiante para o cliente", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([makeRoleDto()]);
     const controller = new AbortController();
@@ -226,7 +230,7 @@ describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', (
     expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
   });
 
-  it('lança ApiError(parse) quando o backend devolve payload inválido (não-array)', async () => {
+  it("lança ApiError(parse) quando o backend devolve payload inválido (não-array)", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce({ malformed: true });
 
@@ -237,12 +241,12 @@ describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', (
         client as unknown as ApiClient,
       ),
     ).rejects.toMatchObject({
-      kind: 'parse',
-      message: 'Resposta inválida do servidor.',
+      kind: "parse",
+      message: "Resposta inválida do servidor.",
     });
   });
 
-  it('lança ApiError(parse) quando algum item do array não é RoleDto', async () => {
+  it("lança ApiError(parse) quando algum item do array não é RoleDto", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([makeRoleDto(), { broken: true }]);
 
@@ -252,12 +256,12 @@ describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', (
         undefined,
         client as unknown as ApiClient,
       ),
-    ).rejects.toMatchObject({ kind: 'parse' });
+    ).rejects.toMatchObject({ kind: "parse" });
   });
 
-  it('propaga rejeições do cliente sem traduzir', async () => {
+  it("propaga rejeições do cliente sem traduzir", async () => {
     const client = createStub();
-    const apiError = { kind: 'http', status: 401, message: 'Sessão expirada.' };
+    const apiError = { kind: "http", status: 401, message: "Sessão expirada." };
     client.get.mockRejectedValueOnce(apiError);
 
     await expect(
@@ -270,15 +274,15 @@ describe('listRoles — endpoint atual /roles (GET cru, adapter client-side)', (
   });
 });
 
-describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => {
-  it('filtra deletedAt quando includeDeleted=false (default)', async () => {
+describe("listRoles — adapter client-side (filtros/ordem/paginação)", () => {
+  it("filtra deletedAt quando includeDeleted=false (default)", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: 'a', code: 'aroot' }),
+      makeRoleDto({ id: "a", code: "aroot" }),
       makeRoleDto({
-        id: 'b',
-        code: 'bdeleted',
-        deletedAt: '2026-02-01T00:00:00Z',
+        id: "b",
+        code: "bdeleted",
+        deletedAt: "2026-02-01T00:00:00Z",
       }),
     ]);
 
@@ -289,18 +293,18 @@ describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => 
     );
 
     expect(result.data).toHaveLength(1);
-    expect(result.data[0].id).toBe('a');
+    expect(result.data[0].id).toBe("a");
     expect(result.total).toBe(1);
   });
 
-  it('inclui deletedAt quando includeDeleted=true', async () => {
+  it("inclui deletedAt quando includeDeleted=true", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: 'a', code: 'aroot' }),
+      makeRoleDto({ id: "a", code: "aroot" }),
       makeRoleDto({
-        id: 'b',
-        code: 'bdeleted',
-        deletedAt: '2026-02-01T00:00:00Z',
+        id: "b",
+        code: "bdeleted",
+        deletedAt: "2026-02-01T00:00:00Z",
       }),
     ]);
 
@@ -314,33 +318,33 @@ describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => 
     expect(result.total).toBe(2);
   });
 
-  it('filtra por q (case-insensitive em name e code) após trim', async () => {
+  it("filtra por q (case-insensitive em name e code) após trim", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: 'a', name: 'Root', code: 'root' }),
-      makeRoleDto({ id: 'b', name: 'Admin', code: 'admin' }),
-      makeRoleDto({ id: 'c', name: 'Viewer', code: 'viewer' }),
+      makeRoleDto({ id: "a", name: "Root", code: "root" }),
+      makeRoleDto({ id: "b", name: "Admin", code: "admin" }),
+      makeRoleDto({ id: "c", name: "Viewer", code: "viewer" }),
     ]);
 
     const result = await listRoles(
-      { systemId: SYS_ID, q: '  ROO  ' },
+      { systemId: SYS_ID, q: "  ROO  " },
       undefined,
       client as unknown as ApiClient,
     );
 
-    expect(result.data.map((r) => r.id)).toEqual(['a']);
+    expect(result.data.map((r) => r.id)).toEqual(["a"]);
     expect(result.total).toBe(1);
   });
 
-  it('q vazio após trim devolve todos os resultados', async () => {
+  it("q vazio após trim devolve todos os resultados", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: 'a', code: 'a' }),
-      makeRoleDto({ id: 'b', code: 'b' }),
+      makeRoleDto({ id: "a", code: "a" }),
+      makeRoleDto({ id: "b", code: "b" }),
     ]);
 
     const result = await listRoles(
-      { systemId: SYS_ID, q: '   ' },
+      { systemId: SYS_ID, q: "   " },
       undefined,
       client as unknown as ApiClient,
     );
@@ -348,12 +352,12 @@ describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => 
     expect(result.total).toBe(2);
   });
 
-  it('ordena por code (estabilidade visual entre refetches)', async () => {
+  it("ordena por code (estabilidade visual entre refetches)", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: 'c', code: 'charlie' }),
-      makeRoleDto({ id: 'a', code: 'alpha' }),
-      makeRoleDto({ id: 'b', code: 'bravo' }),
+      makeRoleDto({ id: "c", code: "charlie" }),
+      makeRoleDto({ id: "a", code: "alpha" }),
+      makeRoleDto({ id: "b", code: "bravo" }),
     ]);
 
     const result = await listRoles(
@@ -362,13 +366,17 @@ describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => 
       client as unknown as ApiClient,
     );
 
-    expect(result.data.map((r) => r.code)).toEqual(['alpha', 'bravo', 'charlie']);
+    expect(result.data.map((r) => r.code)).toEqual([
+      "alpha",
+      "bravo",
+      "charlie",
+    ]);
   });
 
-  it('aplica page/pageSize em memória; total reflete o conjunto após filtros', async () => {
+  it("aplica page/pageSize em memória; total reflete o conjunto após filtros", async () => {
     const client = createStub();
     const rows = Array.from({ length: 25 }, (_, i) =>
-      makeRoleDto({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
+      makeRoleDto({ id: `id-${i}`, code: `r${String(i).padStart(2, "0")}` }),
     );
     client.get.mockResolvedValueOnce(rows);
 
@@ -382,21 +390,22 @@ describe('listRoles — adapter client-side (filtros/ordem/paginação)', () => 
     expect(result.pageSize).toBe(10);
     expect(result.total).toBe(25);
     expect(result.data).toHaveLength(10);
-    expect(result.data[0].code).toBe('r10');
+    expect(result.data[0].code).toBe("r10");
   });
 });
 
-describe('createRole', () => {
-  it('emite POST /roles com body trimado e devolve RoleDto', async () => {
+describe("createRole", () => {
+  it("emite POST /roles com body trimado (incluindo systemId) e devolve RoleDto", async () => {
     const client = createStub();
     const created = makeRoleDto();
     client.post.mockResolvedValueOnce(created);
 
     const result = await createRole(
       {
-        name: '  Root  ',
-        code: ' root ',
-        description: '  desc  ',
+        systemId: SYS_ID,
+        name: "  Root  ",
+        code: " root ",
+        description: "  desc  ",
       },
       undefined,
       client as unknown as ApiClient,
@@ -404,56 +413,63 @@ describe('createRole', () => {
 
     expect(client.post).toHaveBeenCalledTimes(1);
     const [path, body] = client.post.mock.calls[0];
-    expect(path).toBe('/roles');
+    expect(path).toBe("/roles");
+    // `systemId` é exigido pelo backend após o enriquecimento do
+    // contrato em `lfc-authenticator#163`/`#164` — wrapper sempre o
+    // propaga sem trim (vem da URL já normalizada). `name`/`code`/
+    // `description` recebem trim defensivo.
     expect(body).toEqual({
-      name: 'Root',
-      code: 'root',
-      description: 'desc',
+      systemId: SYS_ID,
+      name: "Root",
+      code: "root",
+      description: "desc",
     });
     expect(result).toEqual(created);
   });
 
-  it('omite description quando string vazia/whitespace após trim', async () => {
+  it("omite description quando string vazia/whitespace após trim", async () => {
     const client = createStub();
     client.post.mockResolvedValueOnce(makeRoleDto());
 
     await createRole(
-      { name: 'Root', code: 'root', description: '   ' },
+      { systemId: SYS_ID, name: "Root", code: "root", description: "   " },
       undefined,
       client as unknown as ApiClient,
     );
 
     expect(client.post.mock.calls[0][1]).toEqual({
-      name: 'Root',
-      code: 'root',
+      systemId: SYS_ID,
+      name: "Root",
+      code: "root",
     });
   });
 
-  it('lança ApiError(parse) quando resposta não é RoleDto', async () => {
+  it("lança ApiError(parse) quando resposta não é RoleDto", async () => {
     const client = createStub();
     client.post.mockResolvedValueOnce({ malformed: true });
 
     await expect(
       createRole(
-        { name: 'X', code: 'X' },
+        { systemId: SYS_ID, name: "X", code: "X" },
         undefined,
         client as unknown as ApiClient,
       ),
-    ).rejects.toMatchObject({ kind: 'parse' });
+    ).rejects.toMatchObject({ kind: "parse" });
   });
 });
 
-describe('updateRole', () => {
-  it('emite PUT /roles/{id} com body trimado e devolve RoleDto', async () => {
+describe("updateRole", () => {
+  it("emite PUT /roles/{id} com body trimado (incluindo systemId) e devolve RoleDto", async () => {
     const client = createStub();
-    const updated = makeRoleDto({ name: 'Root (atualizado)' });
+    const updated = makeRoleDto({ name: "Root (atualizado)" });
     client.put.mockResolvedValueOnce(updated);
 
     const result = await updateRole(
       ROLE_ID,
       {
-        name: '  Root (atualizado)  ',
-        code: 'root',
+        systemId: SYS_ID,
+        name: "  Root (atualizado)  ",
+        code: "root",
       },
       undefined,
       client as unknown as ApiClient,
@@ -462,30 +478,36 @@ describe('updateRole', () => {
     expect(client.put).toHaveBeenCalledTimes(1);
     const [path, body] = client.put.mock.calls[0];
     expect(path).toBe(`/roles/${ROLE_ID}`);
+    // `systemId` é exigido pelo backend (`UpdateRoleRequest` herda
+    // `SystemId` de `RoleRequestBase`). Tentar mudá-lo retorna 400
+    // com "SystemId é imutável após a criação do role." — o wrapper
+    // só repassa, é responsabilidade do caller injetar o valor
+    // correto (vindo da URL `/systems/:systemId/roles`).
     expect(body).toEqual({
-      name: 'Root (atualizado)',
-      code: 'root',
+      systemId: SYS_ID,
+      name: "Root (atualizado)",
+      code: "root",
     });
     expect(result).toEqual(updated);
   });
 
-  it('lança ApiError(parse) quando resposta não é RoleDto', async () => {
+  it("lança ApiError(parse) quando resposta não é RoleDto", async () => {
     const client = createStub();
     client.put.mockResolvedValueOnce(null);
 
     await expect(
       updateRole(
         ROLE_ID,
-        { name: 'X', code: 'X' },
+        { systemId: SYS_ID, name: "X", code: "X" },
         undefined,
         client as unknown as ApiClient,
       ),
-    ).rejects.toMatchObject({ kind: 'parse' });
+    ).rejects.toMatchObject({ kind: "parse" });
   });
 });
 
-describe('deleteRole', () => {
-  it('emite DELETE /roles/{id} e resolve void', async () => {
+describe("deleteRole", () => {
+  it("emite DELETE /roles/{id} e resolve void", async () => {
     const client = createStub();
     client.delete.mockResolvedValueOnce(undefined);
 
@@ -496,9 +518,13 @@ describe('deleteRole', () => {
     expect(client.delete.mock.calls[0][0]).toBe(`/roles/${ROLE_ID}`);
   });
 
-  it('propaga rejeições do cliente sem traduzir', async () => {
+  it("propaga rejeições do cliente sem traduzir", async () => {
     const client = createStub();
-    const apiError = { kind: 'http', status: 404, message: 'Role não encontrada.' };
+    const apiError = {
+      kind: "http",
+      status: 404,
+      message: "Role não encontrada.",
+    };
     client.delete.mockRejectedValueOnce(apiError);
 
     await expect(


### PR DESCRIPTION
## Contexto

Sub-issue da EPIC #47 (CRUD de Roles por Sistema). Backend `lfc-authenticator` foi enriquecido em #163/#164 — `RoleResponse` agora carrega `SystemId` e `Description`, e o contrato `RoleRequestBase` exige `SystemId` em create/update. Esta PR cobre o caminho de edição (#68).

## Objetivo

Habilitar a edição de roles existentes a partir da `RolesPage`, com modal pré-populado, gating por `AUTH_V1_ROLES_UPDATE`, mapeamento completo de erros do backend e — fundamentalmente — evitar a 7ª recorrência de New Code Duplication no Sonar (lições PRs #119/#123/#127/#128/#134/#135).

## O que foi feito

### Modal de edição (Issue #68)
- `src/pages/roles/EditRoleModal.tsx` — modal espelhando `EditSystemModal`/`EditRouteModal`. Pré-popula Name/Code/Description a partir do `RoleDto` (Description vem do enriquecimento backend; quando vier `null`/`undefined` cai em string vazia).
- `src/pages/roles/RoleFormFields.tsx` — wrapper fino do helper genérico, injetando placeholders/copy de "role".
- `src/pages/roles/useRoleForm.ts` — hook delegando para `useNameCodeDescriptionForm` e injetando `systemId` no `prepareSubmit`.
- `src/pages/roles/rolesFormShared.ts` — alias estruturais (`RoleFormState`, `RoleFieldErrors`, `validateRoleForm`, `classifyRoleSubmitError`, etc.) delegando ao helper genérico.
- `src/pages/RolesPage.tsx` — wiring: ação "Editar" gateada por permissão e por `row.deletedAt === null`, montagem do modal com `systemId` lido da URL.

### Mapeamento de erros do backend
- 409 (`Já existe outro role com este Code neste sistema.`) → mensagem inline no campo `code` ("Já existe outra role com este código neste sistema.").
- 404 → toast vermelho + close + refetch (role removida concorrentemente).
- 400 → fluxo padrão (errors mapeáveis viram inline; restante vai para Alert no topo).
- 401/403/network → toast vermelho com mensagem do backend ou fallback genérico.

### Camada HTTP (`src/shared/api/roles.ts`)
- `CreateRolePayload` agora exige `systemId: string` — backend rejeita PUT/POST sem o campo (`SystemId é obrigatório`) após o enriquecimento.
- `buildRoleMutationBody` propaga `systemId` no body.
- Testes em `tests/shared/api/roles.test.ts` verificam a presença do campo no body de create/update.

### Refatoração contra duplicação Sonar (lição PR #134/#135 reforçada)
Antes desta PR, `SystemFormFields`/`SystemFormBody` (~250 linhas) seriam clonados pelo recurso "roles" — Sonar tokenizou >100 linhas idênticas (gatilho garantido de >3% de New Code Duplication). Centralizamos em `src/shared/forms/`:

- `NameCodeDescriptionForm.tsx` — `NameCodeDescriptionFormBody` (form completo: shell + Alert + fields + footer), `validateNameCodeDescriptionForm`, `extractNameCodeDescriptionValidationErrors`, `decideNameCodeDescriptionBadRequestHandling`.
- `useNameCodeDescriptionForm.ts` — hook genérico de estado + handlers + `prepareSubmit` + `applyBadRequest`.

`SystemFormFields`/`systemFormShared`/`useSystemForm` foram convertidos em wrappers finos que delegam para esses helpers (preservando a API local — `SystemFormBody`, `validateSystemForm`, `useSystemForm`, etc. — para não quebrar `NewSystemModal`/`EditSystemModal` nem suas suítes).

**Resultado:** baseline `development` 2.73% → 2.61% após a PR (queda de 0.12 pp **mesmo introduzindo um recurso novo**).

## Arquivos impactados

- **Novos**: `src/pages/roles/{EditRoleModal,RoleFormFields,rolesFormShared,useRoleForm}`, `src/shared/forms/{NameCodeDescriptionForm,useNameCodeDescriptionForm}`, `tests/pages/RolesPage.edit.test.tsx`.
- **Modificados**: `src/pages/RolesPage.tsx` (wiring do modal), `src/shared/api/roles.ts` (`systemId` no payload), `src/shared/forms/index.ts` (barrel atualizado), `src/pages/systems/{SystemFormFields,systemFormShared,useSystemForm}` (delegação aos helpers genéricos), `tests/pages/__helpers__/rolesTestHelpers.tsx` (helpers `openEditRoleModal`/`fillEditRoleForm`/`submitEditRoleForm`/`mockOpenEditModalResponses`), `tests/shared/api/roles.test.ts` (asserts de `systemId` no body).

## Testes

Suite completa via container Docker (`docker compose run --rm web npm test`):

\`\`\`
Test Files  50 passed (50)
Tests       719 passed (719)
\`\`\`

Cobertura específica em `tests/pages/RolesPage.edit.test.tsx` (21 testes):
- Gating do botão "Editar" (sem permissão / com permissão / linha soft-deletada).
- Abertura do modal pré-populado.
- Fechamento sem persistir (Esc, Cancelar, backdrop) — `it.each`.
- Validação client-side (campos obrigatórios, whitespace-only, descrição > 500).
- Submissão bem-sucedida (body trimado com `systemId`, modal fecha, toast verde, refetch).
- Submit sem description (omissão na camada HTTP).
- 5 cenários comuns + 409 + 404 (com refetch mesmo em erro) — `it.each`.

Gate de qualidade pré-PR (`programmer.md`):
- \`npm run lint\` → 0 erros, 0 warnings.
- \`npm run typecheck\` → 0 erros.
- \`npm test\` → 719/719 verde.
- \`npx jscpd src --threshold 3 --min-lines 10\` → 2.61% (sob o limite).

## Visual

- Form layout idêntico aos modals de Sistema/Rota (Name input + Code input + Description textarea + helper "Campos com * são obrigatórios" + footer Cancelar/Salvar alterações).
- Estados: hover/focus/disabled/loading no botão de submit (herdados do design system); inline errors em vermelho; Alert danger no topo para erro genérico; toast verde "Role atualizada." em sucesso.
- `data-modal-initial-focus` no campo Name garante foco no abrir.
- Cores via tokens (\`var(--space-*)\`, \`var(--text-*)\`, etc.) — nenhum hardcode.
- Mobile: ação "Editar" também aparece no `EntityCard` (paridade com `RoutesPage`/`SystemsPage`).

## Segurança

Nenhum impacto adicional. Token JWT propagado por `apiClient`; `systemId` vindo da URL do router (já sanitizado pelo React Router); inputs renderizados como texto (sem `dangerouslySetInnerHTML`); validação `MaxLength` espelha o backend, evitando payloads gigantes; sem `eval`/URLs externas.

## Riscos

- **Baixo**: SystemFormBody/systemFormShared/useSystemForm foram refatorados para delegar — mantivemos a API pública (mesmos exports/props), e a suíte completa de Sistemas (147 testes) passa intacta.
- **Mitigado**: extensão de `CreateRolePayload` com `systemId` quebraria callers — só temos um caller hoje (`buildRoleMutationBody`), atualizado nesta PR; os testes de `roles.test.ts` foram atualizados em sincronia.

## Issue relacionada

Closes #68