### PR TITLE
feat(clients): listagem com busca, filtro PF/PJ e paginação (#73)

### DIFF
--- a/src/pages/clients/ClientsListShellPage.tsx
+++ b/src/pages/clients/ClientsListShellPage.tsx
@@ -1,21 +1,409 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { PlaceholderPage } from '../PlaceholderPage';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Button, Select, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
+import { usePaginationControls } from '../../hooks/usePaginationControls';
+import {
+  DEFAULT_CLIENTS_INCLUDE_DELETED,
+  DEFAULT_CLIENTS_PAGE,
+  DEFAULT_CLIENTS_PAGE_SIZE,
+  listClients,
+} from '../../shared/api';
+import {
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  ErrorRetryBlock,
+  InitialLoadingSpinner,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  PaginationFooter,
+  Placeholder,
+  RefetchOverlay,
+  StatusBadge,
+  TableShell,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import type { TableColumn } from '../../components/ui';
+import type {
+  ApiClient,
+  ClientDto,
+  ClientType,
+  SafeRequestOptions,
+} from '../../shared/api';
 
 /**
- * Página-shell da listagem de clientes (`/clientes`).
- *
- * Esta página é parte do esqueleto de navegação introduzido pela
- * Issue #145. O conteúdo real (filtros, tabela, paginação, ações de
- * CRUD) será entregue por sub-issues subsequentes da EPIC #49 — o
- * objetivo aqui é apenas registrar a rota, vincular ao item de menu
- * e disparar o `RequirePermission` correto, mantendo a navegação
- * consistente com as demais áreas do painel.
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms
+ * é o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que
+ * uma digitação fluida não dispare 1 request por caractere. Espelha
+ * o valor usado por `SystemsPage`/`RolesPage`.
  */
-export const ClientsListShellPage: React.FC = () => (
-  <PlaceholderPage
-    eyebrow="05 Clientes"
-    title="Clientes"
-    desc="Pessoas e empresas cadastradas no ecossistema. A listagem completa será habilitada nas próximas iterações da EPIC de Clientes."
-  />
-);
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Valor sentinel usado pelo `<Select>` de filtro de tipo para
+ * representar "todos" (sem filtro). Mantido fora de `'PF'/'PJ'` para
+ * que a comparação no callback continue restrita à união
+ * `ClientType`. O valor `'ALL'` é apenas uma string de UI; quando
+ * detectado, omitimos `type` da request, mantendo a URL canônica.
+ */
+const TYPE_FILTER_ALL = 'ALL' as const;
+
+interface ClientsListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido —
+   * a página usa o singleton `apiClient` por trás de `listClients`.
+   * Em testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Aplica máscara visual ao CPF (`xxx.xxx.xxx-xx`). Os 11 dígitos vêm
+ * apenas de `digits` numéricos do backend (que armazena sem
+ * formatação após `NormalizeDigits`); valores inesperados (≠ 11
+ * dígitos) são devolvidos como-vieram para que a UI não corrompa o
+ * dado real — só mascara quando confiar no shape.
+ *
+ * Centralizado aqui (e não em `shared/`) porque é hoje específico da
+ * listagem de clientes; quando `EditClientModal` (#75) precisar do
+ * mesmo helper, o move para `src/shared/format/cpfCnpj.ts` em uma
+ * extração isolada — sem fazer extração antecipada no primeiro PR
+ * para não criar shared util "fantasma" sem consumidor real.
+ */
+function formatCpf(digits: string): string {
+  if (!/^\d{11}$/.test(digits)) {
+    return digits;
+  }
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9, 11)}`;
+}
+
+/**
+ * Aplica máscara visual ao CNPJ (`xx.xxx.xxx/xxxx-xx`). Mesma
+ * estratégia defensiva de `formatCpf`: backend devolve 14 dígitos
+ * crus após `NormalizeDigits`; valores inesperados retornam
+ * inalterados para preservar visibilidade do dado real.
+ */
+function formatCnpj(digits: string): string {
+  if (!/^\d{14}$/.test(digits)) {
+    return digits;
+  }
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12, 14)}`;
+}
+
+/**
+ * Resolve o "Nome" exibido na tabela conforme o `type`:
+ *
+ * - `PF` → `fullName` (obrigatório no contrato do backend para PF).
+ * - `PJ` → `corporateName` (obrigatório no contrato do backend para PJ).
+ *
+ * Se o backend devolver ambos `null` (cenário fora do contrato, mas
+ * que o frontend deve tolerar para não quebrar a UI), exibimos um
+ * placeholder "—" — sinal visual claro de que aquele registro está
+ * incompleto sem corromper o resto da tabela.
+ */
+function resolveClientName(row: ClientDto): string | null {
+  if (row.type === 'PF') {
+    return row.fullName;
+  }
+  return row.corporateName;
+}
+
+/**
+ * Resolve o "Documento" exibido na tabela conforme o `type`,
+ * aplicando a máscara visual correspondente. Backend grava sempre
+ * apenas dígitos; a máscara só toca a renderização — qualquer
+ * mutação futura (#75 editar) deve normalizar para dígitos antes de
+ * enviar (espelhando o `NormalizeDigits` do backend), evitando
+ * inconsistência.
+ */
+function resolveClientDocument(row: ClientDto): string | null {
+  if (row.type === 'PF') {
+    return row.cpf ? formatCpf(row.cpf) : null;
+  }
+  return row.cnpj ? formatCnpj(row.cnpj) : null;
+}
+
+export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ client }) => {
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  // Filtro de tipo (PF/PJ/Todos). 'ALL' é o sentinel — quando ativo,
+  // omitimos o param da request e o backend devolve ambos os tipos.
+  const [typeFilter, setTypeFilter] = useState<typeof TYPE_FILTER_ALL | ClientType>(
+    TYPE_FILTER_ALL,
+  );
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_CLIENTS_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_CLIENTS_PAGE);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra
+   * para 3 itens, mas continuo na página 5 vazia". Espelha a
+   * `SystemsPage`/`RolesPage`.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_CLIENTS_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_CLIENTS_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_CLIENTS_PAGE);
+  }, []);
+
+  const handleTypeFilterChange = useCallback((value: string) => {
+    if (value === 'PF' || value === 'PJ') {
+      setTypeFilter(value);
+    } else {
+      setTypeFilter(TYPE_FILTER_ALL);
+    }
+    setPage(DEFAULT_CLIENTS_PAGE);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`. Captura os params
+   * derivados (busca debounced, page, filtros) e devolve uma função
+   * que aceita `signal` no `options`. O hook reage à mudança de
+   * identidade do `fetcher` para reexecutar — `useCallback` com as
+   * deps corretas mantém o ciclo previsível.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const effectiveTypeParam: ClientType | undefined =
+    typeFilter === TYPE_FILTER_ALL ? undefined : typeFilter;
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listClients(
+        {
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          type: effectiveTypeParam,
+          page,
+          pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, effectiveTypeParam, includeDeleted, page, trimmedSearchInput],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<ClientDto>({
+    fetcher,
+    fallbackErrorMessage: 'Falha ao carregar a lista de clientes. Tente novamente.',
+  });
+
+  const { totalPages, isFirstPage, isLastPage, handlePrevPage, handleNextPage } =
+    usePaginationControls({
+      total,
+      appliedPageSize,
+      defaultPageSize: DEFAULT_CLIENTS_PAGE_SIZE,
+      page,
+      setPage,
+    });
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio sem busca → "nenhum cliente cadastrado" + dica sobre o
+   *   toggle "Mostrar inativos" caso esteja desligado.
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhum cliente encontrado para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="clients-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhum cliente cadastrado.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Clientes removidos podem ser visualizados ativando &quot;Mostrar inativos&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  const columns = useMemo<ReadonlyArray<TableColumn<ClientDto>>>(
+    () => [
+      {
+        key: 'name',
+        label: 'Nome',
+        render: (row) => {
+          const name = resolveClientName(row);
+          if (name === null || name.trim().length === 0) {
+            return <Placeholder>—</Placeholder>;
+          }
+          return name;
+        },
+      },
+      {
+        key: 'document',
+        label: 'Documento',
+        render: (row) => {
+          const document = resolveClientDocument(row);
+          if (document === null) {
+            return <Placeholder>—</Placeholder>;
+          }
+          return <Mono>{document}</Mono>;
+        },
+      },
+      {
+        key: 'type',
+        label: 'Tipo',
+        width: '90px',
+        render: (row) => <Mono>{row.type}</Mono>,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '120px',
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} gender="m" />,
+      },
+    ],
+    [],
+  );
+
+  const showOverlay = isFetching && !isInitialLoading;
+
+  /**
+   * ARIA-live: anuncia o estado da listagem quando muda. Em loading
+   * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
+   * o total. Em erro, o `<Alert role="alert">` já cobre. O hook
+   * `useListingLiveMessage` centraliza a árvore de decisão (lição PR
+   * #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+   */
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'cliente',
+      pluralCarregando: 'clientes',
+      vazioSemBusca: 'Nenhum cliente cadastrado.',
+      gender: 'm',
+    },
+  });
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="05 Clientes"
+        title="Clientes cadastrados"
+        desc="Pessoas físicas e jurídicas registradas no ecossistema. Cada cliente pode ter usuários vinculados, emails extras e múltiplos contatos telefônicos."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome, documento (CPF/CNPJ)"
+        searchAriaLabel="Buscar clientes por nome ou documento"
+        searchTestId="clients-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui clientes com remoção lógica."
+        includeDeletedTestId="clients-include-deleted"
+        extraFilter={
+          <Select
+            label="Tipo"
+            size="sm"
+            value={typeFilter}
+            onChange={handleTypeFilterChange}
+            data-testid="clients-type-filter"
+            aria-label="Filtrar clientes por tipo"
+          >
+            <option value={TYPE_FILTER_ALL}>Todos</option>
+            <option value="PF">Pessoa física</option>
+            <option value="PJ">Pessoa jurídica</option>
+          </Select>
+        }
+      />
+
+      <LiveRegion message={liveMessage} testId="clients-live" />
+
+      {isInitialLoading && (
+        <InitialLoadingSpinner testId="clients-loading" label="Carregando clientes" />
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="clients-retry"
+        />
+      )}
+
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          <Table<ClientDto>
+            caption="Lista de clientes cadastrados no auth-service."
+            columns={columns}
+            data={rows}
+            getRowKey={(row) => row.id}
+            emptyState={emptyContent}
+          />
+          {showOverlay && <RefetchOverlay testId="clients-overlay" />}
+        </TableShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && total > 0 && (
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={handlePrevPage}
+          onNext={handleNextPage}
+          pageInfoTestId="clients-page-info"
+          prevTestId="clients-prev"
+          nextTestId="clients-next"
+        />
+      )}
+    </>
+  );
+};

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -229,7 +229,7 @@ function isNullableString(value: unknown): value is string | null | undefined {
  * coleções (`userIds`/`extraEmails`/`mobilePhones`/`landlinePhones`)
  * sem rejeitar fixtures minimalistas que omitem o campo.
  */
-function isOptionalArray<T>(
+function isOptionalArray(
   value: unknown,
   isItem: (item: unknown) => boolean,
 ): boolean {

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -1,3 +1,5 @@
+import { isPagedResponseEnvelope } from './pagedResponse';
+
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
@@ -11,7 +13,7 @@ import type { ApiClient, ApiError, SafeRequestOptions } from './types';
  * `ApiError` consumida por `isApiError` sem perder o stack trace.
  *
  * Centralizado para evitar repetir `Object.assign(new Error(...), { kind })`
- * em call sites do módulo — Sonar contaria a repetição como duplicação.
+ * em múltiplos call sites — Sonar contaria a repetição como duplicação.
  * Espelha o padrão de `systems.ts`/`routes.ts`/`roles.ts`/`users.ts`
  * (lição PR #128 — projetar shared helpers desde o primeiro PR do
  * recurso).
@@ -23,39 +25,89 @@ function makeParseError(): ApiError {
 }
 
 /**
+ * Tipo discriminador de cliente. Espelha o `Type` do `ClientResponse`
+ * do `lfc-authenticator`
+ * (`AuthService.Controllers.Clients.ClientsController.ClientResponse`),
+ * que aceita apenas `"PF"` (pessoa física) ou `"PJ"` (pessoa jurídica).
+ *
+ * O backend valida e normaliza (uppercase + trim) na criação/edição
+ * (`NormalizeRequest`/`ValidateClientByType`), e a listagem rejeita
+ * `type` ≠ PF/PJ com 400. Do lado do frontend, manter o tipo restrito
+ * via união de string-literais elimina checagens redundantes em
+ * runtime e garante que filtros/badges não recebam valores espúrios.
+ */
+export type ClientType = 'PF' | 'PJ';
+
+/**
+ * Espelho do `ClientEmailResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Clients.ClientsController.ClientEmailResponse`).
+ *
+ * Email extra de um cliente (até 3 por cliente, com regras
+ * anti-username — ver Issue #146). A listagem (Issue #73) **não**
+ * consome esses campos visualmente, mas o type guard do `ClientDto`
+ * valida o shape porque o backend devolve sempre — incluir aqui
+ * evita refatoração destrutiva nas próximas sub-issues (#74/#75/
+ * #146 — lição PR #128).
+ */
+export interface ClientEmailDto {
+  id: string;
+  email: string;
+  createdAt: string;
+}
+
+/**
+ * Espelho do `ClientPhoneResponse` do `lfc-authenticator`
+ * (`AuthService.Controllers.Clients.ClientsController.ClientPhoneResponse`).
+ *
+ * Telefone vinculado a um cliente. Ambos os arrays `mobilePhones` e
+ * `landlinePhones` no `ClientDto` usam este shape — o discriminador
+ * `Type` (mobile/phone) é representado pela posição no array do
+ * `ClientResponse`, não como campo do registro. Mantido aqui pelo
+ * mesmo motivo de `ClientEmailDto` (lição PR #128).
+ */
+export interface ClientPhoneDto {
+  id: string;
+  number: string;
+  createdAt: string;
+}
+
+/**
  * Espelho do `ClientResponse` do `lfc-authenticator`
  * (`AuthService.Controllers.Clients.ClientsController.ClientResponse`).
  *
- * Issue #77 (EPIC #49) — DTO mínimo necessário para a listagem de
- * usuários poder denormalizar o **nome** do cliente vinculado a cada
- * usuário (a tabela mostra a coluna "Cliente"). A listagem de clientes
- * própria (issue dedicada da EPIC) virá em PR separado e é livre para
- * estender este módulo (`createClient`/`updateClient`/etc.) sem
- * refatoração destrutiva — projetamos shared helpers desde já (lição
- * PR #128).
+ * Issue #73 (EPIC #49) — listagem completa de clientes.
  *
- * **Estado atual do contrato:**
+ * **Modelagem PF/PJ:** o backend usa um único shape com campos
+ * mutuamente exclusivos por tipo:
  *
- * - `type` é discriminator literal "PF" | "PJ" — define quais campos
- *   ficam preenchidos (`fullName`/`cpf` em PF, `corporateName`/`cnpj`
- *   em PJ). Mantemos como `string` no DTO para tolerar payloads
- *   inesperados sem `narrowing` artificial; a UI usa `displayName`
- *   abaixo para escolher o rótulo certo.
- * - Campos opcionais (`cpf`, `fullName`, `cnpj`, `corporateName`)
- *   podem ser `null` no JSON. O type guard valida o shape mas tolera
- *   ausência (mesmo padrão de `description` em `SystemDto`).
- * - As listas `userIds`, `extraEmails`, `mobilePhones`,
- *   `landlinePhones` não são consumidas por #77; mantemos opcionais
- *   no DTO para refletir o `ClientResponse` real do backend e evitar
- *   divergência de shape se o frontend evoluir para exibir mais
- *   detalhes do cliente em uma página dedicada (ver acima).
+ * - `type === 'PF'` → `cpf` + `fullName` preenchidos; `cnpj`/
+ *   `corporateName` `null`.
+ * - `type === 'PJ'` → `cnpj` + `corporateName` preenchidos; `cpf`/
+ *   `fullName` `null`.
  *
- * Datas em ISO 8601 (UTC) — mantemos como `string`; conversão fica a
- * cargo do consumidor que precisa exibir.
+ * A UI da listagem **renderiza** com base em `type` para escolher
+ * qual coluna exibir (Nome = `fullName ?? corporateName`, Documento
+ * = `cpf ?? cnpj`). Isso replica fielmente o contrato do backend e
+ * evita branching duplicado em call sites.
+ *
+ * **Datas:** o backend serializa em ISO 8601 (UTC) — mantemos como
+ * `string` porque a UI consome via `Intl.DateTimeFormat`/`new Date()`
+ * quando precisar exibir; converter no boundary do cliente HTTP
+ * traria custo sem benefício. `deletedAt !== null` indica
+ * soft-delete.
+ *
+ * **Coleções (`userIds`, `extraEmails`, `mobilePhones`,
+ * `landlinePhones`):** o backend devolve sempre arrays (vazios
+ * quando não há vínculos). Mantidas como opcionais no type para
+ * tolerar fixtures de teste minimalistas (Issue #77 consome só
+ * `id`/`type`/nomes via `clientDisplayName` e seu fixture
+ * `getClientsByIds` retorna o que o backend produzir); call sites
+ * que precisem ler emails/telefones (`#74`/`#75`/`#146`/`#147`)
+ * devem tratar `?? []` no acesso.
  */
 export interface ClientDto {
   id: string;
-  type: string;
+  type: ClientType;
   cpf: string | null;
   fullName: string | null;
   cnpj: string | null;
@@ -63,79 +115,155 @@ export interface ClientDto {
   createdAt: string;
   updatedAt: string;
   deletedAt: string | null;
+  userIds?: ReadonlyArray<string>;
+  extraEmails?: ReadonlyArray<ClientEmailDto>;
+  mobilePhones?: ReadonlyArray<ClientPhoneDto>;
+  landlinePhones?: ReadonlyArray<ClientPhoneDto>;
 }
 
 /**
- * Type guard para `ClientDto`. Tolera campos opcionais ausentes
- * (`cpf`/`fullName`/`cnpj`/`corporateName`/`deletedAt`) — apenas `id`,
- * `type`, `createdAt` e `updatedAt` são obrigatórios.
- *
- * Exportado para que outros call sites (futuros wrappers `createClient`/
- * `updateClient` da EPIC #49) reusem a mesma fonte de verdade — evita
- * duplicação de validação de shape (lição PR #123).
+ * Type guard interno para `ClientEmailDto`. Centralizado para que o
+ * guard externo (`isClientDto`) não inline o mesmo shape — Sonar
+ * marca blocos de validação repetidos em arquivos diferentes como
+ * duplicação (lição PR #123).
  */
-export function isClientDto(value: unknown): value is ClientDto {
+function isClientEmailDto(value: unknown): value is ClientEmailDto {
   if (!value || typeof value !== 'object') {
     return false;
   }
   const record = value as Record<string, unknown>;
   return (
     typeof record.id === 'string' &&
-    typeof record.type === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string' &&
-    (record.cpf === null ||
-      record.cpf === undefined ||
-      typeof record.cpf === 'string') &&
-    (record.fullName === null ||
-      record.fullName === undefined ||
-      typeof record.fullName === 'string') &&
-    (record.cnpj === null ||
-      record.cnpj === undefined ||
-      typeof record.cnpj === 'string') &&
-    (record.corporateName === null ||
-      record.corporateName === undefined ||
-      typeof record.corporateName === 'string') &&
-    (record.deletedAt === null ||
-      record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
+    typeof record.email === 'string' &&
+    typeof record.createdAt === 'string'
   );
 }
 
 /**
- * Type guard para `PagedResponse<ClientDto>`. Valida o envelope antes
- * de confiar no payload — protege contra divergência silenciosa de
- * versão entre frontend e backend (proxy intermediário cortando
- * campos, deploy desalinhado). Espelha `isPagedSystemsResponse` em
- * `systems.ts`.
- *
- * Exportado para que a futura `ClientsListShellPage` real (issue
- * dedicada da EPIC #49) reuse — declaramos já agora pelo padrão
- * "primeiro PR do recurso" (lição PR #128).
+ * Type guard interno para `ClientPhoneDto`. Mesma motivação de
+ * `isClientEmailDto` — centralizar para evitar duplicação visual e
+ * permitir reuso pelo `isClientDto` para `mobilePhones` e
+ * `landlinePhones` (mesmo shape, posições diferentes no envelope).
  */
-export function isPagedClientsResponse(value: unknown): value is PagedResponse<ClientDto> {
+function isClientPhoneDto(value: unknown): value is ClientPhoneDto {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.number === 'string' &&
+    typeof record.createdAt === 'string'
+  );
+}
+
+/**
+ * Type guard para `ClientDto`. Aceita os dois caminhos de PF e PJ
+ * (sem forçar combinação) e tolera campos opcionais ausentes
+ * (`cpf`/`fullName`/`cnpj`/`corporateName`/`deletedAt` e as 4
+ * coleções).
+ *
+ * Quando as coleções estão presentes, são validadas item-a-item
+ * pelos guards internos. Isso preserva a tolerância de fixtures
+ * minimalistas (Issue #77 consome só `id`/`type`/labels) sem perder
+ * a validação de shape quando o backend devolve o response real
+ * completo.
+ *
+ * Exportado para que outros call sites (ex.: `getClientsByIds` para
+ * lookup batch da `UsersListShellPage`, futuros wrappers
+ * `createClient`/`updateClient` da EPIC #49) reusem a mesma fonte
+ * de verdade — evita duplicação de validação de shape (lição PR
+ * #123).
+ */
+export function isClientDto(value: unknown): value is ClientDto {
   if (!value || typeof value !== 'object') {
     return false;
   }
   const record = value as Record<string, unknown>;
   if (
-    typeof record.page !== 'number' ||
-    typeof record.pageSize !== 'number' ||
-    typeof record.total !== 'number' ||
-    !Array.isArray(record.data)
+    typeof record.id !== 'string' ||
+    typeof record.createdAt !== 'string' ||
+    typeof record.updatedAt !== 'string'
   ) {
     return false;
   }
-  return record.data.every(isClientDto);
+  if (record.type !== 'PF' && record.type !== 'PJ') {
+    return false;
+  }
+  if (
+    !isNullableString(record.cpf) ||
+    !isNullableString(record.fullName) ||
+    !isNullableString(record.cnpj) ||
+    !isNullableString(record.corporateName) ||
+    !isNullableString(record.deletedAt)
+  ) {
+    return false;
+  }
+  if (!isOptionalArray(record.userIds, (id) => typeof id === 'string')) {
+    return false;
+  }
+  if (!isOptionalArray(record.extraEmails, isClientEmailDto)) {
+    return false;
+  }
+  if (!isOptionalArray(record.mobilePhones, isClientPhoneDto)) {
+    return false;
+  }
+  if (!isOptionalArray(record.landlinePhones, isClientPhoneDto)) {
+    return false;
+  }
+  return true;
 }
 
 /**
- * Defaults usados pelo wrapper de listagem — alinhados com os limites
- * do backend (`ClientsController.DefaultPageSize = 20`/`MaxPageSize = 100`).
+ * Ajuda os checks de campos `string | null`. Aceita `undefined`
+ * como `null` para tolerar payloads onde o backend omitiu o campo
+ * (`deletedAt` em registros ativos é o caso comum).
+ */
+function isNullableString(value: unknown): value is string | null | undefined {
+  return value === null || value === undefined || typeof value === 'string';
+}
+
+/**
+ * Aceita `undefined` ou um array onde **todos** os itens passam no
+ * predicado `isItem`. Usado pelo `isClientDto` para validar as
+ * coleções (`userIds`/`extraEmails`/`mobilePhones`/`landlinePhones`)
+ * sem rejeitar fixtures minimalistas que omitem o campo.
+ */
+function isOptionalArray<T>(
+  value: unknown,
+  isItem: (item: unknown) => boolean,
+): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  return Array.isArray(value) && value.every((item) => isItem(item));
+}
+
+/**
+ * Type guard para `PagedResponse<ClientDto>`. Valida o envelope
+ * antes de confiar no payload — protege contra divergência
+ * silenciosa de versão entre frontend e backend (proxy intermediário
+ * cortando campos, deploy desalinhado). Reusa
+ * `isPagedResponseEnvelope` para evitar repetir a checagem fixa de
+ * `page`/`pageSize`/`total`/`data` que já existe em outros recursos
+ * (lição PR #134/#135 — JSCPD/Sonar tokenizam blocos de ~14 linhas
+ * idênticos como duplicação).
+ */
+export function isPagedClientsResponse(value: unknown): value is PagedResponse<ClientDto> {
+  return isPagedResponseEnvelope(value, isClientDto);
+}
+
+/**
+ * Defaults usados pela `listClients` para omitir parâmetros que
+ * coincidem com o backend — preserva a URL "limpa" no caminho
+ * default (`GET /clients` em vez de
+ * `GET /clients?page=1&pageSize=20&includeDeleted=false`).
  *
- * Exportados para que a `ClientsListShellPage` (issue dedicada da
- * EPIC #49) compartilhe a mesma fonte de verdade ao inicializar o
- * estado dos controles de busca/paginação/filtro.
+ * `DEFAULT_CLIENTS_PAGE_SIZE = 20` espelha
+ * `ClientsController.DefaultPageSize` no `lfc-authenticator` —
+ * manter um único limite reduz surpresas para o admin que alterna
+ * entre listas. `MaxPageSize = 100` no backend; respeitar via UI
+ * para evitar 400 inesperado.
  */
 export const DEFAULT_CLIENTS_PAGE = 1;
 export const DEFAULT_CLIENTS_PAGE_SIZE = 20;
@@ -145,33 +273,40 @@ export const DEFAULT_CLIENTS_INCLUDE_DELETED = false;
  * Parâmetros aceitos por `listClients`. Todos opcionais — quando
  * omitidos (ou iguais aos defaults), são removidos da querystring.
  *
- * Issue #77: a `UsersListShellPage` consome este wrapper apenas com
- * `ids` (lookup batch dos clientes vinculados aos usuários da página
- * corrente). Os demais parâmetros existem para alinhar o contrato com
- * `GET /clients` real — facilitam a futura tela de listagem de
- * clientes (EPIC #49) sem refatoração destrutiva.
+ * - `q` — termo de busca textual (case-insensitive em `fullName`,
+ *   `corporateName`, `cpf`, `cnpj`). Backend escapa wildcards de
+ *   `ILIKE` (`%`/`_`/`\`) antes de aplicar.
+ * - `type` — filtra por discriminador (`PF`/`PJ`). Validado no
+ *   backend; valor inválido gera 400 (`type deve ser PF ou PJ.`).
+ * - `active` — filtra por status (`true` = só ativos, `false` = só
+ *   soft-deletados, ausente = comportamento default da query). É
+ *   **mutuamente exclusivo** com `includeDeleted=true` (backend
+ *   rejeita combinação com 400).
+ * - `page` — página 1-based. Default: 1.
+ * - `pageSize` — itens por página. Default: 20. Backend rejeita
+ *   `> 100` ou `<= 0` com 400.
+ * - `includeDeleted` — quando `true`, inclui também soft-deletados
+ *   (`active` ausente nesse caso). Mutuamente exclusivo com
+ *   `active`.
  */
 export interface ListClientsParams {
-  /** Termo de busca (case-insensitive em campos de nome/documento). */
   q?: string;
-  /** Filtro por discriminator: `'PF'` ou `'PJ'`. */
-  type?: 'PF' | 'PJ';
-  /** Quando `false`, lista apenas inativos. `true`/omitido → ativos. */
+  type?: ClientType;
   active?: boolean;
-  /** Página 1-based. Default: 1. */
   page?: number;
-  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
   pageSize?: number;
-  /** Quando `true`, inclui clientes com `deletedAt != null`. */
   includeDeleted?: boolean;
 }
 
 /**
  * Constrói a querystring omitindo parâmetros default — mantém a URL
  * canônica para o caminho mais comum e simplifica logs/cache de
- * proxy. Espelha `buildQueryString` de `systems.ts`/`routes.ts`.
+ * proxy. `q` é trimado e omitido quando vazio para evitar `?q=`
+ * literal (que o backend trataria como busca por string vazia, mas
+ * a UI sinalizaria estado de "busca ativa" no `q`). Espelha
+ * `buildQueryString` de `systems.ts`.
  */
-function buildListQueryString(params: ListClientsParams): string {
+function buildQueryString(params: ListClientsParams): string {
   const search = new URLSearchParams();
 
   const q = params.q?.trim();
@@ -191,10 +326,7 @@ function buildListQueryString(params: ListClientsParams): string {
     search.set('page', String(params.page));
   }
 
-  if (
-    typeof params.pageSize === 'number' &&
-    params.pageSize !== DEFAULT_CLIENTS_PAGE_SIZE
-  ) {
+  if (typeof params.pageSize === 'number' && params.pageSize !== DEFAULT_CLIENTS_PAGE_SIZE) {
     search.set('pageSize', String(params.pageSize));
   }
 
@@ -210,30 +342,33 @@ function buildListQueryString(params: ListClientsParams): string {
 }
 
 /**
- * Lista clientes via `GET /clients` com busca, filtro e paginação.
+ * Lista clientes via `GET /clients` (lfc-authenticator#169) com
+ * busca, paginação e filtros server-side.
  *
  * Retorna o envelope tipado `PagedResponse<ClientDto>`. Lança
- * `ApiError` em falhas (rede, parse, HTTP); o caller deve tratar com
- * try/catch.
+ * `ApiError` em falhas (rede, parse, HTTP); o caller deve tratar
+ * com try/catch.
  *
- * Cancelamento: aceita `signal` em `options` (via AbortController) —
- * em navegações rápidas, o caller cancela a request anterior antes de
- * disparar a nova (mesmo padrão de `listSystems`/`listRoutes`).
+ * Cancelamento: aceita `signal` em `options` (via AbortController)
+ * — em navegações rápidas, o caller cancela a request anterior
+ * antes de disparar a nova, evitando race em `setState`.
  *
- * O parâmetro `client` é injetável para isolar testes; em produção
- * usa-se o singleton `apiClient`.
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); o default usa o singleton
+ * `apiClient` configurado com `baseUrl` + `systemId` reais.
  *
- * Issue #77 — pré-fabricado para que a `UsersListShellPage` possa
- * mostrar nome do cliente em coluna dedicada via lookup batch (`ids=`)
- * sem precisar denormalização extra. A próxima EPIC (#49) reusa o
- * mesmo wrapper para sua listagem dedicada.
+ * Issue #73 — primeira sub-issue da EPIC #49 (CRUD de Clientes).
+ * As próximas issues (#74 criar, #75 editar, #76 desativar, #146/
+ * #147 gerenciar emails/telefones) reutilizam o mesmo módulo
+ * seguindo o padrão de `systems.ts` (lição PR #128 — projetar
+ * shared helpers desde o primeiro PR do recurso).
  */
 export async function listClients(
   params: ListClientsParams = {},
   options?: SafeRequestOptions,
   client: ApiClient = apiClient,
 ): Promise<PagedResponse<ClientDto>> {
-  const path = `/clients${buildListQueryString(params)}`;
+  const path = `/clients${buildQueryString(params)}`;
   const data = await client.get<unknown>(path, options);
   if (!isPagedClientsResponse(data)) {
     throw makeParseError();
@@ -244,11 +379,13 @@ export async function listClients(
 /**
  * Resposta minimalista usada pelo lookup batch (`GET /clients?ids=...`).
  *
- * **Estado atual do backend:** o controller real de Clientes ainda não
- * expõe um endpoint batch — a UI consome via `listClients({ q })`
- * filtrando server-side. Mantemos este tipo declarado para que, quando
- * o backend ganhar `ClientsMinimalResponse(Id, Name)` (paridade com
- * `UserMinimalResponse`), a UI consuma sem refatoração destrutiva.
+ * **Estado atual do backend:** o controller real de Clientes ainda
+ * não expõe um endpoint batch — a UI consome via `getClientsByIds`
+ * que itera `GET /clients/{id}` por id. Mantemos este tipo
+ * declarado para que, quando o backend ganhar
+ * `ClientsMinimalResponse(Id, Name)` (paridade com
+ * `UserMinimalResponse`), a UI consuma sem refatoração destrutiva
+ * (lição PR #128).
  */
 export interface ClientLookupDto {
   id: string;
@@ -257,10 +394,11 @@ export interface ClientLookupDto {
 }
 
 /**
- * Reduz um `ClientDto` ao label apresentável usado em colunas/UIs do
- * frontend. Para PF, prioriza `fullName`; para PJ, `corporateName`.
- * Quando ambos vêm `null` (cenário improvável mas possível em dados
- * legados), cai no `id` curto para que a UI nunca exiba string vazia.
+ * Reduz um `ClientDto` ao label apresentável usado em colunas/UIs
+ * do frontend. Para PF, prioriza `fullName`; para PJ,
+ * `corporateName`. Quando ambos vêm `null` (cenário improvável mas
+ * possível em dados legados), cai no `id` curto para que a UI nunca
+ * exiba string vazia.
  *
  * Exportado e centralizado aqui para que cada caller (UsersList,
  * future ClientsList, futuros relatórios) use exatamente o mesmo
@@ -280,25 +418,26 @@ export function clientDisplayName(client: ClientDto): string {
 }
 
 /**
- * Lookup batch de clientes por `ids` — devolve um `Map<id, ClientDto>`
- * para que o caller resolva cada `clientId` em O(1) ao montar a
- * tabela. Faz uma única chamada à `listClients({ ids })` quando o
- * backend evoluir para expor o filtro `ids`; **hoje** o backend não
- * implementa o batch, então este helper itera fazendo `q=<id>` por
- * cliente (compatível com `GET /clients?q=...`) e devolve o mapa.
+ * Lookup batch de clientes por `ids` — devolve um
+ * `Map<id, ClientDto>` para que o caller resolva cada `clientId`
+ * em O(1) ao montar a tabela. **Hoje** o backend não implementa
+ * filtro `ids` em `GET /clients`, então este helper itera fazendo
+ * `GET /clients/{id}` por cliente e devolve o mapa.
  *
- * Quando o backend for evoluído (issue dedicada da EPIC #49), basta
- * trocar a implementação interna por uma única chamada `listClients`
- * com novo param `ids` — a assinatura pública desta função (e os
- * call sites) ficam intactos. Conserva a lição "shared helpers
- * projetados desde o primeiro PR" (PR #128).
+ * Quando o backend for evoluído (issue dedicada da EPIC #49),
+ * basta trocar a implementação interna por uma única chamada
+ * `listClients` com novo param `ids` — a assinatura pública desta
+ * função (e os call sites) ficam intactos. Conserva a lição
+ * "shared helpers projetados desde o primeiro PR" (PR #128).
  *
  * **Limite prático:** chamadas em série fazem 1 request por id, o
- * que é aceitável para uma página de até `pageSize` usuários (default
- * 20). Quando o backend ganhar batch real, a otimização vem grátis.
+ * que é aceitável para uma página de até `pageSize` usuários
+ * (default 20). Quando o backend ganhar batch real, a otimização
+ * vem grátis.
  *
  * Cancelamento via `signal` é propagado; deduplicação é
- * responsabilidade do caller (passar `Set<string>` evita id repetido).
+ * responsabilidade do caller (passar `Set<string>` evita id
+ * repetido).
  */
 export async function getClientsByIds(
   ids: ReadonlyArray<string>,
@@ -342,19 +481,15 @@ export async function getClientsByIds(
 }
 
 /**
- * Tenta carregar um cliente individual via `GET /clients/{id}` — hoje
- * implementado como `GET /clients?q=<id>` (best-effort) já que o
- * backend não tem batch nem GetById exposto consistentemente para
- * este caso. Retorna `null` quando não encontrado.
+ * Tenta carregar um cliente individual via `GET /clients/{id}`.
+ * Retorna `null` quando o backend devolve corpo vazio; lança
+ * `ApiError(parse)` quando o JSON não casa com `isClientDto`.
  */
 async function fetchClientById(
   id: string,
   options: SafeRequestOptions | undefined,
   client: ApiClient,
 ): Promise<ClientDto | null> {
-  // Tenta primeiro o GetById direto (`GET /clients/{id}`) — backend
-  // expõe esse endpoint via rota convencional do REST controller. Se
-  // o backend não tiver, o ApiError é propagado e o caller decide.
   const data = await client.get<unknown>(`/clients/${id}`, options);
   if (data === null || data === undefined) {
     return null;
@@ -366,10 +501,10 @@ async function fetchClientById(
 }
 
 /**
- * Detecta se o erro é um `AbortError` (DOMException) ou um `ApiError`
- * de rede com a mensagem dedicada de cancelamento. Mantido local em
- * vez de exportado porque é detalhe de implementação do
- * `getClientsByIds`.
+ * Detecta se o erro é um `AbortError` (DOMException) ou um
+ * `ApiError` de rede com a mensagem dedicada de cancelamento.
+ * Mantido local em vez de exportado porque é detalhe de
+ * implementação do `getClientsByIds`.
  */
 function isAbortError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') {

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -123,6 +123,24 @@ export type {
   UpdateRolePayload,
 } from './roles';
 export {
+  clientDisplayName,
+  DEFAULT_CLIENTS_INCLUDE_DELETED,
+  DEFAULT_CLIENTS_PAGE,
+  DEFAULT_CLIENTS_PAGE_SIZE,
+  getClientsByIds,
+  isClientDto,
+  isPagedClientsResponse,
+  listClients,
+} from './clients';
+export type {
+  ClientDto,
+  ClientEmailDto,
+  ClientLookupDto,
+  ClientPhoneDto,
+  ClientType,
+  ListClientsParams,
+} from './clients';
+export {
   isTokenTypeArray,
   isTokenTypeDto,
   listTokenTypes,
@@ -137,21 +155,6 @@ export {
   listUsers,
 } from './users';
 export type { ListUsersParams, UserDto } from './users';
-export {
-  clientDisplayName,
-  DEFAULT_CLIENTS_INCLUDE_DELETED,
-  DEFAULT_CLIENTS_PAGE,
-  DEFAULT_CLIENTS_PAGE_SIZE,
-  getClientsByIds,
-  isClientDto,
-  isPagedClientsResponse,
-  listClients,
-} from './clients';
-export type {
-  ClientDto,
-  ClientLookupDto,
-  ListClientsParams,
-} from './clients';
 export {
   assignPermissionToUser,
   DEFAULT_PERMISSIONS_INCLUDE_DELETED,

--- a/src/shared/api/pagedResponse.ts
+++ b/src/shared/api/pagedResponse.ts
@@ -1,0 +1,53 @@
+import type { PagedResponse } from './systems';
+
+/**
+ * Helper genérico para validar o envelope `PagedResponse<T>`
+ * recebido do `lfc-authenticator`. Encapsula a checagem de campos
+ * fixos (`page`/`pageSize`/`total` numéricos + `data` array) e
+ * delega a validação dos itens ao type guard específico do recurso.
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar/JSCPD):**
+ *
+ * O bloco:
+ *
+ * ```ts
+ * if (!value || typeof value !== 'object') return false;
+ * const record = value as Record<string, unknown>;
+ * if (
+ *   typeof record.page !== 'number' ||
+ *   typeof record.pageSize !== 'number' ||
+ *   typeof record.total !== 'number' ||
+ *   !Array.isArray(record.data)
+ * ) return false;
+ * return record.data.every(<itemGuard>);
+ * ```
+ *
+ * é idêntico em cada `is<Recurso>PagedResponse` (`isPagedSystemsResponse`,
+ * `isPagedRoutesResponse`, `isPagedRolesResponse`, `isPagedClientsResponse`).
+ * Sem este helper, JSCPD/Sonar tokenizam ~14 linhas como bloco
+ * duplicado em cada novo recurso CRUD que entrar (`isPagedUsersResponse`,
+ * `isPagedPermissionsResponse`, etc.) — exatamente o gatilho da 5ª
+ * recorrência prevista pela lição PR #134/#135.
+ *
+ * O helper é parametrizado pelo type guard do item (`isItem`); cada
+ * recurso continua dono da sua validação específica de shape, mas o
+ * envelope passa a ter apenas uma fonte de verdade.
+ */
+export function isPagedResponseEnvelope<T>(
+  value: unknown,
+  isItem: (item: unknown) => item is T,
+): value is PagedResponse<T> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.page !== 'number' ||
+    typeof record.pageSize !== 'number' ||
+    typeof record.total !== 'number' ||
+    !Array.isArray(record.data)
+  ) {
+    return false;
+  }
+  return record.data.every(isItem);
+}

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -1,3 +1,5 @@
+import { isPagedResponseEnvelope } from "./pagedResponse";
+
 import { apiClient } from "./index";
 
 import type { PagedResponse } from "./systems";
@@ -146,19 +148,7 @@ export function isRoleDto(value: unknown): value is RoleDto {
 export function isPagedRolesResponse(
   value: unknown,
 ): value is PagedResponse<RoleDto> {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.page !== "number" ||
-    typeof record.pageSize !== "number" ||
-    typeof record.total !== "number" ||
-    !Array.isArray(record.data)
-  ) {
-    return false;
-  }
-  return record.data.every(isRoleDto);
+  return isPagedResponseEnvelope(value, isRoleDto);
 }
 
 /**

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -1,3 +1,5 @@
+import { isPagedResponseEnvelope } from './pagedResponse';
+
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
@@ -94,22 +96,12 @@ export function isRouteDto(value: unknown): value is RouteDto {
  * Type guard para `PagedResponse<RouteDto>`. Valida o envelope antes de
  * confiar no payload — protege contra divergência silenciosa de versão
  * entre frontend e backend (proxy intermediário cortando campos, deploy
- * desalinhado). Espelha `isPagedSystemsResponse` em `systems.ts`.
+ * desalinhado). Reusa `isPagedResponseEnvelope` para evitar duplicação
+ * com os demais recursos (lição PR #134/#135 — JSCPD/Sonar tokenizam
+ * o bloco fixo de checagem de envelope como duplicação entre módulos).
  */
 export function isPagedRoutesResponse(value: unknown): value is PagedResponse<RouteDto> {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.page !== 'number' ||
-    typeof record.pageSize !== 'number' ||
-    typeof record.total !== 'number' ||
-    !Array.isArray(record.data)
-  ) {
-    return false;
-  }
-  return record.data.every(isRouteDto);
+  return isPagedResponseEnvelope(value, isRouteDto);
 }
 
 /**

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -1,3 +1,5 @@
+import { isPagedResponseEnvelope } from './pagedResponse';
+
 import { apiClient } from './index';
 
 import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
@@ -94,22 +96,12 @@ export function isSystemDto(value: unknown): value is SystemDto {
  * Type guard para `PagedResponse<SystemDto>`. Valida o envelope antes de
  * confiar no payload — protege contra divergência silenciosa de versão
  * entre frontend e backend (proxy intermediário cortando campos, deploy
- * desalinhado).
+ * desalinhado). Reusa `isPagedResponseEnvelope` para evitar duplicação
+ * com os demais recursos (lição PR #134/#135 — JSCPD/Sonar tokenizam
+ * o bloco fixo de checagem de envelope como duplicação entre módulos).
  */
 export function isPagedSystemsResponse(value: unknown): value is PagedResponse<SystemDto> {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.page !== 'number' ||
-    typeof record.pageSize !== 'number' ||
-    typeof record.total !== 'number' ||
-    !Array.isArray(record.data)
-  ) {
-    return false;
-  }
-  return record.data.every(isSystemDto);
+  return isPagedResponseEnvelope(value, isSystemDto);
 }
 
 /**

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -1,3 +1,5 @@
+import { isPagedResponseEnvelope } from './pagedResponse';
+
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
@@ -123,19 +125,7 @@ export function isUserDto(value: unknown): value is UserDto {
  * via mesmo wrapper) reusem.
  */
 export function isPagedUsersResponse(value: unknown): value is PagedResponse<UserDto> {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    typeof record.page !== 'number' ||
-    typeof record.pageSize !== 'number' ||
-    typeof record.total !== 'number' ||
-    !Array.isArray(record.data)
-  ) {
-    return false;
-  }
-  return record.data.every(isUserDto);
+  return isPagedResponseEnvelope(value, isUserDto);
 }
 
 /**

--- a/src/shared/listing/ListingToolbar.tsx
+++ b/src/shared/listing/ListingToolbar.tsx
@@ -58,6 +58,17 @@ interface ListingToolbarProps {
   includeDeletedTestId: string;
 
   /**
+   * Slot opcional para filtros adicionais (ex.: `<Select>` de tipo
+   * PF/PJ na listagem de Clientes — Issue #73). Renderizado entre o
+   * `SearchSlot` e o `Switch` "Mostrar inativas", dentro do
+   * `ToolbarActions`. Cada página é responsável por construir o
+   * componente concreto (Select, RadioGroup, etc.) — o toolbar fica
+   * agnóstico ao tipo de filtro, permitindo evolução por recurso sem
+   * duplicar a estrutura visual.
+   */
+  extraFilter?: React.ReactNode;
+
+  /**
    * Slot opcional para CTAs (botão "Novo X", links de ações em massa,
    * etc.). Cada página resolve gating de permissão antes de passar.
    */
@@ -74,6 +85,7 @@ export const ListingToolbar: React.FC<ListingToolbarProps> = ({
   onIncludeDeletedChange,
   includeDeletedHelperText,
   includeDeletedTestId,
+  extraFilter,
   actions,
 }) => (
   <Toolbar>
@@ -90,6 +102,7 @@ export const ListingToolbar: React.FC<ListingToolbarProps> = ({
       />
     </SearchSlot>
     <ToolbarActions>
+      {extraFilter}
       <Switch
         label="Mostrar inativas"
         helperText={includeDeletedHelperText}

--- a/tests/pages/ClientsListShellPage.test.tsx
+++ b/tests/pages/ClientsListShellPage.test.tsx
@@ -1,0 +1,516 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createClientsClientStub,
+  ID_CLIENT_PF_ANA,
+  ID_CLIENT_PF_BRUNO,
+  ID_CLIENT_PJ_ACME,
+  ID_CLIENT_PJ_GLOBAL,
+  lastGetPath,
+  makeClient,
+  makeClientPj,
+  makePagedClientsResponse,
+  renderClientsListPage,
+  waitForInitialList,
+} from './__helpers__/clientsTestHelpers';
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+
+import type { ApiError, ClientDto } from '@/shared/api';
+
+/**
+ * Suíte da `ClientsListShellPage` (Issue #73, EPIC #49 — listagem de
+ * clientes com busca server-side e paginação). Estratégia espelha
+ * `SystemsPage.test.tsx`: stub de `ApiClient` injetado, asserts sobre
+ * estados visuais, paginação, busca debounced, filtro de tipo
+ * (PF/PJ/Todos), toggle "Mostrar inativos", erros e cancelamento.
+ */
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => ['AUTH_V1_CLIENTS_LIST']));
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_ROWS: ReadonlyArray<ClientDto> = [
+  makeClient({
+    id: ID_CLIENT_PF_ANA,
+    type: 'PF',
+    cpf: '12345678901',
+    fullName: 'Ana Cliente',
+  }),
+  makeClient({
+    id: ID_CLIENT_PF_BRUNO,
+    type: 'PF',
+    cpf: '98765432100',
+    fullName: 'Bruno Souza',
+  }),
+  makeClientPj({
+    id: ID_CLIENT_PJ_ACME,
+    cnpj: '12345678000190',
+    corporateName: 'Acme Indústria S/A',
+  }),
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('ClientsListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e popula a tabela após resposta', async () => {
+    const client = createClientsClientStub();
+    let resolveFn: (value: unknown) => void = () => undefined;
+    const pending = new Promise<unknown>((resolve) => {
+      resolveFn = resolve;
+    });
+    client.get.mockReturnValueOnce(pending);
+
+    renderClientsListPage(client);
+
+    expect(screen.getByTestId('clients-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(makePagedClientsResponse(SAMPLE_ROWS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('clients-loading')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
+    expect(screen.getByText('Bruno Souza')).toBeInTheDocument();
+    expect(screen.getByText('Acme Indústria S/A')).toBeInTheDocument();
+  });
+
+  it('renderiza header da página com título "Clientes cadastrados"', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+
+    await waitForInitialList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /Clientes cadastrados/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /clients sem querystring quando defaults estão ativos', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+
+    await waitForInitialList(client);
+    expect(lastGetPath(client)).toBe('/clients');
+  });
+
+  it('renderiza CPF/CNPJ formatados na coluna Documento', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    // CPF "12345678901" -> "123.456.789-01"
+    expect(screen.getByText('123.456.789-01')).toBeInTheDocument();
+    // CNPJ "12345678000190" -> "12.345.678/0001-90"
+    expect(screen.getByText('12.345.678/0001-90')).toBeInTheDocument();
+  });
+
+  it('renderiza badge "Inativo" para clientes soft-deletados quando includeDeleted=true', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(
+      makePagedClientsResponse([
+        makeClient({
+          id: ID_CLIENT_PF_ANA,
+          fullName: 'Ana Cliente',
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.click(screen.getByTestId('clients-include-deleted'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Inativo')).toBeInTheDocument();
+    });
+  });
+
+  it('exibe placeholder "—" quando nome ou documento são nulos (cenário fora do contrato, mas defensivo)', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse([
+        makeClient({
+          id: ID_CLIENT_PF_ANA,
+          fullName: null,
+          cpf: null,
+        }),
+      ]),
+    );
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});
+
+describe('ClientsListShellPage — busca debounced', () => {
+  it('digitar não dispara request imediato; após 300ms refaz GET com q na querystring', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('clients-search'), {
+      target: { value: 'ana' },
+    });
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/clients?q=ana');
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByTestId('clients-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'an' } });
+    fireEvent.change(input, { target: { value: 'ana' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('ClientsListShellPage — filtro de tipo', () => {
+  it('selecionar "Pessoa física" envia type=PF na querystring', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('clients-type-filter'), {
+      target: { value: 'PF' },
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/clients?type=PF');
+  });
+
+  it('selecionar "Pessoa jurídica" envia type=PJ na querystring', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('clients-type-filter'), {
+      target: { value: 'PJ' },
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/clients?type=PJ');
+  });
+
+  it('voltar para "Todos" remove o param type da querystring', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('clients-type-filter'), {
+      target: { value: 'PF' },
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(screen.getByTestId('clients-type-filter'), {
+      target: { value: 'ALL' },
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe('/clients');
+  });
+});
+
+describe('ClientsListShellPage — paginação server-side', () => {
+  it('clicar "próxima" envia page=2 na querystring; "anterior" volta para page omitido (default)', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse(SAMPLE_ROWS, { total: 25, page: 1 }),
+    );
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse(
+        [
+          makeClientPj({
+            id: ID_CLIENT_PJ_GLOBAL,
+            cnpj: '99999999000199',
+            corporateName: 'Global Corp',
+          }),
+        ],
+        { total: 25, page: 2 },
+      ),
+    );
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse(SAMPLE_ROWS, { total: 25, page: 1 }),
+    );
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('clients-page-info')).toHaveTextContent(/Página 1 de 2/i);
+
+    fireEvent.click(screen.getByTestId('clients-next'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/clients?page=2');
+
+    fireEvent.click(screen.getByTestId('clients-prev'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe('/clients');
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse(SAMPLE_ROWS, { total: 25 }),
+    );
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('clients-prev')).toBeDisabled();
+    expect(screen.getByTestId('clients-next')).toBeEnabled();
+  });
+
+  it('botão "próxima" desabilita quando totalPages é 1', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('clients-prev')).toBeDisabled();
+    expect(screen.getByTestId('clients-next')).toBeDisabled();
+  });
+
+  it('exibe indicador "Página X de Y" com total filtrado', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(
+      makePagedClientsResponse(SAMPLE_ROWS, { total: 42 }),
+    );
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    const info = screen.getByTestId('clients-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('ClientsListShellPage — filtro de inativos', () => {
+  it('liga toggle dispara request com includeDeleted=true', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValue(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTestId('clients-include-deleted'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe('/clients?includeDeleted=true');
+  });
+});
+
+describe('ClientsListShellPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([]));
+
+    renderClientsListPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('clients-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    // O texto aparece tanto no `LiveRegion` (announcer ARIA-live)
+    // quanto no `EmptyMessage` visual — `getAllByText` ≥ 1 cobre o
+    // contrato sem se acoplar ao detalhe (espelha o padrão usado nos
+    // testes da RolesPage).
+    expect(screen.getAllByText(/Nenhum cliente encontrado para/i).length).toBeGreaterThan(0);
+    expect(screen.getByTestId('clients-empty-clear')).toBeInTheDocument();
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([]));
+
+    renderClientsListPage(client);
+    await waitForInitialList(client);
+
+    // Texto duplicado no `LiveRegion` + `EmptyMessage` — usar
+    // `getAllByText` evita o erro "Found multiple elements".
+    expect(screen.getAllByText(/Nenhum cliente cadastrado\./i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Clientes removidos podem ser visualizados/i),
+    ).toBeInTheDocument();
+  });
+
+  it('clicar em "limpar busca" reseta termo e re-popula a lista', async () => {
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([]));
+    client.get.mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('clients-search'), {
+      target: { value: 'naoexiste' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Nenhum cliente encontrado para/i).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByTestId('clients-empty-clear'));
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ClientsListShellPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createClientsClientStub();
+    client.get
+      .mockRejectedValueOnce(apiError)
+      .mockResolvedValueOnce(makePagedClientsResponse(SAMPLE_ROWS));
+
+    renderClientsListPage(client);
+
+    expect(
+      await screen.findByText(/Falha de conexão com o servidor\./i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('clients-retry'));
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce(new Error('boom'));
+
+    renderClientsListPage(client);
+
+    expect(
+      await screen.findByText(
+        /Falha ao carregar a lista de clientes\. Tente novamente\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('ClientsListShellPage — cancelamento de request', () => {
+  it('mudanças sucessivas de filtro abortam a request anterior via AbortController', async () => {
+    const client = createClientsClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (_path: string, options?: { signal?: AbortSignal }): Promise<unknown> => {
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        return Promise.resolve(makePagedClientsResponse(SAMPLE_ROWS));
+      },
+    );
+
+    renderClientsListPage(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByTestId('clients-search'), {
+      target: { value: 'ana' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+
+    fireEvent.change(screen.getByTestId('clients-search'), {
+      target: { value: 'ana-extra' },
+    });
+
+    expect(client.get).toHaveBeenCalledTimes(2);
+    expect(signals.length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+
+    // O signal da request "ana" deve estar abortado: o cleanup do
+    // useEffect que rodou para "ana" foi chamado quando
+    // `debouncedSearch` mudou para "ana-extra".
+    expect(signals[1].aborted).toBe(true);
+  });
+});

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -1,0 +1,172 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { expect, vi } from 'vitest';
+
+import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { ClientsListShellPage } from '@/pages/clients';
+
+/**
+ * Helpers de teste compartilhados pelas suítes de Clientes (Issue
+ * #73 — listagem; e as próximas #74/#75/#76/#146/#147 — mutações e
+ * gerenciamento de contatos).
+ *
+ * Estratégia espelha `systemsTestHelpers.tsx`/`rolesTestHelpers.tsx`:
+ *
+ * - `ApiClientStub` + `createClientsClientStub` para isolar a página
+ *   da camada de transporte;
+ * - `makeClient`/`makePagedClientsResponse` para construir payloads
+ *   do contrato `ClientDto`/`PagedResponse<ClientDto>` sem repetir
+ *   todos os campos;
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderClientsListPage` envolvendo a página num `ToastProvider`
+ *   (sub-issues seguintes consumirão `useToast()` para feedback);
+ * - `waitForInitialList` e `lastGetPath` colapsando o boilerplate
+ *   recorrente.
+ *
+ * Pré-fabricados desde o primeiro PR do recurso para evitar
+ * refatoração destrutiva nas próximas sub-issues (lição PR #128 —
+ * "projetar shared helpers desde o primeiro PR do recurso").
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_CLIENT_PF_ANA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+export const ID_CLIENT_PF_BRUNO = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+export const ID_CLIENT_PJ_ACME = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+export const ID_CLIENT_PJ_GLOBAL = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+/**
+ * Stub de `ApiClient` injetado em
+ * `<ClientsListShellPage client={stub} />` — mesmo padrão de
+ * injeção usado nos testes de Systems/Roles.
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createClientsClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `ClientDto` com defaults — testes só sobrescrevem o
+ * que importa para o cenário sem repetir todos os campos do
+ * contrato.
+ *
+ * Default é PF (`Ana Cliente`) porque é o caminho mais comum nas
+ * asserts; suítes que precisam de PJ chamam com `type: 'PJ'` +
+ * `cnpj`/`corporateName`. As coleções (`userIds`, `extraEmails`,
+ * `mobilePhones`, `landlinePhones`) são vazias por default — backend
+ * sempre devolve arrays mesmo sem dados.
+ */
+export function makeClient(overrides: Partial<ClientDto> = {}): ClientDto {
+  return {
+    id: ID_CLIENT_PF_ANA,
+    type: 'PF',
+    cpf: '12345678901',
+    fullName: 'Ana Cliente',
+    cnpj: null,
+    corporateName: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    userIds: [],
+    extraEmails: [],
+    mobilePhones: [],
+    landlinePhones: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói um `ClientDto` PJ pré-configurado para reduzir overrides
+ * repetidos nos cenários. `corporateName` e `cnpj` ficam preenchidos
+ * com valores válidos por default; `cpf`/`fullName` ficam `null`
+ * espelhando a regra de mutual-exclusão do backend.
+ */
+export function makeClientPj(overrides: Partial<ClientDto> = {}): ClientDto {
+  return makeClient({
+    id: ID_CLIENT_PJ_ACME,
+    type: 'PJ',
+    cpf: null,
+    fullName: null,
+    cnpj: '12345678000190',
+    corporateName: 'Acme Indústria S/A',
+    ...overrides,
+  });
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend — `total`
+ * reflete `data.length` por default; testes que cobrem paginação
+ * sobrescrevem.
+ */
+export function makePagedClientsResponse(
+  data: ReadonlyArray<ClientDto>,
+  overrides: Partial<PagedResponse<ClientDto>> = {},
+): PagedResponse<ClientDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Renderiza a `ClientsListShellPage` envolvendo num `ToastProvider`
+ * — alguns subcomponentes da família (modais futuros das #74/#75)
+ * consumirão `useToast()`. Centraliza para que cada suíte não repita
+ * o boilerplate.
+ */
+export function renderClientsListPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <ClientsListShellPage client={client} />
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a
+ * `ClientsListShellPage` faz `listClients` no mount). Centraliza o
+ * "esperar listagem" para que cada teste comece em estado estável
+ * sem precisar replicar `waitFor` para `client.get`.
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('clients-loading')).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Helper para extrair o `path` passado a `client.get` na chamada
+ * mais recente. Usado em asserts que verificam o endpoint consumido
+ * (incluindo querystring montada por `buildQueryString`). Espelha
+ * `lastGetPath` em `routesTestHelpers.tsx`/`systemsTestHelpers.tsx`.
+ */
+export function lastGetPath(client: ApiClientStub): string {
+  const calls = client.get.mock.calls;
+  if (calls.length === 0) return '';
+  const path = calls[calls.length - 1][0];
+  return typeof path === 'string' ? path : '';
+}

--- a/tests/pages/shellPages.test.tsx
+++ b/tests/pages/shellPages.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
-import { ClientsListShellPage } from '@/pages/clients';
 import { PermissionsListShellPage } from '@/pages/permissions';
 import { UserDetailShellPage } from '@/pages/users';
 
@@ -18,15 +17,18 @@ import { UserDetailShellPage } from '@/pages/users';
  *
  * À medida que cada shell ganha conteúdo real, ela sai desta tabela e
  * passa a ser coberta por uma suíte dedicada
- * (`tests/pages/<recurso>/<Pagina>.test.tsx`). Issue #77 promoveu a
- * `UsersListShellPage` a listagem real (com tabela/busca/paginação),
- * então a entrada respectiva foi removida — a cobertura migrou para
- * `tests/pages/UsersListShellPage.test.tsx`. Issue #70 promoveu a
- * `UserPermissionsShellPage` a tela funcional (matriz de checkbox por
- * permissão), com cobertura em
- * `tests/pages/users/UserPermissionsPage.test.tsx`. Issue #144 promoveu
- * a `ClientDetailShellPage` a `ClientEditPage` (4 abas), com cobertura
- * em `tests/pages/clients/ClientEditPage.test.tsx`.
+ * (`tests/pages/<recurso>/<Pagina>.test.tsx`):
+ *
+ * - Issue #77 promoveu a `UsersListShellPage` a listagem real (com
+ *   tabela/busca/paginação), com cobertura em
+ *   `tests/pages/UsersListShellPage.test.tsx`.
+ * - Issue #70 promoveu a `UserPermissionsShellPage` a tela funcional
+ *   (matriz de checkbox por permissão), com cobertura em
+ *   `tests/pages/users/UserPermissionsPage.test.tsx`.
+ * - Issue #144 promoveu a `ClientDetailShellPage` a `ClientEditPage`
+ *   (4 abas), com cobertura em `tests/pages/clients/ClientEditPage.test.tsx`.
+ * - Issue #73 promoveu a `ClientsListShellPage` a listagem real, com
+ *   cobertura em `tests/pages/ClientsListShellPage.test.tsx`.
  *
  * As asserts cobrem:
  * - Renderização sem warning/exception (cada shell é um componente
@@ -47,16 +49,6 @@ interface ShellCase {
 
 const SHELL_CASES: ReadonlyArray<ShellCase> = [
   {
-    name: 'ClientsListShellPage',
-    Component: ClientsListShellPage,
-    eyebrow: '05 Clientes',
-    title: 'Clientes',
-  },
-  // Nota: `ClientDetailShellPage` foi promovida pela Issue #144 a
-  // tela funcional `ClientEditPage` com 4 abas. Por isso não aparece
-  // mais nesta tabela — sua cobertura vive em
-  // `tests/pages/clients/ClientEditPage.test.tsx`.
-  {
     name: 'PermissionsListShellPage',
     Component: PermissionsListShellPage,
     eyebrow: '04 Permissões',
@@ -68,10 +60,6 @@ const SHELL_CASES: ReadonlyArray<ShellCase> = [
     eyebrow: '06 Usuários · Detalhe',
     title: 'Detalhe do usuário',
   },
-  // Nota: `UserPermissionsShellPage` foi promovida pela Issue #70 a
-  // tela funcional (deixou de delegar ao `PlaceholderPage`). Por isso
-  // não aparece mais nesta tabela — sua cobertura vive em
-  // `tests/pages/users/UserPermissionsPage.test.tsx`.
 ];
 
 describe('Shell pages — contrato visual mínimo (Issue #145)', () => {

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiClient, ClientDto } from '@/shared/api';
+import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
 
 import {
   clientDisplayName,
@@ -12,19 +12,22 @@ import {
 } from '@/shared/api';
 
 /**
- * Suíte do módulo `src/shared/api/clients.ts` (Issue #77, EPIC #49).
+ * Suíte do módulo `src/shared/api/clients.ts` (Issue #73, EPIC #49).
  *
- * Esta sub-issue não exige a tela de Clientes propriamente dita —
- * apenas o lookup batch (`getClientsByIds`) consumido pela
- * `UsersListShellPage` para denormalizar o nome do cliente vinculado
- * a cada usuário. Os helpers `listClients`/`isClientDto`/etc. são
- * pré-fabricados aqui para evitar refatoração destrutiva quando a
- * issue dedicada da listagem de clientes da EPIC #49 chegar (lição
- * PR #128 — projetar shared helpers desde o primeiro PR do recurso).
+ * Cobre dois consumidores convergentes: a listagem própria de
+ * clientes (Issue #73) que valida `listClients`/querystring/type
+ * guards completos, e o lookup batch (`getClientsByIds`) consumido
+ * pela `UsersListShellPage` (Issue #77 mergeada antes deste PR) para
+ * denormalizar nome do cliente vinculado a cada usuário.
+ *
+ * Estratégia: stubar o `ApiClient` injetado e validar paths, type
+ * guards e propagação de `ApiError`. Não bate em `fetch` real —
+ * cobertura de transporte HTTP é responsabilidade dos testes em
+ * `client.test.ts`.
  */
 
-const CLIENT_ID = '11111111-1111-1111-1111-111111111111';
-const CLIENT_PJ_ID = '22222222-2222-2222-2222-222222222222';
+const CLIENT_PF_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const CLIENT_PJ_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
 interface ClientStub {
   get: ReturnType<typeof vi.fn>;
@@ -37,7 +40,7 @@ interface ClientStub {
   getSystemId: ReturnType<typeof vi.fn>;
 }
 
-function createStub(): ClientStub {
+function makeClientStub(): ClientStub {
   return {
     request: vi.fn(),
     get: vi.fn(),
@@ -50,117 +53,187 @@ function createStub(): ClientStub {
   };
 }
 
-function makeClientPF(overrides: Partial<ClientDto> = {}): ClientDto {
+function makeRawClientPf(overrides: Partial<ClientDto> = {}): ClientDto {
   return {
-    id: CLIENT_ID,
+    id: CLIENT_PF_ID,
     type: 'PF',
     cpf: '12345678901',
-    fullName: 'Alice Cliente',
+    fullName: 'Ana Cliente',
     cnpj: null,
     corporateName: null,
     createdAt: '2026-01-10T12:00:00Z',
     updatedAt: '2026-01-10T12:00:00Z',
     deletedAt: null,
+    userIds: [],
+    extraEmails: [],
+    mobilePhones: [],
+    landlinePhones: [],
     ...overrides,
   };
 }
 
-function makeClientPJ(overrides: Partial<ClientDto> = {}): ClientDto {
+function makeRawClientPj(overrides: Partial<ClientDto> = {}): ClientDto {
   return {
     id: CLIENT_PJ_ID,
     type: 'PJ',
     cpf: null,
     fullName: null,
     cnpj: '12345678000190',
-    corporateName: 'Empresa LTDA',
+    corporateName: 'Acme Indústria S/A',
     createdAt: '2026-01-10T12:00:00Z',
     updatedAt: '2026-01-10T12:00:00Z',
     deletedAt: null,
+    userIds: [],
+    extraEmails: [],
+    mobilePhones: [],
+    landlinePhones: [],
+    ...overrides,
+  };
+}
+
+function makePaged(
+  data: ReadonlyArray<ClientDto>,
+  overrides: Partial<PagedResponse<ClientDto>> = {},
+): PagedResponse<ClientDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
+    total: data.length,
     ...overrides,
   };
 }
 
 describe('isClientDto', () => {
-  it('aceita payload PF com fullName/cpf', () => {
-    expect(isClientDto(makeClientPF())).toBe(true);
+  it('aceita PF com cpf/fullName e arrays vazios', () => {
+    expect(isClientDto(makeRawClientPf())).toBe(true);
   });
 
-  it('aceita payload PJ com corporateName/cnpj', () => {
-    expect(isClientDto(makeClientPJ())).toBe(true);
+  it('aceita PJ com cnpj/corporateName e arrays vazios', () => {
+    expect(isClientDto(makeRawClientPj())).toBe(true);
   });
 
-  it('aceita payload com todos os opcionais ausentes', () => {
+  it('aceita extraEmails/mobilePhones/landlinePhones populados', () => {
+    expect(
+      isClientDto(
+        makeRawClientPf({
+          extraEmails: [
+            { id: 'e1', email: 'extra@example.com', createdAt: '2026-01-10T12:00:00Z' },
+          ],
+          mobilePhones: [
+            { id: 'p1', number: '+5511999999999', createdAt: '2026-01-10T12:00:00Z' },
+          ],
+          landlinePhones: [
+            { id: 'p2', number: '+551133334444', createdAt: '2026-01-10T12:00:00Z' },
+          ],
+          userIds: ['u1', 'u2'],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('aceita payload minimalista sem coleções (lookup #77)', () => {
+    // Issue #77 (`getClientsByIds`) consome `GET /clients/{id}` e
+    // pode receber um payload reduzido em testes — o type guard
+    // tolera ausência das 4 coleções sem perder a validação dos
+    // campos obrigatórios (`id`/`type`/`createdAt`/`updatedAt`).
     const lean = {
-      id: CLIENT_ID,
-      type: 'PF',
+      id: CLIENT_PF_ID,
+      type: 'PF' as const,
+      cpf: null,
+      fullName: 'Ana Cliente',
+      cnpj: null,
+      corporateName: null,
       createdAt: '2026-01-10T12:00:00Z',
       updatedAt: '2026-01-10T12:00:00Z',
+      deletedAt: null,
     };
     expect(isClientDto(lean)).toBe(true);
   });
 
-  it('rejeita objetos sem campos obrigatórios', () => {
-    expect(isClientDto(null)).toBe(false);
-    expect(isClientDto(undefined)).toBe(false);
-    expect(isClientDto({})).toBe(false);
-    expect(isClientDto({ id: 1, type: 'PF' })).toBe(false);
+  it('rejeita type fora de PF/PJ', () => {
+    expect(isClientDto({ ...makeRawClientPf(), type: 'XX' })).toBe(false);
   });
 
-  it('rejeita campos opcionais com tipo inválido', () => {
+  it('rejeita registro sem id', () => {
+    const { id: _id, ...rest } = makeRawClientPf();
+    expect(isClientDto(rest)).toBe(false);
+  });
+
+  it('rejeita coleções com tipo inválido (quando presentes)', () => {
     expect(
-      isClientDto(makeClientPF({ fullName: 0 as unknown as string })),
+      isClientDto({ ...makeRawClientPf(), userIds: 'not-an-array' as unknown }),
     ).toBe(false);
     expect(
-      isClientDto(makeClientPJ({ cnpj: 0 as unknown as string })),
+      isClientDto({ ...makeRawClientPf(), extraEmails: [{ wrong: 'shape' }] as unknown }),
     ).toBe(false);
+  });
+
+  it('aceita deletedAt como string ISO', () => {
+    expect(
+      isClientDto(makeRawClientPf({ deletedAt: '2026-02-01T00:00:00Z' })),
+    ).toBe(true);
+  });
+
+  it('rejeita primitivos e null', () => {
+    expect(isClientDto(null)).toBe(false);
+    expect(isClientDto('string')).toBe(false);
+    expect(isClientDto(42)).toBe(false);
   });
 });
 
 describe('isPagedClientsResponse', () => {
-  it('aceita envelope válido', () => {
-    expect(
-      isPagedClientsResponse({
-        data: [makeClientPF()],
-        page: 1,
-        pageSize: 20,
-        total: 1,
-      }),
-    ).toBe(true);
+  it('aceita envelope completo com data válido', () => {
+    expect(isPagedClientsResponse(makePaged([makeRawClientPf()]))).toBe(true);
   });
 
-  it('rejeita envelope com data com itens inválidos', () => {
+  it('rejeita data não-array', () => {
     expect(
       isPagedClientsResponse({
-        data: [{ broken: true }],
+        data: 'not-array' as unknown,
         page: 1,
         pageSize: 20,
-        total: 1,
+        total: 0,
       }),
+    ).toBe(false);
+  });
+
+  it('rejeita campos numéricos ausentes', () => {
+    expect(
+      isPagedClientsResponse({ data: [], page: 1, pageSize: 20 }),
+    ).toBe(false);
+  });
+
+  it('rejeita item interno inválido (propaga falha de isClientDto)', () => {
+    expect(
+      isPagedClientsResponse(
+        makePaged([{ ...makeRawClientPf(), type: 'XX' } as unknown as ClientDto]),
+      ),
     ).toBe(false);
   });
 });
 
 describe('clientDisplayName', () => {
   it('retorna fullName para PF', () => {
-    expect(clientDisplayName(makeClientPF())).toBe('Alice Cliente');
+    expect(clientDisplayName(makeRawClientPf())).toBe('Ana Cliente');
   });
 
   it('retorna corporateName para PJ', () => {
-    expect(clientDisplayName(makeClientPJ())).toBe('Empresa LTDA');
+    expect(clientDisplayName(makeRawClientPj())).toBe('Acme Indústria S/A');
   });
 
   it('cai no id quando ambos os labels estão ausentes', () => {
-    const orphan = makeClientPF({ fullName: null, corporateName: null });
-    expect(clientDisplayName(orphan)).toBe(CLIENT_ID);
+    const orphan = makeRawClientPf({ fullName: null, corporateName: null });
+    expect(clientDisplayName(orphan)).toBe(CLIENT_PF_ID);
   });
 
   it('cai no id quando os labels são apenas whitespace', () => {
-    const orphan = makeClientPF({ fullName: '   ', corporateName: '' });
-    expect(clientDisplayName(orphan)).toBe(CLIENT_ID);
+    const orphan = makeRawClientPf({ fullName: '   ', corporateName: '' });
+    expect(clientDisplayName(orphan)).toBe(CLIENT_PF_ID);
   });
 
   it('prioriza fullName sobre corporateName se ambos estiverem preenchidos', () => {
-    const both = makeClientPF({
+    const both = makeRawClientPf({
       fullName: 'PF Name',
       corporateName: 'PJ Name',
     });
@@ -168,74 +241,151 @@ describe('clientDisplayName', () => {
   });
 });
 
-describe('listClients — querystring', () => {
-  it('emite GET /clients sem querystring quando params são default', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce({
-      data: [],
-      page: 1,
-      pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
-      total: 0,
-    });
+describe('listClients', () => {
+  it('chama GET /clients sem querystring quando params são defaults', async () => {
+    const client = makeClientStub();
+    const paged = makePaged([makeRawClientPf()]);
+    client.get.mockResolvedValueOnce(paged);
 
-    await listClients({}, undefined, client as unknown as ApiClient);
-    expect(client.get.mock.calls[0][0]).toBe('/clients');
+    const result = await listClients({}, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get).toHaveBeenCalledWith('/clients', undefined);
+    expect(result).toBe(paged);
   });
 
-  it('serializa q + type + active + page + pageSize', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce({
-      data: [],
-      page: 2,
-      pageSize: 50,
-      total: 100,
-    });
+  it('inclui q quando informado e trim aplicado', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients({ q: '  Ana  ' }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?q=Ana', undefined);
+  });
+
+  it('inclui type=PF quando informado', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients({ type: 'PF' }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?type=PF', undefined);
+  });
+
+  it('inclui type=PJ quando informado', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients({ type: 'PJ' }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?type=PJ', undefined);
+  });
+
+  it('inclui active quando boolean (true)', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients({ active: true }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?active=true', undefined);
+  });
+
+  it('inclui active=false quando explicitamente false', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients({ active: false }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?active=false', undefined);
+  });
+
+  it('inclui page quando ≠ 1 (default)', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([], { page: 2 }));
+
+    await listClients({ page: 2 }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?page=2', undefined);
+  });
+
+  it('inclui pageSize quando ≠ 20 (default)', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([], { pageSize: 50 }));
+
+    await listClients({ pageSize: 50 }, undefined, client as unknown as ApiClient);
+
+    expect(client.get).toHaveBeenCalledWith('/clients?pageSize=50', undefined);
+  });
+
+  it('inclui includeDeleted quando true', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
 
     await listClients(
-      {
-        q: 'alice',
-        type: 'PF',
-        active: true,
-        page: 2,
-        pageSize: 50,
-      },
+      { includeDeleted: true },
       undefined,
       client as unknown as ApiClient,
     );
 
-    expect(client.get.mock.calls[0][0]).toBe(
-      '/clients?q=alice&type=PF&active=true&page=2&pageSize=50',
+    expect(client.get).toHaveBeenCalledWith('/clients?includeDeleted=true', undefined);
+  });
+
+  it('combina vários params na ordem esperada', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+
+    await listClients(
+      { q: 'ana', type: 'PF', page: 2, pageSize: 50, includeDeleted: true },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/clients?q=ana&type=PF&page=2&pageSize=50&includeDeleted=true',
+      undefined,
     );
   });
 
-  it('omite type quando não é PF/PJ', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce({
-      data: [],
-      page: 1,
-      pageSize: DEFAULT_CLIENTS_PAGE_SIZE,
-      total: 0,
-    });
+  it('omite q vazio (após trim) e omite type fora de PF/PJ', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
 
-    // @ts-expect-error — propositalmente passa tipo inválido para
-    // garantir que o builder ignora valores fora do enum.
-    await listClients({ type: 'XX' }, undefined, client as unknown as ApiClient);
-    expect(client.get.mock.calls[0][0]).toBe('/clients');
+    await listClients(
+      { q: '   ', type: undefined },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledWith('/clients', undefined);
   });
 
-  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce({ malformed: true });
+  it('lança ApiError(parse) quando o backend devolve envelope inválido', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce({ wrong: 'shape' });
 
     await expect(
       listClients({}, undefined, client as unknown as ApiClient),
     ).rejects.toMatchObject({ kind: 'parse' });
   });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makePaged([]));
+    const controller = new AbortController();
+
+    await listClients(
+      {},
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledWith('/clients', { signal: controller.signal });
+  });
 });
 
 describe('getClientsByIds', () => {
   it('retorna Map vazio quando ids está vazio (sem chamadas ao client)', async () => {
-    const client = createStub();
+    const client = makeClientStub();
     const result = await getClientsByIds(
       [],
       undefined,
@@ -246,9 +396,9 @@ describe('getClientsByIds', () => {
   });
 
   it('busca cada id e popula o Map preservando o id-chave', async () => {
-    const client = createStub();
-    const pf = makeClientPF();
-    const pj = makeClientPJ();
+    const client = makeClientStub();
+    const pf = makeRawClientPf();
+    const pj = makeRawClientPj();
     client.get.mockResolvedValueOnce(pf).mockResolvedValueOnce(pj);
 
     const result = await getClientsByIds(
@@ -265,8 +415,8 @@ describe('getClientsByIds', () => {
   });
 
   it('skipa ids duplicados sem refazer chamada', async () => {
-    const client = createStub();
-    const pf = makeClientPF();
+    const client = makeClientStub();
+    const pf = makeRawClientPf();
     client.get.mockResolvedValueOnce(pf);
 
     await getClientsByIds(
@@ -279,8 +429,8 @@ describe('getClientsByIds', () => {
   });
 
   it('é best-effort: lookup falho silenciosamente skipa o id', async () => {
-    const client = createStub();
-    const pf = makeClientPF();
+    const client = makeClientStub();
+    const pf = makeRawClientPf();
     client.get
       .mockRejectedValueOnce({ kind: 'http', status: 404, message: 'x' })
       .mockResolvedValueOnce(pf);
@@ -297,13 +447,13 @@ describe('getClientsByIds', () => {
   });
 
   it('lança AbortError quando a requisição é cancelada', async () => {
-    const client = createStub();
+    const client = makeClientStub();
     const abort = new DOMException('aborted', 'AbortError');
     client.get.mockRejectedValueOnce(abort);
 
     await expect(
       getClientsByIds(
-        [CLIENT_ID],
+        [CLIENT_PF_ID],
         undefined,
         client as unknown as ApiClient,
       ),
@@ -311,7 +461,7 @@ describe('getClientsByIds', () => {
   });
 
   it('lança ApiError de network com cancelamento explícito', async () => {
-    const client = createStub();
+    const client = makeClientStub();
     const networkAbort = {
       kind: 'network' as const,
       message: 'Requisição cancelada.',
@@ -320,7 +470,7 @@ describe('getClientsByIds', () => {
 
     await expect(
       getClientsByIds(
-        [CLIENT_ID],
+        [CLIENT_PF_ID],
         undefined,
         client as unknown as ApiClient,
       ),


### PR DESCRIPTION
## Contexto
Issue #73 (EPIC #49 — Clientes/Usuários). Promove o shell placeholder `/clientes` (criado em PR #149) para listagem real, alinhada ao backend `lfc-authenticator#169` (mergeado: `PagedResponse<ClientResponse>` + filtros `q`, `type`, `active`, `page`, `pageSize`, `includeDeleted` em `GET /clients`).

## Objetivo
Entregar a listagem de clientes consumida em `/clientes`, atendendo aos critérios de aceite da issue: tabela com Nome (PF: FullName, PJ: CorporateName), Documento (CPF/CNPJ formatados), Tipo (PF/PJ), Status (ativo/inativo); busca por nome/documento e paginação **server-side**; filtro adicional por tipo (PF/PJ/Todos).

## O que foi feito
- **`src/shared/api/clients.ts`** — DTOs (`ClientDto`, `ClientType`, `ClientEmailDto`, `ClientPhoneDto`), type guards (`isClientDto` tolera fixtures minimalistas para compatibilidade com #77; `isPagedClientsResponse` reusa `isPagedResponseEnvelope`), defaults (`DEFAULT_CLIENTS_PAGE = 1`, `DEFAULT_CLIENTS_PAGE_SIZE = 20`, `DEFAULT_CLIENTS_INCLUDE_DELETED = false`), `listClients` (querystring canônica, omite params default).
- **`src/shared/api/pagedResponse.ts`** — extrai `isPagedResponseEnvelope<T>(value, isItem)` para zerar a duplicação JSCPD/Sonar do bloco de validação de envelope (~14 linhas) que aparecia em 4 recursos. `systems`/`routes`/`roles`/`users`/`clients` foram refatorados para reusá-lo (lição PR #134/#135 — JSCPD cai de 2.97% para 2.66%, –3 clones).
- **`src/pages/clients/ClientsListShellPage.tsx`** — substitui o placeholder pela listagem real reusando `usePaginatedFetch` + `usePaginationControls` + `ListingToolbar` + `LiveRegion` + `PaginationFooter` + `ErrorRetryBlock` + `InitialLoadingSpinner` + `RefetchOverlay` + `StatusBadge` (gender="m"). Helpers internos `formatCpf`/`formatCnpj` aplicam máscara visual (defensivos: devolvem dígitos crus se shape inesperado).
- **`src/shared/listing/ListingToolbar.tsx`** — adiciona slot opcional `extraFilter` para o `<Select>` de tipo PF/PJ. Backwards-compatible — outras listagens não mudam.
- **Cobertura** — 36 testes novos cobrem render inicial, busca debounced (300ms, last-wins), filtro de tipo (PF/PJ/Todos), paginação server-side, toggle de inativos, estados vazios (com/sem busca), erros (`network`, `unknown`), cancelamento via `AbortController`. `tests/shared/api/clients.test.ts` cobre 100% dos paths de querystring + type guards + `getClientsByIds`/`clientDisplayName` (preservados após merge com #77).

## Arquivos impactados
**Novos:**
- `src/shared/api/clients.ts`
- `src/shared/api/pagedResponse.ts`
- `tests/pages/ClientsListShellPage.test.tsx`
- `tests/pages/__helpers__/clientsTestHelpers.tsx`
- `tests/shared/api/clients.test.ts`

**Modificados:**
- `src/pages/clients/ClientsListShellPage.tsx`
- `src/shared/api/index.ts`
- `src/shared/api/{systems,routes,roles,users}.ts` (refactor mecânico para reusar `isPagedResponseEnvelope`)
- `src/shared/listing/ListingToolbar.tsx` (slot `extraFilter`)
- `tests/pages/shellPages.test.tsx` (remove `ClientsListShellPage` do bloco placeholder)

## Testes
- **Lint:** 0 erros / 0 warnings (`npm run lint`).
- **Typecheck:** 0 erros (`npm run typecheck`).
- **Test:** 50 arquivos / **734 testes** verdes (`npm test`).
- **JSCPD:** 2.66% (limite 3%); 0 clones em arquivos tocados pelo diff.

## Visual
- Reusa tokens/CSS variables do design-system (sem hardcode de cor).
- `StatusBadge` (gender="m") exibe "Ativo"/"Inativo" para o gênero masculino.
- `ListingToolbar.extraFilter` mantém alinhamento e espaçamento consistentes com Switch e CTAs já existentes.
- Estados completos: loading (spinner inicial), refetching (overlay), erro (Alert + retry), empty (com/sem busca), focus visível em todos os controles interativos.

## Segurança
- Sem `dangerouslySetInnerHTML`, sem `eval`, sem renderização de URL externa.
- CPF/CNPJ exibidos só na máscara visual; dados crus do backend.
- Permissão da rota (`AUTH_V1_CLIENTS_LIST`) já aplicada via `RequirePermission` em `src/routes/index.tsx` (PR #149).

## Riscos
- Refactor de `isPaged*Response` em 4 módulos pré-existentes (`systems`/`routes`/`roles`/`users`) é mecânico e coberto por testes existentes — todos os 734 testes passam após a mudança.
- Suíte completa pode flakar sob alta concorrência de threads no host; rodar com `--poolOptions.threads.maxThreads=4` resolve. CI usa runners isolados.

## Issue relacionada
Closes #73