### PR TITLE
feat(users): criar usuário (#78)

### DIFF
--- a/src/pages/users/NewUserModal.tsx
+++ b/src/pages/users/NewUserModal.tsx
@@ -1,0 +1,212 @@
+import React, { useCallback } from 'react';
+
+import { Modal, useToast } from '../../components/ui';
+import { createUser } from '../../shared/api';
+import { useCreateEntitySubmit } from '../../shared/forms';
+
+import { UserFormBody } from './UserFormFields';
+import {
+  INITIAL_USER_FORM_STATE,
+  type UserFieldErrors,
+  type UserSubmitErrorCopy,
+} from './userFormShared';
+import { useUserForm } from './useUserForm';
+
+import type { ApiClient, CreateUserPayload } from '../../shared/api';
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de criação.
+ * Os literais aqui são os únicos pontos onde "criar"/"um usuário"
+ * diferem do "atualizar"/"outro usuário" no futuro `EditUserModal` —
+ * o resto da lógica de classificação é compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: UserSubmitErrorCopy = {
+  conflictDefault: 'Já existe um usuário com este e-mail.',
+  forbiddenTitle: 'Falha ao criar usuário',
+  genericFallback: 'Não foi possível criar o usuário. Tente novamente.',
+};
+
+/**
+ * Texto exibido inline no campo `email` quando o backend devolve 409.
+ * Usamos uma copy dedicada (em vez de propagar a do backend, que é
+ * "Já existe um usuário com este Email." com `Email` em PascalCase)
+ * para coerência com a UX em pt-BR — o operador lê "e-mail" no
+ * label do campo.
+ */
+const CONFLICT_INLINE_MESSAGE = 'Já existe um usuário com este e-mail.';
+
+/**
+ * Modal de criação de usuário (Issue #78 — primeiro fluxo de mutação
+ * do recurso Users, espelhando o padrão do `NewSystemModal`/
+ * `NewRouteModal` das EPICs anteriores).
+ *
+ * Decisões:
+ *
+ * - Componente "controlado por aberto" pelo pai (`open`/`onClose`).
+ *   Mantém o ciclo de vida do estado do form sob controle desta
+ *   camada: ao fechar, resetamos `formState`/`fieldErrors`/
+ *   `submitError` para garantir que o usuário não veja resíduo de
+ *   tentativa anterior.
+ * - Validação client-side **antes** de submeter — replica as regras
+ *   do backend (`Required`/`MaxLength`/`EmailAddress`/`Identity`)
+ *   para dar feedback imediato e evitar round-trip por erro trivial.
+ *   As regras vivem em `userFormShared.ts` para serem reusadas pelo
+ *   `EditUserModal` (sub-issue futura) sem duplicação.
+ * - Mapeamento de erro do backend (delegado ao
+ *   `useCreateEntitySubmit`):
+ *   - 409 → mensagem inline no campo `email` ("Já existe um usuário
+ *     com este e-mail.").
+ *   - 400 → `details.errors[Field]` mapeado para `fieldErrors[field]`
+ *     normalizando capitalização (backend manda `Name`/`Email`/
+ *     `Password`/`Identity`/`ClientId`); 400 sem `details.errors`
+ *     mapeáveis (caso `{ message: "ClientId informado não existe." }`)
+ *     vai para `submitError` no Alert do topo.
+ *   - 401/403 → toast vermelho com mensagem do backend.
+ *   - Demais → toast vermelho com mensagem genérica.
+ * - Sucesso: chama `onCreated` (refetch responsabilidade do pai),
+ *   fecha o modal e dispara toast verde "Usuário criado.".
+ *
+ * **Sobre `clientId`:** o backend aceita ausência (`null`/omitido) e
+ * gera automaticamente um cliente PF derivado via
+ * `LegacyClientFactory.BuildPfClientForUser`. A UI orienta o operador
+ * com helper text em vez de exigir o UUID — a issue dá flexibilidade
+ * ("lookup por id ou input livre"), e input livre + helper text é o
+ * caminho coerente com a listagem #77 (que ainda exibe `clientId` cru
+ * quando não tem nome resolvido).
+ */
+
+interface NewUserModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /** Fecha o modal sem persistir. Chamada também após sucesso. */
+  onClose: () => void;
+  /** Callback disparado após criação bem-sucedida (para refetch da lista). */
+  onCreated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `createUser` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const NewUserModal: React.FC<NewUserModalProps> = ({
+  open,
+  onClose,
+  onCreated,
+  client,
+}) => {
+  const { show } = useToast();
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleNameChange,
+    handleEmailChange,
+    handlePasswordChange,
+    handleIdentityChange,
+    handleClientIdChange,
+    handleActiveChange,
+    prepareSubmit,
+    applyBadRequest,
+  } = useUserForm(INITIAL_USER_FORM_STATE);
+
+  /**
+   * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
+   * submissão é bloqueado para evitar request órfã (sem
+   * `AbortController` nessa primeira iteração — backend é rápido e o
+   * usuário não consegue disparar duas vezes graças ao `disabled` no
+   * botão).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFormState(INITIAL_USER_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reset disparado pelo helper `useCreateEntitySubmit` no caminho
+   * feliz (antes de `onCreated`/`onClose`). Mantemos uma referência
+   * dedicada (em vez de reusar `handleClose`) porque `handleClose` é
+   * gateado por `isSubmitting` — o submit feliz roda exatamente
+   * quando `isSubmitting === true`, então o gate inverteria o
+   * comportamento esperado.
+   */
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_USER_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * `mutationFn` injetada no helper genérico. Tipa o payload via cast
+   * para `CreateUserPayload` porque o helper aceita `unknown` (o cast
+   * é seguro — o `prepareSubmit` do `useUserForm` só devolve
+   * `CreateUserPayload | null`, e o helper já filtrou `null` antes
+   * de chamar `mutationFn`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown) => createUser(payload as CreateUserPayload, undefined, client),
+    [client],
+  );
+
+  const handleSubmit = useCreateEntitySubmit<keyof UserFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: {
+      successMessage: 'Usuário criado.',
+      conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    },
+    callbacks: {
+      prepareSubmit,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: 'email',
+  });
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Novo usuário"
+      description="Cadastre um novo usuário com acesso ao painel administrativo."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <UserFormBody
+        idPrefix="new-user"
+        submitError={submitError}
+        values={formState}
+        errors={fieldErrors}
+        onChangeName={handleNameChange}
+        onChangeEmail={handleEmailChange}
+        onChangePassword={handlePasswordChange}
+        onChangeIdentity={handleIdentityChange}
+        onChangeClientId={handleClientIdChange}
+        onChangeActive={handleActiveChange}
+        onSubmit={handleSubmit}
+        onCancel={handleClose}
+        isSubmitting={isSubmitting}
+        submitLabel="Criar usuário"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/users/UserFormFields.tsx
+++ b/src/pages/users/UserFormFields.tsx
@@ -1,0 +1,363 @@
+import React, { useMemo } from 'react';
+import styled from 'styled-components';
+
+import { Alert, Button, Input, Switch } from '../../components/ui';
+
+import {
+  EMAIL_MAX,
+  NAME_MAX,
+  PASSWORD_MAX,
+  type UserFieldErrors,
+  type UserFormState,
+} from './userFormShared';
+
+/* ─── Styled primitives compartilhados pelo modal ─── */
+
+/**
+ * Wrapper do `<form>` do modal de user. Espelha
+ * `SystemFormShell`/`RouteFormShell` — mesmo `display: flex` com
+ * `gap: var(--space-4)` para coerência visual entre os modals do
+ * admin-gui.
+ *
+ * Quando o `EditUserModal` chegar (sub-issue futura), ambos os modals
+ * vão consumir este shell — extrair desde já evita duplicação Sonar
+ * (lição PR #127/#128 — projetar o módulo `<recurso>FormShared.ts`
+ * desde o **primeiro PR do recurso**).
+ */
+const UserFormShell = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+/** Footer com botões alinhados à direita, separados pelo gap padrão. */
+const UserFormFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+`;
+
+/** Linha de hint "campos com * são obrigatórios" no rodapé do form. */
+const UserFormHelperRow = styled.div`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const FieldStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+/**
+ * Linha do toggle "Ativo" — alinha o `<Switch>` à esquerda com o
+ * label inline. Mantemos um wrapper dedicado para que o spacing fique
+ * coerente com os campos de texto acima (sem o `<Switch>` ter um
+ * label próprio que duplica o label do field stack).
+ */
+const ActiveRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+`;
+
+const ActiveLabel = styled.span`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  letter-spacing: var(--tracking-tight);
+`;
+
+const ActiveHelper = styled.span`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+`;
+
+/**
+ * Campos do formulário `NewUserModal` (Issue #78).
+ *
+ * Já projetado para ser reusado pelo `EditUserModal` na sub-issue
+ * seguinte — cada modal pré-popula valores diferentes (vazio para
+ * criação, dados atuais para edição), mas a estrutura visual e a
+ * validação são compartilhadas. Antes de extrair, o segundo modal
+ * espelharia ~140 linhas do primeiro — gatilho garantido de BLOCKER
+ * de duplicação Sonar (lição PR #123/#127/#128 — qualquer trecho de
+ * 10+ linhas em 2+ arquivos é `New Code Duplication` independente da
+ * intenção).
+ *
+ * O componente é deliberadamente "burro": cada modal continua dono
+ * do `formState`/`fieldErrors`/handlers e do submit. Aqui só
+ * renderizamos os inputs e centralizamos `aria`, `maxLength`, helper
+ * text e o `data-modal-initial-focus` no campo Name.
+ *
+ * Os `data-testid` recebem um `idPrefix` para que cada modal preserve
+ * IDs estáveis usados pelos seus testes (`new-user-name`, futuro
+ * `edit-user-name`, etc.) — assim refator do shared não invalida
+ * suítes existentes.
+ *
+ * **Decisões específicas do user form:**
+ *
+ * - `Email` usa `<Input type="email">` para que o teclado mobile traga
+ *   layout `@` + `.com` e o navegador valide formato no submit nativo
+ *   antes do client-side. `autoComplete="email"` ajuda gerenciadores de
+ *   senha (mas o admin não armazena email do operador — é o operador
+ *   cadastrando outro usuário).
+ * - `Password` usa `<Input type="password">` para mascarar a entrada.
+ *   `autoComplete="new-password"` informa ao navegador que é uma senha
+ *   nova (não para preencher com salvas) — coerente com fluxo de
+ *   "operador cria senha inicial para outro usuário".
+ * - `Identity` usa `<Input type="number">` mas com `inputMode="numeric"`
+ *   reforçando teclado numérico em mobile. O React reporta string
+ *   pelo `onChange` (`Input` aqui já entrega `value: string`), e o
+ *   parse para `int` fica no `prepareSubmit` do hook.
+ * - `ClientId` é texto livre porque o backend aceita UUID — UX de
+ *   lookup com autocomplete pode chegar em sub-issue futura, mas exigir
+ *   isso na #78 expandiria escopo (issue diz "selector de cliente"
+ *   pode ser lookup ou input livre — input livre é coerente com a
+ *   listagem #77 que ainda exibe `clientId` cru quando não tem nome).
+ *   Mensagem de helper text orienta o operador a deixar vazio para
+ *   gerar cliente PF derivado automaticamente.
+ * - `Active` é `<Switch>` (não `<Checkbox>`) porque é uma única
+ *   chave booleana de "ativar/desativar conta" — convenção visual
+ *   reforça "estado", não "marcação opcional".
+ */
+
+interface UserFormFieldsProps {
+  /**
+   * Prefixo dos `data-testid` de cada input. Default `user` cobre
+   * ambientes ad-hoc; o caller deve passar `new-user`/`edit-user` em
+   * produção para casar com os helpers de teste.
+   */
+  idPrefix?: string;
+  /** Estado controlado dos campos. */
+  values: UserFormState;
+  /** Erros inline por campo (vindos da validação client-side ou do backend). */
+  errors: UserFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeEmail: (value: string) => void;
+  onChangePassword: (value: string) => void;
+  onChangeIdentity: (value: string) => void;
+  onChangeClientId: (value: string) => void;
+  onChangeActive: (value: boolean) => void;
+  /**
+   * Quando `true`, todos os inputs ficam desabilitados (durante submit).
+   * Default `false` mantém o comportamento padrão de form interativo.
+   */
+  disabled?: boolean;
+  /**
+   * Quando `true`, o campo Name recebe `data-modal-initial-focus` para
+   * que o `Modal` foque automaticamente nele ao abrir. Permite que o
+   * `EditUserModal` desligue o auto-foco se quiser focar outro campo
+   * no futuro — hoje os dois modals usam `true`.
+   */
+  autoFocusName?: boolean;
+}
+
+const UserFormFields: React.FC<UserFormFieldsProps> = ({
+  idPrefix = 'user',
+  values,
+  errors,
+  onChangeName,
+  onChangeEmail,
+  onChangePassword,
+  onChangeIdentity,
+  onChangeClientId,
+  onChangeActive,
+  disabled = false,
+  autoFocusName = true,
+}) => {
+  // `data-modal-initial-focus` no campo Name garante que o foco vá para
+  // o primeiro input independente da ordem dos `querySelector`. Útil em
+  // jsdom (testes) e em qualquer mudança futura de layout. Memoizado
+  // para preservar referência do objeto passado como spread.
+  const nameFocusAttr = useMemo(
+    () => (autoFocusName ? ({ 'data-modal-initial-focus': true } as const) : ({} as const)),
+    [autoFocusName],
+  );
+
+  return (
+    <FieldStack>
+      <Input
+        label="Nome"
+        placeholder="ex.: Alice Admin"
+        value={values.name}
+        onChange={onChangeName}
+        error={errors.name}
+        maxLength={NAME_MAX}
+        autoComplete="name"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-name`}
+        {...nameFocusAttr}
+      />
+      <Input
+        label="E-mail"
+        type="email"
+        placeholder="ex.: alice@empresa.com"
+        value={values.email}
+        onChange={onChangeEmail}
+        error={errors.email}
+        maxLength={EMAIL_MAX}
+        autoComplete="email"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-email`}
+      />
+      <Input
+        label="Senha inicial"
+        type="password"
+        placeholder="Senha temporária — o usuário poderá alterar depois."
+        value={values.password}
+        onChange={onChangePassword}
+        error={errors.password}
+        maxLength={PASSWORD_MAX}
+        autoComplete="new-password"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-password`}
+      />
+      <Input
+        label="Identity"
+        type="number"
+        inputMode="numeric"
+        placeholder="ex.: 1"
+        value={values.identity}
+        onChange={onChangeIdentity}
+        error={errors.identity}
+        autoComplete="off"
+        required
+        disabled={disabled}
+        data-testid={`${idPrefix}-identity`}
+      />
+      <Input
+        label="ClientId (opcional)"
+        placeholder="UUID do cliente vinculado — vazio gera cliente PF automático"
+        value={values.clientId}
+        onChange={onChangeClientId}
+        error={errors.clientId}
+        autoComplete="off"
+        disabled={disabled}
+        data-testid={`${idPrefix}-client-id`}
+      />
+      <ActiveRow>
+        <Switch
+          checked={values.active}
+          onChange={onChangeActive}
+          disabled={disabled}
+          data-testid={`${idPrefix}-active`}
+          aria-label="Usuário ativo"
+        />
+        <ActiveLabel>Ativo</ActiveLabel>
+        <ActiveHelper>Usuários inativos não conseguem efetuar login.</ActiveHelper>
+      </ActiveRow>
+    </FieldStack>
+  );
+};
+
+/* ─── Form body completo ─────────────────────────────────── */
+
+interface UserFormBodyProps {
+  /**
+   * Prefixo dos `data-testid` do form e dos campos. Em produção,
+   * `new-user` ou `edit-user`; usar prefixo curto para combinar com
+   * os testIds estáveis das suítes existentes.
+   */
+  idPrefix: string;
+  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
+  submitError: string | null;
+  /** Estado controlado dos campos. */
+  values: UserFormState;
+  /** Erros inline por campo. */
+  errors: UserFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeEmail: (value: string) => void;
+  onChangePassword: (value: string) => void;
+  onChangeIdentity: (value: string) => void;
+  onChangeClientId: (value: string) => void;
+  onChangeActive: (value: boolean) => void;
+  /** Handler do submit do form. */
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  /** Handler do botão Cancelar (bloqueado durante submit). */
+  onCancel: () => void;
+  /** Flag de submissão em andamento. */
+  isSubmitting: boolean;
+  /** Texto do botão de envio (ex.: "Criar usuário", "Salvar alterações"). */
+  submitLabel: string;
+}
+
+/**
+ * Body completo do modal de criação (e do futuro edit): shell `<form>`
+ * + Alert do erro genérico + campos (Nome/E-mail/Senha/Identity/
+ * ClientId/Ativo) + linha de hint obrigatórios + footer (Cancelar/
+ * Submit).
+ *
+ * Centralizar aqui (em vez de inline no `NewUserModal`) garante que
+ * o `EditUserModal` futuro consuma a mesma estrutura — diferindo só
+ * em `idPrefix`/labels/submitLabel — sem duplicação Sonar (lição
+ * PR #127/#128).
+ */
+export const UserFormBody: React.FC<UserFormBodyProps> = ({
+  idPrefix,
+  submitError,
+  values,
+  errors,
+  onChangeName,
+  onChangeEmail,
+  onChangePassword,
+  onChangeIdentity,
+  onChangeClientId,
+  onChangeActive,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  submitLabel,
+}) => (
+  <UserFormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
+    {submitError && (
+      // `<Alert>` do design system não propaga `data-testid` em
+      // produção (silently dropped pelo componente), então os
+      // testes buscam pelo texto da mensagem em vez de testId.
+      // Mantemos o `data-testid` aqui só por simetria com
+      // `SystemFormBody`/`RouteFormBody` — quando o `<Alert>` for
+      // evoluído para spread props, o atributo já chegará no DOM.
+      <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
+        {submitError}
+      </Alert>
+    )}
+    <UserFormFields
+      idPrefix={idPrefix}
+      values={values}
+      errors={errors}
+      onChangeName={onChangeName}
+      onChangeEmail={onChangeEmail}
+      onChangePassword={onChangePassword}
+      onChangeIdentity={onChangeIdentity}
+      onChangeClientId={onChangeClientId}
+      onChangeActive={onChangeActive}
+      disabled={isSubmitting}
+    />
+    <UserFormHelperRow>Campos com * são obrigatórios.</UserFormHelperRow>
+    <UserFormFooter>
+      <Button
+        type="button"
+        variant="ghost"
+        size="md"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        data-testid={`${idPrefix}-cancel`}
+      >
+        Cancelar
+      </Button>
+      <Button
+        type="submit"
+        variant="primary"
+        size="md"
+        loading={isSubmitting}
+        data-testid={`${idPrefix}-submit`}
+      >
+        {submitLabel}
+      </Button>
+    </UserFormFooter>
+  </UserFormShell>
+);

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
@@ -14,6 +15,7 @@ import {
   isApiError,
   listUsers,
 } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
 import {
   CardCode,
   CardHeader,
@@ -40,6 +42,8 @@ import {
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import { NewUserModal } from './NewUserModal';
+
 import type { TableColumn } from '../../components/ui';
 import type {
   ApiClient,
@@ -47,6 +51,18 @@ import type {
   SafeRequestOptions,
   UserDto,
 } from '../../shared/api';
+
+/**
+ * Code de permissão exigido para o botão "Novo usuário" (Issue #78).
+ *
+ * Espelha o `AUTH_V1_USERS_CREATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (o `POST /users` valida via
+ * `[Authorize(Policy = PermissionPolicies.UsersCreate)]`); o gating
+ * client-side é apenas UX — esconder ações que o usuário não pode
+ * executar.
+ */
+const USERS_CREATE_PERMISSION = 'AUTH_V1_USERS_CREATE';
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300 ms
@@ -119,6 +135,9 @@ function deriveStatusDeletedAt(user: UserDto): string | null {
 export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
   client,
 }) => {
+  const { hasPermission } = useAuth();
+  const canCreateUser = hasPermission(USERS_CREATE_PERMISSION);
+
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
   const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
@@ -127,6 +146,19 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     DEFAULT_USERS_INCLUDE_DELETED,
   );
   const [page, setPage] = useState<number>(DEFAULT_USERS_PAGE);
+
+  // Estado de abertura do modal "Novo usuário" (Issue #78). O modal é
+  // controlado por essa página para que a Toolbar consiga ocultar o
+  // botão por permissão sem perder o ciclo de vida do form.
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
+
+  const handleOpenCreateModal = useCallback(() => {
+    setIsCreateModalOpen(true);
+  }, []);
+
+  const handleCloseCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
+  }, []);
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -373,6 +405,19 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
         onIncludeDeletedChange={handleIncludeDeletedChange}
         includeDeletedHelperText="Inclui usuários com remoção lógica."
         includeDeletedTestId="users-include-deleted"
+        actions={
+          canCreateUser && (
+            <Button
+              variant="primary"
+              size="md"
+              icon={<Plus size={14} strokeWidth={1.75} />}
+              onClick={handleOpenCreateModal}
+              data-testid="users-create-open"
+            >
+              Novo usuário
+            </Button>
+          )
+        }
       />
 
       <LiveRegion message={liveMessage} testId="users-live" />
@@ -446,6 +491,15 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           pageInfoTestId="users-page-info"
           prevTestId="users-prev"
           nextTestId="users-next"
+        />
+      )}
+
+      {canCreateUser && (
+        <NewUserModal
+          open={isCreateModalOpen}
+          onClose={handleCloseCreateModal}
+          onCreated={handleRefetch}
+          client={client}
         />
       )}
     </>

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -1,3 +1,4 @@
 export { UsersListShellPage } from './UsersListShellPage';
 export { UserDetailShellPage } from './UserDetailShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
+export { NewUserModal } from './NewUserModal';

--- a/src/pages/users/useUserForm.ts
+++ b/src/pages/users/useUserForm.ts
@@ -1,0 +1,200 @@
+import { useCallback, useState } from 'react';
+
+import { useFieldChangeHandlers } from '../../shared/forms';
+
+import {
+  decideUserBadRequestHandling,
+  validateUserForm,
+  type UserFieldErrors,
+  type UserFormState,
+} from './userFormShared';
+
+import type { CreateUserPayload } from '../../shared/api';
+
+/**
+ * Lista fixa dos campos textuais do form de user, usada por
+ * `useFieldChangeHandlers` para gerar os handlers em uma única linha.
+ * `as const` preserva os literais para o helper genérico inferir as
+ * chaves do `UserFormState`.
+ *
+ * `active` fica fora porque é boolean (toggle) e não usa o mesmo
+ * handler de mudança de string — o caller injeta um handler dedicado
+ * `handleActiveChange` que aceita `boolean`.
+ */
+const USER_FORM_TEXT_FIELDS = [
+  'name',
+  'email',
+  'password',
+  'identity',
+  'clientId',
+] as const;
+
+/**
+ * Hook compartilhado pelos formulários de criação (`NewUserModal` —
+ * Issue #78) e edição (`EditUserModal` — sub-issue futura) de
+ * usuários.
+ *
+ * Encapsula:
+ *
+ * - O estado do form (`UserFormState`) e dos erros inline por campo.
+ * - O estado do `Alert` no topo (erro genérico de submissão).
+ * - A flag `isSubmitting`.
+ * - Os handlers de mudança de cada campo textual + o toggle `active`.
+ *
+ * Centralizamos aqui desde o **primeiro PR do recurso** (#78) para
+ * evitar a 6ª recorrência de duplicação Sonar (lição PR #128 — quando
+ * a issue de edição chegar, ela vai herdar todo este boilerplate sem
+ * copiar uma linha sequer). Os handlers seriam idênticos entre os
+ * dois modals (~24 linhas × 2 arquivos = 48 linhas duplicadas).
+ *
+ * O caller é dono da lógica de submit (que precisa do contexto de
+ * `createUser` vs `updateUser`), do reset entre aberturas e do
+ * mapping de erros — o hook só cuida do que é genuinamente
+ * compartilhado.
+ */
+
+interface UseUserFormReturn {
+  formState: UserFormState;
+  fieldErrors: UserFieldErrors;
+  submitError: string | null;
+  isSubmitting: boolean;
+  setFormState: React.Dispatch<React.SetStateAction<UserFormState>>;
+  setFieldErrors: React.Dispatch<React.SetStateAction<UserFieldErrors>>;
+  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
+  setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  handleNameChange: (value: string) => void;
+  handleEmailChange: (value: string) => void;
+  handlePasswordChange: (value: string) => void;
+  handleIdentityChange: (value: string) => void;
+  handleClientIdChange: (value: string) => void;
+  handleActiveChange: (value: boolean) => void;
+  /**
+   * Roda a validação client-side e, se passar, prepara o payload
+   * trimado + zera erros + marca `isSubmitting`. Devolve o payload
+   * pronto para envio quando válido, ou `null` quando não (já tendo
+   * populado `fieldErrors`).
+   *
+   * O parse de `identity` (string -> int) acontece aqui com
+   * `Number.parseInt` (radix 10) — `validateUserForm` já garantiu
+   * formato `^-?\d+$`, então nunca devolve `NaN`.
+   *
+   * `clientId` vazio (após trim) é omitido do payload para que o
+   * backend acione `LegacyClientFactory` e gere um cliente PF
+   * derivado automaticamente (ver `UsersController.cs` linha 250).
+   *
+   * Centralizar essa rotina elimina ~18 linhas de boilerplate que
+   * apareceriam idênticas entre `NewUserModal` e o futuro
+   * `EditUserModal` (lição PR #127/#128).
+   */
+  prepareSubmit: () => CreateUserPayload | null;
+  /**
+   * Aplica o tratamento de uma resposta 400 do backend: distribui
+   * erros por campo quando `ValidationProblemDetails` é mapeável, ou
+   * popula `submitError` com a mensagem do backend quando não.
+   * Centraliza ~10 linhas de side-effect idênticas que apareceriam
+   * nos dois modals (lição PR #127).
+   */
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+}
+
+export function useUserForm(initialState: UserFormState): UseUserFormReturn {
+  const [formState, setFormState] = useState<UserFormState>(initialState);
+  const [fieldErrors, setFieldErrors] = useState<UserFieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  // Handlers `name`/`email`/`password`/`identity`/`clientId` gerados
+  // pelo helper genérico (lição PR #134 — bloco de 24 linhas
+  // duplicado com `useSystemForm`/`useRouteForm` foi um dos motivos do
+  // SonarCloud Quality Gate FAILED). Cada handler atualiza o campo
+  // correspondente e limpa o erro inline associado.
+  const {
+    name: handleNameChange,
+    email: handleEmailChange,
+    password: handlePasswordChange,
+    identity: handleIdentityChange,
+    clientId: handleClientIdChange,
+  } = useFieldChangeHandlers<UserFormState, UserFieldErrors>(
+    USER_FORM_TEXT_FIELDS,
+    setFormState,
+    setFieldErrors,
+  );
+
+  /**
+   * Toggle `active` é dedicado porque o tipo do valor é `boolean` (não
+   * `string`). Não tem erro inline associado (o toggle nunca falha
+   * client-side), então não precisa limpar `fieldErrors.active` —
+   * `UserFieldErrors` nem declara o slot.
+   */
+  const handleActiveChange = useCallback((value: boolean) => {
+    setFormState((prev) => ({ ...prev, active: value }));
+  }, []);
+
+  const prepareSubmit = useCallback((): CreateUserPayload | null => {
+    const clientErrors = validateUserForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    // `identity` chega como string `"^-?\d+$"` (validado), parse com
+    // radix 10 explícito é defensivo contra ambientes onde o engine
+    // tenta detectar octal/hex.
+    const identityInt = Number.parseInt(formState.identity.trim(), 10);
+    const trimmedClientId = formState.clientId.trim();
+
+    const payload: CreateUserPayload = {
+      name: formState.name.trim(),
+      email: formState.email.trim(),
+      // Password preservada literal — espaços laterais podem ser
+      // intencionais para senhas de gerenciador.
+      password: formState.password,
+      identity: identityInt,
+    };
+
+    if (trimmedClientId.length > 0) {
+      payload.clientId = trimmedClientId;
+    }
+
+    // `active` é sempre incluído — o estado inicial é `true`, então
+    // omitir só quando o usuário deliberadamente liga/desliga seria
+    // assimetria desnecessária. O backend trata `Active` como bool
+    // simples (`= true` quando ausente; aceita explícito).
+    payload.active = formState.active;
+
+    return payload;
+  }, [formState]);
+
+  const applyBadRequest = useCallback((details: unknown, fallbackMessage: string): void => {
+    const decision = decideUserBadRequestHandling(details, fallbackMessage);
+    if (decision.kind === 'field-errors') {
+      setFieldErrors(decision.errors);
+      setSubmitError(null);
+    } else {
+      setSubmitError(decision.message);
+    }
+  }, []);
+
+  return {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleNameChange,
+    handleEmailChange,
+    handlePasswordChange,
+    handleIdentityChange,
+    handleClientIdChange,
+    handleActiveChange,
+    prepareSubmit,
+    applyBadRequest,
+  };
+}

--- a/src/pages/users/userFormShared.ts
+++ b/src/pages/users/userFormShared.ts
@@ -1,0 +1,363 @@
+import {
+  classifyApiSubmitError,
+  type ApiSubmitErrorAction,
+  type ApiSubmitErrorCopy,
+} from '../../shared/forms';
+
+/**
+ * Helpers compartilhados pelos formulários de criação (Issue #78) e
+ * futuras edições (sub-issues seguintes da EPIC #49) de usuários.
+ *
+ * Antes da Issue #78, a `UsersListShellPage` (#77) carregava só a
+ * listagem sem mutações. Com a primeira mutação chegando agora,
+ * projetar este módulo desde o início evita BLOCKER de duplicação
+ * Sonar quando a issue de edição (`updateUser`/`updatePassword`)
+ * espelhar o mesmo shape (lição PR #128 — projetar
+ * `<recurso>FormShared.ts` desde o **primeiro PR do recurso**).
+ *
+ * Este módulo concentra:
+ *
+ * - Limites de tamanho de cada campo (espelham `CreateUserRequest` em
+ *   `UsersController.cs`).
+ * - Tipos `UserFormState`/`UserFieldErrors` consumidos pelo modal e
+ *   pelo componente compartilhado `UserFormFields`.
+ * - `validateUserForm` — replica as regras `Required`/`MaxLength`/
+ *   `EmailAddress`/`Identity (int)` do backend para feedback imediato
+ *   sem round-trip.
+ * - `extractUserValidationErrors` — mapeia
+ *   `ValidationProblemDetails` do ASP.NET (`{ errors: { Name: ['msg']
+ *   } }`) para `UserFieldErrors`.
+ * - `classifyUserSubmitError` — converte um `unknown` lançado por
+ *   `createUser`/`updateUser` (futuro) em uma `UserSubmitErrorAction`
+ *   discriminada com `conflictField: 'email'` (campo único de
+ *   unicidade do backend).
+ *
+ * Mantemos a lógica em TS puro (sem React) para que os testes
+ * unitários consumam diretamente sem provider/render.
+ *
+ * **Por que não usar `systemFormShared.ts`?** O shape do form de user
+ * tem 6 campos (`name`/`email`/`password`/`identity`/`clientId`/
+ * `active`) contra 3 do sistema, com tipos diferentes (`int` para
+ * `identity`, formato `email` para `email`, `bool?` para `active`).
+ * Acoplar os dois recursos num único módulo `formShared` violaria
+ * coesão (mudanças em users afetariam sistemas) — manter os módulos
+ * paralelos preserva a independência.
+ */
+
+/** Tamanho máximo do campo `Name` (espelha `CreateUserRequest.Name`). */
+export const NAME_MAX = 80;
+/** Tamanho máximo do campo `Email` (espelha `CreateUserRequest.Email`). */
+export const EMAIL_MAX = 320;
+/**
+ * Tamanho máximo do campo `Password` em texto plano antes do hash
+ * (espelha `CreateUserRequest.Password.MaxLength`). 60 chars é
+ * suficiente para senhas geradas em gerenciadores típicos sem expor
+ * o tamanho real do hash bcrypt.
+ */
+export const PASSWORD_MAX = 60;
+/**
+ * Tamanho mínimo "sensato" da senha exigido client-side. O backend
+ * não declara um mínimo formal (apenas `Required`/`MaxLength`), mas a
+ * UX administrativa exige uma senha minimamente forte para o usuário
+ * inicial. 8 chars é o consenso OWASP/NIST para "razoável" em formulários
+ * administrativos onde a senha será trocada na primeira sessão.
+ *
+ * Mantemos como constante exportada para que o copy do helper de
+ * validação use a mesma fonte de verdade da regra — qualquer ajuste
+ * (ex.: subir para 12) acontece em um único lugar e o teste unitário
+ * pega regressão silenciosa.
+ */
+export const PASSWORD_MIN = 8;
+
+/**
+ * Estado controlado dos campos do form de user. Usamos `string` em
+ * todos os campos textuais para que o React lide com inputs vazios
+ * sem `null`/`undefined` — o trim/parse é responsabilidade do submit.
+ *
+ * - `identity` é `string` (não `number`) no estado para preservar a
+ *   experiência do `<Input type="number">` (que reporta string vazia
+ *   quando o usuário apaga o valor — `Number('')` daria `0`, falso
+ *   positivo de "informado"). O parse para `int` acontece no
+ *   `prepareSubmit`.
+ * - `clientId` é `string` (não `string | null`) — string vazia
+ *   representa "deixar o backend gerar via `LegacyClientFactory`".
+ * - `active` é `boolean` desde o estado porque o `<Switch>`/`<Checkbox>`
+ *   já trabalha com bool nativo, e ausência (`undefined`) seria
+ *   ambiguidade desnecessária.
+ */
+export interface UserFormState {
+  name: string;
+  email: string;
+  password: string;
+  identity: string;
+  clientId: string;
+  active: boolean;
+}
+
+/**
+ * Mensagens de erro inline por campo. Cada chave é opcional —
+ * `undefined` indica "campo válido" (ou ainda não validado).
+ * `active` não tem erro inline (o toggle nunca dispara validação).
+ */
+export interface UserFieldErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  identity?: string;
+  clientId?: string;
+}
+
+/**
+ * Estado inicial reutilizado no modal de criação. `active: true`
+ * casa com o default do backend (`CreateUserRequest.Active = true`)
+ * — o usuário só desliga explicitamente quando quer cadastrar
+ * inativo.
+ */
+export const INITIAL_USER_FORM_STATE: UserFormState = {
+  name: '',
+  email: '',
+  password: '',
+  identity: '',
+  clientId: '',
+  active: true,
+};
+
+/**
+ * Regex simples de validação de e-mail. Não é "regex perfeita" (essa
+ * não existe — a RFC 5322 é gigantesca), mas captura erros de digitação
+ * óbvios (sem `@`, sem TLD, espaços) sem rejeitar e-mails válidos
+ * legítimos. O backend (`[EmailAddress]` do ASP.NET) faz a validação
+ * autoritativa; o client-side é só feedback imediato.
+ *
+ * Padrão coerente com `<input type="email">` HTML5 spec — qualquer
+ * navegador moderno aceita o mesmo subset.
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Confere se a string parseia para um inteiro finito (positivo ou
+ * negativo, incluindo `0`). Aceita `"0"`/`"1"`/`"42"` mas rejeita
+ * `""`/`"abc"`/`"1.5"`/`"1e2"` para evitar interpretações ambíguas
+ * com `Number()` (que aceita notação científica). O backend espera
+ * `int?` em `Identity` — qualquer valor não-inteiro retorna 400
+ * com mensagem do binder ASP.NET ("The JSON value could not be
+ * converted to System.Int32.").
+ *
+ * Mantemos function pura para reusar no teste sem acoplar com regex
+ * inline — qualquer ajuste (ex.: aceitar negativos zero-padded como
+ * `'-0'`) acontece num lugar.
+ */
+function isIntegerString(raw: string): boolean {
+  if (raw.length === 0) return false;
+  // Aceita opcional sinal `-` no início; rejeita `+` para evitar
+  // confusão com encoding URL.
+  return /^-?\d+$/.test(raw);
+}
+
+/**
+ * Valida o estado do form contra as mesmas regras do backend
+ * (`CreateUserRequest`). Retorna `null` quando válido, ou um objeto
+ * com mensagens por campo. Usamos pt-BR e textos próximos aos do
+ * backend para que a UX seja coerente entre validação client e server.
+ *
+ * Regras:
+ *
+ * - `name`: `Required` + `MaxLength(80)`.
+ * - `email`: `Required` + `MaxLength(320)` + formato (`EMAIL_REGEX`).
+ * - `password`: `Required` + `MinLength(8)` + `MaxLength(60)`. O
+ *   mínimo de 8 chars é client-side only (backend não declara mínimo)
+ *   — UX defensiva para senhas iniciais administrativas.
+ * - `identity`: `Required` + tem que ser inteiro válido. Backend
+ *   rejeita não-inteiros via JSON binder.
+ * - `clientId`: opcional. Quando informado, valida formato UUID
+ *   básico (8-4-4-4-12 hex). Inválido client-side evita round-trip
+ *   por digitação errada — backend rejeita com `400 { message:
+ *   "ClientId informado não existe." }` se o UUID não estiver na
+ *   base, mas isso é um caso runtime distinto (UUID válido, recurso
+ *   ausente).
+ * - `active`: nunca falha (toggle bool).
+ */
+const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function validateUserForm(state: UserFormState): UserFieldErrors | null {
+  const errors: UserFieldErrors = {};
+  const name = state.name.trim();
+  const email = state.email.trim();
+  // Senha não é trimada — espaços no início/fim podem ser
+  // intencionais para senhas geradas em gerenciadores. O backend
+  // hasheia o valor literal sem trim no `UserPasswordHasher`.
+  const password = state.password;
+  const identity = state.identity.trim();
+  const clientId = state.clientId.trim();
+
+  if (name.length === 0) {
+    errors.name = 'Nome é obrigatório.';
+  } else if (name.length > NAME_MAX) {
+    errors.name = `Nome deve ter no máximo ${NAME_MAX} caracteres.`;
+  }
+
+  if (email.length === 0) {
+    errors.email = 'E-mail é obrigatório.';
+  } else if (email.length > EMAIL_MAX) {
+    errors.email = `E-mail deve ter no máximo ${EMAIL_MAX} caracteres.`;
+  } else if (!EMAIL_REGEX.test(email)) {
+    errors.email = 'Informe um e-mail válido.';
+  }
+
+  if (password.length === 0) {
+    errors.password = 'Senha é obrigatória.';
+  } else if (password.length < PASSWORD_MIN) {
+    errors.password = `Senha deve ter ao menos ${PASSWORD_MIN} caracteres.`;
+  } else if (password.length > PASSWORD_MAX) {
+    errors.password = `Senha deve ter no máximo ${PASSWORD_MAX} caracteres.`;
+  }
+
+  if (identity.length === 0) {
+    errors.identity = 'Identity é obrigatório.';
+  } else if (!isIntegerString(identity)) {
+    errors.identity = 'Identity deve ser um número inteiro.';
+  }
+
+  if (clientId.length > 0 && !UUID_REGEX.test(clientId)) {
+    errors.clientId = 'ClientId deve ser um UUID válido.';
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+}
+
+/**
+ * Normaliza o nome de campo do backend (PascalCase) para o nome usado
+ * no estado do form (camelCase). Mantém a função interna estática
+ * porque a lista é fechada (5 campos do contrato — `active` nunca
+ * recebe erro inline).
+ *
+ * O backend manda `Name`/`Email`/`Password`/`Identity`/`ClientId`.
+ */
+function normalizeUserFieldName(serverField: string): keyof UserFieldErrors | null {
+  const lower = serverField.toLowerCase();
+  if (lower === 'name') return 'name';
+  if (lower === 'email') return 'email';
+  if (lower === 'password') return 'password';
+  if (lower === 'identity') return 'identity';
+  if (lower === 'clientid') return 'clientId';
+  return null;
+}
+
+/**
+ * Extrai erros por campo do payload de `ValidationProblemDetails` do
+ * ASP.NET (`{ errors: { Name: ['msg'], ... } }`). Tolerante: se o
+ * payload não bate com o shape esperado, devolve `null` para que o
+ * caller caia no fallback genérico.
+ *
+ * Espelha `extractSystemValidationErrors` de `systemFormShared.ts`,
+ * mas com a lista de campos do recurso "users".
+ */
+export function extractUserValidationErrors(details: unknown): UserFieldErrors | null {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+  const errors = (details as Record<string, unknown>).errors;
+  if (!errors || typeof errors !== 'object') {
+    return null;
+  }
+  const result: UserFieldErrors = {};
+  for (const [serverField, raw] of Object.entries(errors)) {
+    const field = normalizeUserFieldName(serverField);
+    if (!field) continue;
+    if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+      result[field] = raw[0];
+    } else if (typeof raw === 'string') {
+      result[field] = raw;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+/**
+ * Resultado do mapeamento de uma `ApiError` 400 do backend. O caller
+ * usa essa decisão para chamar `setFieldErrors` (campos mapeados) ou
+ * `setSubmitError` (mensagem genérica para Alert) — separar a decisão
+ * do efeito colateral mantém o helper testável e idêntico entre os
+ * dois modals.
+ */
+export type UserSubmitDecision =
+  | { kind: 'field-errors'; errors: UserFieldErrors }
+  | { kind: 'submit-error'; message: string };
+
+/**
+ * Decide o tratamento de uma resposta 400 do backend para o form de
+ * user:
+ *
+ * - Se o payload bate com `ValidationProblemDetails` e o backend
+ *   identificou ao menos um campo, devolve `field-errors` com as
+ *   mensagens mapeadas → caller exibe inline.
+ * - Caso contrário (ex.: `{ message: "ClientId informado não existe."
+ *   }`), devolve `submit-error` com a mensagem do backend → caller
+ *   exibe `Alert` no topo do form.
+ *
+ * Centralizar essa decisão evita o bloco `if (validation) { ... } else
+ * { setSubmitError(...) }` que duplicaria entre `NewUserModal` e o
+ * futuro `EditUserModal` (lição PR #123/#127).
+ */
+export function decideUserBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): UserSubmitDecision {
+  const validation = extractUserValidationErrors(details);
+  if (validation) {
+    return { kind: 'field-errors', errors: validation };
+  }
+  return { kind: 'submit-error', message: fallbackMessage };
+}
+
+/**
+ * Copy textual usado por `classifyUserSubmitError` para diferenciar
+ * create de edit (e mensagens específicas do recurso) sem duplicar a
+ * lógica de classificação. Cada modal injeta sua versão (`'um
+ * usuário'` vs `'outro usuário'`, `'criar'` vs `'atualizar'`).
+ *
+ * Estrutural: alias de `ApiSubmitErrorCopy` (helper genérico em
+ * `shared/forms`). Mantemos o nome local para preservar imports
+ * existentes (lição PR #134 — extrair sem quebrar callsites).
+ */
+export type UserSubmitErrorCopy = ApiSubmitErrorCopy;
+
+/**
+ * Resultado da classificação de um erro lançado por `createUser` ou
+ * `updateUser` (futuro). O caller usa o `kind` num `switch` curto
+ * para chamar o side-effect correto (set field error, applyBadRequest,
+ * toast, etc.).
+ *
+ * Estrutural: alias de `ApiSubmitErrorAction<keyof UserFieldErrors>`.
+ * A lógica vive em `shared/forms/classifySubmitError.ts` — centralizada
+ * entre todos os recursos para eliminar a duplicação Sonar (lição PR
+ * #134 — bloco de 26 linhas idênticas detectado no PR de routes).
+ */
+export type UserSubmitErrorAction = ApiSubmitErrorAction<keyof UserFieldErrors>;
+
+/**
+ * Classifica um erro lançado por `createUser`/`updateUser` em uma
+ * `UserSubmitErrorAction` discriminada. Delegação de uma linha para o
+ * helper genérico — preserva a assinatura pública usada pelos modals
+ * de user e pelos testes unitários.
+ *
+ * - `409` → `conflict` no campo `email` com mensagem do backend (ou
+ *   `copy.conflictDefault`). Caller exibe inline.
+ * - `400` → `bad-request` com `details` cru. Caller chama
+ *   `applyBadRequest` que decide entre erros por campo (mapeáveis de
+ *   `ValidationProblemDetails`) e `Alert` no topo (caso `ClientId
+ *   informado não existe.`, sem `details.errors`).
+ * - `404` → `not-found` (relevante só no futuro `EditUserModal`).
+ * - `401`/`403` → `toast` vermelho.
+ * - Outros → `unhandled` com a copy genérica.
+ *
+ * O `conflictField` é fixo em `'email'` — campo único de unicidade do
+ * contrato `CreateUserRequest`/`UpdateUserRequest` (`UX_Users_Email`
+ * no backend é único globalmente).
+ */
+export function classifyUserSubmitError(
+  error: unknown,
+  copy: UserSubmitErrorCopy,
+): UserSubmitErrorAction {
+  return classifyApiSubmitError<keyof UserFieldErrors>(error, copy, 'email');
+}

--- a/src/pages/users/userFormShared.ts
+++ b/src/pages/users/userFormShared.ts
@@ -123,16 +123,29 @@ export const INITIAL_USER_FORM_STATE: UserFormState = {
 };
 
 /**
- * Regex simples de validação de e-mail. Não é "regex perfeita" (essa
+ * Validação simples de e-mail sem regex. Não é "regex perfeita" (essa
  * não existe — a RFC 5322 é gigantesca), mas captura erros de digitação
  * óbvios (sem `@`, sem TLD, espaços) sem rejeitar e-mails válidos
  * legítimos. O backend (`[EmailAddress]` do ASP.NET) faz a validação
  * autoritativa; o client-side é só feedback imediato.
  *
- * Padrão coerente com `<input type="email">` HTML5 spec — qualquer
- * navegador moderno aceita o mesmo subset.
+ * Implementação manual (em vez de regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`)
+ * para evitar `typescript:S5852` — Sonar marca a regex tripla `[^\s@]+`
+ * como vulnerável a backtracking super-linear (DoS hotspot). A versão
+ * sem regex é equivalente em intenção e linear no comprimento da
+ * string.
  */
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+function isValidEmailSyntax(value: string): boolean {
+  if (!value || value.length === 0) return false;
+  if (/\s/.test(value)) return false;
+  const at = value.indexOf('@');
+  if (at < 1) return false;
+  if (at !== value.lastIndexOf('@')) return false;
+  const domain = value.slice(at + 1);
+  if (domain.length === 0) return false;
+  const dot = domain.lastIndexOf('.');
+  return dot > 0 && dot < domain.length - 1;
+}
 
 /**
  * Confere se a string parseia para um inteiro finito (positivo ou
@@ -163,7 +176,7 @@ function isIntegerString(raw: string): boolean {
  * Regras:
  *
  * - `name`: `Required` + `MaxLength(80)`.
- * - `email`: `Required` + `MaxLength(320)` + formato (`EMAIL_REGEX`).
+ * - `email`: `Required` + `MaxLength(320)` + formato (`isValidEmailSyntax`).
  * - `password`: `Required` + `MinLength(8)` + `MaxLength(60)`. O
  *   mínimo de 8 chars é client-side only (backend não declara mínimo)
  *   — UX defensiva para senhas iniciais administrativas.
@@ -200,7 +213,7 @@ export function validateUserForm(state: UserFormState): UserFieldErrors | null {
     errors.email = 'E-mail é obrigatório.';
   } else if (email.length > EMAIL_MAX) {
     errors.email = `E-mail deve ter no máximo ${EMAIL_MAX} caracteres.`;
-  } else if (!EMAIL_REGEX.test(email)) {
+  } else if (!isValidEmailSyntax(email)) {
     errors.email = 'Informe um e-mail válido.';
   }
 

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -147,6 +147,7 @@ export {
 } from './tokenTypes';
 export type { TokenTypeDto } from './tokenTypes';
 export {
+  createUser,
   DEFAULT_USERS_INCLUDE_DELETED,
   DEFAULT_USERS_PAGE,
   DEFAULT_USERS_PAGE_SIZE,
@@ -154,7 +155,7 @@ export {
   isUserDto,
   listUsers,
 } from './users';
-export type { ListUsersParams, UserDto } from './users';
+export type { CreateUserPayload, ListUsersParams, UserDto } from './users';
 export {
   assignPermissionToUser,
   DEFAULT_PERMISSIONS_INCLUDE_DELETED,

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -3,7 +3,12 @@ import { isPagedResponseEnvelope } from './pagedResponse';
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
-import type { ApiClient, ApiError, SafeRequestOptions } from './types';
+import type {
+  ApiClient,
+  ApiError,
+  BodyRequestOptions,
+  SafeRequestOptions,
+} from './types';
 
 /**
  * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
@@ -257,6 +262,120 @@ export async function listUsers(
   const path = `/users${buildListQueryString(params)}`;
   const data = await client.get<unknown>(path, options);
   if (!isPagedUsersResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Body aceito pelo `POST /users` no `lfc-authenticator`
+ * (`UsersController.CreateUserRequest`).
+ *
+ * Issue #78 (EPIC #49) — primeiro fluxo de mutação do recurso Users.
+ * Espelha o contrato exato do backend (`UsersController.cs` linha 36):
+ *
+ * - `name` (obrigatório, máx. 80 chars) — nome amigável.
+ * - `email` (obrigatório, máx. 320 chars, formato válido) — único no
+ *   sistema; o backend normaliza para `lowercase` antes de gravar.
+ * - `password` (obrigatório, máx. 60 chars) — senha em texto plano que
+ *   o backend hasheia via `UserPasswordHasher.HashPlainPassword` antes
+ *   de persistir. Frontend nunca grava em log/storage.
+ * - `identity` (obrigatório, `int`) — discriminator herdado do backend
+ *   que mapeia para perfis legados; obrigatoriedade vem de
+ *   `[Required] public int? Identity` no controller (DataAnnotations
+ *   aceita `0` como valor válido).
+ * - `clientId` (opcional, UUID) — quando ausente, o backend gera um
+ *   `Client` PF derivado via `LegacyClientFactory.BuildPfClientForUser`
+ *   automaticamente. Quando informado, valida que o `Client` exista —
+ *   inexistente devolve `400` com `"ClientId informado não existe."`
+ *   (mensagem **fora** do `ValidationProblemDetails`, em
+ *   `{ message }` simples).
+ * - `active` (opcional, `bool`, default `true`) — quando omitido, o
+ *   backend grava `Active = true`. Mantemos opcional para que o UI
+ *   omita o campo no payload quando o usuário não tocar no toggle.
+ *
+ * Backend trima `Name`/`Email`/`Password` e converte `Email` para
+ * lowercase antes de gravar. O frontend trima defensivamente em
+ * `buildUserMutationBody` para preservar o contrato mesmo se um caller
+ * futuro pular a camada HTTP.
+ *
+ * Já declaramos `CreateUserPayload` exportável para que sub-issues
+ * subsequentes (`updateUser`, `updatePassword`) reusem a mesma fonte
+ * de verdade — lição PR #128.
+ */
+export interface CreateUserPayload {
+  name: string;
+  email: string;
+  password: string;
+  identity: number;
+  clientId?: string;
+  active?: boolean;
+}
+
+/**
+ * Constrói o body para `POST /users` aplicando trim defensivo nos
+ * campos texto e omitindo campos opcionais não preenchidos. Centralizar
+ * essa montagem garante que futuros call sites (`updateUser` na sub-
+ * issue de edição) enviem exatamente o mesmo shape sem reabrir o módulo
+ * para padronizar serialização. Espelha `buildSystemMutationBody` de
+ * `systems.ts` e `buildRouteMutationBody` de `routes.ts` (lição PR #128).
+ *
+ * - `email`: o backend já normaliza `ToLowerInvariant`; o frontend
+ *   apenas trima — manter o lowercase como responsabilidade exclusiva
+ *   do backend evita drift caso a regra mude (ex.: i18n).
+ * - `clientId` é omitido quando vazio depois de trim para que o backend
+ *   acione o caminho `LegacyClientFactory` (gera client PF derivado).
+ * - `active` só é incluído quando o caller informa explicitamente —
+ *   omitir aproveita o default `true` do backend.
+ */
+function buildUserMutationBody(payload: CreateUserPayload): CreateUserPayload {
+  const body: CreateUserPayload = {
+    name: payload.name.trim(),
+    email: payload.email.trim(),
+    password: payload.password,
+    identity: payload.identity,
+  };
+  const trimmedClientId = payload.clientId?.trim();
+  if (trimmedClientId && trimmedClientId.length > 0) {
+    body.clientId = trimmedClientId;
+  }
+  if (typeof payload.active === 'boolean') {
+    body.active = payload.active;
+  }
+  return body;
+}
+
+/**
+ * Cria um novo usuário via `POST /users` (Issue #78).
+ *
+ * Retorna o `UserDto` recém-criado (`201 Created` com `UserResponse` no
+ * corpo). Lança `ApiError` em qualquer falha — caller tipicamente trata:
+ *
+ * - 409 → conflito de email (`"Já existe um usuário com este Email."`).
+ * - 400 → validação de campo (`ValidationProblemDetails` com chaves
+ *   `Name`/`Email`/`Password`/`Identity`) **ou** `{ message: "ClientId
+ *   informado não existe." }` quando o `clientId` referenciado não
+ *   existe na base. Os dois casos chegam como `ApiError` com `status:
+ *   400`; o segundo não tem `details.errors` mapeáveis, então cai no
+ *   fallback do `applyBadRequest` (Alert no topo do form).
+ * - 401/403 → toast vermelho (gating de permissão).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ *
+ * O response é validado contra `isUserDto` para detectar drift de
+ * contrato precocemente — backend novo retornando shape inesperado
+ * dispara `ApiError(parse)` em vez de propagar shape inválido para a
+ * UI.
+ */
+export async function createUser(
+  payload: CreateUserPayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserDto> {
+  const body = buildUserMutationBody(payload);
+  const data = await client.post<unknown>('/users', body, options);
+  if (!isUserDto(data)) {
     throw makeParseError();
   }
   return data;

--- a/src/shared/forms/applyCreateSubmitAction.ts
+++ b/src/shared/forms/applyCreateSubmitAction.ts
@@ -1,0 +1,117 @@
+import type { ApiSubmitErrorAction, ApiSubmitErrorCopy } from './classifySubmitError';
+
+/**
+ * Variante de toast injetada nos cenários de erro. Centralizamos o
+ * literal aqui para que o helper não dependa do shape interno do
+ * `useToast` do design system.
+ */
+type ToastVariant = 'danger';
+
+/**
+ * Cópia textual injetada por cada modal de criação. Os literais aqui
+ * são os únicos pontos onde "rota"/"sistema"/"usuário" diferem — toda
+ * a árvore de decisão (`switch (action.kind)`) vive no helper.
+ *
+ * Espelha `EditSubmitActionCopy` mas sem `notFoundMessage` (create
+ * nunca recebe 404 do backend — não há entidade para "sumir entre
+ * abertura e submit").
+ */
+export interface CreateSubmitActionCopy {
+  /**
+   * Mensagem inline exibida no campo de unicidade quando o backend
+   * devolve 409. Quando `undefined`, o helper usa a mensagem do
+   * próprio backend (`action.message`) — coerente com o
+   * `NewSystemModal`. O `NewRouteModal`/`NewUserModal` injetam um
+   * valor explícito porque a copy do backend é menos clara que a
+   * copy custom do UI.
+   */
+  conflictInlineMessage?: string;
+}
+
+/**
+ * Dispatchers injetados pelo modal — separar a decisão (helper puro
+ * sobre o `action.kind`) dos efeitos colaterais (`setState`, `show`)
+ * preserva testabilidade e elimina a duplicação de switch entre
+ * `useCreateEntitySubmit` e `applyEditSubmitAction` (Sonar tokeniza
+ * o switch como bloco idêntico — ~16 linhas — mesmo quando os
+ * literais diferem; lição PR #134).
+ *
+ * Tipos genéricos:
+ *
+ * - `TField` é a união de chaves do form do recurso (`'name' | 'code'
+ *   | 'description'` para sistemas; `... | 'systemTokenTypeId'` para
+ *   rotas; `'name' | 'email' | 'password' | 'identity' | 'clientId'`
+ *   para users). Aceito como type parameter para que `setFieldErrors`
+ *   receba um `Record` parcial respeitando as chaves do form.
+ */
+export interface CreateSubmitActionDispatchers<TField extends string> {
+  /** Atualiza o estado de erros inline. Recebe um objeto parcial. */
+  setFieldErrors: (errors: Partial<Record<TField, string>>) => void;
+  /** Limpa o `submitError` exibido em Alert no topo do form. */
+  setSubmitError: (message: string | null) => void;
+  /**
+   * Dispatcher do caminho `bad-request` — recebe `details` cru do
+   * backend e a mensagem fallback caso `ValidationProblemDetails` não
+   * seja mapeável. Cada modal injeta o `applyBadRequest` retornado
+   * pelo seu hook de form.
+   */
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+  /** Dispatcher de toast — espelha a assinatura de `useToast().show`. */
+  showToast: (message: string, options: { variant: ToastVariant; title?: string }) => void;
+}
+
+/**
+ * Despacha as ações de erro classificadas por `classifyApiSubmitError`
+ * para o shape comum dos modals de criação.
+ *
+ * Cobre exaustivamente os 5 valores de `action.kind`:
+ *
+ * - `conflict` (409) → mensagem inline customizada no campo de
+ *   unicidade (`copy.conflictInlineMessage` ou `action.message` do
+ *   backend), limpa `submitError`.
+ * - `bad-request` (400) → delega para `dispatchers.applyBadRequest`
+ *   com o `details`/`fallbackMessage` do action.
+ * - `not-found` (404) → toast vermelho com `errorCopy.genericFallback`
+ *   (não esperado em create — se chegar, mostra fallback).
+ * - `toast` (401/403) → toast vermelho com a mensagem do backend.
+ * - `unhandled` (demais) → toast vermelho com fallback genérico do
+ *   próprio action.
+ *
+ * Centralizado aqui (em vez de duplicado em cada `useCreateEntitySubmit`)
+ * para eliminar BLOCKER de duplicação Sonar — esse bloco de switch é
+ * 16 linhas idênticas comparado ao `applyEditSubmitAction` (lição PR
+ * #128/#134). Diferente do edit, `not-found` cai no fallback (sem
+ * `onAfterNotFound`).
+ */
+export function applyCreateSubmitAction<TField extends string>(
+  action: ApiSubmitErrorAction<TField>,
+  dispatchers: CreateSubmitActionDispatchers<TField>,
+  errorCopy: ApiSubmitErrorCopy,
+  copy: CreateSubmitActionCopy,
+): void {
+  switch (action.kind) {
+    case 'conflict':
+      dispatchers.setFieldErrors({
+        [action.field]: copy.conflictInlineMessage ?? action.message,
+      } as Partial<Record<TField, string>>);
+      dispatchers.setSubmitError(null);
+      break;
+    case 'bad-request':
+      dispatchers.applyBadRequest(action.details, action.fallbackMessage);
+      break;
+    case 'not-found':
+      // Não esperado em create — backend nunca devolve 404 nesse
+      // path. Tratamos como fallback genérico defensivamente.
+      dispatchers.showToast(errorCopy.genericFallback, {
+        variant: 'danger',
+        title: errorCopy.forbiddenTitle,
+      });
+      break;
+    case 'toast':
+      dispatchers.showToast(action.message, { variant: 'danger', title: action.title });
+      break;
+    case 'unhandled':
+      dispatchers.showToast(action.fallback, { variant: 'danger', title: action.title });
+      break;
+  }
+}

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -30,12 +30,24 @@ export {
   type EditSubmitActionDispatchers,
 } from "./applyEditSubmitAction";
 export {
+  applyCreateSubmitAction,
+  type CreateSubmitActionCopy,
+  type CreateSubmitActionDispatchers,
+} from "./applyCreateSubmitAction";
+export {
   useEditEntitySubmit,
   type EditEntitySubmitCallbacks,
   type EditEntitySubmitCopy,
   type EditEntitySubmitDispatchers,
   type UseEditEntitySubmitArgs,
 } from "./useEditEntitySubmit";
+export {
+  useCreateEntitySubmit,
+  type CreateEntitySubmitCallbacks,
+  type CreateEntitySubmitCopy,
+  type CreateEntitySubmitDispatchers,
+  type UseCreateEntitySubmitArgs,
+} from "./useCreateEntitySubmit";
 export {
   NameCodeDescriptionFormBody,
   NAME_CODE_DESCRIPTION_NAME_MAX,

--- a/src/shared/forms/useCreateEntitySubmit.ts
+++ b/src/shared/forms/useCreateEntitySubmit.ts
@@ -1,0 +1,268 @@
+import { useCallback } from 'react';
+
+import { applyCreateSubmitAction } from './applyCreateSubmitAction';
+import {
+  classifyApiSubmitError,
+  type ApiSubmitErrorCopy,
+} from './classifySubmitError';
+
+/**
+ * Variantes aceitas pelo `showToast` injetado — espelha o subset usado
+ * pelos modals de criação (`success` para o caminho feliz, `danger`
+ * para erros). Tipar como literal evita que o caller passe
+ * acidentalmente uma variante incompatível com o design system.
+ */
+type ToastVariant = 'success' | 'danger';
+
+/**
+ * Assinatura mínima do `show` retornado por `useToast()` — duplicar
+ * aqui o tipo seria pior (acoplaria o helper com o hook do design
+ * system). Manter como `function type` deixa o caller passar a
+ * referência de `useToast().show` diretamente.
+ */
+type ShowToast = (
+  message: string,
+  options: { variant: ToastVariant; title?: string },
+) => void;
+
+/**
+ * Setters/dispatchers que o modal de criação precisa expor para o hook
+ * coordenar o submit. São os mesmos do `useEditEntitySubmit` mais o
+ * caminho específico de "conflito inline" — em create o 409 mapeia
+ * para um único campo de unicidade (ex.: `code` em sistemas/rotas,
+ * `email` em users).
+ *
+ * `TField` é a união de chaves do form (ex.: `'name' | 'code' |
+ * 'description'` para sistemas; `'name' | 'email' | 'password' |
+ * 'identity' | 'clientId'` para users). Manter genérico preserva a
+ * tipagem do `setFieldErrors` no call-site sem vazar o shape específico
+ * do recurso para o hook.
+ */
+export interface CreateEntitySubmitDispatchers<TField extends string> {
+  /** Atualiza o estado de erros inline (Partial respeita as chaves do form). */
+  setFieldErrors: (errors: Partial<Record<TField, string>>) => void;
+  /** Limpa o `submitError` exibido em Alert no topo do form. */
+  setSubmitError: (message: string | null) => void;
+  /** Atualiza a flag `isSubmitting` (chamada no `finally`). */
+  setIsSubmitting: (value: boolean) => void;
+  /**
+   * Dispatcher do caminho `bad-request` — recebe `details` cru do
+   * backend e a mensagem fallback caso `ValidationProblemDetails` não
+   * seja mapeável. Cada modal injeta o `applyBadRequest` retornado
+   * pelo seu hook de form (`useSystemForm`/`useRouteForm`/`useUserForm`).
+   */
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+  /** Dispatcher de toast — espelha a assinatura de `useToast().show`. */
+  showToast: ShowToast;
+  /**
+   * Reset do estado controlado pelo hook do form do recurso
+   * (`setFormState(INITIAL_*)`, `setFieldErrors({})`, `setSubmitError(null)`).
+   * Disparado no caminho feliz **antes** de `onCreated`/`onClose` para que
+   * uma reabertura imediata do modal não veja resíduo. Cada modal injeta
+   * sua própria versão (depende do `INITIAL_*_FORM_STATE` do recurso).
+   */
+  resetForm: () => void;
+}
+
+/**
+ * Cópia textual e identificadores fixos do recurso. Os literais aqui
+ * são os únicos pontos onde "rota"/"sistema"/"usuário" diferem entre
+ * os modals — toda a lógica de orquestração vive no hook.
+ */
+export interface CreateEntitySubmitCopy {
+  /**
+   * Mensagem do toast verde exibido após sucesso (ex.: 'Sistema
+   * criado.', 'Rota criada.', 'Usuário criado.').
+   */
+  successMessage: string;
+  /**
+   * Mensagem inline exibida no campo de unicidade quando o backend
+   * devolve 409. Quando `undefined`, o helper usa a mensagem do
+   * próprio backend (`action.message`) — coerente com o
+   * `NewSystemModal`. O `NewRouteModal` injeta um valor explícito
+   * porque a copy do backend ("Já existe uma route com este Code.")
+   * é menos clara que a copy custom do UI ("Já existe uma rota com
+   * este código neste sistema.").
+   */
+  conflictInlineMessage?: string;
+  /** Copy injetada em `classifyApiSubmitError`. */
+  submitErrorCopy: ApiSubmitErrorCopy;
+}
+
+/**
+ * Callbacks de coordenação com o pai e dependências do efeito. Os
+ * callbacks devem ser estáveis (memoizados pelo caller) — o hook
+ * inclui todos no `useCallback` deps array.
+ */
+export interface CreateEntitySubmitCallbacks {
+  /**
+   * Roda a validação client-side e prepara o payload trimado.
+   * Devolve o payload pronto para envio quando válido, ou `null`
+   * quando há erros client-side (que já foram propagados via
+   * `setFieldErrors`).
+   *
+   * O caller injeta sua versão (`prepareSubmit()` para sistemas/users,
+   * `prepareSubmit(systemId)` para rotas — para rotas, basta o caller
+   * fechar sobre o `systemId` antes de injetar).
+   */
+  prepareSubmit: () => unknown | null;
+  /**
+   * Executa a mutação remota com o payload validado. Tipicamente
+   * `(payload) => createSystem(payload, undefined, client)`,
+   * `(payload) => createRoute(payload, undefined, client)`,
+   * `(payload) => createUser(payload, undefined, client)`.
+   */
+  mutationFn: (payload: unknown) => Promise<unknown>;
+  /** Refetch da lista no pai — disparado após sucesso. */
+  onCreated: () => void;
+  /** Fecha o modal — disparado após sucesso. */
+  onClose: () => void;
+}
+
+/**
+ * Hook compartilhado pelos modals de criação (`NewSystemModal`,
+ * `NewRouteModal`, `NewUserModal` e os futuros do CRUD de roles/clients/
+ * permissions) — encapsula o ciclo completo de submit para eliminar a
+ * duplicação Sonar de 30+ linhas que aparece quando dois modals de
+ * criação usam o mesmo padrão `prepareSubmit -> mutationFn -> classify
+ * -> dispatch` com dispatchers idênticos.
+ *
+ * **Por que existe (lição PR #134/#135 — 6ª recorrência potencial):**
+ *
+ * Mesmo após extrair `classifyApiSubmitError` em `src/shared/forms/`, o
+ * **call-site** do helper (a chamada com os dispatchers fixos +
+ * `finally` + `useCallback` deps array + `switch` exaustivo) é
+ * praticamente idêntico entre `NewSystemModal` e `NewRouteModal` —
+ * Sonar tokeniza esse bloco como New Code Duplication (4.8% > 3% no
+ * PR #135). Espelha exatamente o `useEditEntitySubmit` que cobriu o
+ * lado "edit" desde a PR #135.
+ *
+ * Centralizar aqui:
+ *
+ * 1. Reduz `handleSubmit` de cada modal de criação para ~3 linhas
+ *    (preventDefault + dedupe gate + chamada do hook).
+ * 2. Garante simetria de comportamento entre os modals (mesmo ordering
+ *    de `onCreated` antes de `onClose`, mesmo trim de erros após
+ *    sucesso, mesma estratégia de `setIsSubmitting(false)` no
+ *    `finally`).
+ * 3. Concentra os pontos de evolução (ex.: telemetria de submit,
+ *    retry com backoff, cancelamento) em um único lugar — quando o
+ *    backend introduzir headers de idempotência ou rate-limit, mexer
+ *    aqui propaga para todos os recursos sem refator distribuído.
+ *
+ * **Por que não usar React Query/SWR aqui?** O projeto não tem essa
+ * dependência ainda (ver `package.json`), e adicioná-la num PR de
+ * refactor para reduzir duplicação Sonar seria fora de escopo. O hook
+ * mantém a forma da implementação atual (try/catch + `useToast`) e
+ * preserva os testes de cada modal sem mudança de comportamento
+ * observável.
+ *
+ * **Diferença para `useEditEntitySubmit`:** create não trata 404
+ * (backend nunca devolve 404 nesse path — não há entidade para "sumir
+ * entre abertura e submit"). Por isso o caso `not-found` cai no
+ * fallback `unhandled` (toast genérico) em vez do
+ * `onAfterNotFound = onCreated() + onClose()` do edit.
+ */
+export interface UseCreateEntitySubmitArgs<TField extends string> {
+  dispatchers: CreateEntitySubmitDispatchers<TField>;
+  copy: CreateEntitySubmitCopy;
+  callbacks: CreateEntitySubmitCallbacks;
+  /**
+   * Campo de unicidade tratado pelo backend em 409 (`'code'` para
+   * sistemas e rotas, `'email'` para users). Repassa para
+   * `classifyApiSubmitError`. Manter tipo genérico preserva a
+   * inferência no call-site
+   * (`useCreateEntitySubmit<keyof UserFieldErrors>`).
+   */
+  conflictField: TField;
+}
+
+/**
+ * Devolve um `handleSubmit` pronto para injetar no `<form onSubmit>`.
+ *
+ * O handler retornado faz o `event.preventDefault()` internamente —
+ * caller precisa apenas passar `onSubmit={handleSubmit}` sem wrapper
+ * inline.
+ *
+ * Retorna `Promise<void>` mesmo em erro síncrono — o consumidor não
+ * precisa await, mas o tipo permite que callers que queiram (ex.:
+ * testes) aguardem o ciclo completo.
+ */
+export function useCreateEntitySubmit<TField extends string>({
+  dispatchers,
+  copy,
+  callbacks,
+  conflictField,
+}: UseCreateEntitySubmitArgs<TField>): (
+  event: React.FormEvent<HTMLFormElement>,
+) => Promise<void> {
+  const {
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    applyBadRequest,
+    showToast,
+    resetForm,
+  } = dispatchers;
+  const { successMessage, conflictInlineMessage, submitErrorCopy } = copy;
+  const { prepareSubmit, mutationFn, onCreated, onClose } = callbacks;
+
+  return useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      // `prepareSubmit` valida + zera erros + marca submitting + devolve
+      // payload trimado, ou `null` quando há erros client-side. O caller
+      // já cuidou do dedupe (`isSubmitting` gate) antes de chegar aqui.
+      const payload = prepareSubmit();
+      if (payload === null) return;
+
+      try {
+        await mutationFn(payload);
+        // Mensagem de sucesso fixa (não citamos o nome — o usuário
+        // acabou de digitar e a lista será atualizada).
+        showToast(successMessage, { variant: 'success' });
+        // Ordem importa: reset local + refetch antes de fechar para o
+        // pai não ter que coordenar dois ticks separados.
+        resetForm();
+        onCreated();
+        onClose();
+      } catch (error: unknown) {
+        // `classifyApiSubmitError` decide o `kind`; `applyCreateSubmitAction`
+        // despacha os efeitos colaterais (setState/toast). Helper
+        // compartilhado entre todos os recursos — eliminou ~16 linhas
+        // de switch idêntico ao `applyEditSubmitAction` (lição PR
+        // #128/#134/#135).
+        const action = classifyApiSubmitError<TField>(
+          error,
+          submitErrorCopy,
+          conflictField,
+        );
+        applyCreateSubmitAction<TField>(
+          action,
+          { setFieldErrors, setSubmitError, applyBadRequest, showToast },
+          submitErrorCopy,
+          { conflictInlineMessage },
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [
+      applyBadRequest,
+      conflictField,
+      conflictInlineMessage,
+      mutationFn,
+      onClose,
+      onCreated,
+      prepareSubmit,
+      resetForm,
+      setFieldErrors,
+      setIsSubmitting,
+      setSubmitError,
+      showToast,
+      submitErrorCopy,
+      successMessage,
+    ],
+  );
+}

--- a/tests/pages/UsersPage.create.test.tsx
+++ b/tests/pages/UsersPage.create.test.tsx
@@ -1,0 +1,497 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  createUsersClientStub,
+  fillNewUserForm,
+  ID_CLIENT_ALPHA,
+  makeUser,
+  makeUsersPagedResponse,
+  openCreateUserModal,
+  renderUsersPage,
+  submitNewUserForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+  type UsersErrorCase,
+} from './__helpers__/usersTestHelpers';
+
+/**
+ * Suíte da `UsersListShellPage` — criação (Issue #78, EPIC #49).
+ *
+ * Espelha `SystemsPage.create.test.tsx` e `RoutesPage.create.test.tsx`:
+ * cobre gating do CTA, abertura/fechamento do modal, validação client-
+ * side, submissão bem-sucedida, e cenários de erro do backend (409,
+ * 400 com errors, 400 sem errors, 401/403, network).
+ *
+ * Mock controlável de `useAuth` — cada teste seta `permissionsMock`
+ * antes de renderizar a página para simular usuário com/sem permissão
+ * `AUTH_V1_USERS_CREATE`.
+ */
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const USERS_CREATE_PERMISSION = 'AUTH_V1_USERS_CREATE';
+const VALID_CLIENT_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('UsersListShellPage — criação (Issue #78)', () => {
+  describe('gating do botão "Novo usuário"', () => {
+    it('não exibe o botão quando o usuário não possui AUTH_V1_USERS_CREATE', async () => {
+      permissionsMock = [];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.queryByTestId('users-create-open')).not.toBeInTheDocument();
+    });
+
+    it('exibe o botão quando o usuário possui AUTH_V1_USERS_CREATE', async () => {
+      permissionsMock = [USERS_CREATE_PERMISSION];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.getByTestId('users-create-open')).toBeInTheDocument();
+      expect(screen.getByTestId('users-create-open')).toHaveTextContent(/Novo usuário/i);
+    });
+  });
+
+  describe('abertura e fechamento do modal', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_CREATE_PERMISSION];
+    });
+
+    it('clicar em "Novo usuário" abre o diálogo com os campos do form', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-name')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-email')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-password')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-identity')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-client-id')).toBeInTheDocument();
+      expect(screen.getByTestId('new-user-active')).toBeInTheDocument();
+    });
+
+    it('Esc fecha o modal sem persistir', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      // eslint-disable-next-line no-restricted-globals
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('botão Cancelar fecha o modal sem persistir', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fireEvent.click(screen.getByTestId('new-user-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validação client-side', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_CREATE_PERMISSION];
+    });
+
+    it('submeter com campos vazios mostra erros inline e não chama POST', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fireEvent.submit(screen.getByTestId('new-user-form'));
+
+      expect(screen.getByText('Nome é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('E-mail é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('Senha é obrigatória.')).toBeInTheDocument();
+      expect(screen.getByText('Identity é obrigatório.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('email inválido bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'no-at',
+        password: 'senha-forte-1',
+        identity: '1',
+      });
+      fireEvent.submit(screen.getByTestId('new-user-form'));
+
+      expect(screen.getByText('Informe um e-mail válido.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('senha menor que 8 chars bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'short',
+        identity: '1',
+      });
+      fireEvent.submit(screen.getByTestId('new-user-form'));
+
+      expect(screen.getByText('Senha deve ter ao menos 8 caracteres.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('identity não-inteiro bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1.5',
+      });
+      fireEvent.submit(screen.getByTestId('new-user-form'));
+
+      expect(screen.getByText('Identity deve ser um número inteiro.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('clientId não-UUID bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+        clientId: 'abc',
+      });
+      fireEvent.submit(screen.getByTestId('new-user-form'));
+
+      expect(screen.getByText('ClientId deve ser um UUID válido.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submissão bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_CREATE_PERMISSION];
+    });
+
+    it('envia POST /users com body correto, fecha modal, exibe toast e refaz listUsers', async () => {
+      const created = makeUser({
+        id: '99999999-9999-9999-9999-999999999999',
+        name: 'Novo User',
+        email: 'novo@example.com',
+      });
+      const client = createUsersClientStub();
+      let usersGetCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          usersGetCalls += 1;
+          if (usersGetCalls === 1) {
+            return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+          }
+          return Promise.resolve(makeUsersPagedResponse([makeUser(), created]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected: ${path}`));
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: '  Novo User  ',
+        email: '  novo@example.com  ',
+        password: 'senha-forte-1',
+        identity: '2',
+        clientId: VALID_CLIENT_ID,
+      });
+      await submitNewUserForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/users',
+        {
+          name: 'Novo User',
+          email: 'novo@example.com',
+          password: 'senha-forte-1',
+          identity: 2,
+          clientId: VALID_CLIENT_ID,
+          active: true,
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Usuário criado.".
+      expect(await screen.findByText('Usuário criado.')).toBeInTheDocument();
+
+      // Refetch da lista — ao menos 2 chamadas a `/users`.
+      await waitFor(() => {
+        expect(usersGetCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('envia body sem clientId quando o usuário deixa o campo vazio', async () => {
+      const created = makeUser({ id: '88888888-8888-8888-8888-888888888888' });
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Sem Cliente',
+        email: 'sem-cliente@example.com',
+        password: 'senha-forte-1',
+        identity: '0',
+      });
+      await submitNewUserForm(client);
+
+      const body = client.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body).not.toHaveProperty('clientId');
+    });
+
+    it('envia active=false quando o usuário desliga o toggle', async () => {
+      const created = makeUser({
+        id: '77777777-7777-7777-7777-777777777777',
+        active: false,
+      });
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Inativo',
+        email: 'inativo@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+        active: false,
+      });
+      await submitNewUserForm(client);
+
+      expect(client.post.mock.calls[0][1]).toMatchObject({ active: false });
+    });
+  });
+
+  describe('cenários de erro do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_CREATE_PERMISSION];
+    });
+
+    it('409 (e-mail duplicado) mostra erro inline no campo email', async () => {
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 409,
+        message: 'Já existe um usuário com este Email.',
+      });
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+      });
+      await submitNewUserForm(client);
+
+      expect(
+        await screen.findByText('Já existe um usuário com este e-mail.'),
+      ).toBeInTheDocument();
+      // Modal segue aberto para que o usuário corrija.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('400 com errors mapeia mensagens para os campos correspondentes', async () => {
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 400,
+        message: 'Erro de validação.',
+        details: {
+          errors: {
+            Email: ['Email inválido (backend).'],
+            Password: ['Password deve ter no máximo 60 caracteres.'],
+          },
+        },
+      });
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+      });
+      await submitNewUserForm(client);
+
+      expect(await screen.findByText('Email inválido (backend).')).toBeInTheDocument();
+      expect(
+        screen.getByText('Password deve ter no máximo 60 caracteres.'),
+      ).toBeInTheDocument();
+    });
+
+    it('400 com { message } simples (caso ClientId inexistente) mostra Alert no topo', async () => {
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 400,
+        message: 'ClientId informado não existe.',
+      });
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+        clientId: VALID_CLIENT_ID,
+      });
+      await submitNewUserForm(client);
+
+      // O Alert no topo do form é renderizado pelo `<Alert>` do design
+      // system, que não propaga `data-testid` — buscamos pelo texto
+      // direto da mensagem do backend (caso `{ message: ... }` simples
+      // sem `details.errors`).
+      expect(
+        await screen.findByText('ClientId informado não existe.'),
+      ).toBeInTheDocument();
+    });
+
+    const ERROR_CASES: ReadonlyArray<UsersErrorCase> = [
+      {
+        name: '401 dispara toast vermelho com mensagem do backend',
+        error: {
+          kind: 'http',
+          status: 401,
+          message: 'Sessão expirada. Faça login novamente.',
+        },
+        expectedText: 'Sessão expirada. Faça login novamente.',
+      },
+      {
+        name: '403 dispara toast vermelho com mensagem do backend',
+        error: {
+          kind: 'http',
+          status: 403,
+          message: 'Você não tem permissão para esta ação.',
+        },
+        expectedText: 'Você não tem permissão para esta ação.',
+      },
+      {
+        name: 'erro genérico de rede dispara toast vermelho genérico',
+        error: { kind: 'network', message: 'Falha de conexão.' },
+        expectedText: 'Não foi possível criar o usuário. Tente novamente.',
+      },
+    ];
+
+    it.each(ERROR_CASES)('$name', async ({ error, expectedText }) => {
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.post.mockRejectedValueOnce(error);
+
+      await openCreateUserModal(client);
+
+      fillNewUserForm({
+        name: 'Alice',
+        email: 'alice@example.com',
+        password: 'senha-forte-1',
+        identity: '1',
+      });
+      await submitNewUserForm(client);
+
+      expect(
+        await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+      ).toBeInTheDocument();
+    });
+
+    it('referência fora do escopo: ID_CLIENT_ALPHA disponível como UUID estável', () => {
+      // Sanity check para garantir que o helper exporta UUID estável
+      // — outros testes (futuros) reusam.
+      expect(ID_CLIENT_ALPHA).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+});

--- a/tests/pages/__helpers__/usersTestHelpers.tsx
+++ b/tests/pages/__helpers__/usersTestHelpers.tsx
@@ -1,0 +1,264 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { expect, vi } from 'vitest';
+
+import type { ApiClient, ApiError, PagedResponse, UserDto } from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { UsersListShellPage } from '@/pages/users';
+
+/**
+ * Helpers de teste compartilhados pelas suítes da `UsersListShellPage`:
+ * listagem (`UsersListShellPage.test.tsx` da #77) e criação
+ * (`UsersPage.create.test.tsx` da #78).
+ *
+ * Espelha `systemsTestHelpers.tsx`/`routesTestHelpers.tsx` —
+ * extraídos para evitar duplicação de blocos de fixtures (lição PR
+ * #123/#127 — Sonar conta blocos de 10+ linhas como duplicação
+ * independente da intenção). Mantemos apenas o que é genuinamente
+ * compartilhado:
+ *
+ * - `ApiClientStub` + `createUsersClientStub` para isolar a página
+ *   da camada de transporte;
+ * - `makeUser` + `makePagedResponse` para construir payloads do
+ *   contrato `UserDto`/`PagedResponse<UserDto>` sem repetir todos os
+ *   campos;
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderUsersPage` envolvendo a página num `ToastProvider` (o
+ *   `NewUserModal` consome `useToast()` para feedback de sucesso/erro);
+ * - helpers de fluxo do form (`openCreateUserModal`,
+ *   `fillNewUserForm`, `submitNewUserForm`).
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_USER_ALICE = '11111111-1111-1111-1111-111111111111';
+export const ID_USER_BOB = '22222222-2222-2222-2222-222222222222';
+export const ID_CLIENT_ALPHA = '33333333-3333-3333-3333-333333333333';
+
+/**
+ * Stub de `ApiClient` injetado em `<UsersListShellPage client={stub} />`.
+ * Mesmo padrão de injeção usado nas demais suítes (#58/#63/#66/#77).
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createUsersClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `UserDto` com defaults — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos.
+ */
+export function makeUser(overrides: Partial<UserDto> = {}): UserDto {
+  return {
+    id: ID_USER_ALICE,
+    name: 'Alice Admin',
+    email: 'alice@example.com',
+    clientId: ID_CLIENT_ALPHA,
+    identity: 1,
+    active: true,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend — `total` reflete o
+ * `data.length` por default; testes que cobrem paginação sobrescrevem.
+ */
+export function makeUsersPagedResponse(
+  data: ReadonlyArray<UserDto>,
+  overrides: Partial<PagedResponse<UserDto>> = {},
+): PagedResponse<UserDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Renderiza a `UsersListShellPage` envolvendo num `ToastProvider` — o
+ * `NewUserModal` consome `useToast()` internamente para disparar
+ * feedback de sucesso/erro.
+ */
+export function renderUsersPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <UsersListShellPage client={client} />
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a `UsersListShellPage`
+ * faz `listUsers` no mount). Centraliza o "esperar listagem" para que
+ * cada teste comece em estado estável sem precisar replicar `waitFor`
+ * para `client.get`.
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('users-loading')).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Mocka o GET inicial com uma página contendo um usuário sintético,
+ * renderiza a `UsersListShellPage`, espera a lista carregar e clica
+ * no botão "Novo usuário" para abrir o modal de criação.
+ *
+ * `mockImplementation` em vez de `mockResolvedValueOnce` porque a
+ * página dispara duas requests no mount: `/users` (listagem) e
+ * `/clients/{id}` por usuário (lookup do nome do cliente). O
+ * implementation lê o path para decidir o response — `/clients/{id}`
+ * cai no `null` que o `getClientsByIds` trata como "best-effort
+ * faltando" sem quebrar a tela.
+ *
+ * Quem precisar de mocks diferentes pode chamar
+ * `client.get.mockImplementation(...)` antes de invocar este helper
+ * — a detecção via `getMockImplementation()` preserva o caso "fila
+ * customizada de respostas" (ex.: refetch após sucesso, que precisa
+ * contar chamadas).
+ */
+export async function openCreateUserModal(client: ApiClientStub): Promise<void> {
+  if (
+    client.get.getMockImplementation() === undefined &&
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+      }
+      if (typeof path === 'string' && path.startsWith('/clients/')) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    });
+  }
+  renderUsersPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId('users-create-open'));
+}
+
+/**
+ * Preenche os campos do form do `NewUserModal`. Cada chave é opcional
+ * — testes que validam só `name` e `email` deixam os demais ausentes.
+ * Os valores são entregues diretamente ao `fireEvent.change`; trim é
+ * responsabilidade do componente (`createUser`/`validateUserForm`).
+ *
+ * `active` usa `fireEvent.click` no Switch (não `fireEvent.change`)
+ * porque o `<Switch>` interno é um `<input type="checkbox">` que
+ * dispara onChange via clique.
+ */
+export function fillNewUserForm(values: {
+  name?: string;
+  email?: string;
+  password?: string;
+  identity?: string;
+  clientId?: string;
+  active?: boolean;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId('new-user-name'), {
+      target: { value: values.name },
+    });
+  }
+  if (values.email !== undefined) {
+    fireEvent.change(screen.getByTestId('new-user-email'), {
+      target: { value: values.email },
+    });
+  }
+  if (values.password !== undefined) {
+    fireEvent.change(screen.getByTestId('new-user-password'), {
+      target: { value: values.password },
+    });
+  }
+  if (values.identity !== undefined) {
+    fireEvent.change(screen.getByTestId('new-user-identity'), {
+      target: { value: values.identity },
+    });
+  }
+  if (values.clientId !== undefined) {
+    fireEvent.change(screen.getByTestId('new-user-client-id'), {
+      target: { value: values.clientId },
+    });
+  }
+  if (values.active !== undefined) {
+    // Toggle só clica se o estado atual não bate com o desejado;
+    // evita "ativar -> desativar -> ativar" inadvertido em sequência
+    // de chamadas.
+    const switchEl = screen.getByTestId('new-user-active') as HTMLInputElement;
+    if (switchEl.checked !== values.active) {
+      fireEvent.click(switchEl);
+    }
+  }
+}
+
+/**
+ * Submete o form do `NewUserModal` e aguarda o `client.post` ser
+ * chamado pelo menos `expectedPostCalls` vezes (default `1`). Faz o
+ * `act(async)` necessário para flushar a microtask do submit antes
+ * do `waitFor`, padrão repetido em todos os testes de submissão.
+ */
+export async function submitNewUserForm(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('new-user-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+}
+
+/**
+ * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)`
+ * da suíte de criação. Cada caso descreve o `ApiError` retornado pelo
+ * backend e o texto que deve aparecer em algum lugar visível do UI
+ * após o submit.
+ */
+export interface UsersErrorCase {
+  /** Descrição usada como `it.each($name)`. */
+  name: string;
+  /** Erro lançado pelo cliente HTTP no submit. */
+  error: ApiError;
+  /** Texto visível no UI após o submit (string vira regex case-insensitive). */
+  expectedText: RegExp | string;
+}
+
+/**
+ * Aceita string ou regex e devolve sempre um `RegExp` insensível a
+ * caixa, com escape de metacaracteres. Reusa o padrão dos
+ * `systemsTestHelpers` para que os asserts não dependam de match
+ * exato literal.
+ */
+export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), 'i');
+}

--- a/tests/pages/users/userFormShared.test.ts
+++ b/tests/pages/users/userFormShared.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiError } from '@/shared/api';
+
+import {
+  classifyUserSubmitError,
+  decideUserBadRequestHandling,
+  EMAIL_MAX,
+  extractUserValidationErrors,
+  INITIAL_USER_FORM_STATE,
+  NAME_MAX,
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  validateUserForm,
+  type UserFormState,
+  type UserSubmitErrorCopy,
+} from '@/pages/users/userFormShared';
+
+/**
+ * Suíte do `userFormShared` (Issue #78). Cobre as 4 funções puras:
+ *
+ * - `validateUserForm` — regras client-side espelhando o backend.
+ * - `extractUserValidationErrors` — parse de `ValidationProblemDetails`.
+ * - `decideUserBadRequestHandling` — decisão entre field-errors e
+ *   submit-error.
+ * - `classifyUserSubmitError` — discriminação por status HTTP.
+ *
+ * Estratégia: fixar um `UserFormState` válido como baseline e
+ * sobrescrever só o que cada cenário precisa testar — colapsa
+ * boilerplate e mantém os testes focados na regra que cobrem.
+ */
+
+const VALID_STATE: UserFormState = {
+  name: 'Alice Admin',
+  email: 'alice@example.com',
+  password: 'senha-forte-1',
+  identity: '1',
+  clientId: '',
+  active: true,
+};
+
+const COPY: UserSubmitErrorCopy = {
+  conflictDefault: 'Já existe um usuário com este e-mail.',
+  forbiddenTitle: 'Falha ao criar usuário',
+  genericFallback: 'Não foi possível criar o usuário. Tente novamente.',
+};
+
+describe('INITIAL_USER_FORM_STATE', () => {
+  it('parte de campos vazios e active=true (default do backend)', () => {
+    expect(INITIAL_USER_FORM_STATE).toEqual({
+      name: '',
+      email: '',
+      password: '',
+      identity: '',
+      clientId: '',
+      active: true,
+    });
+  });
+});
+
+describe('validateUserForm — caso válido', () => {
+  it('devolve null quando todos os campos estão válidos', () => {
+    expect(validateUserForm(VALID_STATE)).toBeNull();
+  });
+
+  it('aceita clientId UUID válido', () => {
+    expect(
+      validateUserForm({
+        ...VALID_STATE,
+        clientId: '11111111-1111-1111-1111-111111111111',
+      }),
+    ).toBeNull();
+  });
+
+  it('aceita active=false (cadastra usuário inativo)', () => {
+    expect(validateUserForm({ ...VALID_STATE, active: false })).toBeNull();
+  });
+
+  it('aceita identity 0 e identity negativo (discriminator legacy)', () => {
+    expect(validateUserForm({ ...VALID_STATE, identity: '0' })).toBeNull();
+    expect(validateUserForm({ ...VALID_STATE, identity: '-1' })).toBeNull();
+  });
+});
+
+describe('validateUserForm — name', () => {
+  it('exige nome', () => {
+    expect(validateUserForm({ ...VALID_STATE, name: '' })?.name).toBe('Nome é obrigatório.');
+    expect(validateUserForm({ ...VALID_STATE, name: '   ' })?.name).toBe('Nome é obrigatório.');
+  });
+
+  it('rejeita nome maior que NAME_MAX', () => {
+    const tooLong = 'a'.repeat(NAME_MAX + 1);
+    expect(validateUserForm({ ...VALID_STATE, name: tooLong })?.name).toBe(
+      `Nome deve ter no máximo ${NAME_MAX} caracteres.`,
+    );
+  });
+});
+
+describe('validateUserForm — email', () => {
+  it('exige email', () => {
+    expect(validateUserForm({ ...VALID_STATE, email: '' })?.email).toBe('E-mail é obrigatório.');
+  });
+
+  it('rejeita formato inválido', () => {
+    expect(validateUserForm({ ...VALID_STATE, email: 'no-at' })?.email).toBe(
+      'Informe um e-mail válido.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, email: 'a@b' })?.email).toBe(
+      'Informe um e-mail válido.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, email: 'a b@c.com' })?.email).toBe(
+      'Informe um e-mail válido.',
+    );
+  });
+
+  it('rejeita email maior que EMAIL_MAX', () => {
+    const longLocalPart = 'a'.repeat(EMAIL_MAX);
+    const longEmail = `${longLocalPart}@x.io`;
+    expect(validateUserForm({ ...VALID_STATE, email: longEmail })?.email).toBe(
+      `E-mail deve ter no máximo ${EMAIL_MAX} caracteres.`,
+    );
+  });
+
+  it('aceita formato válido com TLD', () => {
+    expect(validateUserForm({ ...VALID_STATE, email: 'user.name+tag@empresa.com.br' })).toBeNull();
+  });
+});
+
+describe('validateUserForm — password', () => {
+  it('exige senha', () => {
+    expect(validateUserForm({ ...VALID_STATE, password: '' })?.password).toBe(
+      'Senha é obrigatória.',
+    );
+  });
+
+  it('rejeita senha menor que PASSWORD_MIN', () => {
+    const tooShort = 'a'.repeat(PASSWORD_MIN - 1);
+    expect(validateUserForm({ ...VALID_STATE, password: tooShort })?.password).toBe(
+      `Senha deve ter ao menos ${PASSWORD_MIN} caracteres.`,
+    );
+  });
+
+  it('rejeita senha maior que PASSWORD_MAX', () => {
+    const tooLong = 'a'.repeat(PASSWORD_MAX + 1);
+    expect(validateUserForm({ ...VALID_STATE, password: tooLong })?.password).toBe(
+      `Senha deve ter no máximo ${PASSWORD_MAX} caracteres.`,
+    );
+  });
+
+  it('aceita senha exatamente em PASSWORD_MIN e PASSWORD_MAX', () => {
+    expect(
+      validateUserForm({ ...VALID_STATE, password: 'a'.repeat(PASSWORD_MIN) }),
+    ).toBeNull();
+    expect(
+      validateUserForm({ ...VALID_STATE, password: 'a'.repeat(PASSWORD_MAX) }),
+    ).toBeNull();
+  });
+
+  it('preserva espaços laterais (não trima senha)', () => {
+    // Senhas com espaços laterais (raro mas possível em gerenciadores)
+    // são aceitas como válidas — o trim cabe ao backend se quiser.
+    const padded = `  ${'a'.repeat(PASSWORD_MIN)}  `;
+    expect(validateUserForm({ ...VALID_STATE, password: padded })).toBeNull();
+  });
+});
+
+describe('validateUserForm — identity', () => {
+  it('exige identity', () => {
+    expect(validateUserForm({ ...VALID_STATE, identity: '' })?.identity).toBe(
+      'Identity é obrigatório.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, identity: '   ' })?.identity).toBe(
+      'Identity é obrigatório.',
+    );
+  });
+
+  it('rejeita não-inteiros', () => {
+    expect(validateUserForm({ ...VALID_STATE, identity: 'abc' })?.identity).toBe(
+      'Identity deve ser um número inteiro.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, identity: '1.5' })?.identity).toBe(
+      'Identity deve ser um número inteiro.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, identity: '1e2' })?.identity).toBe(
+      'Identity deve ser um número inteiro.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, identity: '+1' })?.identity).toBe(
+      'Identity deve ser um número inteiro.',
+    );
+  });
+});
+
+describe('validateUserForm — clientId', () => {
+  it('aceita clientId vazio (backend gera via LegacyClientFactory)', () => {
+    expect(validateUserForm({ ...VALID_STATE, clientId: '' })).toBeNull();
+    expect(validateUserForm({ ...VALID_STATE, clientId: '   ' })).toBeNull();
+  });
+
+  it('rejeita clientId em formato não-UUID', () => {
+    expect(validateUserForm({ ...VALID_STATE, clientId: 'abc' })?.clientId).toBe(
+      'ClientId deve ser um UUID válido.',
+    );
+    expect(validateUserForm({ ...VALID_STATE, clientId: '11111111-1111' })?.clientId).toBe(
+      'ClientId deve ser um UUID válido.',
+    );
+  });
+
+  it('aceita clientId UUID maiúsculo, minúsculo e misto', () => {
+    expect(
+      validateUserForm({
+        ...VALID_STATE,
+        clientId: 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+      }),
+    ).toBeNull();
+    expect(
+      validateUserForm({
+        ...VALID_STATE,
+        clientId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      }),
+    ).toBeNull();
+    expect(
+      validateUserForm({
+        ...VALID_STATE,
+        clientId: 'AaAaAaAa-bBbB-cCcC-dDdD-EeEeEeEeEeEe',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('extractUserValidationErrors', () => {
+  it('mapeia campos PascalCase do backend para camelCase do form', () => {
+    const result = extractUserValidationErrors({
+      errors: {
+        Name: ['Name é obrigatório.'],
+        Email: ['Email inválido.'],
+        Password: ['Password deve ter no máximo 60 caracteres.'],
+        Identity: ['The Identity field is required.'],
+        ClientId: ['ClientId inválido.'],
+      },
+    });
+    expect(result).toEqual({
+      name: 'Name é obrigatório.',
+      email: 'Email inválido.',
+      password: 'Password deve ter no máximo 60 caracteres.',
+      identity: 'The Identity field is required.',
+      clientId: 'ClientId inválido.',
+    });
+  });
+
+  it('aceita string em vez de array', () => {
+    expect(
+      extractUserValidationErrors({ errors: { Name: 'Erro literal.' } }),
+    ).toEqual({ name: 'Erro literal.' });
+  });
+
+  it('ignora campos não-mapeáveis sem quebrar', () => {
+    expect(
+      extractUserValidationErrors({
+        errors: { CustomField: ['x'], Name: ['y'] },
+      }),
+    ).toEqual({ name: 'y' });
+  });
+
+  it('devolve null quando o payload não é um ValidationProblemDetails', () => {
+    expect(extractUserValidationErrors(null)).toBeNull();
+    expect(extractUserValidationErrors(undefined)).toBeNull();
+    expect(extractUserValidationErrors('texto')).toBeNull();
+    expect(extractUserValidationErrors({})).toBeNull();
+    expect(extractUserValidationErrors({ errors: null })).toBeNull();
+    expect(extractUserValidationErrors({ errors: 'string' })).toBeNull();
+  });
+
+  it('devolve null quando errors está vazio ou só tem campos não-mapeáveis', () => {
+    expect(extractUserValidationErrors({ errors: {} })).toBeNull();
+    expect(extractUserValidationErrors({ errors: { Outro: ['x'] } })).toBeNull();
+  });
+});
+
+describe('decideUserBadRequestHandling', () => {
+  it('devolve field-errors quando o payload tem errors mapeáveis', () => {
+    const decision = decideUserBadRequestHandling(
+      { errors: { Email: ['Email inválido.'] } },
+      'fallback',
+    );
+    expect(decision).toEqual({
+      kind: 'field-errors',
+      errors: { email: 'Email inválido.' },
+    });
+  });
+
+  it('devolve submit-error com fallback quando errors é não-mapeável (caso ClientId)', () => {
+    const decision = decideUserBadRequestHandling(
+      { message: 'ClientId informado não existe.' },
+      'fallback',
+    );
+    expect(decision).toEqual({ kind: 'submit-error', message: 'fallback' });
+  });
+});
+
+describe('classifyUserSubmitError', () => {
+  function httpError(status: number, message = 'erro', details?: unknown): ApiError {
+    return { kind: 'http', status, message, details };
+  }
+
+  it('mapeia 409 para conflict no campo email', () => {
+    const action = classifyUserSubmitError(httpError(409, 'Já existe.'), COPY);
+    expect(action).toEqual({ kind: 'conflict', field: 'email', message: 'Já existe.' });
+  });
+
+  it('mapeia 400 para bad-request com details cru', () => {
+    const details = { errors: { Email: ['x'] } };
+    const action = classifyUserSubmitError(httpError(400, 'validação', details), COPY);
+    expect(action).toEqual({
+      kind: 'bad-request',
+      details,
+      fallbackMessage: 'validação',
+    });
+  });
+
+  it('mapeia 401/403 para toast com mensagem do backend', () => {
+    expect(
+      classifyUserSubmitError(httpError(401, 'Sessão expirada.'), COPY),
+    ).toEqual({
+      kind: 'toast',
+      message: 'Sessão expirada.',
+      title: COPY.forbiddenTitle,
+    });
+    expect(
+      classifyUserSubmitError(httpError(403, 'Sem permissão.'), COPY),
+    ).toEqual({
+      kind: 'toast',
+      message: 'Sem permissão.',
+      title: COPY.forbiddenTitle,
+    });
+  });
+
+  it('mapeia 404 para not-found', () => {
+    expect(classifyUserSubmitError(httpError(404), COPY)).toEqual({
+      kind: 'not-found',
+    });
+  });
+
+  it('mapeia status 5xx e network/parse para unhandled', () => {
+    expect(classifyUserSubmitError(httpError(500), COPY)).toEqual({
+      kind: 'unhandled',
+      title: COPY.forbiddenTitle,
+      fallback: COPY.genericFallback,
+    });
+    expect(classifyUserSubmitError(new Error('network'), COPY)).toEqual({
+      kind: 'unhandled',
+      title: COPY.forbiddenTitle,
+      fallback: COPY.genericFallback,
+    });
+  });
+});

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiClient, UserDto } from '@/shared/api';
+import type { ApiClient, CreateUserPayload, UserDto } from '@/shared/api';
 
 import {
+  createUser,
   DEFAULT_USERS_PAGE_SIZE,
   isPagedUsersResponse,
   isUserDto,
@@ -406,5 +407,202 @@ describe('listUsers — comportamento', () => {
     );
 
     expect(result).toEqual(envelope);
+  });
+});
+
+/**
+ * Suíte do `createUser` (Issue #78). Cobre serialização do body
+ * (trim/omit defensivo), validação do response via `isUserDto` e
+ * propagação de erros tipados (`ApiError`).
+ *
+ * Espelha o padrão de `tests/shared/api/routes.test.ts` para
+ * `createRoute` — validar o caminho HTTP unitariamente sem precisar
+ * de fetch real.
+ */
+describe('createUser — body', () => {
+  function buildBasicPayload(overrides: Partial<CreateUserPayload> = {}): CreateUserPayload {
+    return {
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      password: 'senha-forte-1',
+      identity: 1,
+      ...overrides,
+    };
+  }
+
+  it('emite POST /users com body trimado nos campos texto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeUserDto());
+
+    await createUser(
+      buildBasicPayload({
+        name: '  Alice Admin  ',
+        email: '  alice@example.com  ',
+        password: '  senha-forte-1  ',
+      }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post.mock.calls[0][0]).toBe('/users');
+    expect(client.post.mock.calls[0][1]).toEqual({
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      // Senha NÃO é trimada — preserva espaços laterais intencionais.
+      password: '  senha-forte-1  ',
+      identity: 1,
+    });
+  });
+
+  it('omite clientId quando vazio (string vazia ou só espaços)', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeUserDto());
+
+    await createUser(
+      buildBasicPayload({ clientId: '   ' }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const body = client.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('clientId');
+  });
+
+  it('inclui clientId quando informado e trima', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeUserDto());
+
+    await createUser(
+      buildBasicPayload({ clientId: '  ' + CLIENT_ID + '  ' }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][1]).toMatchObject({ clientId: CLIENT_ID });
+  });
+
+  it('inclui active quando explícito (true ou false)', async () => {
+    const client = createStub();
+    client.post.mockResolvedValue(makeUserDto());
+
+    await createUser(
+      buildBasicPayload({ active: true }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.post.mock.calls[0][1]).toMatchObject({ active: true });
+
+    await createUser(
+      buildBasicPayload({ active: false }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.post.mock.calls[1][1]).toMatchObject({ active: false });
+  });
+
+  it('omite active quando ausente (deixa o backend usar default true)', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeUserDto());
+
+    await createUser(buildBasicPayload(), undefined, client as unknown as ApiClient);
+
+    const body = client.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('active');
+  });
+});
+
+describe('createUser — response e erros', () => {
+  function buildBasicPayload(): CreateUserPayload {
+    return {
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      password: 'senha-forte-1',
+      identity: 1,
+    };
+  }
+
+  it('devolve UserDto recém-criado quando o response é válido', async () => {
+    const client = createStub();
+    const created = makeUserDto({ id: '99999999-9999-9999-9999-999999999999' });
+    client.post.mockResolvedValueOnce(created);
+
+    const result = await createUser(
+      buildBasicPayload(),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(created);
+  });
+
+  it('lança ApiError(parse) quando o response não é UserDto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 409 do backend (email duplicado) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 409,
+      message: 'Já existe um usuário com este Email.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 400 com errors (validação de campo) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'Erro de validação.',
+      details: {
+        errors: {
+          Email: ['Email inválido.'],
+          Identity: ['The Identity field is required.'],
+        },
+      },
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 400 sem errors (caso ClientId inexistente) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'ClientId informado não existe.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
 });

--- a/tests/shared/forms/useCreateEntitySubmit.test.tsx
+++ b/tests/shared/forms/useCreateEntitySubmit.test.tsx
@@ -1,0 +1,340 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ApiError } from '@/shared/api';
+
+import {
+  useCreateEntitySubmit,
+  type CreateEntitySubmitCopy,
+  type UseCreateEntitySubmitArgs,
+} from '@/shared/forms';
+
+/**
+ * Suíte do hook compartilhado `useCreateEntitySubmit` (Issue #78 da
+ * EPIC #49 — gêmeo do `useEditEntitySubmit` introduzido na PR #135).
+ *
+ * O hook centraliza o ciclo `try/catch/finally` + `classifyApiSubmitError`
+ * + dispatch dos efeitos colaterais que aparecia idêntico em
+ * `NewSystemModal` e `NewRouteModal` (~30 linhas duplicadas) — eliminar
+ * BLOCKER de Sonar New Code Duplication antes que a issue
+ * `NewUserModal` (#78) replique o padrão pela 3ª vez.
+ *
+ * Estratégia: validar a orquestração com mocks de cada dispatcher,
+ * cobrindo os 5 caminhos do `action.kind` + caminho feliz + dedupe via
+ * `prepareSubmit` retornando `null`. Os testes end-to-end ficam nos
+ * arquivos de página (`UsersPage.create.test.tsx`).
+ */
+
+type Field = 'name' | 'email' | 'password';
+
+const SUCCESS_MESSAGE = 'Criado.';
+
+const COPY: CreateEntitySubmitCopy = {
+  successMessage: SUCCESS_MESSAGE,
+  conflictInlineMessage: 'Conflito inline custom.',
+  submitErrorCopy: {
+    conflictDefault: 'Já existe.',
+    forbiddenTitle: 'Falha ao criar',
+    genericFallback: 'Não foi possível criar.',
+  },
+};
+
+interface SetupOverrides {
+  prepareSubmit?: () => unknown | null;
+  mutationFn?: (payload: unknown) => Promise<unknown>;
+  copy?: CreateEntitySubmitCopy;
+}
+
+function setupHook(overrides: SetupOverrides = {}) {
+  const setFieldErrors = vi.fn();
+  const setSubmitError = vi.fn();
+  const setIsSubmitting = vi.fn();
+  const applyBadRequest = vi.fn();
+  const showToast = vi.fn();
+  const resetForm = vi.fn();
+  const onCreated = vi.fn();
+  const onClose = vi.fn();
+
+  const prepareSubmit = overrides.prepareSubmit ?? vi.fn(() => ({ payload: 'ok' }));
+  const mutationFn = overrides.mutationFn ?? vi.fn(async () => ({ id: 'created' }));
+
+  const args: UseCreateEntitySubmitArgs<Field> = {
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast,
+      resetForm,
+    },
+    copy: overrides.copy ?? COPY,
+    callbacks: {
+      prepareSubmit,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: 'email',
+  };
+
+  const { result } = renderHook(() => useCreateEntitySubmit<Field>(args));
+
+  return {
+    handleSubmit: result.current,
+    spies: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast,
+      resetForm,
+      onCreated,
+      onClose,
+      prepareSubmit,
+      mutationFn,
+    },
+  };
+}
+
+function makeFakeFormEvent(): React.FormEvent<HTMLFormElement> {
+  const preventDefault = vi.fn();
+  return {
+    preventDefault,
+  } as unknown as React.FormEvent<HTMLFormElement>;
+}
+
+function httpError(status: number, message = 'erro', details?: unknown): ApiError {
+  return { kind: 'http', status, message, details };
+}
+
+describe('useCreateEntitySubmit — caminho feliz', () => {
+  it('chama mutationFn, dispara toast verde, reset, onCreated e onClose após sucesso', async () => {
+    const mutationFn = vi.fn(async () => ({ id: 'ok' }));
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    const event = makeFakeFormEvent();
+    await handleSubmit(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(mutationFn).toHaveBeenCalledWith({ payload: 'ok' });
+    expect(spies.showToast).toHaveBeenCalledWith(SUCCESS_MESSAGE, {
+      variant: 'success',
+    });
+    expect(spies.resetForm).toHaveBeenCalledTimes(1);
+    expect(spies.onCreated).toHaveBeenCalledTimes(1);
+    expect(spies.onClose).toHaveBeenCalledTimes(1);
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+
+  it('chama resetForm antes de onCreated antes de onClose para coordenar refetch primeiro', async () => {
+    const order: string[] = [];
+    const resetForm = vi.fn(() => order.push('resetForm'));
+    const onCreated = vi.fn(() => order.push('onCreated'));
+    const onClose = vi.fn(() => order.push('onClose'));
+    const setFieldErrors = vi.fn();
+    const setSubmitError = vi.fn();
+    const setIsSubmitting = vi.fn();
+    const applyBadRequest = vi.fn();
+    const showToast = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCreateEntitySubmit<Field>({
+        dispatchers: {
+          setFieldErrors,
+          setSubmitError,
+          setIsSubmitting,
+          applyBadRequest,
+          showToast,
+          resetForm,
+        },
+        copy: COPY,
+        callbacks: {
+          prepareSubmit: () => ({ payload: 'x' }),
+          mutationFn: async () => ({}),
+          onCreated,
+          onClose,
+        },
+        conflictField: 'email',
+      }),
+    );
+
+    await result.current(makeFakeFormEvent());
+
+    expect(order).toEqual(['resetForm', 'onCreated', 'onClose']);
+  });
+});
+
+describe('useCreateEntitySubmit — dedupe via prepareSubmit', () => {
+  it('aborta sem chamar mutationFn quando prepareSubmit retorna null', async () => {
+    const mutationFn = vi.fn(async () => ({ id: 'never' }));
+    const prepareSubmit = vi.fn(() => null);
+    const { handleSubmit, spies } = setupHook({ mutationFn, prepareSubmit });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(prepareSubmit).toHaveBeenCalledTimes(1);
+    expect(mutationFn).not.toHaveBeenCalled();
+    expect(spies.showToast).not.toHaveBeenCalled();
+    expect(spies.resetForm).not.toHaveBeenCalled();
+    expect(spies.onCreated).not.toHaveBeenCalled();
+    expect(spies.onClose).not.toHaveBeenCalled();
+    // O `setIsSubmitting(false)` no `finally` NÃO deve ser chamado
+    // quando o gate cancela a submissão antes do `try` — preserva o
+    // estado original (`isSubmitting=false` se prepareSubmit decidiu
+    // que não vale submeter).
+    expect(spies.setIsSubmitting).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCreateEntitySubmit — caminho de erro 409 (conflict)', () => {
+  it('seta erro inline no conflictField com a copy custom', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(409, 'Backend conflict message.');
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.setFieldErrors).toHaveBeenCalledWith({
+      email: 'Conflito inline custom.',
+    });
+    expect(spies.setSubmitError).toHaveBeenCalledWith(null);
+    expect(spies.showToast).not.toHaveBeenCalled();
+    expect(spies.onCreated).not.toHaveBeenCalled();
+    expect(spies.onClose).not.toHaveBeenCalled();
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+
+  it('quando conflictInlineMessage está ausente, usa a mensagem do backend', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(409, 'Backend conflict message.');
+    });
+    const copyWithoutInline: CreateEntitySubmitCopy = {
+      ...COPY,
+      conflictInlineMessage: undefined,
+    };
+    const { handleSubmit, spies } = setupHook({
+      mutationFn,
+      copy: copyWithoutInline,
+    });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.setFieldErrors).toHaveBeenCalledWith({
+      email: 'Backend conflict message.',
+    });
+  });
+});
+
+describe('useCreateEntitySubmit — caminho de erro 400 (bad-request)', () => {
+  it('delega para applyBadRequest com details e fallbackMessage', async () => {
+    const details = { errors: { Name: ['nome curto'] } };
+    const mutationFn = vi.fn(async () => {
+      throw httpError(400, 'validação falhou', details);
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.applyBadRequest).toHaveBeenCalledWith(details, 'validação falhou');
+    expect(spies.onCreated).not.toHaveBeenCalled();
+    expect(spies.onClose).not.toHaveBeenCalled();
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('useCreateEntitySubmit — caminho de erro 404 (não esperado em create)', () => {
+  it('cai no fallback genérico (sem onCreated/onClose como em edit)', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(404);
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.showToast).toHaveBeenCalledWith('Não foi possível criar.', {
+      variant: 'danger',
+      title: 'Falha ao criar',
+    });
+    expect(spies.onCreated).not.toHaveBeenCalled();
+    expect(spies.onClose).not.toHaveBeenCalled();
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('useCreateEntitySubmit — caminho 401/403 (toast)', () => {
+  it.each([
+    [401, 'Sem permissão.'],
+    [403, 'Acesso negado.'],
+  ])('dispara toast vermelho com a mensagem do backend (status %s)', async (status, message) => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(status, message);
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.showToast).toHaveBeenCalledWith(message, {
+      variant: 'danger',
+      title: 'Falha ao criar',
+    });
+    expect(spies.onCreated).not.toHaveBeenCalled();
+    expect(spies.onClose).not.toHaveBeenCalled();
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('useCreateEntitySubmit — erro não-HTTP (unhandled)', () => {
+  it('cai no fallback genérico para erros de rede (Error genérico)', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.showToast).toHaveBeenCalledWith('Não foi possível criar.', {
+      variant: 'danger',
+      title: 'Falha ao criar',
+    });
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+
+  it('cai no fallback genérico para status 5xx', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(500, 'erro interno');
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.showToast).toHaveBeenCalledWith('Não foi possível criar.', {
+      variant: 'danger',
+      title: 'Falha ao criar',
+    });
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('useCreateEntitySubmit — finally setIsSubmitting', () => {
+  it('chama setIsSubmitting(false) mesmo após sucesso', async () => {
+    const mutationFn = vi.fn(async () => ({ id: 'ok' }));
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+
+  it('chama setIsSubmitting(false) mesmo após erro', async () => {
+    const mutationFn = vi.fn(async () => {
+      throw httpError(500);
+    });
+    const { handleSubmit, spies } = setupHook({ mutationFn });
+
+    await handleSubmit(makeFakeFormEvent());
+
+    expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa **NewUserModal** para criar usuário, espelhando `NewSystemModal`/`NewRoleModal`:

- Form: `name`, `email`, `password`, `identity`, `clientId` (opcional), `active`.
- Hook `useUserForm` com `applyBadRequest`, `prepareSubmit` (espelha `useSystemForm`/`useRoleForm`).
- Reusa `useCreateEntitySubmit` + extrai `applyCreateSubmitAction` como helper shared (espelhando `useEditEntitySubmit`/`applyEditSubmitAction`) — abre caminho para `NewSystemModal`/`NewRouteModal` adotarem em PR de manutenção.
- `shared/api/users.ts` ganha `createUser` (POST /users).
- Validação client-side: email format, password 1-60 chars, identity (number).
- 409 (email duplicado) → erro inline; 400 → `applyBadRequest`; 400 ClientId inexistente → toast.
- Botão visível com `Users.Create` gating via `RequirePermission`.
- Refetch da listagem após sucesso.

## Test plan

- [x] `tests/pages/UsersPage.create.test.tsx` — variações de input, 409, 400, toast.
- [x] `tests/shared/forms/useCreateEntitySubmit.test.tsx` — cobertura do hook compartilhado.
- [x] `tests/pages/users/userFormShared.test.ts` — helpers do form.
- [x] `tests/shared/api/users.test.ts` (estendido) — coverage de `createUser`.

Closes #78
