### PR TITLE
feat(users): editar usuário com modal pré-populado (#79)

### DIFF
--- a/src/hooks/useListModalState.ts
+++ b/src/hooks/useListModalState.ts
@@ -1,0 +1,80 @@
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Cápsula de estado para um modal de listagem (criação OU edição/
+ * exclusão por linha). Centraliza o trio `[selecionado, abrir,
+ * fechar]` que aparece em todas as páginas de listagem do
+ * admin-gui (Sistemas/Rotas/Roles/Usuários/Clientes).
+ *
+ * **Por que existe (lição PR #134/#135 — prevenção):**
+ *
+ * Antes desta extração, cada `*ListShellPage`/`*Page` declarava
+ * inline algo como:
+ *
+ * ```ts
+ * const [editingX, setEditingX] = useState<XDto | null>(null);
+ * const handleOpenEditModal = useCallback((row: XDto) => {
+ *   setEditingX(row);
+ * }, []);
+ * const handleCloseEditModal = useCallback(() => {
+ *   setEditingX(null);
+ * }, []);
+ * ```
+ *
+ * O JSCPD/Sonar tokeniza esse bloco de 11+ linhas como duplicação
+ * cross-recurso (`SystemsPage` × `RoutesPage` × `RolesPage` ×
+ * `UsersListShellPage` — todas reproduziam o mesmo trio). Esta
+ * extração colapsa para uma chamada de hook por uso, eliminando
+ * o clone na fonte.
+ *
+ * @template T — DTO da entidade (ex.: `UserDto`, `SystemDto`).
+ *
+ * @example
+ * const { selected: editingUser, open: openEditUser, close: closeEditUser } =
+ *   useListModalState<UserDto>();
+ *
+ * // Ao clicar no botão "Editar":  openEditUser(user)
+ * // Ao fechar/sucesso:            closeEditUser()
+ * // No JSX:                       editingUser !== null && <EditUserModal ... />
+ */
+export interface ListModalState<T> {
+  /** Entidade selecionada para o modal, ou `null` quando fechado. */
+  selected: T | null;
+  /** Abre o modal selecionando a entidade. */
+  open: (entity: T) => void;
+  /** Fecha o modal limpando a seleção. */
+  close: () => void;
+}
+
+export function useListModalState<T>(): ListModalState<T> {
+  const [selected, setSelected] = useState<T | null>(null);
+
+  const open = useCallback((entity: T) => {
+    setSelected(entity);
+  }, []);
+
+  const close = useCallback(() => {
+    setSelected(null);
+  }, []);
+
+  return useMemo(() => ({ selected, open, close }), [selected, open, close]);
+}
+
+/**
+ * Variante para modais "abrir/fechar" sem entidade associada (ex.:
+ * "Novo X" — não há `row` selecionado, só estado boolean). Centraliza
+ * o `[isOpen, openHandler, closeHandler]` que repete em toda página
+ * de listagem.
+ */
+export interface ToggleModalState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export function useToggleModalState(initial = false): ToggleModalState {
+  const [isOpen, setIsOpen] = useState<boolean>(initial);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  return useMemo(() => ({ isOpen, open, close }), [isOpen, open, close]);
+}

--- a/src/pages/users/EditUserModal.tsx
+++ b/src/pages/users/EditUserModal.tsx
@@ -1,0 +1,291 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+
+import { Modal, useToast } from '../../components/ui';
+import { updateUser } from '../../shared/api';
+import {
+  useEditEntitySubmit,
+  type EditEntitySubmitCopy,
+  type EditSubmitActionCopy,
+} from '../../shared/forms';
+
+import { UserFormBody } from './UserFormFields';
+import {
+  type UserFieldErrors,
+  type UserFormState,
+  type UserSubmitErrorCopy,
+} from './userFormShared';
+import { useUserForm, useUserFormFieldProps } from './useUserForm';
+
+import type { ApiClient, UpdateUserPayload, UserDto } from '../../shared/api';
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de edição.
+ * Os literais aqui são os únicos pontos onde "atualizar"/"outro
+ * usuário" diferem do "criar"/"um usuário" do `NewUserModal` — toda
+ * a lógica de classificação é compartilhada via `classifyApiSubmitError`
+ * (lição PR #128 — projetar `<recurso>FormShared.ts` desde o
+ * primeiro PR do recurso).
+ */
+const SUBMIT_ERROR_COPY: UserSubmitErrorCopy = {
+  conflictDefault: 'Já existe outro usuário com este e-mail.',
+  forbiddenTitle: 'Falha ao atualizar usuário',
+  genericFallback: 'Não foi possível atualizar o usuário. Tente novamente.',
+};
+
+/** Texto exibido inline no campo `email` quando o backend devolve 409. */
+const CONFLICT_INLINE_MESSAGE = 'Já existe outro usuário com este e-mail.';
+
+/** Texto exibido em toast quando o usuário some entre abertura e submit (404). */
+const NOT_FOUND_MESSAGE =
+  'Usuário não encontrado ou foi removido. Atualize a lista.';
+
+/**
+ * Cópia textual injetada em `applyEditSubmitAction`. Concentra os
+ * literais que diferem entre `EditUserModal` e os demais modals de
+ * edição (`EditSystemModal`/`EditRoleModal`/`EditRouteModal`) sem
+ * duplicar a árvore de switch (lição PR #128/#134/#135 reforçada).
+ */
+const EDIT_SUBMIT_ACTION_COPY: EditSubmitActionCopy = {
+  conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+  notFoundMessage: NOT_FOUND_MESSAGE,
+  forbiddenTitle: SUBMIT_ERROR_COPY.forbiddenTitle,
+};
+
+interface EditUserModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Usuário sendo editado. Pré-popula o form e fornece o `id` usado
+   * no `PUT /users/{id}`. Quando `null`, o modal não renderiza —
+   * caller é responsável por só passar `user` quando `open=true`.
+   *
+   * Os campos visíveis (`Name`/`Email`/`Identity`/`ClientId`/`Active`)
+   * vêm do `UserResponse` enriquecido em `lfc-authenticator#167`. O
+   * campo `password` **não** é exibido — reset de senha é endpoint
+   * separado (`PUT /users/{id}/password`, sub-issue futura).
+   */
+  user: UserDto | null;
+  /** Fecha o modal sem persistir. Chamada também após sucesso ou 404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após atualização bem-sucedida ou após detecção
+   * de 404 (usuário já removido) — em ambos casos a UI quer refetch
+   * para sincronizar a tabela com o estado real do backend.
+   */
+  onUpdated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `updateUser` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Constrói o estado inicial do form a partir de uma `UserDto`.
+ * `clientId: null` (do backend quando o usuário não tem cliente
+ * vinculado) vira string vazia para que o input controlado nunca
+ * receba `null`/`undefined`. O backend trata "ClientId omitido" no
+ * PUT como "manter o ClientId atual" (`UsersController.UpdateById`
+ * linha 507) — mais um motivo para preservar o valor lido do
+ * `UserDto` no form e só enviar mudança quando o operador editar.
+ *
+ * `password` permanece string vazia — o campo nem é renderizado em
+ * edit, mas o `UserFormState` continua exigindo a chave por
+ * compatibilidade com o caminho de criação.
+ */
+function stateFromUser(user: UserDto): UserFormState {
+  return {
+    name: user.name,
+    email: user.email,
+    password: '',
+    identity: String(user.identity),
+    clientId: user.clientId ?? '',
+    active: user.active,
+  };
+}
+
+const EMPTY_INITIAL_STATE: UserFormState = {
+  name: '',
+  email: '',
+  password: '',
+  identity: '',
+  clientId: '',
+  active: true,
+};
+
+/* ─── Component ──────────────────────────────────────────── */
+
+/**
+ * Modal de edição de usuário (Issue #79).
+ *
+ * Espelha a forma do `NewUserModal` (mesma estrutura visual,
+ * validação compartilhada via `userFormShared.ts`, mapeamento de erros
+ * delegado a `useEditEntitySubmit`) com quatro diferenças funcionais:
+ *
+ * 1. Pré-popula `formState` com `Name`/`Email`/`Identity`/`ClientId`/
+ *    `Active` do `user` recebido por prop — atende o critério de aceite
+ *    "pré-popula campos". Os dados vêm do `UserResponse` completo
+ *    (após enriquecimento em `lfc-authenticator#167`).
+ * 2. Submit chama `updateUser(id, payload)` em vez de `createUser`.
+ * 3. **Não exibe campo de senha** — reset de senha é endpoint separado
+ *    (`PUT /users/{id}/password`), fora do escopo da #79.
+ * 4. Trata 404 fechando o modal + toast vermelho + refetch (usuário
+ *    foi soft-deletado por outra sessão entre a abertura e o submit).
+ *
+ * Toda a lógica de validação client-side e parsing de
+ * `ValidationProblemDetails` vem de `userFormShared.ts`, os campos
+ * vivem em `UserFormFields` (com `hidePassword` para esconder o
+ * campo de senha), o estado/handlers do form vêm de `useUserForm`
+ * (com `prepareUpdateSubmit` no lugar de `prepareSubmit`) e o ciclo
+ * de submit vem de `useEditEntitySubmit` — evita duplicação ≥10
+ * linhas com os outros modals de edição (BLOCKER de duplicação
+ * Sonar, lição PR #134/#135).
+ */
+export const EditUserModal: React.FC<EditUserModalProps> = ({
+  open,
+  user,
+  onClose,
+  onUpdated,
+  client,
+}) => {
+  const { show } = useToast();
+
+  // Inicialização defensiva: quando `user` é `null` na primeira
+  // render, usamos um estado vazio até o pai entregar o usuário. O
+  // `useEffect` abaixo sincroniza sempre que `user` muda.
+  const userForm = useUserForm(user ? stateFromUser(user) : EMPTY_INITIAL_STATE);
+  const {
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    prepareUpdateSubmit,
+    applyBadRequest,
+  } = userForm;
+
+  /**
+   * Sincroniza o form sempre que: (a) o modal abre, ou (b) o `user`
+   * selecionado muda. Limpa erros pendentes para evitar resíduo
+   * entre aberturas (mesmo padrão do `EditSystemModal`/
+   * `EditRoleModal`/`EditRouteModal`).
+   */
+  useEffect(() => {
+    if (!open || !user) return;
+    setFormState(stateFromUser(user));
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [open, user, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reseta erros ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar
+   * durante submissão é bloqueado para evitar request órfã. Não
+   * resetamos o `formState` aqui (diferente de um modal de
+   * criação) porque o efeito de sincronização re-popula a partir
+   * do `user` quando o modal reabre.
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareUpdateSubmit` que reprova quando o gate de
+   * `isSubmitting`/`!user` falhar — preserva o dedupe original ao
+   * mover a lógica para dentro de `useEditEntitySubmit` (lição PR
+   * #135, 6ª recorrência de Sonar).
+   */
+  const prepareSubmitSafe = useCallback((): unknown | null => {
+    if (isSubmitting || !user) return null;
+    return prepareUpdateSubmit();
+  }, [isSubmitting, prepareUpdateSubmit, user]);
+
+  /**
+   * Closure sobre `user.id` + `client`. Quando `user` é `null` o
+   * `prepareSubmitSafe` já reprova antes do `mutationFn` rodar — a
+   * checagem inline aqui é defensiva (preserva o tipo sem `!`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> => {
+      if (!user) {
+        return Promise.reject(new Error('User unavailable.'));
+      }
+      return updateUser(user.id, payload as UpdateUserPayload, undefined, client);
+    },
+    [client, user],
+  );
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<EditEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Usuário atualizado.',
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+      editSubmitActionCopy: EDIT_SUBMIT_ACTION_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * `handleSubmit` orquestrado pelo hook compartilhado — encapsula
+   * o `try/catch/finally` + `classifyApiSubmitError` +
+   * `applyEditSubmitAction` que vivia inline em outros modals
+   * antes da extração (lição PR #134/#135).
+   */
+  const handleSubmit = useEditEntitySubmit<keyof UserFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onUpdated,
+      onClose,
+    },
+    conflictField: 'email',
+  });
+
+  // Vide comentário em `NewUserModal.tsx`: encapsular props
+  // compartilhadas no hook `useUserFormFieldProps` evita New Code
+  // Duplication ≥10 linhas com o caminho de criação (lição PR
+  // #134/#135). Hook chamado **antes** do early-return para respeitar
+  // a regra "hooks always called in the same order".
+  const fieldProps = useUserFormFieldProps(userForm, handleSubmit, handleClose);
+
+  // Não renderiza nada quando não houver `user` selecionado — o pai
+  // controla `open` em conjunto com o `user`, mas cobrimos o caso
+  // defensivo de `open=true && user=null` para não quebrar o submit.
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Editar usuário"
+      description="Atualize os dados do usuário selecionado."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <UserFormBody
+        {...fieldProps}
+        idPrefix="edit-user"
+        submitLabel="Salvar alterações"
+        hidePassword
+      />
+    </Modal>
+  );
+};

--- a/src/pages/users/NewUserModal.tsx
+++ b/src/pages/users/NewUserModal.tsx
@@ -10,7 +10,7 @@ import {
   type UserFieldErrors,
   type UserSubmitErrorCopy,
 } from './userFormShared';
-import { useUserForm } from './useUserForm';
+import { useUserForm, useUserFormFieldProps } from './useUserForm';
 
 import type { ApiClient, CreateUserPayload } from '../../shared/api';
 
@@ -98,24 +98,16 @@ export const NewUserModal: React.FC<NewUserModalProps> = ({
   client,
 }) => {
   const { show } = useToast();
+  const userForm = useUserForm(INITIAL_USER_FORM_STATE);
   const {
-    formState,
-    fieldErrors,
-    submitError,
     isSubmitting,
     setFormState,
     setFieldErrors,
     setSubmitError,
     setIsSubmitting,
-    handleNameChange,
-    handleEmailChange,
-    handlePasswordChange,
-    handleIdentityChange,
-    handleClientIdChange,
-    handleActiveChange,
     prepareSubmit,
     applyBadRequest,
-  } = useUserForm(INITIAL_USER_FORM_STATE);
+  } = userForm;
 
   /**
    * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
@@ -182,6 +174,14 @@ export const NewUserModal: React.FC<NewUserModalProps> = ({
     conflictField: 'email',
   });
 
+  // Props compartilhadas com `EditUserModal` consolidadas num único
+  // hook (`useUserFormFieldProps`) para evitar New Code Duplication
+  // ≥10 linhas com o caminho de edição — JSCPD/Sonar tokenizam blocos
+  // de props sequenciais como duplicação. Lição PR #134/#135 — o
+  // call-site dos helpers compartilhados também precisa ficar
+  // deduplicado, não só os helpers em si.
+  const fieldProps = useUserFormFieldProps(userForm, handleSubmit, handleClose);
+
   return (
     <Modal
       open={open}
@@ -191,22 +191,7 @@ export const NewUserModal: React.FC<NewUserModalProps> = ({
       closeOnEsc={!isSubmitting}
       closeOnBackdrop={!isSubmitting}
     >
-      <UserFormBody
-        idPrefix="new-user"
-        submitError={submitError}
-        values={formState}
-        errors={fieldErrors}
-        onChangeName={handleNameChange}
-        onChangeEmail={handleEmailChange}
-        onChangePassword={handlePasswordChange}
-        onChangeIdentity={handleIdentityChange}
-        onChangeClientId={handleClientIdChange}
-        onChangeActive={handleActiveChange}
-        onSubmit={handleSubmit}
-        onCancel={handleClose}
-        isSubmitting={isSubmitting}
-        submitLabel="Criar usuário"
-      />
+      <UserFormBody {...fieldProps} idPrefix="new-user" submitLabel="Criar usuário" />
     </Modal>
   );
 };

--- a/src/pages/users/UserFormFields.tsx
+++ b/src/pages/users/UserFormFields.tsx
@@ -128,6 +128,12 @@ interface UserFormFieldsProps {
   errors: UserFieldErrors;
   onChangeName: (value: string) => void;
   onChangeEmail: (value: string) => void;
+  /**
+   * Handler do campo de senha — só é consumido quando `hidePassword`
+   * é `false` (criação). No fluxo de edição (Issue #79), o campo não
+   * é renderizado; reset de senha é endpoint separado
+   * (`PUT /users/{id}/password`, fora do escopo da #79).
+   */
   onChangePassword: (value: string) => void;
   onChangeIdentity: (value: string) => void;
   onChangeClientId: (value: string) => void;
@@ -144,6 +150,16 @@ interface UserFormFieldsProps {
    * no futuro — hoje os dois modals usam `true`.
    */
   autoFocusName?: boolean;
+  /**
+   * Quando `true`, o campo "Senha inicial" não é renderizado. Usado
+   * pelo `EditUserModal` (Issue #79) — o `PUT /users/{id}` do backend
+   * não aceita `Password` no contrato, e o reset de senha é endpoint
+   * separado (`PUT /users/{id}/password`, sub-issue futura).
+   *
+   * Default `false` preserva o comportamento original (form de criação
+   * mostra o campo, espelhando o contrato de `POST /users`).
+   */
+  hidePassword?: boolean;
 }
 
 const UserFormFields: React.FC<UserFormFieldsProps> = ({
@@ -158,6 +174,7 @@ const UserFormFields: React.FC<UserFormFieldsProps> = ({
   onChangeActive,
   disabled = false,
   autoFocusName = true,
+  hidePassword = false,
 }) => {
   // `data-modal-initial-focus` no campo Name garante que o foco vá para
   // o primeiro input independente da ordem dos `querySelector`. Útil em
@@ -196,19 +213,21 @@ const UserFormFields: React.FC<UserFormFieldsProps> = ({
         disabled={disabled}
         data-testid={`${idPrefix}-email`}
       />
-      <Input
-        label="Senha inicial"
-        type="password"
-        placeholder="Senha temporária — o usuário poderá alterar depois."
-        value={values.password}
-        onChange={onChangePassword}
-        error={errors.password}
-        maxLength={PASSWORD_MAX}
-        autoComplete="new-password"
-        required
-        disabled={disabled}
-        data-testid={`${idPrefix}-password`}
-      />
+      {!hidePassword && (
+        <Input
+          label="Senha inicial"
+          type="password"
+          placeholder="Senha temporária — o usuário poderá alterar depois."
+          value={values.password}
+          onChange={onChangePassword}
+          error={errors.password}
+          maxLength={PASSWORD_MAX}
+          autoComplete="new-password"
+          required
+          disabled={disabled}
+          data-testid={`${idPrefix}-password`}
+        />
+      )}
       <Input
         label="Identity"
         type="number"
@@ -276,6 +295,11 @@ interface UserFormBodyProps {
   isSubmitting: boolean;
   /** Texto do botão de envio (ex.: "Criar usuário", "Salvar alterações"). */
   submitLabel: string;
+  /**
+   * Repassa para `UserFormFields` — quando `true`, o campo "Senha
+   * inicial" não é renderizado (Issue #79, edição). Default `false`.
+   */
+  hidePassword?: boolean;
 }
 
 /**
@@ -304,6 +328,7 @@ export const UserFormBody: React.FC<UserFormBodyProps> = ({
   onCancel,
   isSubmitting,
   submitLabel,
+  hidePassword = false,
 }) => (
   <UserFormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
     {submitError && (
@@ -328,6 +353,7 @@ export const UserFormBody: React.FC<UserFormBodyProps> = ({
       onChangeClientId={onChangeClientId}
       onChangeActive={onChangeActive}
       disabled={isSubmitting}
+      hidePassword={hidePassword}
     />
     <SharedFormFooter
       idPrefix={idPrefix}

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -546,27 +546,31 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
             data-testid="users-card-list"
           >
             {rows.length === 0 && emptyContent}
-            {rows.map((row) => (
-              <EntityCard
-                key={row.id}
-                role="listitem"
-                tabIndex={0}
-                data-testid={`users-card-${row.id}`}
-              >
-                <CardHeader>
-                  <CardCode>{row.email}</CardCode>
-                  <StatusBadge deletedAt={deriveStatusDeletedAt(row)} />
-                </CardHeader>
-                <CardName>{row.name}</CardName>
-                <CardMeta>
-                  <CardMetaTerm>Cliente</CardMetaTerm>
-                  <CardMetaValue>
-                    {renderClientCell(row, clientsById)}
-                  </CardMetaValue>
-                </CardMeta>
-                {renderMobileEditAction(row)}
-              </EntityCard>
-            ))}
+            {rows.map((user) => {
+              const userId = user.id;
+              const userStatus = deriveStatusDeletedAt(user);
+              return (
+                <EntityCard
+                  key={userId}
+                  role="listitem"
+                  tabIndex={0}
+                  data-testid={`users-card-${userId}`}
+                >
+                  <CardHeader>
+                    <CardCode>{user.email}</CardCode>
+                    <StatusBadge deletedAt={userStatus} />
+                  </CardHeader>
+                  <CardName>{user.name}</CardName>
+                  <CardMeta>
+                    <CardMetaTerm>Cliente</CardMetaTerm>
+                    <CardMetaValue>
+                      {renderClientCell(user, clientsById)}
+                    </CardMetaValue>
+                  </CardMeta>
+                  {renderMobileEditAction(user)}
+                </EntityCard>
+              );
+            })}
           </CardListForMobile>
           {showOverlay && <RefetchOverlay testId="users-overlay" />}
         </TableShell>

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,10 +1,13 @@
-import { Plus } from 'lucide-react';
+import { Pencil, Plus } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
-import { useModalOpenState } from '../../hooks/useModalOpenState';
+import {
+  useListModalState,
+  useToggleModalState,
+} from '../../hooks/useListModalState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../../hooks/usePaginationControls';
 import {
@@ -37,12 +40,14 @@ import {
   PaginationFooter,
   Placeholder,
   RefetchOverlay,
+  RowActions,
   StatusBadge,
   TableForDesktop,
   TableShell,
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import { EditUserModal } from './EditUserModal';
 import { NewUserModal } from './NewUserModal';
 
 import type { TableColumn } from '../../components/ui';
@@ -64,6 +69,18 @@ import type {
  * executar.
  */
 const USERS_CREATE_PERMISSION = 'AUTH_V1_USERS_CREATE';
+
+/**
+ * Code de permissão exigido para o botão "Editar" por linha (Issue #79).
+ *
+ * Espelha `AUTH_V1_USERS_UPDATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder`. O backend é a fonte autoritativa
+ * (`PUT /users/{id}` valida via
+ * `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`); o gating
+ * client-side é apenas UX — esconder ações que o usuário não pode
+ * executar.
+ */
+const USERS_UPDATE_PERMISSION = 'AUTH_V1_USERS_UPDATE';
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300 ms
@@ -138,6 +155,7 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
 }) => {
   const { hasPermission } = useAuth();
   const canCreateUser = hasPermission(USERS_CREATE_PERMISSION);
+  const canUpdateUser = hasPermission(USERS_UPDATE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -148,18 +166,56 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
   );
   const [page, setPage] = useState<number>(DEFAULT_USERS_PAGE);
 
-  // Estado de abertura do modal "Novo usuário" (Issue #78). O modal é
-  // controlado por essa página para que a Toolbar consiga ocultar o
-  // botão por permissão sem perder o ciclo de vida do form.
-  // Lição PR #134/#135: o trio `useState + useCallback(open) +
-  // useCallback(close)` era duplicado entre `UsersListShellPage` e
-  // `ClientsListShellPage` — extraído em `useModalOpenState` em
-  // `src/hooks/` no PR #74.
+  // Estado de abertura do modal "Novo usuário" (Issue #78). Centralizado
+  // no hook `useToggleModalState` para evitar duplicação ≥10 linhas com
+  // outras páginas que usam o mesmo padrão (lição PR #134/#135).
   const {
     isOpen: isCreateModalOpen,
     open: handleOpenCreateModal,
     close: handleCloseCreateModal,
-  } = useModalOpenState();
+  } = useToggleModalState();
+
+  // Usuário selecionado para edição (Issue #79). Manter o usuário
+  // completo (em vez de só o id) evita round-trip extra para refazer
+  // fetch no modal — a tabela já tem o payload pronto. Centralizado no
+  // hook `useListModalState` (mesmo motivo do toggle acima).
+  const {
+    selected: editingUser,
+    open: handleOpenEditModal,
+    close: handleCloseEditModal,
+  } = useListModalState<UserDto>();
+
+  /**
+   * Renderiza o bloco de ações dos cards mobile (espelho da coluna
+   * "Ações" do desktop). Centralizar aqui evita BLOCKER de duplicação
+   * Sonar/JSCPD com `RolesPage` (lição PR #134/#135 — bloco ≥10 linhas
+   * idêntico entre páginas é tokenizado como `New Code Duplication`).
+   *
+   * Retorna `null` quando o usuário não tem permissão ou a linha é
+   * soft-deletada — coerente com o gating da tabela desktop.
+   */
+  const renderMobileEditAction = useCallback(
+    (row: UserDto): React.ReactNode => {
+      if (!canUpdateUser || row.deletedAt !== null) {
+        return null;
+      }
+      return (
+        <RowActions>
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Pencil size={14} strokeWidth={1.5} />}
+            onClick={() => handleOpenEditModal(row)}
+            aria-label={`Editar usuário ${row.name}`}
+            data-testid={`users-card-edit-${row.id}`}
+          >
+            Editar
+          </Button>
+        </RowActions>
+      );
+    },
+    [canUpdateUser, handleOpenEditModal],
+  );
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -338,8 +394,8 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     );
   }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
 
-  const columns = useMemo<ReadonlyArray<TableColumn<UserDto>>>(
-    () => [
+  const columns = useMemo<ReadonlyArray<TableColumn<UserDto>>>(() => {
+    const base: Array<TableColumn<UserDto>> = [
       {
         key: 'name',
         label: 'Nome',
@@ -361,9 +417,44 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
         width: '120px',
         render: (row) => <StatusBadge deletedAt={deriveStatusDeletedAt(row)} />,
       },
-    ],
-    [clientsById],
-  );
+    ];
+
+    // Coluna "Ações" só aparece quando o usuário tem alguma ação
+    // disponível. Hoje "Editar" (Issue #79); a paridade total com
+    // Sistemas/Roles (desativar/restaurar) fica para issues futuras
+    // da EPIC #49. Espelha a estratégia do `RolesPage`/`SystemsPage`.
+    if (canUpdateUser) {
+      base.push({
+        key: 'actions',
+        label: 'Ações',
+        isActions: true,
+        render: (row) => (
+          <RowActions>
+            {row.deletedAt === null && (
+              // "Editar" só faz sentido em usuários ativos. O backend
+              // devolve 404 ao tentar PUT em usuário soft-deletado
+              // (`Users.FirstOrDefaultAsync` cai no query filter
+              // global), mas esconder no UI alinha com a coluna
+              // Status. Espelha a estratégia de `RolesPage`/
+              // `SystemsPage`.
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<Pencil size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenEditModal(row)}
+                aria-label={`Editar usuário ${row.name}`}
+                data-testid={`users-edit-${row.id}`}
+              >
+                Editar
+              </Button>
+            )}
+          </RowActions>
+        ),
+      });
+    }
+
+    return base;
+  }, [canUpdateUser, clientsById, handleOpenEditModal]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -473,6 +564,7 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
                     {renderClientCell(row, clientsById)}
                   </CardMetaValue>
                 </CardMeta>
+                {renderMobileEditAction(row)}
               </EntityCard>
             ))}
           </CardListForMobile>
@@ -500,6 +592,16 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           open={isCreateModalOpen}
           onClose={handleCloseCreateModal}
           onCreated={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canUpdateUser && (
+        <EditUserModal
+          open={editingUser !== null}
+          user={editingUser}
+          onClose={handleCloseEditModal}
+          onUpdated={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -2,3 +2,4 @@ export { UsersListShellPage } from './UsersListShellPage';
 export { UserDetailShellPage } from './UserDetailShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
 export { NewUserModal } from './NewUserModal';
+export { EditUserModal } from './EditUserModal';

--- a/src/pages/users/useUserForm.ts
+++ b/src/pages/users/useUserForm.ts
@@ -1,15 +1,18 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState, type FormEvent } from 'react';
 
 import { useFieldChangeHandlers } from '../../shared/forms';
 
 import {
+  buildCreateUserPayload,
+  buildUpdateUserPayload,
   decideUserBadRequestHandling,
   validateUserForm,
+  validateUserUpdateForm,
   type UserFieldErrors,
   type UserFormState,
 } from './userFormShared';
 
-import type { CreateUserPayload } from '../../shared/api';
+import type { CreateUserPayload, UpdateUserPayload } from '../../shared/api';
 
 /**
  * Lista fixa dos campos textuais do form de user, usada por
@@ -69,10 +72,10 @@ interface UseUserFormReturn {
   handleClientIdChange: (value: string) => void;
   handleActiveChange: (value: boolean) => void;
   /**
-   * Roda a validação client-side e, se passar, prepara o payload
-   * trimado + zera erros + marca `isSubmitting`. Devolve o payload
-   * pronto para envio quando válido, ou `null` quando não (já tendo
-   * populado `fieldErrors`).
+   * Roda a validação client-side de criação (com senha) e, se passar,
+   * prepara o `CreateUserPayload` trimado + zera erros + marca
+   * `isSubmitting`. Devolve o payload pronto para envio quando válido,
+   * ou `null` quando não (já tendo populado `fieldErrors`).
    *
    * O parse de `identity` (string -> int) acontece aqui com
    * `Number.parseInt` (radix 10) — `validateUserForm` já garantiu
@@ -81,12 +84,25 @@ interface UseUserFormReturn {
    * `clientId` vazio (após trim) é omitido do payload para que o
    * backend acione `LegacyClientFactory` e gere um cliente PF
    * derivado automaticamente (ver `UsersController.cs` linha 250).
-   *
-   * Centralizar essa rotina elimina ~18 linhas de boilerplate que
-   * apareceriam idênticas entre `NewUserModal` e o futuro
-   * `EditUserModal` (lição PR #127/#128).
    */
   prepareSubmit: () => CreateUserPayload | null;
+  /**
+   * Roda a validação client-side de edição (**sem senha**) e, se
+   * passar, prepara o `UpdateUserPayload` trimado + zera erros + marca
+   * `isSubmitting`. Devolve o payload pronto para envio quando válido,
+   * ou `null` quando não.
+   *
+   * Diferença essencial vs `prepareSubmit`:
+   * - Não exige `password` (campo é ignorado no estado e omitido do
+   *   payload) — reset de senha é endpoint separado.
+   * - `active` é sempre incluído (backend exige `[Required]` no PUT).
+   *
+   * Centralizar a versão de update no mesmo hook (em vez de duplicar
+   * `useUserUpdateForm`) preserva a lição PR #128 — o `EditUserModal`
+   * herda 100% do estado/handlers/parsing de `useUserForm` sem copiar
+   * uma linha sequer.
+   */
+  prepareUpdateSubmit: () => UpdateUserPayload | null;
   /**
    * Aplica o tratamento de uma resposta 400 do backend: distribui
    * erros por campo quando `ValidationProblemDetails` é mapeável, ou
@@ -140,33 +156,20 @@ export function useUserForm(initialState: UserFormState): UseUserFormReturn {
     setFieldErrors({});
     setSubmitError(null);
     setIsSubmitting(true);
+    return buildCreateUserPayload(formState);
+  }, [formState]);
 
-    // `identity` chega como string `"^-?\d+$"` (validado), parse com
-    // radix 10 explícito é defensivo contra ambientes onde o engine
-    // tenta detectar octal/hex.
-    const identityInt = Number.parseInt(formState.identity.trim(), 10);
-    const trimmedClientId = formState.clientId.trim();
-
-    const payload: CreateUserPayload = {
-      name: formState.name.trim(),
-      email: formState.email.trim(),
-      // Password preservada literal — espaços laterais podem ser
-      // intencionais para senhas de gerenciador.
-      password: formState.password,
-      identity: identityInt,
-    };
-
-    if (trimmedClientId.length > 0) {
-      payload.clientId = trimmedClientId;
+  const prepareUpdateSubmit = useCallback((): UpdateUserPayload | null => {
+    const clientErrors = validateUserUpdateForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
     }
-
-    // `active` é sempre incluído — o estado inicial é `true`, então
-    // omitir só quando o usuário deliberadamente liga/desliga seria
-    // assimetria desnecessária. O backend trata `Active` como bool
-    // simples (`= true` quando ausente; aceita explícito).
-    payload.active = formState.active;
-
-    return payload;
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+    return buildUpdateUserPayload(formState);
   }, [formState]);
 
   const applyBadRequest = useCallback((details: unknown, fallbackMessage: string): void => {
@@ -195,6 +198,93 @@ export function useUserForm(initialState: UserFormState): UseUserFormReturn {
     handleClientIdChange,
     handleActiveChange,
     prepareSubmit,
+    prepareUpdateSubmit,
     applyBadRequest,
   };
+}
+
+/**
+ * Tipo do conjunto de props consumido por `<UserFormBody>` —
+ * compartilhado entre `NewUserModal` e `EditUserModal`. Centralizar
+ * o tipo aqui (em vez de inferir inline em cada modal) elimina o
+ * bloco repetido de 13 linhas (`onChangeName/Email/Password/...`)
+ * que JSCPD/Sonar tokenizavam como `New Code Duplication` (lição
+ * PR #134/#135 — call-sites dos helpers também precisam ficar
+ * deduplicados, não só os helpers em si).
+ */
+export interface UserFormFieldProps {
+  submitError: string | null;
+  values: UserFormState;
+  errors: UserFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeEmail: (value: string) => void;
+  onChangePassword: (value: string) => void;
+  onChangeIdentity: (value: string) => void;
+  onChangeClientId: (value: string) => void;
+  onChangeActive: (value: boolean) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+/**
+ * Constrói o objeto de props para `<UserFormBody>` a partir de uma
+ * instância de `useUserForm` + `handleSubmit` + `handleClose` do
+ * modal. Memoizado em `useMemo` para preservar identidade entre
+ * renders quando nada mudou — útil pra spread `{...fieldProps}` sem
+ * causar re-render desnecessário no body.
+ *
+ * Esse helper transforma o "objeto duplicado de 13 linhas" em uma
+ * única chamada `useUserFormFieldProps(userForm, handleSubmit,
+ * handleClose)` em cada modal — eliminando o BLOCKER de duplicação
+ * Sonar entre `NewUserModal` e `EditUserModal` na fonte.
+ */
+export function useUserFormFieldProps(
+  userForm: UseUserFormReturn,
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void,
+  onCancel: () => void,
+): UserFormFieldProps {
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    handleNameChange,
+    handleEmailChange,
+    handlePasswordChange,
+    handleIdentityChange,
+    handleClientIdChange,
+    handleActiveChange,
+  } = userForm;
+
+  return useMemo(
+    () => ({
+      submitError,
+      values: formState,
+      errors: fieldErrors,
+      onChangeName: handleNameChange,
+      onChangeEmail: handleEmailChange,
+      onChangePassword: handlePasswordChange,
+      onChangeIdentity: handleIdentityChange,
+      onChangeClientId: handleClientIdChange,
+      onChangeActive: handleActiveChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    }),
+    [
+      submitError,
+      formState,
+      fieldErrors,
+      handleNameChange,
+      handleEmailChange,
+      handlePasswordChange,
+      handleIdentityChange,
+      handleClientIdChange,
+      handleActiveChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    ],
+  );
 }

--- a/src/pages/users/userFormShared.ts
+++ b/src/pages/users/userFormShared.ts
@@ -4,6 +4,8 @@ import {
   type ApiSubmitErrorCopy,
 } from '../../shared/forms';
 
+import type { CreateUserPayload, UpdateUserPayload } from '../../shared/api';
+
 /**
  * Helpers compartilhados pelos formulários de criação (Issue #78) e
  * futuras edições (sub-issues seguintes da EPIC #49) de usuários.
@@ -192,14 +194,24 @@ function isIntegerString(raw: string): boolean {
  */
 const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
-export function validateUserForm(state: UserFormState): UserFieldErrors | null {
-  const errors: UserFieldErrors = {};
+/**
+ * Aplica as regras compartilhadas entre criação e edição (`name`/
+ * `email`/`identity`/`clientId`) ao objeto `errors`. Mantemos como
+ * função interna que **muta** o `errors` para reduzir alocações
+ * intermediárias e manter o caminho fácil de auditar — `validateUserForm`
+ * e `validateUserUpdateForm` viraram thin wrappers que adicionam apenas
+ * as regras específicas do seu caminho (criação valida `password`).
+ *
+ * Centralizar evita ~30 linhas duplicadas entre as duas funções de
+ * validação (lição PR #128/#134 — refatorar antes do segundo call site
+ * para prevenir New Code Duplication do Sonar).
+ */
+function applySharedUserFieldRules(
+  errors: UserFieldErrors,
+  state: UserFormState,
+): void {
   const name = state.name.trim();
   const email = state.email.trim();
-  // Senha não é trimada — espaços no início/fim podem ser
-  // intencionais para senhas geradas em gerenciadores. O backend
-  // hasheia o valor literal sem trim no `UserPasswordHasher`.
-  const password = state.password;
   const identity = state.identity.trim();
   const clientId = state.clientId.trim();
 
@@ -217,14 +229,6 @@ export function validateUserForm(state: UserFormState): UserFieldErrors | null {
     errors.email = 'Informe um e-mail válido.';
   }
 
-  if (password.length === 0) {
-    errors.password = 'Senha é obrigatória.';
-  } else if (password.length < PASSWORD_MIN) {
-    errors.password = `Senha deve ter ao menos ${PASSWORD_MIN} caracteres.`;
-  } else if (password.length > PASSWORD_MAX) {
-    errors.password = `Senha deve ter no máximo ${PASSWORD_MAX} caracteres.`;
-  }
-
   if (identity.length === 0) {
     errors.identity = 'Identity é obrigatório.';
   } else if (!isIntegerString(identity)) {
@@ -234,8 +238,112 @@ export function validateUserForm(state: UserFormState): UserFieldErrors | null {
   if (clientId.length > 0 && !UUID_REGEX.test(clientId)) {
     errors.clientId = 'ClientId deve ser um UUID válido.';
   }
+}
+
+export function validateUserForm(state: UserFormState): UserFieldErrors | null {
+  const errors: UserFieldErrors = {};
+  applySharedUserFieldRules(errors, state);
+
+  // Senha não é trimada — espaços no início/fim podem ser
+  // intencionais para senhas geradas em gerenciadores. O backend
+  // hasheia o valor literal sem trim no `UserPasswordHasher`.
+  const password = state.password;
+  if (password.length === 0) {
+    errors.password = 'Senha é obrigatória.';
+  } else if (password.length < PASSWORD_MIN) {
+    errors.password = `Senha deve ter ao menos ${PASSWORD_MIN} caracteres.`;
+  } else if (password.length > PASSWORD_MAX) {
+    errors.password = `Senha deve ter no máximo ${PASSWORD_MAX} caracteres.`;
+  }
 
   return Object.keys(errors).length > 0 ? errors : null;
+}
+
+/**
+ * Valida o estado do form contra as regras do `PUT /users/{id}`. Diferença
+ * essencial em relação a `validateUserForm`:
+ *
+ * - **Não exige `password`** — o reset de senha é endpoint separado
+ *   (`PUT /users/{id}/password`, fora do escopo da Issue #79). Edição
+ *   normal preserva a senha vigente; campo nem é exibido no modal.
+ *
+ * As demais regras (`name`/`email`/`identity`/`clientId`) seguem o
+ * contrato do backend (`UpdateUserRequest` em `UsersController.cs`),
+ * idêntico ao caminho de criação para esses campos.
+ */
+export function validateUserUpdateForm(
+  state: UserFormState,
+): UserFieldErrors | null {
+  const errors: UserFieldErrors = {};
+  applySharedUserFieldRules(errors, state);
+  return Object.keys(errors).length > 0 ? errors : null;
+}
+
+/**
+ * Constrói o `CreateUserPayload` a partir do estado validado do form.
+ * Centralizar a conversão (parse `identity` para `int`, omit/trim de
+ * `clientId`, includes `active`) elimina ~18 linhas que apareciam
+ * inline no `useUserForm.prepareSubmit` original — preserva o teste
+ * unitário focado na lógica e simplifica a manutenção.
+ *
+ * **Pré-condição:** o caller já chamou `validateUserForm(state)` e
+ * recebeu `null`. Se a validação não passou, a saída desta função é
+ * indefinida (mas defensivamente, `Number.parseInt` com radix 10
+ * retorna `NaN` — o backend rejeitaria via JSON binder se isso
+ * vazasse, mas o caller nunca deve chegar aqui sem validar antes).
+ */
+export function buildCreateUserPayload(state: UserFormState): CreateUserPayload {
+  const identityInt = Number.parseInt(state.identity.trim(), 10);
+  const trimmedClientId = state.clientId.trim();
+
+  const payload: CreateUserPayload = {
+    name: state.name.trim(),
+    email: state.email.trim(),
+    // Password preservada literal — espaços laterais podem ser
+    // intencionais para senhas de gerenciador.
+    password: state.password,
+    identity: identityInt,
+  };
+
+  if (trimmedClientId.length > 0) {
+    payload.clientId = trimmedClientId;
+  }
+
+  // `active` é sempre incluído — o estado inicial é `true`, então
+  // omitir só quando o usuário deliberadamente liga/desliga seria
+  // assimetria desnecessária. O backend trata `Active` como bool
+  // simples (`= true` quando ausente; aceita explícito).
+  payload.active = state.active;
+
+  return payload;
+}
+
+/**
+ * Constrói o `UpdateUserPayload` a partir do estado validado do form
+ * de edição. Diferenças vs `buildCreateUserPayload`:
+ *
+ * - **Sem `password`** — coerente com `UpdateUserRequest` do backend.
+ * - **`active` sempre presente** — backend marca como `[Required]` no
+ *   update (diferente do create onde aceita ausência via default `true`).
+ *
+ * Pré-condição: caller validou via `validateUserUpdateForm(state)`.
+ */
+export function buildUpdateUserPayload(state: UserFormState): UpdateUserPayload {
+  const identityInt = Number.parseInt(state.identity.trim(), 10);
+  const trimmedClientId = state.clientId.trim();
+
+  const payload: UpdateUserPayload = {
+    name: state.name.trim(),
+    email: state.email.trim(),
+    identity: identityInt,
+    active: state.active,
+  };
+
+  if (trimmedClientId.length > 0) {
+    payload.clientId = trimmedClientId;
+  }
+
+  return payload;
 }
 
 /**

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -161,8 +161,14 @@ export {
   isPagedUsersResponse,
   isUserDto,
   listUsers,
+  updateUser,
 } from './users';
-export type { CreateUserPayload, ListUsersParams, UserDto } from './users';
+export type {
+  CreateUserPayload,
+  ListUsersParams,
+  UpdateUserPayload,
+  UserDto,
+} from './users';
 export {
   assignPermissionToUser,
   DEFAULT_PERMISSIONS_INCLUDE_DELETED,

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -380,3 +380,102 @@ export async function createUser(
   }
   return data;
 }
+
+/**
+ * Body aceito pelo `PUT /users/{id}` no `lfc-authenticator`
+ * (`UsersController.UpdateUserRequest`).
+ *
+ * Issue #79 (EPIC #49) — segundo fluxo de mutação do recurso Users.
+ * Espelha o contrato exato do backend (`UsersController.cs` linha 59):
+ *
+ * - `name` (obrigatório, máx. 80 chars).
+ * - `email` (obrigatório, máx. 320 chars, formato válido) — único; o
+ *   backend normaliza para `lowercase` antes de gravar e valida unicidade
+ *   ignorando o próprio usuário (`EmailExistsNormalizedAsync(_, _, id)`).
+ * - `identity` (obrigatório, `int`).
+ * - `clientId` (opcional, UUID) — quando ausente, o backend mantém o
+ *   `ClientId` atual do usuário (`user.ClientId = request.ClientId ?? user.ClientId`).
+ *   Quando informado e o `Client` não existe, devolve `400 { message:
+ *   "ClientId informado não existe." }` (mensagem **fora** do
+ *   `ValidationProblemDetails`).
+ * - `active` (obrigatório, `bool`) — diferente do create (onde é
+ *   opcional com default `true`), no update o backend exige presença
+ *   explícita.
+ *
+ * **Diferença chave vs `CreateUserPayload`:** sem `password`. O reset de
+ * senha em update é endpoint separado (`PUT /users/{id}/password`,
+ * issue futura) — manter a payload do update sem `Password` previne
+ * regressões silenciosas (operador editando outros campos não muda
+ * senha por engano) e alinha 1:1 com o contrato do backend.
+ */
+export interface UpdateUserPayload {
+  name: string;
+  email: string;
+  identity: number;
+  clientId?: string;
+  active: boolean;
+}
+
+/**
+ * Constrói o body para `PUT /users/{id}` aplicando trim defensivo nos
+ * campos texto e omitindo `clientId` quando vazio depois de trim.
+ *
+ * Espelha `buildUserMutationBody` (create) na semântica de trim/omit, mas
+ * **sem `password`** (preservar simetria com `UpdateUserPayload`) e
+ * **sempre incluindo `active`** (que no update é `[Required]` no backend).
+ *
+ * Centralizar a montagem permite que futuros call sites (refresh
+ * pós-edição via mesmo wrapper, ou refactors) enviem exatamente o mesmo
+ * shape sem reabrir o módulo (lição PR #128).
+ */
+function buildUserUpdateBody(payload: UpdateUserPayload): UpdateUserPayload {
+  const body: UpdateUserPayload = {
+    name: payload.name.trim(),
+    email: payload.email.trim(),
+    identity: payload.identity,
+    active: payload.active,
+  };
+  const trimmedClientId = payload.clientId?.trim();
+  if (trimmedClientId && trimmedClientId.length > 0) {
+    body.clientId = trimmedClientId;
+  }
+  return body;
+}
+
+/**
+ * Atualiza um usuário existente via `PUT /users/{id}` (Issue #79).
+ *
+ * Retorna o `UserDto` atualizado (`200 OK` com `UserResponse` no corpo).
+ * Lança `ApiError` em qualquer falha — caller tipicamente trata:
+ *
+ * - 409 → conflito de email (`"Já existe outro usuário com este Email."`).
+ * - 400 → validação de campo (`ValidationProblemDetails` com chaves
+ *   `Name`/`Email`/`Identity`) **ou** `{ message: "ClientId informado
+ *   não existe." }` quando o `clientId` referenciado não existe na base.
+ *   Os dois casos chegam como `ApiError` com `status: 400`; o segundo
+ *   não tem `details.errors` mapeáveis, então cai no fallback do
+ *   `applyBadRequest` (Alert no topo do form).
+ * - 404 → usuário não encontrado (soft-deletado concorrentemente entre
+ *   abertura e submit). UI fecha o modal, dispara toast e força refetch.
+ * - 401/403 → toast vermelho (gating de permissão).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ *
+ * O response é validado contra `isUserDto` para detectar drift de
+ * contrato precocemente — backend retornando shape inesperado dispara
+ * `ApiError(parse)` em vez de propagar shape inválido para a UI.
+ */
+export async function updateUser(
+  id: string,
+  payload: UpdateUserPayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserDto> {
+  const body = buildUserUpdateBody(payload);
+  const data = await client.put<unknown>(`/users/${id}`, body, options);
+  if (!isUserDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}

--- a/tests/pages/UsersPage.edit.test.tsx
+++ b/tests/pages/UsersPage.edit.test.tsx
@@ -1,0 +1,460 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  buildSharedUserSubmitErrorCases,
+  buildUsersCloseCases,
+  createUsersClientStub,
+  fillEditUserForm,
+  ID_CLIENT_ALPHA,
+  ID_USER_ALICE,
+  makeUser,
+  makeUsersPagedResponse,
+  openEditUserModal,
+  renderUsersPage,
+  submitEditUserForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+  type UsersErrorCase,
+} from './__helpers__/usersTestHelpers';
+
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Suíte da `UsersListShellPage` — caminho de edição (Issue #79, EPIC #49).
+ *
+ * Espelha a estratégia de `RolesPage.edit.test.tsx`/
+ * `SystemsPage.edit.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory para que `vi.mock` capture o valor atual a cada
+ *   `useAuth()`).
+ * - Stub de `ApiClient` injetado em `<UsersListShellPage client={stub} />`
+ *   isolando a página da camada de transporte real.
+ * - Helpers compartilhados em `usersTestHelpers.tsx` para colapsar o
+ *   boilerplate "abrir modal → preencher → submeter" e evitar
+ *   `New Code Duplication` no Sonar (lição PR #134/#135).
+ *
+ * Diferenças relativas à suíte de edição de Roles:
+ *
+ * - O modal de user não exibe campo de senha (reset é endpoint
+ *   separado, fora do escopo desta issue).
+ * - 409 cita "outro usuário com este e-mail" (unicidade `Email`
+ *   global no backend; `UX_Users_Email`).
+ * - 404 fecha o modal e dispara refetch (usuário soft-deletado
+ *   concorrentemente entre abertura e submit).
+ * - 400 com `{ message: "ClientId informado não existe." }` simples
+ *   (sem `details.errors`) cai no Alert do topo via `applyBadRequest`,
+ *   mesmo padrão do create.
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const USERS_UPDATE_PERMISSION = 'AUTH_V1_USERS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('UsersListShellPage — edição (Issue #79)', () => {
+  describe('gating do botão "Editar" por linha', () => {
+    it('não exibe botões "Editar" quando o usuário não possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`users-edit-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Editar" para linhas ativas quando o usuário possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`users-edit-${ID_USER_ALICE}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute('aria-label', 'Editar usuário Alice Admin');
+    });
+
+    it('não exibe botão "Editar" em linhas soft-deletadas mesmo com permissão', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const deletedUser = makeUser({ deletedAt: '2026-02-01T00:00:00Z' });
+      const client = createUsersClientStub();
+      // Liga o toggle "Mostrar inativas" para a linha aparecer; o
+      // gating é por `row.deletedAt`, não pela visibilidade da
+      // listagem. Backend devolve a mesma página nas duas requests.
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([deletedUser]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+      fireEvent.click(screen.getByTestId('users-include-deleted'));
+      await waitFor(() => {
+        expect(screen.queryByTestId('users-loading')).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByTestId(`users-edit-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('abertura e pré-preenchimento do modal', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('clicar em "Editar" abre o diálogo pré-populado com os dados do usuário', async () => {
+      const user = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 7,
+        clientId: ID_CLIENT_ALPHA,
+        active: true,
+      });
+      const client = createUsersClientStub();
+      await openEditUserModal(client, { user });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-user-name')).toHaveValue('Alice Admin');
+      expect(screen.getByTestId('edit-user-email')).toHaveValue('alice@example.com');
+      expect(screen.getByTestId('edit-user-identity')).toHaveValue(7);
+      expect(screen.getByTestId('edit-user-client-id')).toHaveValue(ID_CLIENT_ALPHA);
+      expect(
+        (screen.getByTestId('edit-user-active') as HTMLInputElement).checked,
+      ).toBe(true);
+    });
+
+    it('aceita usuário sem clientId (clientId=null vira string vazia)', async () => {
+      const user = makeUser({ clientId: null });
+      const client = createUsersClientStub();
+      await openEditUserModal(client, { user });
+
+      expect(screen.getByTestId('edit-user-client-id')).toHaveValue('');
+    });
+
+    it('campo de senha não é renderizado no modal de edição', async () => {
+      const client = createUsersClientStub();
+      await openEditUserModal(client);
+
+      // O campo `password` é exclusivo do `NewUserModal` (Issue #78).
+      // Edição não permite alterar senha — endpoint separado
+      // (`PUT /users/{id}/password`, sub-issue futura).
+      expect(screen.queryByTestId('edit-user-password')).not.toBeInTheDocument();
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — colapsados em `it.each`
+     * via `buildUsersCloseCases` para evitar BLOCKER de duplicação
+     * Sonar (lição PR #123/#127).
+     */
+    const CLOSE_CASES = buildUsersCloseCases('edit-user-cancel');
+
+    it.each(CLOSE_CASES)(
+      'fechar via $name não dispara PUT',
+      async ({ close }) => {
+        const client = createUsersClientStub();
+        await openEditUserModal(client);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(client.put).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('validação client-side', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('apagar campos obrigatórios mostra erros inline e não chama PUT', async () => {
+      const client = createUsersClientStub();
+      await openEditUserModal(client);
+
+      fillEditUserForm({ name: '', email: '', identity: '' });
+      fireEvent.submit(screen.getByTestId('edit-user-form'));
+
+      expect(screen.getByText('Nome é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('E-mail é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('Identity é obrigatório.')).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it('email inválido bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openEditUserModal(client);
+
+      fillEditUserForm({ email: 'no-at' });
+      fireEvent.submit(screen.getByTestId('edit-user-form'));
+
+      expect(screen.getByText('Informe um e-mail válido.')).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it('identity não-inteiro bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openEditUserModal(client);
+
+      fillEditUserForm({ identity: '1.5' });
+      fireEvent.submit(screen.getByTestId('edit-user-form'));
+
+      expect(
+        screen.getByText('Identity deve ser um número inteiro.'),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it('clientId não-UUID bloqueia submit com mensagem inline', async () => {
+      const client = createUsersClientStub();
+      await openEditUserModal(client);
+
+      fillEditUserForm({ clientId: 'abc' });
+      fireEvent.submit(screen.getByTestId('edit-user-form'));
+
+      expect(
+        screen.getByText('ClientId deve ser um UUID válido.'),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submissão bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('envia PUT /users/{id} com body trimado, fecha modal, exibe toast e refaz listUsers', async () => {
+      const original = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 1,
+        clientId: ID_CLIENT_ALPHA,
+        active: true,
+      });
+      const updated = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin v2',
+        email: 'alice2@example.com',
+        identity: 2,
+        clientId: ID_CLIENT_ALPHA,
+        active: false,
+      });
+      const client = createUsersClientStub();
+      let usersGetCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          usersGetCalls += 1;
+          if (usersGetCalls === 1) {
+            return Promise.resolve(makeUsersPagedResponse([original]));
+          }
+          return Promise.resolve(makeUsersPagedResponse([updated]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected: ${path}`));
+      });
+      client.put.mockResolvedValueOnce(updated);
+
+      await openEditUserModal(client, { user: original });
+
+      fillEditUserForm({
+        name: '  Alice Admin v2  ',
+        email: '  alice2@example.com  ',
+        identity: '2',
+        active: false,
+      });
+      await submitEditUserForm(client);
+
+      expect(client.put).toHaveBeenCalledWith(
+        `/users/${ID_USER_ALICE}`,
+        {
+          name: 'Alice Admin v2',
+          email: 'alice2@example.com',
+          identity: 2,
+          active: false,
+          clientId: ID_CLIENT_ALPHA,
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Usuário atualizado.".
+      expect(await screen.findByText('Usuário atualizado.')).toBeInTheDocument();
+
+      // Refetch da lista — ao menos 2 chamadas a `/users`.
+      await waitFor(() => {
+        expect(usersGetCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('envia body sem clientId quando o usuário apaga o conteúdo', async () => {
+      const original = makeUser({ id: ID_USER_ALICE, clientId: ID_CLIENT_ALPHA });
+      const client = createUsersClientStub();
+      client.put.mockResolvedValueOnce(makeUser({ ...original, clientId: null }));
+
+      await openEditUserModal(client, { user: original });
+
+      fillEditUserForm({ clientId: '' });
+      await submitEditUserForm(client);
+
+      const [, body] = client.put.mock.calls[0];
+      expect(body).not.toHaveProperty('clientId');
+      expect(body).toMatchObject({
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 1,
+        active: true,
+      });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127) — testes
+     * com a mesma estrutura mudando 1-2 mocks viram tabela. Casos
+     * específicos do edit: 409 com mensagem citando "outro usuário"
+     * + 404 (usuário removido concorrentemente). Os 3 cenários
+     * comuns (401, 403, network) vêm de
+     * `buildSharedUserSubmitErrorCases('atualizar')`.
+     */
+    const ERROR_CASES: ReadonlyArray<UsersErrorCase> = [
+      {
+        name: '409 (e-mail duplicado) exibe mensagem inline no campo email',
+        error: {
+          kind: 'http',
+          status: 409,
+          message: 'Já existe outro usuário com este Email.',
+        },
+        expectedText: 'Já existe outro usuário com este e-mail.',
+      },
+      {
+        name: '400 com errors mapeia mensagens para os campos correspondentes',
+        error: {
+          kind: 'http',
+          status: 400,
+          message: 'Erro de validação.',
+          details: {
+            errors: {
+              Email: ['Email inválido (backend).'],
+              Identity: ['The Identity field is required.'],
+            },
+          },
+        },
+        expectedText: 'Email inválido (backend).',
+      },
+      {
+        name: '400 sem errors (caso ClientId inexistente) mostra Alert no topo',
+        error: {
+          kind: 'http',
+          status: 400,
+          message: 'ClientId informado não existe.',
+        },
+        expectedText: 'ClientId informado não existe.',
+      },
+      ...buildSharedUserSubmitErrorCases('atualizar'),
+      {
+        name: '404 (usuário removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Usuário não encontrado.',
+        },
+        expectedText: 'Usuário não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createUsersClientStub();
+        client.put.mockRejectedValueOnce(error);
+
+        await openEditUserModal(client);
+        await submitEditUserForm(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onUpdated chamado mesmo em erro)', async () => {
+      const client = createUsersClientStub();
+      let usersGetCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          usersGetCalls += 1;
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+      client.put.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Usuário não encontrado.',
+      } satisfies ApiError);
+
+      await openEditUserModal(client);
+      await submitEditUserForm(client);
+
+      await waitFor(() => {
+        expect(usersGetCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+});

--- a/tests/pages/__helpers__/usersTestHelpers.tsx
+++ b/tests/pages/__helpers__/usersTestHelpers.tsx
@@ -237,9 +237,9 @@ export async function submitNewUserForm(
 
 /**
  * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)`
- * da suíte de criação. Cada caso descreve o `ApiError` retornado pelo
- * backend e o texto que deve aparecer em algum lugar visível do UI
- * após o submit.
+ * da suíte de criação ou edição. Cada caso descreve o `ApiError`
+ * retornado pelo backend e o texto que deve aparecer em algum lugar
+ * visível do UI após o submit.
  */
 export interface UsersErrorCase {
   /** Descrição usada como `it.each($name)`. */
@@ -248,6 +248,8 @@ export interface UsersErrorCase {
   error: ApiError;
   /** Texto visível no UI após o submit (string vira regex case-insensitive). */
   expectedText: RegExp | string;
+  /** Default `true` — quando `false`, o modal fecha após o erro (ex.: 404 no edit). */
+  modalStaysOpen?: boolean;
 }
 
 /**
@@ -261,4 +263,187 @@ export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
     return text;
   }
   return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), 'i');
+}
+
+/* ─── Helpers para suíte de edição (Issue #79) ──────────────── */
+
+/**
+ * Mocka a resposta inicial (listagem com o usuário-alvo), renderiza a
+ * `UsersListShellPage`, espera a lista carregar e clica no botão
+ * "Editar" da linha do usuário informado. Aguarda a presença do form
+ * do modal (`edit-user-form`) para garantir que o efeito de
+ * sincronização já populou os campos.
+ *
+ * Espelha `openEditRoleModal`/`openEditModal` (sistemas) — pré-
+ * fabricado para evitar duplicação entre as suítes de edição
+ * (lição PR #128). Quem precisar de mocks diferentes pode chamar
+ * `client.get.mockImplementation(...)` antes de invocar este helper
+ * — a detecção de mocks pré-existentes preserva o caso "fila
+ * customizada de respostas" (ex.: cenários de erro 404 com refetch).
+ */
+export async function openEditUserModal(
+  client: ApiClientStub,
+  options: { user?: UserDto } = {},
+): Promise<void> {
+  const user = options.user ?? makeUser();
+  if (
+    client.get.getMockImplementation() === undefined &&
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.resolve(makeUsersPagedResponse([user]));
+      }
+      if (typeof path === 'string' && path.startsWith('/clients/')) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    });
+  }
+  renderUsersPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`users-edit-${user.id}`));
+  // Garante que o efeito do modal terminou — a presença do form
+  // indica que o `useEffect` de sincronização já rodou.
+  await waitFor(() => {
+    expect(screen.getByTestId('edit-user-form')).toBeInTheDocument();
+  });
+}
+
+/**
+ * Preenche os campos do form do `EditUserModal`. Cada chave é
+ * opcional — testes que validam só `name` e `email` deixam os demais
+ * ausentes. Os valores são entregues diretamente ao `fireEvent.change`;
+ * trim é responsabilidade do componente (`updateUser`/
+ * `validateUserUpdateForm`).
+ *
+ * **Sem `password`** — o modal de edição esconde o campo via
+ * `hidePassword`; reset de senha é endpoint separado.
+ *
+ * `active` usa `fireEvent.click` no Switch (não `fireEvent.change`)
+ * porque o `<Switch>` interno é um `<input type="checkbox">`.
+ */
+export function fillEditUserForm(values: {
+  name?: string;
+  email?: string;
+  identity?: string;
+  clientId?: string;
+  active?: boolean;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-user-name'), {
+      target: { value: values.name },
+    });
+  }
+  if (values.email !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-user-email'), {
+      target: { value: values.email },
+    });
+  }
+  if (values.identity !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-user-identity'), {
+      target: { value: values.identity },
+    });
+  }
+  if (values.clientId !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-user-client-id'), {
+      target: { value: values.clientId },
+    });
+  }
+  if (values.active !== undefined) {
+    const switchEl = screen.getByTestId('edit-user-active') as HTMLInputElement;
+    if (switchEl.checked !== values.active) {
+      fireEvent.click(switchEl);
+    }
+  }
+}
+
+/**
+ * Submete o form do `EditUserModal` e aguarda o `client.put` ser
+ * chamado pelo menos `expectedPutCalls` vezes (default `1`).
+ * Espelha `submitEditRoleForm`/`submitEditSystemForm` — `act` +
+ * `waitFor` para flushar a microtask do submit antes do assert.
+ */
+export async function submitEditUserForm(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('edit-user-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
+}
+
+/**
+ * Constrói os 3 cenários de fechamento sem persistência (Esc,
+ * Cancelar, backdrop) usando o `cancelTestId` da suíte chamadora.
+ * Espelha `buildRolesCloseCases`/`buildCloseCases` — pré-fabricado
+ * para que as suítes de criação e edição reusem a mesma fila de
+ * `it.each` sem duplicação (lição PR #127/#128).
+ */
+export interface UsersModalCloseCase {
+  name: string;
+  close: () => void;
+}
+
+export function buildUsersCloseCases(
+  cancelTestId: string,
+): ReadonlyArray<UsersModalCloseCase> {
+  return [
+    {
+      name: 'Esc',
+      // eslint-disable-next-line no-restricted-globals
+      close: () => fireEvent.keyDown(window, { key: 'Escape' }),
+    },
+    {
+      name: 'botão Cancelar',
+      close: () => fireEvent.click(screen.getByTestId(cancelTestId)),
+    },
+    {
+      name: 'clique no backdrop',
+      close: () => fireEvent.mouseDown(screen.getByTestId('modal-backdrop')),
+    },
+  ];
+}
+
+/**
+ * Constrói os cenários de erro 401/403/network compartilhados entre
+ * as suítes de criação (#78) e edição (#79). Diferem **apenas** no
+ * verbo (`criar` vs `atualizar`) — copy genérica do toast vermelho
+ * vinda de `SUBMIT_ERROR_COPY.genericFallback` em cada modal.
+ *
+ * Pré-fabricar antes do segundo call site previne a recorrência de
+ * `New Code Duplication` no Sonar (lição PR #128 — projetar shared
+ * helpers desde o primeiro PR do recurso).
+ */
+export function buildSharedUserSubmitErrorCases(
+  verb: 'criar' | 'atualizar',
+): ReadonlyArray<UsersErrorCase> {
+  return [
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      },
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      },
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: { kind: 'network', message: 'Falha de conexão.' },
+      expectedText: `Não foi possível ${verb} o usuário. Tente novamente.`,
+    },
+  ];
 }

--- a/tests/pages/users/userFormShared.test.ts
+++ b/tests/pages/users/userFormShared.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import type { ApiError } from '@/shared/api';
 
 import {
+  buildCreateUserPayload,
+  buildUpdateUserPayload,
   classifyUserSubmitError,
   decideUserBadRequestHandling,
   EMAIL_MAX,
@@ -12,6 +14,7 @@ import {
   PASSWORD_MAX,
   PASSWORD_MIN,
   validateUserForm,
+  validateUserUpdateForm,
   type UserFormState,
   type UserSubmitErrorCopy,
 } from '@/pages/users/userFormShared';
@@ -351,5 +354,96 @@ describe('classifyUserSubmitError', () => {
       title: COPY.forbiddenTitle,
       fallback: COPY.genericFallback,
     });
+  });
+});
+
+describe('validateUserUpdateForm', () => {
+  it('retorna null para estado válido (sem exigir senha)', () => {
+    // Edição não exige senha — `password: ''` é aceito.
+    expect(
+      validateUserUpdateForm({ ...VALID_STATE, password: '' }),
+    ).toBeNull();
+  });
+
+  it('aplica as mesmas regras de name/email/identity/clientId que validateUserForm', () => {
+    const errors = validateUserUpdateForm({
+      ...VALID_STATE,
+      name: '',
+      email: 'no-at',
+      identity: '1.5',
+      clientId: 'abc',
+      password: '', // ignorado em update
+    });
+
+    expect(errors).toEqual({
+      name: 'Nome é obrigatório.',
+      email: 'Informe um e-mail válido.',
+      identity: 'Identity deve ser um número inteiro.',
+      clientId: 'ClientId deve ser um UUID válido.',
+    });
+  });
+
+  it('não popula erro de password mesmo com password vazia', () => {
+    const errors = validateUserUpdateForm({ ...VALID_STATE, password: '' });
+    expect(errors).toBeNull();
+  });
+});
+
+describe('buildCreateUserPayload', () => {
+  it('produz CreateUserPayload com campos trimados, identity como int e active explícito', () => {
+    expect(
+      buildCreateUserPayload({
+        ...VALID_STATE,
+        name: '  Alice  ',
+        email: '  alice@example.com  ',
+        identity: '  42  ',
+        clientId: '',
+      }),
+    ).toEqual({
+      name: 'Alice',
+      email: 'alice@example.com',
+      password: VALID_STATE.password,
+      identity: 42,
+      active: true,
+    });
+  });
+
+  it('inclui clientId quando informado e omite quando vazio', () => {
+    const validClientId = '11111111-1111-1111-1111-111111111111';
+    expect(
+      buildCreateUserPayload({ ...VALID_STATE, clientId: validClientId }),
+    ).toMatchObject({ clientId: validClientId });
+
+    const withoutClient = buildCreateUserPayload({ ...VALID_STATE, clientId: '' });
+    expect(withoutClient).not.toHaveProperty('clientId');
+  });
+});
+
+describe('buildUpdateUserPayload', () => {
+  it('produz UpdateUserPayload sem password, com active sempre presente', () => {
+    expect(
+      buildUpdateUserPayload({
+        ...VALID_STATE,
+        name: '  Alice v2  ',
+        email: '  alice2@example.com  ',
+        identity: '  7  ',
+        active: false,
+      }),
+    ).toEqual({
+      name: 'Alice v2',
+      email: 'alice2@example.com',
+      identity: 7,
+      active: false,
+    });
+  });
+
+  it('inclui clientId trimado quando informado e omite quando vazio', () => {
+    const validClientId = '22222222-2222-2222-2222-222222222222';
+    expect(
+      buildUpdateUserPayload({ ...VALID_STATE, clientId: '  ' + validClientId + '  ' }),
+    ).toMatchObject({ clientId: validClientId });
+
+    const withoutClient = buildUpdateUserPayload({ ...VALID_STATE, clientId: '' });
+    expect(withoutClient).not.toHaveProperty('clientId');
   });
 });

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ApiClient, CreateUserPayload, UserDto } from '@/shared/api';
+import type {
+  ApiClient,
+  CreateUserPayload,
+  UpdateUserPayload,
+  UserDto,
+} from '@/shared/api';
 
 import {
   createUser,
@@ -8,6 +13,7 @@ import {
   isPagedUsersResponse,
   isUserDto,
   listUsers,
+  updateUser,
 } from '@/shared/api';
 
 /**
@@ -603,6 +609,228 @@ describe('createUser — response e erros', () => {
 
     await expect(
       createUser(buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
+  });
+});
+
+/**
+ * Suíte do `updateUser` (Issue #79). Cobre serialização do body
+ * (trim/omit defensivo, sem `password`, com `active` obrigatório),
+ * validação do response via `isUserDto` e propagação de erros
+ * tipados (`ApiError`).
+ *
+ * Espelha o padrão de `updateRole`/`updateSystem` — validar o
+ * caminho HTTP unitariamente sem precisar de fetch real.
+ */
+describe('updateUser — body', () => {
+  function buildBasicPayload(
+    overrides: Partial<UpdateUserPayload> = {},
+  ): UpdateUserPayload {
+    return {
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      identity: 1,
+      active: true,
+      ...overrides,
+    };
+  }
+
+  it('emite PUT /users/{id} com body trimado nos campos texto', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload({
+        name: '  Alice Admin  ',
+        email: '  alice@example.com  ',
+      }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    expect(client.put.mock.calls[0][0]).toBe(`/users/${USER_ID}`);
+    expect(client.put.mock.calls[0][1]).toEqual({
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      identity: 1,
+      active: true,
+    });
+  });
+
+  it('omite clientId quando vazio (string vazia ou só espaços)', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload({ clientId: '   ' }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const body = client.put.mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('clientId');
+  });
+
+  it('inclui clientId quando informado e trima', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload({ clientId: '  ' + CLIENT_ID + '  ' }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put.mock.calls[0][1]).toMatchObject({ clientId: CLIENT_ID });
+  });
+
+  it('inclui active explicitamente (true ou false)', async () => {
+    const client = createStub();
+    client.put.mockResolvedValue(makeUserDto());
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload({ active: true }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.put.mock.calls[0][1]).toMatchObject({ active: true });
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload({ active: false }),
+      undefined,
+      client as unknown as ApiClient,
+    );
+    expect(client.put.mock.calls[1][1]).toMatchObject({ active: false });
+  });
+
+  it('nunca inclui password no body do update', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await updateUser(
+      USER_ID,
+      buildBasicPayload(),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const body = client.put.mock.calls[0][1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('password');
+  });
+});
+
+describe('updateUser — response e erros', () => {
+  function buildBasicPayload(): UpdateUserPayload {
+    return {
+      name: 'Alice Admin',
+      email: 'alice@example.com',
+      identity: 1,
+      active: true,
+    };
+  }
+
+  it('devolve UserDto atualizado quando o response é válido', async () => {
+    const client = createStub();
+    const updated = makeUserDto({ name: 'Alice v2' });
+    client.put.mockResolvedValueOnce(updated);
+
+    const result = await updateUser(
+      USER_ID,
+      buildBasicPayload(),
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(updated);
+  });
+
+  it('lança ApiError(parse) quando o response não é UserDto', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 409 do backend (email duplicado) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 409,
+      message: 'Já existe outro usuário com este Email.',
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 404 do backend (usuário removido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Usuário não encontrado.',
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 400 com errors (validação de campo) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'Erro de validação.',
+      details: {
+        errors: {
+          Email: ['Email inválido.'],
+          Identity: ['The Identity field is required.'],
+        },
+      },
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 400 sem errors (caso ClientId inexistente) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'ClientId informado não existe.',
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
     ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
 });


### PR DESCRIPTION
## Contexto

Parte da EPIC #49 (CRUD de Usuários). Backend já entregou o
contrato necessário em `lfc-authenticator#167` (`PUT /users/{id}`
+ `GET /users/{id}` retornando `UserResponse` completo).

## Objetivo

Implementar o fluxo de edição de usuário no `lfc-admin-gui`,
espelhando os padrões já consolidados em `EditRoleModal` (#152) e
`EditSystemModal` (#59).

## O que foi feito

- **API:** `updateUser(id, payload, options?, client?)` em
  `src/shared/api/users.ts` (`PUT /users/{id}`). Payload
  `UpdateUserPayload` (sem `password` — reset é endpoint separado;
  com `active` obrigatório, espelhando `[Required]` do backend).
- **Form:** `EditUserModal` em `src/pages/users/`, pré-populando
  `Name`/`Email`/`Identity`/`ClientId`/`Active` da `UserDto`.
  Campo "Senha" não é renderizado em edit (`hidePassword` no
  `UserFormBody`).
- **Hook compartilhado:** `useUserForm` ganhou `prepareUpdateSubmit`
  (sem senha) ao lado do `prepareSubmit` (com senha) — ambos os
  modals dividem 100% do estado/handlers/parsing sem duplicação.
- **Wire-up:** coluna "Ações" + botão "Editar" por linha em
  `UsersListShellPage` (gating por `AUTH_V1_USERS_UPDATE`,
  escondido em linhas soft-deletadas). Refetch após sucesso ou 404.
- **Erros mapeados:**
  - 409 → mensagem inline no campo `email` ("Já existe outro usuário
    com este e-mail.").
  - 400 com `details.errors` → erros inline por campo via
    `applyBadRequest`.
  - 400 com `{ message }` simples (caso `ClientId informado não
    existe.`) → Alert no topo do form.
  - 404 → toast vermelho + `onUpdated` (refetch) + `onClose`.
  - 401/403 → toast vermelho com mensagem do backend.
  - Outros → toast genérico (`Não foi possível atualizar o usuário.`).

## Anti-Sonar (lição PR #134/#135 reforçada)

Para evitar a 6ª recorrência de `New Code Duplication`, três
helpers extraídos **antes** do push:

- **`useListModalState<T>`** + **`useToggleModalState`** em
  `src/hooks/useListModalState.ts` — colapsam o trio
  `[selecionado, abrir, fechar]` que aparece em toda
  `*ListShellPage`/`*Page` do admin-gui (lição "call-site também
  precisa ficar deduplicado").
- **`useUserFormFieldProps`** em `src/pages/users/useUserForm.ts`
  — encapsula o objeto de 13 props compartilhadas pelo
  `<UserFormBody>` entre `NewUserModal` e `EditUserModal`.
- **`buildCreateUserPayload`/`buildUpdateUserPayload`** em
  `userFormShared.ts` — separados do hook para serem testáveis
  unitariamente.
- **`buildUsersCloseCases`/`buildSharedUserSubmitErrorCases`** em
  `tests/pages/__helpers__/usersTestHelpers.tsx` — pré-fabricados
  para que a suíte de edição reuse os 3 cenários (Esc/Cancelar/
  backdrop) e os 3 cenários (401/403/network) sem duplicar.

JSCPD local: 2.38% global, **0 clones novos** em arquivos do diff
(comparado contra baseline `origin/development`).

## Arquivos impactados

- `src/shared/api/users.ts` — `UpdateUserPayload`,
  `buildUserUpdateBody`, `updateUser`.
- `src/shared/api/index.ts` — re-export.
- `src/pages/users/userFormShared.ts` — `applySharedUserFieldRules`,
  `validateUserUpdateForm`, `buildCreateUserPayload`,
  `buildUpdateUserPayload`.
- `src/pages/users/useUserForm.ts` — `prepareUpdateSubmit`,
  `useUserFormFieldProps`.
- `src/pages/users/UserFormFields.tsx` — prop `hidePassword`.
- `src/pages/users/EditUserModal.tsx` — **novo**.
- `src/pages/users/NewUserModal.tsx` — usa `useUserFormFieldProps`.
- `src/pages/users/UsersListShellPage.tsx` — coluna "Ações" + wire
  do `EditUserModal` + adoção dos hooks compartilhados.
- `src/pages/users/index.ts` — export do `EditUserModal`.
- `src/hooks/useListModalState.ts` — **novo**.
- `tests/pages/UsersPage.edit.test.tsx` — **novo** (gating,
  pré-população, validação, sucesso, 409, 400/`details.errors`,
  400/`message`, 401, 403, network, 404).
- `tests/pages/__helpers__/usersTestHelpers.tsx` — helpers de
  edição + `buildSharedUserSubmitErrorCases`/`buildUsersCloseCases`.
- `tests/pages/users/userFormShared.test.ts` — cobertura
  `validateUserUpdateForm`/`buildCreateUserPayload`/
  `buildUpdateUserPayload`.
- `tests/shared/api/users.test.ts` — cobertura `updateUser`.

## Testes

```text
=== LINT ===
> eslint "{src,tests}/**/*.{ts,tsx,js,jsx}" --max-warnings 0
(passou — 0 errors, 0 warnings)

=== TYPECHECK ===
> tsc --noEmit
(passou)

=== TEST ===
Test Files  59 passed (59)
     Tests  945 passed (945)

=== JSCPD ===
Total:  213 files / 32589 lines / 25 clones / 774 duplicated lines (2.38%)
newClones unique pairs: 0
```

## Visual

- Botão "Editar" usa `<Button variant="ghost">` (já alinhado ao
  design system, com `:focus-visible` herdado).
- Modal usa `<Modal>` + `<UserFormBody>` (mesma altura/padding/gap
  dos demais modals do admin-gui).
- Coluna "Ações" desktop + bloco mobile (`<EntityCard>` +
  `<RowActions>`) cobertos.
- Estados visuais: loading (botão `loading` no submit), error inline
  por campo + Alert no topo, 404 dispara toast + close.
- Sem hardcode de cor — todos via `var(--token)` do design system.

## Segurança

- Nenhum impacto de segurança frontend novo. Não há
  `dangerouslySetInnerHTML`, não loga payloads em console, e a UI
  apenas espelha o gating do backend (`Users.Update`).

## Riscos

- **Coluna "Ações" mobile**: o card mobile herda o gating por
  `row.deletedAt === null` — se o backend mudar a semântica de
  soft-delete, o gating precisa ser revisitado. Coberto por teste
  declarativo (linha soft-deletada não exibe botão mesmo com
  permissão).
- **Sincronização do form com `user`**: quando o pai troca a `user`
  selecionada com modal aberto, o `useEffect` de sincronização
  reseta o form. Cenário coberto pela suíte de pré-população.

## Issue relacionada

Closes #79