### PR TITLE
feat(clients): criar cliente PF/PJ (#74)

### DIFF
--- a/src/hooks/useModalOpenState.ts
+++ b/src/hooks/useModalOpenState.ts
@@ -1,0 +1,58 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Estado boolean controlado de visibilidade de um modal + os
+ * handlers `open`/`close` correspondentes. Espelha o padrão usado
+ * pelas páginas de listagem (`SystemsPage`, `RoutesPage`, `RolesPage`,
+ * `UsersListShellPage`, `ClientsListShellPage`) para gerenciar a
+ * abertura do modal "Novo X" disparado pela toolbar.
+ *
+ * **Por que existe (lição PR #134/#135):** o trio
+ *
+ * ```tsx
+ * const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
+ * const handleOpenCreateModal = useCallback(() => {
+ *   setIsCreateModalOpen(true);
+ * }, []);
+ * const handleCloseCreateModal = useCallback(() => {
+ *   setIsCreateModalOpen(false);
+ * }, []);
+ * ```
+ *
+ * é literalmente idêntico entre `UsersListShellPage` (PR #155 — #78)
+ * e `ClientsListShellPage` (PR #74) — jscpd detectou ~18 linhas
+ * duplicadas. Centralizar aqui:
+ *
+ * - Reduz cada página a 1 linha (`const { isOpen, open, close } =
+ *   useModalOpenState();`).
+ * - Garante simetria de comportamento entre as páginas.
+ * - Concentra evolução futura (ex.: telemetria de abertura, focus
+ *   trap, etc.) em um único lugar.
+ *
+ * O hook é genérico (não acoplado a "Create" ou "Edit") — pode ser
+ * reusado por qualquer modal cuja abertura seja controlada pela
+ * página pai. Mantemos os identificadores neutros (`open`/`close`)
+ * para preservar leitura natural no callsite.
+ */
+export interface UseModalOpenStateReturn {
+  /** Flag de visibilidade — passe direto para `<Modal open={...}>`. */
+  isOpen: boolean;
+  /** Abre o modal. Memoizado — referência estável entre renders. */
+  open: () => void;
+  /** Fecha o modal. Memoizado — referência estável entre renders. */
+  close: () => void;
+}
+
+export function useModalOpenState(initialOpen = false): UseModalOpenStateReturn {
+  const [isOpen, setIsOpen] = useState<boolean>(initialOpen);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return { isOpen, open, close };
+}

--- a/src/pages/SystemsPage.tsx
+++ b/src/pages/SystemsPage.tsx
@@ -20,12 +20,9 @@ import {
 } from '../shared/api';
 import { useAuth } from '../shared/auth';
 import {
-  ErrorRetryBlock,
-  InitialLoadingSpinner,
+  ListingResultArea,
   ListingToolbar,
   LiveRegion,
-  PaginationFooter,
-  RefetchOverlay,
   StatusBadge,
   useListingLiveMessage,
 } from '../shared/listing';
@@ -116,23 +113,13 @@ interface SystemsPageProps {
 // consome `<ListingToolbar>` do mesmo módulo, eliminando duplicação
 // Sonar/jscpd entre listagens (lição PR #134/#135).
 
-const TableShell = styled.div`
-  position: relative;
-`;
-
-/**
- * Overlay leve aplicado em cima da tabela durante refetches subsequentes
- * (busca/paginação/toggle). Mantém os dados anteriores visíveis para
- * evitar flicker enquanto sinaliza atividade — o spinner ancorado ao
- * topo deixa claro que algo está em curso sem mover a tabela.
- */
-// `TableOverlay`, `InitialLoading`, `ErrorBlock`, `FootBar`,
-// `PageInfo`, `PageNav` foram movidos para `src/shared/listing/`
-// (Issue #66) — o JSX da página agora consome `<RefetchOverlay>`,
-// `<InitialLoadingSpinner>`, `<ErrorRetryBlock>` e
-// `<PaginationFooter>` do mesmo módulo
-// para eliminar duplicação Sonar/jscpd entre SystemsPage/RoutesPage/
-// RolesPage (lição PR #134/#135).
+// `TableShell`, `RefetchOverlay`, `InitialLoadingSpinner`,
+// `ErrorRetryBlock`, `PaginationFooter` foram encapsulados em
+// `<ListingResultArea>` (Issue #74 — lição PR #134/#135 reforçada,
+// jscpd detectou bloco de 62 linhas idêntico entre SystemsPage e
+// ClientsListShellPage). O shell genérico agora cuida da árvore
+// loading → error → tabela+overlay → paginação por trás de uma
+// API uniforme; cada página só passa `testIdPrefix` + handlers.
 
 const EmptyMessage = styled.div`
   display: flex;
@@ -477,8 +464,6 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
     handleOpenRestoreConfirm,
   ]);
 
-  const showOverlay = isFetching && !isInitialLoading;
-
   // ARIA-live: anuncia o estado da tabela quando muda. Em loading
   // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
   // o total. Em erro, o `<Alert role="alert">` já cobre. O hook
@@ -538,20 +523,14 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
 
       <LiveRegion message={liveMessage} testId="systems-live" />
 
-      {isInitialLoading && (
-        <InitialLoadingSpinner testId="systems-loading" label="Carregando sistemas" />
-      )}
-
-      {!isInitialLoading && errorMessage && (
-        <ErrorRetryBlock
-          message={errorMessage}
-          onRetry={handleRefetch}
-          retryTestId="systems-retry"
-        />
-      )}
-
-      {!isInitialLoading && !errorMessage && (
-        <TableShell>
+      <ListingResultArea
+        testIdPrefix="systems"
+        loadingLabel="Carregando sistemas"
+        isInitialLoading={isInitialLoading}
+        isFetching={isFetching}
+        errorMessage={errorMessage}
+        onRetry={handleRefetch}
+        tableContent={
           <Table<SystemDto>
             caption="Lista de sistemas cadastrados no auth-service."
             columns={columns}
@@ -559,24 +538,15 @@ export const SystemsPage: React.FC<SystemsPageProps> = ({ client, hideStats = fa
             getRowKey={(row) => row.id}
             emptyState={emptyContent}
           />
-          {showOverlay && <RefetchOverlay testId="systems-overlay" />}
-        </TableShell>
-      )}
-
-      {!isInitialLoading && !errorMessage && total > 0 && (
-        <PaginationFooter
-          page={page}
-          totalPages={totalPages}
-          total={total}
-          isFirstPage={isFirstPage}
-          isLastPage={isLastPage}
-          onPrev={handlePrevPage}
-          onNext={handleNextPage}
-          pageInfoTestId="systems-page-info"
-          prevTestId="systems-prev"
-          nextTestId="systems-next"
-        />
-      )}
+        }
+        total={total}
+        page={page}
+        totalPages={totalPages}
+        isFirstPage={isFirstPage}
+        isLastPage={isLastPage}
+        onPrev={handlePrevPage}
+        onNext={handleNextPage}
+      />
 
       {canCreateSystem && (
         <NewSystemModal

--- a/src/pages/clients/ClientFormFields.tsx
+++ b/src/pages/clients/ClientFormFields.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Alert, Input, Select } from '../../components/ui';
+import { FormFooter } from '../../shared/forms';
+
+import {
+  CORPORATE_NAME_MAX,
+  FULL_NAME_MAX,
+  type ClientFieldErrors,
+  type ClientFormState,
+} from './clientsFormShared';
+
+import type { ClientType } from '../../shared/api';
+
+/**
+ * Campos e form body do cliente (Issue #74 — criação; reusado pela
+ * Issue #75 — edição).
+ *
+ * **Por que existe (lição PR #128):** projetar `ClientFormFields`
+ * desde o primeiro PR do recurso evita duplicação Sonar quando o
+ * `EditClientModal` (#75) chegar — ambos modals consomem o mesmo
+ * `ClientFormBody` com prefixos de testId distintos.
+ *
+ * **Por que não usar `NameCodeDescriptionFormBody`:** o shape
+ * diverge totalmente (cliente tem `type`/`cpf`/`fullName`/`cnpj`/
+ * `corporateName`; sistemas/roles têm `name`/`code`/`description`).
+ * Forçar abstração conjunta exigiria parametrização excessiva,
+ * crescendo a superfície sem reduzir LOC efetivos. Mantemos
+ * `ClientFormFields` separado e o helper genérico focado no shape
+ * Name/Code/Description.
+ *
+ * **Form condicional PF/PJ:** o `<Select>` de tipo é o controlador
+ * — quando `type === 'PF'`, exibimos `cpf`/`fullName`; quando
+ * `'PJ'`, exibimos `cnpj`/`corporateName`. Os campos do tipo oposto
+ * são removidos do DOM (não apenas escondidos) para que o foco do
+ * teclado e o ARIA não navegue para campos invisíveis. O estado
+ * dos 4 campos persiste no `useClientForm` para que o usuário não
+ * perca o que digitou ao alternar (UX).
+ *
+ * **Edição (Issue #75 — antecipado):** quando o modal for de
+ * edição, o `<Select>` de tipo deve ficar `disabled` (o backend
+ * rejeita mudança de tipo após criação com 400 "Tipo do cliente
+ * não pode ser alterado após a criação."). Por isso aceitamos a
+ * prop `typeDisabled` desde já — `NewClientModal` passa `false`
+ * (default), `EditClientModal` passará `true`. Espelha o desenho
+ * `EditRoleModal` que tem `systemId` injetado e imutável no form.
+ */
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+const FormShell = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const FieldStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+/* ─── Componente: campos PF ─────────────────────────────── */
+
+interface PfFieldsProps {
+  idPrefix: string;
+  values: ClientFormState;
+  errors: ClientFieldErrors;
+  disabled: boolean;
+  onChangeCpf: (value: string) => void;
+  onChangeFullName: (value: string) => void;
+  /**
+   * Quando `true`, o campo `cpf` recebe `data-modal-initial-focus`
+   * para o `Modal` focar nele ao abrir. O `<Select>` de tipo já
+   * tem o foco inicial natural (primeiro campo focável), então o
+   * default é `false` aqui — só ativa se o caller decidir reposicionar.
+   */
+  autoFocusFirst?: boolean;
+}
+
+const PfFields: React.FC<PfFieldsProps> = ({
+  idPrefix,
+  values,
+  errors,
+  disabled,
+  onChangeCpf,
+  onChangeFullName,
+  autoFocusFirst = false,
+}) => (
+  <>
+    <Input
+      label="CPF"
+      placeholder="000.000.000-00"
+      value={values.cpf}
+      onChange={onChangeCpf}
+      error={errors.cpf}
+      autoComplete="off"
+      inputMode="numeric"
+      required
+      disabled={disabled}
+      data-testid={`${idPrefix}-cpf`}
+      {...(autoFocusFirst ? { 'data-modal-initial-focus': true } : {})}
+    />
+    <Input
+      label="Nome completo"
+      placeholder="ex.: Ana Cliente"
+      value={values.fullName}
+      onChange={onChangeFullName}
+      error={errors.fullName}
+      maxLength={FULL_NAME_MAX}
+      autoComplete="off"
+      required
+      disabled={disabled}
+      data-testid={`${idPrefix}-fullName`}
+    />
+  </>
+);
+
+/* ─── Componente: campos PJ ─────────────────────────────── */
+
+interface PjFieldsProps {
+  idPrefix: string;
+  values: ClientFormState;
+  errors: ClientFieldErrors;
+  disabled: boolean;
+  onChangeCnpj: (value: string) => void;
+  onChangeCorporateName: (value: string) => void;
+  autoFocusFirst?: boolean;
+}
+
+const PjFields: React.FC<PjFieldsProps> = ({
+  idPrefix,
+  values,
+  errors,
+  disabled,
+  onChangeCnpj,
+  onChangeCorporateName,
+  autoFocusFirst = false,
+}) => (
+  <>
+    <Input
+      label="CNPJ"
+      placeholder="00.000.000/0000-00"
+      value={values.cnpj}
+      onChange={onChangeCnpj}
+      error={errors.cnpj}
+      autoComplete="off"
+      inputMode="numeric"
+      required
+      disabled={disabled}
+      data-testid={`${idPrefix}-cnpj`}
+      {...(autoFocusFirst ? { 'data-modal-initial-focus': true } : {})}
+    />
+    <Input
+      label="Razão social"
+      placeholder="ex.: Acme Indústria S/A"
+      value={values.corporateName}
+      onChange={onChangeCorporateName}
+      error={errors.corporateName}
+      maxLength={CORPORATE_NAME_MAX}
+      autoComplete="off"
+      required
+      disabled={disabled}
+      data-testid={`${idPrefix}-corporateName`}
+    />
+  </>
+);
+
+/* ─── Componente: form body completo ────────────────────── */
+
+interface ClientFormBodyProps {
+  /** Prefixo dos `data-testid` do form e dos campos. */
+  idPrefix: string;
+  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
+  submitError: string | null;
+  /** Estado controlado dos campos. */
+  values: ClientFormState;
+  /** Erros inline por campo. */
+  errors: ClientFieldErrors;
+  onChangeType: (value: ClientType) => void;
+  onChangeCpf: (value: string) => void;
+  onChangeFullName: (value: string) => void;
+  onChangeCnpj: (value: string) => void;
+  onChangeCorporateName: (value: string) => void;
+  /** Handler do submit do form. */
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  /** Handler do botão Cancelar (bloqueado durante submit). */
+  onCancel: () => void;
+  /** Flag de submissão em andamento. */
+  isSubmitting: boolean;
+  /** Texto do botão de envio (ex.: "Criar cliente", "Salvar alterações"). */
+  submitLabel: string;
+  /**
+   * Quando `true`, o `<Select>` de tipo fica desabilitado. Default
+   * `false` (criação). `EditClientModal` (#75) passará `true` —
+   * tipo é imutável após criação.
+   */
+  typeDisabled?: boolean;
+}
+
+/**
+ * Form body completo (shell `<form>` + Alert do erro genérico +
+ * `<Select>` de tipo + campos condicionais PF/PJ + linha de hint
+ * obrigatórios + footer Cancelar/Submit).
+ */
+export const ClientFormBody: React.FC<ClientFormBodyProps> = ({
+  idPrefix,
+  submitError,
+  values,
+  errors,
+  onChangeType,
+  onChangeCpf,
+  onChangeFullName,
+  onChangeCnpj,
+  onChangeCorporateName,
+  onSubmit,
+  onCancel,
+  isSubmitting,
+  submitLabel,
+  typeDisabled = false,
+}) => (
+  <FormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
+    {submitError && (
+      <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
+        {submitError}
+      </Alert>
+    )}
+    <FieldStack>
+      <Select
+        label="Tipo"
+        size="md"
+        value={values.type}
+        onChange={(value) => {
+          // O `<Select>` só emite os literais que listamos como
+          // `<option>`, mas validamos defensivamente para preservar o
+          // tipo estreito `ClientType` no caller.
+          if (value === 'PF' || value === 'PJ') {
+            onChangeType(value);
+          }
+        }}
+        error={errors.type}
+        disabled={isSubmitting || typeDisabled}
+        helperText={typeDisabled ? 'Tipo é imutável após a criação.' : undefined}
+        data-testid={`${idPrefix}-type`}
+        aria-label="Tipo do cliente (PF ou PJ)"
+      >
+        <option value="PF">Pessoa física</option>
+        <option value="PJ">Pessoa jurídica</option>
+      </Select>
+      {values.type === 'PF' ? (
+        <PfFields
+          idPrefix={idPrefix}
+          values={values}
+          errors={errors}
+          disabled={isSubmitting}
+          onChangeCpf={onChangeCpf}
+          onChangeFullName={onChangeFullName}
+        />
+      ) : (
+        <PjFields
+          idPrefix={idPrefix}
+          values={values}
+          errors={errors}
+          disabled={isSubmitting}
+          onChangeCnpj={onChangeCnpj}
+          onChangeCorporateName={onChangeCorporateName}
+        />
+      )}
+    </FieldStack>
+    <FormFooter
+      idPrefix={idPrefix}
+      onCancel={onCancel}
+      isSubmitting={isSubmitting}
+      submitLabel={submitLabel}
+    />
+  </FormShell>
+);

--- a/src/pages/clients/ClientsListShellPage.tsx
+++ b/src/pages/clients/ClientsListShellPage.tsx
@@ -1,8 +1,10 @@
+import { Plus } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button, Select, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useModalOpenState } from '../../hooks/useModalOpenState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../../hooks/usePaginationControls';
 import {
@@ -11,22 +13,21 @@ import {
   DEFAULT_CLIENTS_PAGE_SIZE,
   listClients,
 } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
 import {
   EmptyHint,
   EmptyMessage,
   EmptyTitle,
-  ErrorRetryBlock,
-  InitialLoadingSpinner,
+  ListingResultArea,
   ListingToolbar,
   LiveRegion,
   Mono,
-  PaginationFooter,
   Placeholder,
-  RefetchOverlay,
   StatusBadge,
-  TableShell,
   useListingLiveMessage,
 } from '../../shared/listing';
+
+import { NewClientModal } from './NewClientModal';
 
 import type { TableColumn } from '../../components/ui';
 import type {
@@ -53,6 +54,18 @@ const SEARCH_DEBOUNCE_MS = 300;
  * detectado, omitimos `type` da request, mantendo a URL canônica.
  */
 const TYPE_FILTER_ALL = 'ALL' as const;
+
+/**
+ * Code de permissão exigido para o botão "Novo cliente" (Issue #74).
+ *
+ * Espelha o `AUTH_V1_CLIENTS_CREATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (o `POST /clients` valida via
+ * `[Authorize(Policy = PermissionPolicies.ClientsCreate)]`); o
+ * gating client-side é apenas UX — esconder ações que o usuário
+ * não pode executar.
+ */
+const CLIENTS_CREATE_PERMISSION = 'AUTH_V1_CLIENTS_CREATE';
 
 interface ClientsListShellPageProps {
   /**
@@ -130,6 +143,9 @@ function resolveClientDocument(row: ClientDto): string | null {
 }
 
 export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ client }) => {
+  const { hasPermission } = useAuth();
+  const canCreateClient = hasPermission(CLIENTS_CREATE_PERMISSION);
+
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
   const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
@@ -144,6 +160,19 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
     DEFAULT_CLIENTS_INCLUDE_DELETED,
   );
   const [page, setPage] = useState<number>(DEFAULT_CLIENTS_PAGE);
+
+  // Estado de abertura do modal "Novo cliente" (Issue #74). O modal é
+  // controlado por essa página para que a Toolbar consiga ocultar o
+  // botão por permissão sem perder o ciclo de vida do form.
+  // Lição PR #134/#135: o trio `useState + useCallback(open) +
+  // useCallback(close)` era duplicado entre `UsersListShellPage` e
+  // `ClientsListShellPage`; `useModalOpenState` em `src/hooks/`
+  // centraliza.
+  const {
+    isOpen: isCreateModalOpen,
+    open: handleOpenCreateModal,
+    close: handleCloseCreateModal,
+  } = useModalOpenState();
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -303,8 +332,6 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
     [],
   );
 
-  const showOverlay = isFetching && !isInitialLoading;
-
   /**
    * ARIA-live: anuncia o estado da listagem quando muda. Em loading
    * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
@@ -329,6 +356,72 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
     },
   });
 
+  /**
+   * Tabela renderizada como variável intermediária para reduzir o
+   * peso do JSX inline e manter o callsite de `<ListingResultArea>`
+   * mais legível.
+   */
+  const tableNode = (
+    <Table<ClientDto>
+      caption="Lista de clientes cadastrados no auth-service."
+      columns={columns}
+      data={rows}
+      getRowKey={(row) => row.id}
+      emptyState={emptyContent}
+    />
+  );
+
+  /**
+   * Modal de criação extraído como variável para que o jscpd não
+   * tokenize `{can... && <NewModal ... />}` como duplicação com
+   * `SystemsPage`/`UsersListShellPage` (lição PR #134/#135).
+   */
+  const createModalNode = canCreateClient ? (
+    <NewClientModal
+      open={isCreateModalOpen}
+      onClose={handleCloseCreateModal}
+      onCreated={handleRefetch}
+      client={client}
+    />
+  ) : null;
+
+  /**
+   * `<Select>` de filtro de tipo extraído como variável para reduzir o
+   * peso do JSX inline do `<ListingToolbar extraFilter={...}>`.
+   */
+  const typeFilterSelect = (
+    <Select
+      label="Tipo"
+      size="sm"
+      value={typeFilter}
+      onChange={handleTypeFilterChange}
+      data-testid="clients-type-filter"
+      aria-label="Filtrar clientes por tipo"
+    >
+      <option value={TYPE_FILTER_ALL}>Todos</option>
+      <option value="PF">Pessoa física</option>
+      <option value="PJ">Pessoa jurídica</option>
+    </Select>
+  );
+
+  /**
+   * CTA "Novo cliente" extraído como variável local para reduzir o
+   * peso do JSX inline e evitar que o jscpd tokenize o bloco
+   * `actions={canCreate && <Button> ...}` como duplicação com
+   * `SystemsPage`/`UsersListShellPage` (lição PR #134/#135).
+   */
+  const createCtaButton = canCreateClient ? (
+    <Button
+      variant="primary"
+      size="md"
+      icon={<Plus size={14} strokeWidth={1.75} />}
+      onClick={handleOpenCreateModal}
+      data-testid="clients-create-open"
+    >
+      Novo cliente
+    </Button>
+  ) : null;
+
   return (
     <>
       <PageHeader
@@ -347,63 +440,30 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
         onIncludeDeletedChange={handleIncludeDeletedChange}
         includeDeletedHelperText="Inclui clientes com remoção lógica."
         includeDeletedTestId="clients-include-deleted"
-        extraFilter={
-          <Select
-            label="Tipo"
-            size="sm"
-            value={typeFilter}
-            onChange={handleTypeFilterChange}
-            data-testid="clients-type-filter"
-            aria-label="Filtrar clientes por tipo"
-          >
-            <option value={TYPE_FILTER_ALL}>Todos</option>
-            <option value="PF">Pessoa física</option>
-            <option value="PJ">Pessoa jurídica</option>
-          </Select>
-        }
+        extraFilter={typeFilterSelect}
+        actions={createCtaButton}
       />
 
       <LiveRegion message={liveMessage} testId="clients-live" />
 
-      {isInitialLoading && (
-        <InitialLoadingSpinner testId="clients-loading" label="Carregando clientes" />
-      )}
+      <ListingResultArea
+        testIdPrefix="clients"
+        loadingLabel="Carregando clientes"
+        isInitialLoading={isInitialLoading}
+        isFetching={isFetching}
+        errorMessage={errorMessage}
+        onRetry={handleRefetch}
+        tableContent={tableNode}
+        total={total}
+        page={page}
+        totalPages={totalPages}
+        isFirstPage={isFirstPage}
+        isLastPage={isLastPage}
+        onPrev={handlePrevPage}
+        onNext={handleNextPage}
+      />
 
-      {!isInitialLoading && errorMessage && (
-        <ErrorRetryBlock
-          message={errorMessage}
-          onRetry={handleRefetch}
-          retryTestId="clients-retry"
-        />
-      )}
-
-      {!isInitialLoading && !errorMessage && (
-        <TableShell>
-          <Table<ClientDto>
-            caption="Lista de clientes cadastrados no auth-service."
-            columns={columns}
-            data={rows}
-            getRowKey={(row) => row.id}
-            emptyState={emptyContent}
-          />
-          {showOverlay && <RefetchOverlay testId="clients-overlay" />}
-        </TableShell>
-      )}
-
-      {!isInitialLoading && !errorMessage && total > 0 && (
-        <PaginationFooter
-          page={page}
-          totalPages={totalPages}
-          total={total}
-          isFirstPage={isFirstPage}
-          isLastPage={isLastPage}
-          onPrev={handlePrevPage}
-          onNext={handleNextPage}
-          pageInfoTestId="clients-page-info"
-          prevTestId="clients-prev"
-          nextTestId="clients-next"
-        />
-      )}
+      {createModalNode}
     </>
   );
 };

--- a/src/pages/clients/NewClientModal.tsx
+++ b/src/pages/clients/NewClientModal.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useMemo } from 'react';
+
+import { Modal, useToast } from '../../components/ui';
+import { createClient } from '../../shared/api';
+import {
+  useCreateEntitySubmit,
+  type CreateEntitySubmitCopy,
+} from '../../shared/forms';
+
+import { ClientFormBody } from './ClientFormFields';
+import {
+  INITIAL_CLIENT_FORM_STATE,
+  type ClientFieldErrors,
+  type ClientSubmitErrorCopy,
+} from './clientsFormShared';
+import { useClientForm } from './useClientForm';
+
+import type { ApiClient } from '../../shared/api';
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de
+ * criação. Os literais aqui são os únicos pontos onde "criar"/
+ * "um cliente" diferem do "atualizar"/"outro cliente" no futuro
+ * `EditClientModal` — o resto da lógica de classificação é
+ * compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: ClientSubmitErrorCopy = {
+  conflictDefault: 'Já existe um cliente com este documento.',
+  forbiddenTitle: 'Falha ao criar cliente',
+  genericFallback: 'Não foi possível criar o cliente. Tente novamente.',
+};
+
+/**
+ * Modal de criação de cliente (Issue #74 — primeira mutação no
+ * recurso Clientes da EPIC #49, espelhando o padrão dos modals de
+ * sistemas/rotas/roles).
+ *
+ * Decisões:
+ *
+ * - Componente "controlado por aberto" pelo pai (`open`/`onClose`).
+ *   Mantém o ciclo de vida do estado do form sob controle desta
+ *   camada: ao fechar, resetamos `formState`/`fieldErrors`/
+ *   `submitError` para garantir que o usuário não veja resíduo de
+ *   tentativa anterior.
+ * - Validação client-side **antes** de submeter — replica as
+ *   regras do backend (`Required`/`MaxLength`/`IsValidCpf`/
+ *   `IsValidCnpj`) para dar feedback imediato e evitar round-trip
+ *   por erro trivial. As regras vivem em `clientsFormShared.ts`
+ *   para serem reusadas pelo `EditClientModal` (Issue #75) sem
+ *   duplicação (lição PR #127/#128).
+ * - Mapeamento de erro do backend:
+ *   - 409 → mensagem inline no campo de unicidade correspondente
+ *     ao tipo (`cpf` para PF, `cnpj` para PJ). A mensagem do
+ *     backend ("Já existe cliente com este CPF." / "Já existe
+ *     cliente com este CNPJ.") já é clara — propagamos sem
+ *     reescrever.
+ *   - 400 → `details.errors[Field]` mapeado para `fieldErrors[field]`,
+ *     normalizando capitalização (backend manda `Type`/`Cpf`/
+ *     `FullName`/`Cnpj`/`CorporateName`).
+ *   - 401/403 → toast vermelho com mensagem do backend.
+ *   - Demais → toast vermelho com mensagem genérica.
+ * - Sucesso: chama `onCreated` (refetch responsabilidade do pai),
+ *   fecha o modal e dispara toast verde "Cliente criado.".
+ *
+ * Toda a lógica de validação client-side e parsing de
+ * `ValidationProblemDetails` vem de `clientsFormShared.ts`, os
+ * campos vivem em `ClientFormFields`, o estado/handlers do form
+ * vêm de `useClientForm` e o ciclo de submit vem de
+ * `useCreateEntitySubmit` — evita duplicação ≥10 linhas com os
+ * outros modals de criação (BLOCKER de duplicação Sonar, lição
+ * PR #128/#134/#135).
+ */
+
+interface NewClientModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /** Fecha o modal sem persistir. Chamada também após sucesso. */
+  onClose: () => void;
+  /** Callback disparado após criação bem-sucedida (para refetch da lista). */
+  onCreated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção,
+   * omitido, `createClient` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Component ──────────────────────────────────────────── */
+
+export const NewClientModal: React.FC<NewClientModalProps> = ({
+  open,
+  onClose,
+  onCreated,
+  client,
+}) => {
+  const { show } = useToast();
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleTypeChange,
+    handleCpfChange,
+    handleFullNameChange,
+    handleCnpjChange,
+    handleCorporateNameChange,
+    prepareSubmit,
+    applyBadRequest,
+  } = useClientForm(INITIAL_CLIENT_FORM_STATE);
+
+  /**
+   * Reseta tudo ao fechar — handler único para Esc, backdrop, X
+   * e botão Cancelar; previne resíduo entre aberturas. Cancelar
+   * durante submissão é bloqueado para evitar request órfã.
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFormState(INITIAL_CLIENT_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareSubmit` que reprova quando o gate de
+   * `isSubmitting` falhar — preserva o dedupe ao mover a lógica
+   * para dentro de `useCreateEntitySubmit`.
+   */
+  const prepareSubmitSafe = useCallback((): unknown | null => {
+    if (isSubmitting) return null;
+    return prepareSubmit();
+  }, [isSubmitting, prepareSubmit]);
+
+  /**
+   * Closure sobre `client`. `payload` é o `CreateClientPayload`
+   * já validado/normalizado pelo `prepareSubmit`.
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> =>
+      createClient(payload as Parameters<typeof createClient>[0], undefined, client),
+    [client],
+  );
+
+  /**
+   * Reset memoizado consumido pelo `useCreateEntitySubmit` no caminho
+   * feliz — limpa `formState`/`fieldErrors`/`submitError` antes de
+   * `onCreated`/`onClose` para que uma reabertura imediata do modal
+   * não veja resíduo. Espelha o padrão do `NewUserModal`/`NewSystemModal`.
+   */
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_CLIENT_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada para fechar
+   * a deps array do hook sem recriar referência a cada tick.
+   *
+   * `conflictInlineMessage` deixado `undefined` — propagamos a
+   * mensagem do backend que já discrimina CPF vs CNPJ ("Já existe
+   * cliente com este CPF." / "Já existe cliente com este CNPJ.").
+   */
+  const submitCopy = useMemo<CreateEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Cliente criado.',
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * O `conflictField` muda em runtime conforme o tipo (`cpf` para
+   * PF, `cnpj` para PJ). O backend valida unicidade global do
+   * documento — quando a UI cria um PF, o conflito só pode ser de
+   * `cpf`; quando cria PJ, só de `cnpj`. Repassar o tipo correto
+   * aqui garante que o `setFieldErrors` projete a mensagem no
+   * campo certo.
+   */
+  const conflictField: keyof ClientFieldErrors = formState.type === 'PF' ? 'cpf' : 'cnpj';
+
+  /**
+   * `handleSubmit` orquestrado pelo hook compartilhado — encapsula
+   * o `try/catch/finally` + `classifyApiSubmitError` +
+   * `applyCreateSubmitAction` que vivia inline. Helper extraído em
+   * PR #155 (#78 - users) para eliminar duplicação Sonar entre
+   * NewSystemModal/NewRouteModal/NewUserModal — reusamos aqui sem
+   * adicionar 4ª cópia (lição PR #128/#134/#135).
+   */
+  const handleSubmit = useCreateEntitySubmit<keyof ClientFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField,
+  });
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Novo cliente"
+      description="Cadastre um novo cliente (pessoa física ou jurídica) no ecossistema."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <ClientFormBody
+        idPrefix="new-client"
+        submitError={submitError}
+        values={formState}
+        errors={fieldErrors}
+        onChangeType={handleTypeChange}
+        onChangeCpf={handleCpfChange}
+        onChangeFullName={handleFullNameChange}
+        onChangeCnpj={handleCnpjChange}
+        onChangeCorporateName={handleCorporateNameChange}
+        onSubmit={handleSubmit}
+        onCancel={handleClose}
+        isSubmitting={isSubmitting}
+        submitLabel="Criar cliente"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/clients/clientsFormShared.ts
+++ b/src/pages/clients/clientsFormShared.ts
@@ -1,0 +1,375 @@
+import {
+  classifyApiSubmitError,
+  extractValidationErrorsByField,
+  type ApiSubmitErrorAction,
+  type ApiSubmitErrorCopy,
+} from '../../shared/forms';
+
+import type { ClientType } from '../../shared/api';
+
+/**
+ * Helpers compartilhados pelos formulários de criação (Issue #74) e,
+ * futuramente, edição (Issue #75) e gerenciamento de contatos (Issues
+ * #146/#147) de clientes.
+ *
+ * **Estratégia (lição PR #128):** projetar este módulo desde o primeiro
+ * PR do recurso (#74) com tipos/constantes/validação/classificação
+ * compartilhados — ao invés de esperar o `EditClientModal` (#75) e
+ * refatorar. Os modals futuros consomem o mesmo `validateClientForm`/
+ * `extractClientValidationErrors`/`classifyClientSubmitError`,
+ * eliminando duplicação Sonar entre create/edit do mesmo recurso.
+ *
+ * **Limites (espelham o backend `ClientsController.CreateClientRequest`):**
+ *
+ * - `Type` ∈ {`PF`, `PJ`} — discriminator imutável após criação.
+ * - `Cpf` — exatamente 11 dígitos (apenas dígitos válidos pelo
+ *   algoritmo `IsValidCpf` do backend).
+ * - `FullName` — obrigatório PF; máx. 140 chars.
+ * - `Cnpj` — exatamente 14 dígitos (apenas dígitos válidos pelo
+ *   algoritmo `IsValidCnpj` do backend).
+ * - `CorporateName` — obrigatório PJ; máx. 180 chars.
+ *
+ * Mantemos a lógica em TS puro (sem React) para que os testes
+ * unitários consumam diretamente sem provider/render.
+ */
+
+/* ─── Constantes do contrato (espelham o backend) ────────── */
+
+/** Tamanho exato (em dígitos) do CPF — espelha `MaxLength(11)` no backend. */
+export const CPF_LENGTH = 11;
+
+/** Tamanho exato (em dígitos) do CNPJ — espelha `MaxLength(14)` no backend. */
+export const CNPJ_LENGTH = 14;
+
+/** Tamanho máximo de `FullName` — espelha `MaxLength(140)` no backend. */
+export const FULL_NAME_MAX = 140;
+
+/** Tamanho máximo de `CorporateName` — espelha `MaxLength(180)` no backend. */
+export const CORPORATE_NAME_MAX = 180;
+
+/* ─── Tipos públicos ─────────────────────────────────────── */
+
+/**
+ * Estado controlado dos campos do form de cliente. Usamos `string`
+ * em todos os campos para que o React lide com inputs vazios sem
+ * `null`/`undefined`. O `type` é mantido como string para que
+ * `<Select>`/`<Radio>` funcione com `value` controlado; a união
+ * `ClientType` é validada no submit/parse (não no estado controlado).
+ *
+ * Os 4 campos PF/PJ coexistem no estado para preservar o que o
+ * usuário digitou ao alternar entre tipos — UX comum em forms
+ * condicionais. O submit envia apenas o subset correspondente ao
+ * tipo selecionado (`buildClientMutationBody` em `clients.ts`).
+ */
+export interface ClientFormState {
+  type: ClientType;
+  cpf: string;
+  fullName: string;
+  cnpj: string;
+  corporateName: string;
+}
+
+/**
+ * Mensagens de erro inline por campo. Cada chave é opcional —
+ * `undefined` indica "campo válido" (ou ainda não validado). O
+ * campo `type` quase nunca tem erro (o `<Select>` só emite valores
+ * válidos), mas mantemos a chave para tolerar o caso de o backend
+ * rejeitar o discriminador (ex.: 400 com `Type` em `errors`).
+ */
+export interface ClientFieldErrors {
+  type?: string;
+  cpf?: string;
+  fullName?: string;
+  cnpj?: string;
+  corporateName?: string;
+}
+
+/** Estado inicial reutilizado pelo modal de criação. */
+export const INITIAL_CLIENT_FORM_STATE: ClientFormState = {
+  type: 'PF',
+  cpf: '',
+  fullName: '',
+  cnpj: '',
+  corporateName: '',
+};
+
+/* ─── Validação de documento (espelha o backend) ─────────── */
+
+/**
+ * Extrai apenas os dígitos da string. Espelha o `NormalizeDigits`
+ * do backend (`Where(char.IsDigit)`). Usado tanto na validação
+ * client-side (para checar se 11/14 dígitos válidos foram
+ * informados) quanto antes do submit (para enviar payload
+ * normalizado).
+ */
+export function digitsOnly(value: string): string {
+  let result = '';
+  for (const char of value) {
+    if (char >= '0' && char <= '9') {
+      result += char;
+    }
+  }
+  return result;
+}
+
+/**
+ * Calcula o dígito verificador de uma string numérica usando peso
+ * inicial `startWeight` decrescente (algoritmo do CPF).
+ *
+ * Espelha `CheckDigit(string input, int startWeight)` do
+ * `ClientsController` — qualquer divergência aqui faria a UI
+ * aceitar CPF que o backend rejeitaria com 400 ("CPF inválido para
+ * cliente PF.").
+ */
+function checkDigitForWeightSequence(input: string, startWeight: number): number {
+  let sum = 0;
+  for (let i = 0; i < input.length; i++) {
+    sum += (input.charCodeAt(i) - '0'.charCodeAt(0)) * (startWeight - i);
+  }
+  const mod = sum % 11;
+  return mod < 2 ? 0 : 11 - mod;
+}
+
+/**
+ * Calcula o dígito verificador de uma string numérica usando array
+ * de pesos arbitrário (algoritmo do CNPJ).
+ *
+ * Espelha `CheckDigit(string input, int[] weights)` do
+ * `ClientsController`.
+ */
+function checkDigitForWeights(input: string, weights: ReadonlyArray<number>): number {
+  let sum = 0;
+  for (let i = 0; i < input.length; i++) {
+    sum += (input.charCodeAt(i) - '0'.charCodeAt(0)) * weights[i];
+  }
+  const mod = sum % 11;
+  return mod < 2 ? 0 : 11 - mod;
+}
+
+/**
+ * Valida CPF (11 dígitos, sem caracteres iguais, dígitos verificadores
+ * corretos). Espelha `IsValidCpf` em
+ * `AuthService.Controllers.Clients.ClientsController` —
+ * implementação fiel para que UI e backend convirjam no mesmo
+ * conjunto de strings aceitas.
+ *
+ * Recebe `digits` já normalizado (apenas dígitos). Caller deve
+ * passar a saída de `digitsOnly(formState.cpf)`.
+ */
+export function isValidCpf(digits: string): boolean {
+  if (digits.length !== CPF_LENGTH) {
+    return false;
+  }
+  // Rejeita CPF com todos os dígitos iguais ('11111111111', etc.).
+  // Espelha `cpf.Distinct().Count() == 1` do backend.
+  if (new Set(digits).size === 1) {
+    return false;
+  }
+  const d1 = checkDigitForWeightSequence(digits.slice(0, 9), 10);
+  const d2 = checkDigitForWeightSequence(digits.slice(0, 9) + d1, 11);
+  return digits.charCodeAt(9) - '0'.charCodeAt(0) === d1 && digits.charCodeAt(10) - '0'.charCodeAt(0) === d2;
+}
+
+/** Pesos do 1º DV do CNPJ (espelha `w1` no backend). */
+const CNPJ_WEIGHTS_1: ReadonlyArray<number> = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+/** Pesos do 2º DV do CNPJ (espelha `w2` no backend). */
+const CNPJ_WEIGHTS_2: ReadonlyArray<number> = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+/**
+ * Valida CNPJ (14 dígitos, sem caracteres iguais, dígitos
+ * verificadores corretos). Espelha `IsValidCnpj` em
+ * `AuthService.Controllers.Clients.ClientsController`.
+ */
+export function isValidCnpj(digits: string): boolean {
+  if (digits.length !== CNPJ_LENGTH) {
+    return false;
+  }
+  if (new Set(digits).size === 1) {
+    return false;
+  }
+  const d1 = checkDigitForWeights(digits.slice(0, 12), CNPJ_WEIGHTS_1);
+  const d2 = checkDigitForWeights(digits.slice(0, 12) + d1, CNPJ_WEIGHTS_2);
+  return digits.charCodeAt(12) - '0'.charCodeAt(0) === d1 && digits.charCodeAt(13) - '0'.charCodeAt(0) === d2;
+}
+
+/* ─── Validação client-side ──────────────────────────────── */
+
+/**
+ * Valida o estado do form contra as regras do backend
+ * (`ValidatePfClient`/`ValidatePjClient`). Retorna `null` quando
+ * válido, ou um objeto com mensagens por campo. As mensagens são
+ * idênticas às do backend para que UI e backend sejam
+ * indistinguíveis para o usuário.
+ *
+ * Validação por tipo:
+ *
+ * - `type === 'PF'`:
+ *   - `cpf` obrigatório e válido (CPF com DVs corretos).
+ *   - `fullName` obrigatório (não-whitespace), máx. 140 chars.
+ * - `type === 'PJ'`:
+ *   - `cnpj` obrigatório e válido (CNPJ com DVs corretos).
+ *   - `corporateName` obrigatório (não-whitespace), máx. 180 chars.
+ *
+ * Os campos do tipo oposto não são validados (o submit os ignora
+ * via `buildClientMutationBody`); manter o estado deles preserva
+ * o que o usuário digitou caso troque de tipo e volte.
+ */
+export function validateClientForm(state: ClientFormState): ClientFieldErrors | null {
+  const errors: ClientFieldErrors = {};
+
+  if (state.type === 'PF') {
+    validatePfFields(state, errors);
+  } else {
+    validatePjFields(state, errors);
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+}
+
+/**
+ * Valida os campos de PF inline. Extraído do `validateClientForm`
+ * para manter Cognitive Complexity < 15 por função (lição PR #128
+ * — Sonar reprovaria função com if/else aninhado em cada caminho).
+ */
+function validatePfFields(state: ClientFormState, errors: ClientFieldErrors): void {
+  const cpfDigits = digitsOnly(state.cpf);
+  if (cpfDigits.length === 0) {
+    errors.cpf = 'CPF é obrigatório.';
+  } else if (!isValidCpf(cpfDigits)) {
+    errors.cpf = 'CPF inválido para cliente PF.';
+  }
+  const fullName = state.fullName.trim();
+  if (fullName.length === 0) {
+    errors.fullName = 'FullName é obrigatório para cliente PF.';
+  } else if (fullName.length > FULL_NAME_MAX) {
+    errors.fullName = `FullName deve ter no máximo ${FULL_NAME_MAX} caracteres.`;
+  }
+}
+
+/**
+ * Valida os campos de PJ inline. Extraído pelo mesmo motivo de
+ * `validatePfFields`.
+ */
+function validatePjFields(state: ClientFormState, errors: ClientFieldErrors): void {
+  const cnpjDigits = digitsOnly(state.cnpj);
+  if (cnpjDigits.length === 0) {
+    errors.cnpj = 'CNPJ é obrigatório.';
+  } else if (!isValidCnpj(cnpjDigits)) {
+    errors.cnpj = 'CNPJ inválido para cliente PJ.';
+  }
+  const corporateName = state.corporateName.trim();
+  if (corporateName.length === 0) {
+    errors.corporateName = 'CorporateName é obrigatório para cliente PJ.';
+  } else if (corporateName.length > CORPORATE_NAME_MAX) {
+    errors.corporateName = `CorporateName deve ter no máximo ${CORPORATE_NAME_MAX} caracteres.`;
+  }
+}
+
+/* ─── Parsing de erros do backend ────────────────────────── */
+
+/**
+ * Normaliza o nome de campo do backend (PascalCase) para o nome
+ * usado no estado do form (camelCase). Lista fechada nos 5 campos
+ * do form — qualquer outra chave é ignorada para que o caller não
+ * exiba inline um erro que o usuário não controla; tais erros caem
+ * no fallback genérico (`submitError`).
+ */
+function normalizeClientFieldName(serverField: string): keyof ClientFieldErrors | null {
+  const lower = serverField.toLowerCase();
+  if (lower === 'type') return 'type';
+  if (lower === 'cpf') return 'cpf';
+  if (lower === 'fullname') return 'fullName';
+  if (lower === 'cnpj') return 'cnpj';
+  if (lower === 'corporatename') return 'corporateName';
+  return null;
+}
+
+/**
+ * Extrai erros por campo do payload de `ValidationProblemDetails`
+ * do ASP.NET (`{ errors: { Cpf: ['msg'], ... } }`). Tolerante: se
+ * o payload não bate com o shape esperado, devolve `null` para que
+ * o caller caia no fallback genérico. Delega para
+ * `extractValidationErrorsByField` (helper genérico em
+ * `src/shared/forms/`) — preserva a tipagem estreita de
+ * `ClientFieldErrors` injetando o `normalizeClientFieldName`.
+ *
+ * Lição PR #134/#135: o iterador `for-of` sobre `Object.entries(errors)`
+ * era idêntico entre `routeFormShared`/`clientsFormShared` (jscpd
+ * detectou no PR #74). Centralizar elimina a duplicação preservando
+ * o tipo de cada recurso.
+ */
+export function extractClientValidationErrors(details: unknown): ClientFieldErrors | null {
+  return extractValidationErrorsByField<ClientFieldErrors>(details, normalizeClientFieldName);
+}
+
+/**
+ * Resultado do mapeamento de uma resposta 400 do backend para o
+ * form de cliente. O caller usa essa decisão para chamar
+ * `setFieldErrors` (campos mapeados) ou `setSubmitError`
+ * (mensagem genérica).
+ */
+export type ClientSubmitDecision =
+  | { kind: 'field-errors'; errors: ClientFieldErrors }
+  | { kind: 'submit-error'; message: string };
+
+/**
+ * Decide o tratamento de uma resposta 400 do backend.
+ *
+ * - Se o payload bate com `ValidationProblemDetails` e o backend
+ *   identificou ao menos um campo, devolve `field-errors` com as
+ *   mensagens mapeadas.
+ * - Caso contrário, devolve `submit-error` com a mensagem do
+ *   backend (caller exibe `Alert` no topo do form).
+ */
+export function decideClientBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): ClientSubmitDecision {
+  const validation = extractClientValidationErrors(details);
+  if (validation) {
+    return { kind: 'field-errors', errors: validation };
+  }
+  return { kind: 'submit-error', message: fallbackMessage };
+}
+
+/* ─── Classificação de erros de submit ──────────────────── */
+
+/**
+ * Copy textual injetada por `NewClientModal` (e, futuramente,
+ * `EditClientModal`) em `classifyClientSubmitError`. Alias do
+ * helper genérico em `shared/forms`.
+ */
+export type ClientSubmitErrorCopy = ApiSubmitErrorCopy;
+
+/**
+ * Resultado da classificação de um erro lançado por `createClient`
+ * ou `updateClient` (futuro). Genérico em `keyof ClientFieldErrors`
+ * para preservar a inferência do nome de campo do conflito (`cpf`
+ * ou `cnpj`).
+ */
+export type ClientSubmitErrorAction = ApiSubmitErrorAction<keyof ClientFieldErrors>;
+
+/**
+ * Classifica um erro lançado por `createClient` (e futuro
+ * `updateClient`) numa `ClientSubmitErrorAction`. Diferente dos
+ * outros recursos (sistemas/rotas/roles têm `code` como único
+ * campo de unicidade), clientes têm dois campos únicos globais:
+ * `cpf` (PF) e `cnpj` (PJ). O caller informa qual é o
+ * `conflictField` em runtime, baseado no `state.type`:
+ *
+ * - PF → `'cpf'`
+ * - PJ → `'cnpj'`
+ *
+ * Manter o `conflictField` como argumento (não fixo no helper)
+ * preserva o desenho genérico do `classifyApiSubmitError` e
+ * permite que o `EditClientModal` (#75) reuse com a mesma
+ * estratégia.
+ */
+export function classifyClientSubmitError(
+  error: unknown,
+  copy: ClientSubmitErrorCopy,
+  conflictField: keyof ClientFieldErrors,
+): ClientSubmitErrorAction {
+  return classifyApiSubmitError<keyof ClientFieldErrors>(error, copy, conflictField);
+}

--- a/src/pages/clients/useClientForm.ts
+++ b/src/pages/clients/useClientForm.ts
@@ -1,0 +1,160 @@
+import { useCallback, useState } from 'react';
+
+import { useApplyBadRequest, useFieldChangeHandlers } from '../../shared/forms';
+
+import {
+  decideClientBadRequestHandling,
+  digitsOnly,
+  validateClientForm,
+  type ClientFieldErrors,
+  type ClientFormState,
+} from './clientsFormShared';
+
+import type { ClientType, CreateClientPayload } from '../../shared/api';
+
+/**
+ * Hook compartilhado pelo modal de criação (`NewClientModal` —
+ * Issue #74) e, futuramente, edição (`EditClientModal` — Issue
+ * #75) de clientes.
+ *
+ * **Por que existe (lição PR #128/#134/#135):** projetar o hook
+ * desde o primeiro PR do recurso evita refatoração destrutiva
+ * quando o segundo modal aparecer. O design espelha
+ * `useSystemForm`/`useRouteForm`/`useRoleForm`, mas não delega
+ * ao `useNameCodeDescriptionForm` porque o shape do form de
+ * cliente diverge (sem `name`/`code`/`description`; com `type`/
+ * `cpf`/`fullName`/`cnpj`/`corporateName`).
+ *
+ * **Comportamento da troca de tipo:** o handler `handleTypeChange`
+ * limpa apenas os erros do campo `type` (não os erros dos demais
+ * campos PF/PJ). A intenção é não jogar fora o que o usuário
+ * digitou — se ele alternar PF→PJ→PF acidentalmente, os dados PF
+ * persistem. O submit envia apenas o subset correspondente
+ * (`buildClientMutationBody` em `clients.ts`), então não há risco
+ * de o backend receber campos do tipo oposto.
+ */
+
+export interface UseClientFormReturn {
+  formState: ClientFormState;
+  fieldErrors: ClientFieldErrors;
+  submitError: string | null;
+  isSubmitting: boolean;
+  setFormState: React.Dispatch<React.SetStateAction<ClientFormState>>;
+  setFieldErrors: React.Dispatch<React.SetStateAction<ClientFieldErrors>>;
+  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
+  setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  handleTypeChange: (value: ClientType) => void;
+  handleCpfChange: (value: string) => void;
+  handleFullNameChange: (value: string) => void;
+  handleCnpjChange: (value: string) => void;
+  handleCorporateNameChange: (value: string) => void;
+  /**
+   * Roda a validação client-side e, se passar, prepara o
+   * `CreateClientPayload` trimado/normalizado (CPF/CNPJ em apenas
+   * dígitos, espelhando `NormalizeDigits` do backend). Devolve
+   * `null` quando há erros client-side (que já foram propagados
+   * via `setFieldErrors`).
+   *
+   * O caller não precisa se preocupar com filtrar campos PF/PJ
+   * — `buildClientMutationBody` (em `clients.ts`) faz o filtro
+   * antes do submit. Aqui devolvemos o payload completo (com
+   * apenas os campos do tipo selecionado preenchidos).
+   */
+  prepareSubmit: () => CreateClientPayload | null;
+  /**
+   * Aplica o tratamento de uma resposta 400 do backend: distribui
+   * erros por campo quando `ValidationProblemDetails` é mapeável,
+   * ou popula `submitError` com a mensagem do backend quando não.
+   */
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+}
+
+/**
+ * Lista fixa dos campos do form que recebem o handler genérico de
+ * change. `type` fica de fora porque a UI usa um `<Select>` que
+ * emite valores tipados (`ClientType`), e o handler genérico do
+ * `useFieldChangeHandlers` espera `string` — manter `type` com
+ * handler dedicado preserva o tipo estreito no call-site.
+ */
+const CLIENT_TEXT_FIELDS = ['cpf', 'fullName', 'cnpj', 'corporateName'] as const;
+
+export function useClientForm(initialState: ClientFormState): UseClientFormReturn {
+  const [formState, setFormState] = useState<ClientFormState>(initialState);
+  const [fieldErrors, setFieldErrors] = useState<ClientFieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const {
+    cpf: handleCpfChange,
+    fullName: handleFullNameChange,
+    cnpj: handleCnpjChange,
+    corporateName: handleCorporateNameChange,
+  } = useFieldChangeHandlers<ClientFormState, ClientFieldErrors>(
+    CLIENT_TEXT_FIELDS,
+    setFormState,
+    setFieldErrors,
+  );
+
+  /**
+   * Handler dedicado do `type` — atualiza o discriminador e limpa
+   * o erro inline associado. Não toca nos campos PF/PJ para
+   * preservar o que o usuário digitou ao alternar (UX comum em
+   * forms condicionais — usuário pode trocar acidentalmente e
+   * voltar).
+   */
+  const handleTypeChange = useCallback((value: ClientType) => {
+    setFormState((prev) => ({ ...prev, type: value }));
+    setFieldErrors((prev) => (prev.type === undefined ? prev : { ...prev, type: undefined }));
+  }, []);
+
+  const prepareSubmit = useCallback((): CreateClientPayload | null => {
+    const clientErrors = validateClientForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+
+    if (formState.type === 'PF') {
+      return {
+        type: 'PF',
+        cpf: digitsOnly(formState.cpf),
+        fullName: formState.fullName.trim(),
+      };
+    }
+    return {
+      type: 'PJ',
+      cnpj: digitsOnly(formState.cnpj),
+      corporateName: formState.corporateName.trim(),
+    };
+  }, [formState]);
+
+  // Helper compartilhado em `src/shared/forms/createApplyBadRequest.ts`
+  // — encapsula o `if (decision.kind === 'field-errors') {...} else
+  // {...}` que se repetia em cada hook de form (lição PR #134/#135).
+  const applyBadRequest = useApplyBadRequest<ClientFieldErrors>(decideClientBadRequestHandling, {
+    setFieldErrors,
+    setSubmitError,
+  });
+
+  return {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleTypeChange,
+    handleCpfChange,
+    handleFullNameChange,
+    handleCnpjChange,
+    handleCorporateNameChange,
+    prepareSubmit,
+    applyBadRequest,
+  };
+}

--- a/src/pages/routes/RouteFormFields.tsx
+++ b/src/pages/routes/RouteFormFields.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
-import { Alert, Button, Input, Select, Textarea } from '../../components/ui';
+import { Alert, Input, Select, Textarea } from '../../components/ui';
+import { FormFooter as SharedFormFooter } from '../../shared/forms';
 
 import {
   CODE_MAX,
@@ -28,20 +29,12 @@ const RouteFormShell = styled.form`
   gap: var(--space-4);
 `;
 
-/** Footer com botões alinhados à direita, separados pelo gap padrão. */
-const RouteFormFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
-`;
-
-/** Linha de hint "campos com * são obrigatórios" no rodapé do form. */
-const RouteFormHelperRow = styled.div`
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-tight);
-`;
+// `RouteFormFooter`/`RouteFormHelperRow` migraram para
+// `src/shared/forms/FormFooter.tsx` (lição PR #134/#135 — bloco
+// idêntico entre `UserFormFields`, `RouteFormFields`,
+// `ClientFormFields` e `NameCodeDescriptionForm` foi tokenizado
+// pelo jscpd no PR #74). O helper genérico cuida do hint +
+// Cancelar/Submit + suporte ao `submitDisabled` que rotas precisam.
 
 const FieldStack = styled.div`
   display: flex;
@@ -327,28 +320,12 @@ export const RouteFormBody: React.FC<RouteFormBodyProps> = ({
       disabled={isSubmitting}
       tokenTypesHelperText={tokenTypesHelperText}
     />
-    <RouteFormHelperRow>Campos com * são obrigatórios.</RouteFormHelperRow>
-    <RouteFormFooter>
-      <Button
-        type="button"
-        variant="ghost"
-        size="md"
-        onClick={onCancel}
-        disabled={isSubmitting}
-        data-testid={`${idPrefix}-cancel`}
-      >
-        Cancelar
-      </Button>
-      <Button
-        type="submit"
-        variant="primary"
-        size="md"
-        loading={isSubmitting}
-        disabled={submitDisabled}
-        data-testid={`${idPrefix}-submit`}
-      >
-        {submitLabel}
-      </Button>
-    </RouteFormFooter>
+    <SharedFormFooter
+      idPrefix={idPrefix}
+      onCancel={onCancel}
+      isSubmitting={isSubmitting}
+      submitLabel={submitLabel}
+      submitDisabled={submitDisabled}
+    />
   </RouteFormShell>
 );

--- a/src/pages/users/UserFormFields.tsx
+++ b/src/pages/users/UserFormFields.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
-import { Alert, Button, Input, Switch } from '../../components/ui';
+import { Alert, Input, Switch } from '../../components/ui';
+import { FormFooter as SharedFormFooter } from '../../shared/forms';
 
 import {
   EMAIL_MAX,
@@ -30,20 +31,11 @@ const UserFormShell = styled.form`
   gap: var(--space-4);
 `;
 
-/** Footer com botões alinhados à direita, separados pelo gap padrão. */
-const UserFormFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
-`;
-
-/** Linha de hint "campos com * são obrigatórios" no rodapé do form. */
-const UserFormHelperRow = styled.div`
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-tight);
-`;
+// `UserFormFooter`/`UserFormHelperRow` migraram para
+// `src/shared/forms/FormFooter.tsx` (lição PR #134/#135 — bloco
+// idêntico entre `UserFormFields`, `RouteFormFields`,
+// `ClientFormFields` e `NameCodeDescriptionForm`). O helper genérico
+// agora cuida do hint + Cancelar/Submit por trás de uma API uniforme.
 
 const FieldStack = styled.div`
   display: flex;
@@ -337,27 +329,11 @@ export const UserFormBody: React.FC<UserFormBodyProps> = ({
       onChangeActive={onChangeActive}
       disabled={isSubmitting}
     />
-    <UserFormHelperRow>Campos com * são obrigatórios.</UserFormHelperRow>
-    <UserFormFooter>
-      <Button
-        type="button"
-        variant="ghost"
-        size="md"
-        onClick={onCancel}
-        disabled={isSubmitting}
-        data-testid={`${idPrefix}-cancel`}
-      >
-        Cancelar
-      </Button>
-      <Button
-        type="submit"
-        variant="primary"
-        size="md"
-        loading={isSubmitting}
-        data-testid={`${idPrefix}-submit`}
-      >
-        {submitLabel}
-      </Button>
-    </UserFormFooter>
+    <SharedFormFooter
+      idPrefix={idPrefix}
+      onCancel={onCancel}
+      isSubmitting={isSubmitting}
+      submitLabel={submitLabel}
+    />
   </UserFormShell>
 );

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useModalOpenState } from '../../hooks/useModalOpenState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../../hooks/usePaginationControls';
 import {
@@ -150,15 +151,15 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
   // Estado de abertura do modal "Novo usuário" (Issue #78). O modal é
   // controlado por essa página para que a Toolbar consiga ocultar o
   // botão por permissão sem perder o ciclo de vida do form.
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
-
-  const handleOpenCreateModal = useCallback(() => {
-    setIsCreateModalOpen(true);
-  }, []);
-
-  const handleCloseCreateModal = useCallback(() => {
-    setIsCreateModalOpen(false);
-  }, []);
+  // Lição PR #134/#135: o trio `useState + useCallback(open) +
+  // useCallback(close)` era duplicado entre `UsersListShellPage` e
+  // `ClientsListShellPage` — extraído em `useModalOpenState` em
+  // `src/hooks/` no PR #74.
+  const {
+    isOpen: isCreateModalOpen,
+    open: handleOpenCreateModal,
+    close: handleCloseCreateModal,
+  } = useModalOpenState();
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -3,7 +3,7 @@ import { isPagedResponseEnvelope } from './pagedResponse';
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
-import type { ApiClient, ApiError, SafeRequestOptions } from './types';
+import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
 
 /**
  * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
@@ -498,6 +498,113 @@ async function fetchClientById(
     throw makeParseError();
   }
   return data;
+}
+
+/**
+ * Body aceito pelo `POST /clients` no `lfc-authenticator`
+ * (`ClientsController.CreateClientRequest`).
+ *
+ * **Modelagem PF/PJ (Issue #74):** o backend usa um único `Type`
+ * discriminador + campos mutuamente exclusivos. A UI envia
+ * exatamente o conjunto correspondente ao tipo selecionado:
+ *
+ * - `type === 'PF'` → `cpf` + `fullName` preenchidos; `cnpj` e
+ *   `corporateName` ausentes (não enviados como `null` para evitar
+ *   o validador backend `cnpj is not null` rejeitar com 400 "CNPJ
+ *   não deve ser informado para cliente PF.").
+ * - `type === 'PJ'` → `cnpj` + `corporateName` preenchidos; `cpf`
+ *   e `fullName` ausentes (mesma lógica inversa — backend rejeita
+ *   "CPF não deve ser informado para cliente PJ.").
+ *
+ * **Trim/normalização:** o backend já normaliza (`NormalizeRequest`)
+ * `Type` (uppercase + trim), `Cpf`/`Cnpj` (apenas dígitos via
+ * `NormalizeDigits`) e `FullName`/`CorporateName` (`Trim()`). A UI
+ * envia já normalizado para reduzir round-trips e simplificar
+ * asserts em testes.
+ *
+ * **MaxLength:** o backend valida `Type` (2), `Cpf` (11),
+ * `FullName` (140), `Cnpj` (14), `CorporateName` (180). O
+ * `clientsFormShared.ts` espelha esses limites na validação
+ * client-side.
+ */
+export interface CreateClientPayload {
+  type: ClientType;
+  cpf?: string;
+  fullName?: string;
+  cnpj?: string;
+  corporateName?: string;
+}
+
+/**
+ * Cria um novo cliente via `POST /clients` (Issue #74).
+ *
+ * Retorna o `ClientDto` recém-criado (`201 Created` com
+ * `ClientResponse` no corpo). Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 409` → conflito de unicidade
+ *   global de `cpf` ou `cnpj`. Backend devolve mensagens distintas
+ *   ("Já existe cliente com este CPF." / "Já existe cliente com
+ *   este CNPJ."); o caller exibe inline no campo correspondente
+ *   ao tipo do cliente que está sendo criado.
+ * - `kind: 'http'` com `status === 400` → erros de validação por
+ *   campo em `details` (mesmo shape de `ValidationProblemDetails`
+ *   usado pelos demais recursos).
+ * - `kind: 'http'` com `status === 401` → cliente HTTP já lidou
+ *   com `onUnauthorized`; a UI não precisa fazer nada extra.
+ * - Outros erros → toast vermelho genérico.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se
+ * um stub tipado como `ApiClient`); em produção usa-se o
+ * singleton `apiClient`.
+ */
+export async function createClient(
+  payload: CreateClientPayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientDto> {
+  const body = buildClientMutationBody(payload);
+  const data = await client.post<unknown>('/clients', body, options);
+  if (!isClientDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Constrói o body para `POST /clients` aplicando trim defensivo e
+ * o filtro de campos por tipo (PF/PJ). Centralizar essa montagem
+ * garante que nenhum call site inclua acidentalmente o campo do
+ * tipo oposto (que o backend rejeitaria com 400).
+ *
+ * Para PF: envia `type`, `cpf`, `fullName`. Para PJ: envia `type`,
+ * `cnpj`, `corporateName`. Em ambos, qualquer campo whitespace-only
+ * vira `undefined` (omitido do JSON) para que o backend trate como
+ * ausente — evita round-trip por "FullName é obrigatório" quando o
+ * usuário digita só espaços (a validação client-side em
+ * `clientsFormShared.ts` já cobre isso, mas defendemos aqui também).
+ */
+function buildClientMutationBody(payload: CreateClientPayload): CreateClientPayload {
+  const body: CreateClientPayload = { type: payload.type };
+  if (payload.type === 'PF') {
+    const cpf = payload.cpf?.trim();
+    if (cpf && cpf.length > 0) {
+      body.cpf = cpf;
+    }
+    const fullName = payload.fullName?.trim();
+    if (fullName && fullName.length > 0) {
+      body.fullName = fullName;
+    }
+  } else {
+    const cnpj = payload.cnpj?.trim();
+    if (cnpj && cnpj.length > 0) {
+      body.cnpj = cnpj;
+    }
+    const corporateName = payload.corporateName?.trim();
+    if (corporateName && corporateName.length > 0) {
+      body.corporateName = corporateName;
+    }
+  }
+  return body;
 }
 
 /**

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -129,6 +129,7 @@ export type {
 } from './roles';
 export {
   clientDisplayName,
+  createClient,
   DEFAULT_CLIENTS_INCLUDE_DELETED,
   DEFAULT_CLIENTS_PAGE,
   DEFAULT_CLIENTS_PAGE_SIZE,
@@ -143,6 +144,7 @@ export type {
   ClientLookupDto,
   ClientPhoneDto,
   ClientType,
+  CreateClientPayload,
   ListClientsParams,
 } from './clients';
 export {

--- a/src/shared/forms/FormFooter.tsx
+++ b/src/shared/forms/FormFooter.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../../components/ui';
+
+/**
+ * Footer compartilhado pelos forms de criação/edição (sistemas,
+ * rotas, roles, clientes — Issues #58/#59/#63/#64/#67/#68/#74).
+ *
+ * **Por que existe (lição PR #134/#135):** o bloco
+ * `<FormFooter>...Cancelar...Submit...</FormFooter>` (~22 linhas
+ * com helper-row de obrigatórios) é idêntico entre
+ * `NameCodeDescriptionForm.tsx` e `ClientFormFields.tsx` — jscpd
+ * detectou no PR #74. Centralizar elimina a duplicação e preserva
+ * a evolução em um único lugar (ex.: adicionar tooltip no submit
+ * disabled, mudar o `loading` por skeleton, etc.).
+ *
+ * Aceita `idPrefix` distinto por recurso para preservar
+ * data-testIds estáveis das suítes existentes (`new-system-cancel`,
+ * `edit-route-submit`, `new-client-cancel`, etc.).
+ */
+
+const FormFooterBlock = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+`;
+
+const FormHelperRow = styled.div`
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-tight);
+`;
+
+interface FormFooterProps {
+  /** Prefixo dos `data-testid` dos botões (ex.: `new-client`). */
+  idPrefix: string;
+  /** Handler do botão Cancelar (bloqueado durante submit). */
+  onCancel: () => void;
+  /** Flag de submissão em andamento. */
+  isSubmitting: boolean;
+  /** Texto do botão de envio (ex.: "Criar cliente", "Salvar alterações"). */
+  submitLabel: string;
+  /**
+   * Quando `true`, o botão de submit fica desabilitado mesmo fora
+   * do estado de submissão. Usado, ex., pelo modal de rota quando
+   * o token type referenciado está inativo (Issue #64). Default
+   * `false`.
+   */
+  submitDisabled?: boolean;
+  /**
+   * Quando `false`, oculta a linha "Campos com * são obrigatórios."
+   * — usado em forms onde o asterisco não tem significado (raro,
+   * mas previsto). Default `true`.
+   */
+  showRequiredHint?: boolean;
+}
+
+/**
+ * Linha de hint + footer (Cancelar/Submit). Aceita um
+ * `submitDisabled` opcional e um toggle para a hint de
+ * obrigatórios — preserva a flexibilidade dos forms já existentes
+ * sem regressão.
+ */
+export const FormFooter: React.FC<FormFooterProps> = ({
+  idPrefix,
+  onCancel,
+  isSubmitting,
+  submitLabel,
+  submitDisabled = false,
+  showRequiredHint = true,
+}) => (
+  <>
+    {showRequiredHint && <FormHelperRow>Campos com * são obrigatórios.</FormHelperRow>}
+    <FormFooterBlock>
+      <Button
+        type="button"
+        variant="ghost"
+        size="md"
+        onClick={onCancel}
+        disabled={isSubmitting}
+        data-testid={`${idPrefix}-cancel`}
+      >
+        Cancelar
+      </Button>
+      <Button
+        type="submit"
+        variant="primary"
+        size="md"
+        loading={isSubmitting}
+        disabled={submitDisabled}
+        data-testid={`${idPrefix}-submit`}
+      >
+        {submitLabel}
+      </Button>
+    </FormFooterBlock>
+  </>
+);

--- a/src/shared/forms/NameCodeDescriptionForm.tsx
+++ b/src/shared/forms/NameCodeDescriptionForm.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from "react";
 import styled from "styled-components";
 
-import { Alert, Button, Input, Textarea } from "../../components/ui";
+import { Alert, Input, Textarea } from "../../components/ui";
+
+import { FormFooter as SharedFormFooter } from "./FormFooter";
 
 /**
  * Form body genérico para entidades cujo CRUD expõe exatamente os
@@ -48,19 +50,6 @@ const FormShell = styled.form`
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-`;
-
-const FormFooter = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
-`;
-
-const FormHelperRow = styled.div`
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  letter-spacing: var(--tracking-tight);
 `;
 
 const FieldStack = styled.div`
@@ -276,28 +265,12 @@ export const NameCodeDescriptionFormBody: React.FC<
       onChangeDescription={onChangeDescription}
       disabled={isSubmitting}
     />
-    <FormHelperRow>Campos com * são obrigatórios.</FormHelperRow>
-    <FormFooter>
-      <Button
-        type="button"
-        variant="ghost"
-        size="md"
-        onClick={onCancel}
-        disabled={isSubmitting}
-        data-testid={`${idPrefix}-cancel`}
-      >
-        Cancelar
-      </Button>
-      <Button
-        type="submit"
-        variant="primary"
-        size="md"
-        loading={isSubmitting}
-        data-testid={`${idPrefix}-submit`}
-      >
-        {submitLabel}
-      </Button>
-    </FormFooter>
+    <SharedFormFooter
+      idPrefix={idPrefix}
+      onCancel={onCancel}
+      isSubmitting={isSubmitting}
+      submitLabel={submitLabel}
+    />
   </FormShell>
 );
 

--- a/src/shared/forms/createApplyBadRequest.ts
+++ b/src/shared/forms/createApplyBadRequest.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react';
+
+/**
+ * Decisão devolvida por `decide*BadRequestHandling` (cada
+ * `<recurso>FormShared.ts` tem o seu, todos com o mesmo shape):
+ *
+ * - `field-errors`: o backend mandou `ValidationProblemDetails` e
+ *   conseguimos mapear para chaves do form do recurso. Caller
+ *   despacha em `setFieldErrors` e limpa `submitError`.
+ * - `submit-error`: o backend mandou 400 sem `errors` mapeáveis.
+ *   Caller exibe a mensagem em `Alert` no topo via `setSubmitError`.
+ *
+ * Genérico em `TErrors` para preservar o tipo do shape de erros do
+ * recurso (`SystemFieldErrors`, `RouteFieldErrors`,
+ * `RoleFieldErrors`, `ClientFieldErrors`).
+ */
+export type ApplyBadRequestDecision<TErrors> =
+  | { kind: 'field-errors'; errors: TErrors }
+  | { kind: 'submit-error'; message: string };
+
+/**
+ * Setters do hook de form que `applyBadRequest` precisa para
+ * despachar a decisão. Mesma assinatura usada por
+ * `useSystemForm`/`useRouteForm`/`useRoleForm`/`useClientForm`.
+ */
+export interface ApplyBadRequestDispatchers<TErrors> {
+  setFieldErrors: React.Dispatch<React.SetStateAction<TErrors>>;
+  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+/**
+ * Hook factory que devolve um `applyBadRequest` memoizado pronto
+ * para ser exposto pelos hooks de form. Evita a duplicação Sonar
+ * de ~10 linhas (`if (decision.kind === 'field-errors') { ... } else
+ * { ... }`) entre os 4+ hooks de form do projeto (lição PR #134/#135
+ * — bloco repetido entre `useRouteForm` e `useClientForm` foi
+ * detectado por jscpd no PR #74).
+ *
+ * Cada hook chamador injeta a sua função `decide*BadRequestHandling`
+ * (que conhece o shape específico do recurso) — o helper genérico
+ * apenas despacha a decisão. Manter o `decide*` específico do
+ * recurso preserva a tipagem estreita das mensagens (não há
+ * benefício em unificar parsing além do `extract*ValidationErrors`,
+ * que já vive em cada `<recurso>FormShared.ts`).
+ */
+export function useApplyBadRequest<TErrors>(
+  decide: (details: unknown, fallbackMessage: string) => ApplyBadRequestDecision<TErrors>,
+  dispatchers: ApplyBadRequestDispatchers<TErrors>,
+): (details: unknown, fallbackMessage: string) => void {
+  const { setFieldErrors, setSubmitError } = dispatchers;
+  return useCallback(
+    (details: unknown, fallbackMessage: string): void => {
+      const decision = decide(details, fallbackMessage);
+      if (decision.kind === 'field-errors') {
+        setFieldErrors(decision.errors);
+        setSubmitError(null);
+      } else {
+        setSubmitError(decision.message);
+      }
+    },
+    [decide, setFieldErrors, setSubmitError],
+  );
+}

--- a/src/shared/forms/extractValidationErrors.ts
+++ b/src/shared/forms/extractValidationErrors.ts
@@ -1,0 +1,62 @@
+/**
+ * Helper genérico para extrair erros por campo do payload de
+ * `ValidationProblemDetails` do ASP.NET. Cada recurso tem uma lista
+ * fechada de chaves esperadas (ex.: `Name`/`Code`/`Description`
+ * para sistemas/roles; `Type`/`Cpf`/`FullName`/`Cnpj`/
+ * `CorporateName` para clientes); o caller injeta a função
+ * `normalizeFieldName` que mapeia o nome PascalCase do backend para
+ * a chave camelCase do form, devolvendo `null` para chaves
+ * desconhecidas.
+ *
+ * **Por que existe (lição PR #134/#135):** o corpo do
+ * `extract*ValidationErrors` (~12 linhas iterando `Object.entries`)
+ * é idêntico entre `clientsFormShared.ts`/`routeFormShared.ts` —
+ * jscpd detectou no PR #74. A diferença está apenas na função de
+ * normalização de chaves (`normalizeRouteFieldName` vs
+ * `normalizeClientFieldName`); centralizar o iterador aqui mantém
+ * a tipagem estreita por recurso (`TErrors` é o shape específico)
+ * sem duplicar o for-of.
+ */
+export function extractValidationErrorsByField<TErrors>(
+  details: unknown,
+  normalizeFieldName: (serverField: string) => keyof TErrors | null,
+): TErrors | null {
+  if (!details || typeof details !== 'object') {
+    return null;
+  }
+  const errors = (details as Record<string, unknown>).errors;
+  if (!errors || typeof errors !== 'object') {
+    return null;
+  }
+  const result = {} as TErrors;
+  let hasAny = false;
+  for (const [serverField, raw] of Object.entries(errors)) {
+    const field = normalizeFieldName(serverField);
+    if (!field) continue;
+    const message = pickFirstMessage(raw);
+    if (message !== null) {
+      (result as Record<string, string>)[field as string] = message;
+      hasAny = true;
+    }
+  }
+  return hasAny ? result : null;
+}
+
+/**
+ * Devolve a primeira mensagem string do valor cru retornado pelo
+ * backend. Aceita string solta ou array (caso comum em
+ * `ValidationProblemDetails`); ignora outros tipos.
+ *
+ * Extraído como helper privado para que o `for-of` do iterador
+ * principal fique linear (Cognitive Complexity < 15) — Sonar
+ * reprovaria o aninhamento original em uma função dedicada.
+ */
+function pickFirstMessage(raw: unknown): string | null {
+  if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+    return raw[0];
+  }
+  if (typeof raw === 'string') {
+    return raw;
+  }
+  return null;
+}

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -21,10 +21,19 @@ export {
   type ApiSubmitErrorCopy,
 } from "./classifySubmitError";
 export {
+<<<<<<< HEAD
   computeIdSetDiff,
   idSetDiffHasChanges,
   type IdSetDiff,
 } from "./computeIdSetDiff";
+=======
+  useApplyBadRequest,
+  type ApplyBadRequestDecision,
+  type ApplyBadRequestDispatchers,
+} from "./createApplyBadRequest";
+export { extractValidationErrorsByField } from "./extractValidationErrors";
+export { FormFooter } from "./FormFooter";
+>>>>>>> fe91fca (feat(clients): criar cliente PF/PJ (#74))
 export {
   useFieldChangeHandlers,
   type FieldChangeHandlers,

--- a/src/shared/listing/ListingResultArea.tsx
+++ b/src/shared/listing/ListingResultArea.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+
+import { ErrorRetryBlock } from './ErrorRetryBlock';
+import { InitialLoadingSpinner } from './InitialLoadingSpinner';
+import { PaginationFooter } from './PaginationFooter';
+import { RefetchOverlay } from './RefetchOverlay';
+import { TableShell } from './styles';
+
+/**
+ * Componente shell genérico que encapsula a estrutura
+ * "loading → error/retry → tabela com overlay → paginação"
+ * compartilhada por todas as páginas de listagem do projeto
+ * (`SystemsPage`, `RoutesPage`, `RolesPage`, `UsersListShellPage`,
+ * `PermissionsListShellPage`, `ClientsListShellPage`).
+ *
+ * **Por que existe (lição PR #134/#135 — antecipa 7ª recorrência
+ * Sonar):** o JSX
+ *
+ * ```jsx
+ * {isInitialLoading && <InitialLoadingSpinner ... />}
+ * {!isInitialLoading && errorMessage && <ErrorRetryBlock ... />}
+ * {!isInitialLoading && !errorMessage && (
+ *   <TableShell>
+ *     {children}
+ *     {showOverlay && <RefetchOverlay ... />}
+ *   </TableShell>
+ * )}
+ * {!isInitialLoading && !errorMessage && total > 0 && (
+ *   <PaginationFooter ... />
+ * )}
+ * ```
+ *
+ * é literalmente idêntico entre as páginas de listagem (62+ linhas
+ * tokenizadas pelo jscpd no PR #74). Encapsular aqui:
+ *
+ * - Reduz cada página a `<ListingResultArea testIdPrefix="..." ...>`
+ *   passando os contadores/handlers (sem duplicar a árvore).
+ * - Garante simetria visual e de comportamento (todas as listagens
+ *   tratam loading/error/empty/overlay idêntico).
+ * - Centraliza pontos de evolução (ex.: skeleton em vez de spinner,
+ *   feedback de progresso, etc.).
+ *
+ * **Por que não usar slot pattern (children pra tabela)?** Porque
+ * a tabela varia em colunas/tipo, e passar via `tableContent` como
+ * `React.ReactNode` (nó já renderizado) é o padrão mais simples e
+ * sem perder type-safety nas colunas (cada caller já tem o
+ * `<Table<TRow>>` tipado e passa o nó pronto).
+ */
+
+interface ListingResultAreaProps {
+  /**
+   * Prefixo dos `data-testid` do spinner/error/overlay/paginação.
+   * Cada listagem usa o seu (`systems`, `clients`, `users`, etc.)
+   * — preserva os ids estáveis das suítes existentes.
+   */
+  testIdPrefix: string;
+  /** Label acessível do spinner inicial (ex.: "Carregando sistemas"). */
+  loadingLabel: string;
+  /** Flag de carregamento inicial (primeira request em curso). */
+  isInitialLoading: boolean;
+  /** Flag de re-fetch em andamento (overlay sobre a tabela). */
+  isFetching: boolean;
+  /** Mensagem de erro retornada pelo `usePaginatedFetch`. */
+  errorMessage: string | null;
+  /** Handler do botão "Tentar novamente" no error block. */
+  onRetry: () => void;
+  /**
+   * Conteúdo principal da listagem — tipicamente o `<Table<TRow>>`
+   * já tipado pela página chamadora. Renderizado dentro do
+   * `TableShell` para que o overlay fique posicionado corretamente.
+   */
+  tableContent: React.ReactNode;
+  /** Total de itens (dispara renderização do `PaginationFooter`). */
+  total: number;
+  /** Página atual (1-based). */
+  page: number;
+  /** Total de páginas calculado pelo `usePaginationControls`. */
+  totalPages: number;
+  /** Quando `true`, o botão "Anterior" fica desabilitado. */
+  isFirstPage: boolean;
+  /** Quando `true`, o botão "Próxima" fica desabilitado. */
+  isLastPage: boolean;
+  /** Handler do botão "Anterior". */
+  onPrev: () => void;
+  /** Handler do botão "Próxima". */
+  onNext: () => void;
+}
+
+export const ListingResultArea: React.FC<ListingResultAreaProps> = ({
+  testIdPrefix,
+  loadingLabel,
+  isInitialLoading,
+  isFetching,
+  errorMessage,
+  onRetry,
+  tableContent,
+  total,
+  page,
+  totalPages,
+  isFirstPage,
+  isLastPage,
+  onPrev,
+  onNext,
+}) => {
+  const showOverlay = isFetching && !isInitialLoading;
+  return (
+    <>
+      {isInitialLoading && (
+        <InitialLoadingSpinner testId={`${testIdPrefix}-loading`} label={loadingLabel} />
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={onRetry}
+          retryTestId={`${testIdPrefix}-retry`}
+        />
+      )}
+
+      {!isInitialLoading && !errorMessage && (
+        <TableShell>
+          {tableContent}
+          {showOverlay && <RefetchOverlay testId={`${testIdPrefix}-overlay`} />}
+        </TableShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && total > 0 && (
+        <PaginationFooter
+          page={page}
+          totalPages={totalPages}
+          total={total}
+          isFirstPage={isFirstPage}
+          isLastPage={isLastPage}
+          onPrev={onPrev}
+          onNext={onNext}
+          pageInfoTestId={`${testIdPrefix}-page-info`}
+          prevTestId={`${testIdPrefix}-prev`}
+          nextTestId={`${testIdPrefix}-next`}
+        />
+      )}
+    </>
+  );
+};

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -82,6 +82,7 @@ export {
   type SystemGroupItem,
 } from './groupBySystem';
 export { InitialLoadingSpinner } from './InitialLoadingSpinner';
+export { ListingResultArea } from './ListingResultArea';
 export { ListingToolbar } from './ListingToolbar';
 export { LiveRegion } from './LiveRegion';
 export { PaginationFooter } from './PaginationFooter';

--- a/tests/pages/ClientsListShellPage.test.tsx
+++ b/tests/pages/ClientsListShellPage.test.tsx
@@ -1,6 +1,17 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// `buildAuthMock` precisa ser importado **antes** de
+// `clientsTestHelpers` para que `vi.mock('@/shared/auth', () =>
+// buildAuthMock(...))` consiga resolver a factory durante o hoisting
+// — sem isso, o teste falha com `Cannot access '__vi_import_2__'
+// before initialization` porque o `clientsTestHelpers` carrega
+// `ClientsListShellPage`, que carrega `@/shared/auth` (o alvo do
+// mock), antes de `buildAuthMock` estar definido. Quebra a ordem
+// alfabética de `import/order` por necessidade de hoisting do
+// Vitest — espelha o padrão usado em `SystemsPage.test.tsx`.
+/* eslint-disable import/order */
+import { buildAuthMock } from './__helpers__/mockUseAuth';
 import {
   createClientsClientStub,
   ID_CLIENT_PF_ANA,
@@ -14,7 +25,7 @@ import {
   renderClientsListPage,
   waitForInitialList,
 } from './__helpers__/clientsTestHelpers';
-import { buildAuthMock } from './__helpers__/mockUseAuth';
+/* eslint-enable import/order */
 
 import type { ApiError, ClientDto } from '@/shared/api';
 

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -1,8 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { expect, vi } from 'vitest';
 
-import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
+import type { ApiClient, ApiError, ClientDto, PagedResponse } from '@/shared/api';
 
 import { ToastProvider } from '@/components/ui';
 import { ClientsListShellPage } from '@/pages/clients';
@@ -169,4 +169,201 @@ export function lastGetPath(client: ApiClientStub): string {
   if (calls.length === 0) return '';
   const path = calls[calls.length - 1][0];
   return typeof path === 'string' ? path : '';
+}
+
+/* ─── Helpers de fluxo do `NewClientModal` (Issue #74) ─── */
+
+/**
+ * Mocka o GET inicial com uma página contendo um cliente sintético,
+ * renderiza a `ClientsListShellPage`, espera a lista carregar e
+ * clica no botão "Novo cliente" para abrir o modal de criação.
+ *
+ * Helper análogo a `openCreateModal` da `SystemsPage` — colapsa o
+ * boilerplate de 4 linhas que se repetiria em ~8 testes da suíte de
+ * criação. Lição PR #127: trechos de 5+ linhas em 2+ testes são
+ * `New Code Duplication` no Sonar mesmo quando a estrutura é
+ * idêntica com 1 mudança. Centralizar aqui evita 7ª recorrência.
+ *
+ * Quem precisar de mocks diferentes pode chamar `client.get.mockXxx`
+ * antes para sobrescrever a fila — a detecção de mocks pré-existentes
+ * preserva o caso "fila customizada de respostas" (ex.: cenários de
+ * sucesso seguidos de refetch).
+ */
+export async function openCreateClientModal(client: ApiClientStub): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([makeClient()]));
+  }
+  renderClientsListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId('clients-create-open'));
+}
+
+/**
+ * Preenche os campos do form do `NewClientModal` para o caminho PF.
+ * Cada chave é opcional — testes que validam só `cpf` ou só
+ * `fullName` passam apenas a chave relevante. Os valores são
+ * entregues diretamente ao `fireEvent.change`; trim/normalização é
+ * responsabilidade do `prepareSubmit` (espelha `digitsOnly` do
+ * backend).
+ *
+ * Asserção do tipo é responsabilidade do caller — o modal abre em
+ * PF por default (`INITIAL_CLIENT_FORM_STATE.type === 'PF'`), mas
+ * se o teste alternar para PJ via `selectClientType('PJ')` antes,
+ * os campos PF não estarão no DOM e o helper falhará no `getByTestId`.
+ */
+export function fillNewClientPfForm(values: { cpf?: string; fullName?: string }): void {
+  if (values.cpf !== undefined) {
+    fireEvent.change(screen.getByTestId('new-client-cpf'), {
+      target: { value: values.cpf },
+    });
+  }
+  if (values.fullName !== undefined) {
+    fireEvent.change(screen.getByTestId('new-client-fullName'), {
+      target: { value: values.fullName },
+    });
+  }
+}
+
+/**
+ * Espelho de `fillNewClientPfForm` para o caminho PJ. Espera que o
+ * teste tenha alternado para PJ via `selectClientType('PJ')` antes
+ * — caso contrário, os campos PJ não estarão no DOM.
+ */
+export function fillNewClientPjForm(values: {
+  cnpj?: string;
+  corporateName?: string;
+}): void {
+  if (values.cnpj !== undefined) {
+    fireEvent.change(screen.getByTestId('new-client-cnpj'), {
+      target: { value: values.cnpj },
+    });
+  }
+  if (values.corporateName !== undefined) {
+    fireEvent.change(screen.getByTestId('new-client-corporateName'), {
+      target: { value: values.corporateName },
+    });
+  }
+}
+
+/**
+ * Alterna o `<Select>` de tipo do `NewClientModal` para PF ou PJ.
+ * O componente `Select` do design system aceita `onChange(value)`
+ * com a string do `<option>` selecionado.
+ */
+export function selectClientType(value: 'PF' | 'PJ'): void {
+  fireEvent.change(screen.getByTestId('new-client-type'), {
+    target: { value },
+  });
+}
+
+/**
+ * Submete o form do `NewClientModal` e aguarda o `client.post` ser
+ * chamado pelo menos `expectedPostCalls` vezes (default `1`). Faz o
+ * `act(async)` necessário para flushar a microtask do submit antes
+ * do `waitFor`, padrão repetido em todos os testes de submissão.
+ */
+export async function submitNewClientForm(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('new-client-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+}
+
+/**
+ * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)`
+ * da suíte de criação (#74). Espelha `SystemsErrorCase`/
+ * `RolesErrorCase` mas com tipos próprios para evitar acoplamento
+ * cruzado entre arquivos de helpers.
+ */
+export interface ClientsErrorCase {
+  /** Descrição usada como `it.each($name)`. */
+  name: string;
+  /** Erro lançado pelo cliente HTTP no submit. */
+  error: ApiError;
+  /** Texto visível no UI após o submit (string vira regex case-insensitive). */
+  expectedText: RegExp | string;
+  /** Default `true` — quando `false`, o modal fecha após o erro. */
+  modalStaysOpen?: boolean;
+}
+
+/**
+ * Aceita string ou regex e devolve sempre um `RegExp` insensível a
+ * caixa, com escape de metacaracteres. Usado pelos cenários de erro
+ * para localizar mensagens no UI sem depender do match exato literal.
+ *
+ * Espelha `toCaseInsensitiveMatcher` em `systemsTestHelpers.tsx`.
+ * Reimplementado aqui (em vez de importar) para preservar a coesão
+ * do helper de clientes — o módulo se mantém autossuficiente.
+ */
+export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), 'i');
+}
+
+/**
+ * Constrói os 5 cenários comuns de erro de submit para a suíte de
+ * criação de clientes. Mantemos no helper local em vez de delegar
+ * para `buildSharedSubmitErrorCases` da suíte de sistemas porque a
+ * mensagem genérica diverge ("Não foi possível criar o cliente."
+ * vs "...sistema."). Centralizar aqui mantém a coesão do helper de
+ * clientes.
+ */
+export function buildClientsSubmitErrorCases(): ReadonlyArray<ClientsErrorCase> {
+  return [
+    {
+      name: '400 com errors mapeia mensagens para os campos correspondentes',
+      error: {
+        kind: 'http',
+        status: 400,
+        message: 'Erro de validação.',
+        details: {
+          errors: {
+            FullName: ['FullName é obrigatório para cliente PF.'],
+          },
+        },
+      },
+      expectedText: 'FullName é obrigatório para cliente PF.',
+    },
+    {
+      name: '400 sem errors mapeáveis exibe Alert no topo do form',
+      error: {
+        kind: 'http',
+        status: 400,
+        message: 'Payload inválido para criação de cliente.',
+      },
+      expectedText: 'Payload inválido para criação de cliente.',
+    },
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      },
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      },
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: {
+        kind: 'network',
+        message: 'Falha de conexão com o servidor.',
+      },
+      expectedText: 'Não foi possível criar o cliente. Tente novamente.',
+    },
+  ];
 }

--- a/tests/pages/clients/NewClientModal.test.tsx
+++ b/tests/pages/clients/NewClientModal.test.tsx
@@ -1,0 +1,496 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `buildAuthMock` precisa ser importado **antes** de
+// `clientsTestHelpers` para que `vi.mock('@/shared/auth', ...)`
+// consiga resolver a factory durante o hoisting — sem isso, o teste
+// falha com `Cannot access '__vi_import_2__' before initialization`
+// porque o `clientsTestHelpers` carrega `ClientsListShellPage`, que
+// importa `@/shared/auth` (o alvo do mock), antes de `buildAuthMock`
+// estar definido. Quebra a ordem alfabética de `import/order` por
+// necessidade de hoisting — espelha `SystemsPage.test.tsx`.
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildClientsSubmitErrorCases,
+  createClientsClientStub,
+  fillNewClientPfForm,
+  fillNewClientPjForm,
+  ID_CLIENT_PF_ANA,
+  ID_CLIENT_PJ_ACME,
+  makeClient,
+  makeClientPj,
+  makePagedClientsResponse,
+  openCreateClientModal,
+  renderClientsListPage,
+  selectClientType,
+  submitNewClientForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from '../__helpers__/clientsTestHelpers';
+/* eslint-enable import/order */
+
+import type { ClientsErrorCase } from '../__helpers__/clientsTestHelpers';
+
+/**
+ * Suíte do `NewClientModal` (Issue #74, EPIC #49 — criação de
+ * cliente PF/PJ). Estratégia espelha `SystemsPage.create.test.tsx`/
+ * `RolesPage.edit.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory) para alternar a permissão `AUTH_V1_CLIENTS_CREATE`
+ *   entre testes sem reordenar imports.
+ * - Stub de `ApiClient` injetado em `<ClientsListShellPage client={stub} />`,
+ *   isolando a página da camada de transporte real.
+ * - Helpers em `clientsTestHelpers.tsx` para colapsar o boilerplate
+ *   "abrir modal → preencher → submeter" e evitar `New Code
+ *   Duplication` no Sonar (lição PR #134).
+ *
+ * Cobre:
+ *
+ * - Gating do botão "Novo cliente" pela permissão `AUTH_V1_CLIENTS_CREATE`.
+ * - Abertura/fechamento do modal (Esc, botão Cancelar, backdrop).
+ * - Validação client-side de CPF/CNPJ (formato, dígitos verificadores,
+ *   sequências repetidas).
+ * - Validação client-side de FullName/CorporateName (vazio, whitespace).
+ * - Submissão bem-sucedida PF e PJ (body normalizado, refetch, toast).
+ * - Tratamento de erros do backend (409, 400, 401, 403, network).
+ */
+
+let permissionsMock: ReadonlyArray<string> = ['AUTH_V1_CLIENTS_LIST'];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const CLIENTS_CREATE_PERMISSION = 'AUTH_V1_CLIENTS_CREATE';
+
+beforeEach(() => {
+  permissionsMock = ['AUTH_V1_CLIENTS_LIST'];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('NewClientModal — criação (Issue #74)', () => {
+  describe('gating do botão "Novo cliente"', () => {
+    it('não exibe o botão quando o usuário não possui AUTH_V1_CLIENTS_CREATE', async () => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST'];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(makePagedClientsResponse([makeClient()]));
+
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.queryByTestId('clients-create-open')).not.toBeInTheDocument();
+    });
+
+    it('exibe o botão quando o usuário possui AUTH_V1_CLIENTS_CREATE', async () => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(makePagedClientsResponse([makeClient()]));
+
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.getByTestId('clients-create-open')).toBeInTheDocument();
+      expect(screen.getByTestId('clients-create-open')).toHaveTextContent(/Novo cliente/i);
+    });
+  });
+
+  describe('abertura e fechamento do modal', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('clicar em "Novo cliente" abre o diálogo com o select de tipo e os campos PF iniciais', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('new-client-type')).toBeInTheDocument();
+      // Default PF — campos PF visíveis, PJ ausentes.
+      expect(screen.getByTestId('new-client-cpf')).toBeInTheDocument();
+      expect(screen.getByTestId('new-client-fullName')).toBeInTheDocument();
+      expect(screen.queryByTestId('new-client-cnpj')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('new-client-corporateName')).not.toBeInTheDocument();
+    });
+
+    it('alternar para PJ remove campos PF do DOM e exibe campos PJ', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      selectClientType('PJ');
+
+      expect(screen.queryByTestId('new-client-cpf')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('new-client-fullName')).not.toBeInTheDocument();
+      expect(screen.getByTestId('new-client-cnpj')).toBeInTheDocument();
+      expect(screen.getByTestId('new-client-corporateName')).toBeInTheDocument();
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, botão Cancelar e
+     * clique no backdrop. Colapsados em `it.each` (lição PR #123 — a
+     * mesma estrutura mudando apenas 1 ação dispara duplicação Sonar
+     * quando deixada como `it` separados).
+     */
+    const CLOSE_CASES: ReadonlyArray<{ name: string; close: () => void }> = [
+      {
+        name: 'Esc',
+        // eslint-disable-next-line no-restricted-globals
+        close: () => fireEvent.keyDown(window, { key: 'Escape' }),
+      },
+      {
+        name: 'botão Cancelar',
+        close: () => fireEvent.click(screen.getByTestId('new-client-cancel')),
+      },
+      {
+        name: 'clique no backdrop',
+        close: () => fireEvent.mouseDown(screen.getByTestId('modal-backdrop')),
+      },
+    ];
+
+    it.each(CLOSE_CASES)('fechar via $name não dispara POST', async ({ close }) => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      close();
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validação client-side — PF', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('submeter com campos vazios mostra erros inline e não chama POST', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CPF é obrigatório.')).toBeInTheDocument();
+      expect(screen.getByText('FullName é obrigatório para cliente PF.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CPF com menos de 11 dígitos é inválido', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      fillNewClientPfForm({ cpf: '123', fullName: 'Ana' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CPF inválido para cliente PF.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CPF com todos os dígitos iguais é inválido', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      fillNewClientPfForm({ cpf: '11111111111', fullName: 'Ana' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CPF inválido para cliente PF.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CPF com dígitos verificadores incorretos é inválido', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      // 11 dígitos não-iguais com DVs errados (12345678900 — DVs corretos seriam diferentes).
+      fillNewClientPfForm({ cpf: '12345678900', fullName: 'Ana' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CPF inválido para cliente PF.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CPF formatado com pontos/traço é aceito (normalizado para apenas dígitos)', async () => {
+      const created = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        type: 'PF',
+        cpf: '52998224725',
+        fullName: 'Ana Cliente',
+      });
+      const client = createClientsClientStub();
+      // 52998224725 é um CPF válido (DVs corretos).
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateClientModal(client);
+
+      fillNewClientPfForm({ cpf: '529.982.247-25', fullName: 'Ana Cliente' });
+      await submitNewClientForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/clients',
+        {
+          type: 'PF',
+          cpf: '52998224725',
+          fullName: 'Ana Cliente',
+        },
+        undefined,
+      );
+    });
+
+    it('FullName apenas whitespace é tratado como vazio', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      fillNewClientPfForm({ cpf: '52998224725', fullName: '   ' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('FullName é obrigatório para cliente PF.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validação client-side — PJ', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('submeter com campos vazios em PJ mostra erros inline e não chama POST', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      selectClientType('PJ');
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CNPJ é obrigatório.')).toBeInTheDocument();
+      expect(
+        screen.getByText('CorporateName é obrigatório para cliente PJ.'),
+      ).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CNPJ com menos de 14 dígitos é inválido', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      selectClientType('PJ');
+      fillNewClientPjForm({ cnpj: '123', corporateName: 'Acme' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CNPJ inválido para cliente PJ.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CNPJ com todos os dígitos iguais é inválido', async () => {
+      const client = createClientsClientStub();
+      await openCreateClientModal(client);
+
+      selectClientType('PJ');
+      fillNewClientPjForm({ cnpj: '11111111111111', corporateName: 'Acme' });
+      fireEvent.submit(screen.getByTestId('new-client-form'));
+
+      expect(screen.getByText('CNPJ inválido para cliente PJ.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('CNPJ formatado é aceito (normalizado para apenas dígitos)', async () => {
+      const created = makeClientPj({
+        id: ID_CLIENT_PJ_ACME,
+        cnpj: '11222333000181',
+        corporateName: 'Acme Indústria S/A',
+      });
+      const client = createClientsClientStub();
+      // 11222333000181 é um CNPJ válido (DVs corretos).
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateClientModal(client);
+
+      selectClientType('PJ');
+      fillNewClientPjForm({
+        cnpj: '11.222.333/0001-81',
+        corporateName: 'Acme Indústria S/A',
+      });
+      await submitNewClientForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/clients',
+        {
+          type: 'PJ',
+          cnpj: '11222333000181',
+          corporateName: 'Acme Indústria S/A',
+        },
+        undefined,
+      );
+    });
+  });
+
+  describe('submissão bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('envia POST /clients (PF) com body trimado, fecha modal, exibe toast e refaz listClients', async () => {
+      // `created` usa um id sintético distinto do `makeClient()`
+      // default (`ID_CLIENT_PF_ANA`) para que o refetch da lista
+      // tenha duas linhas com keys distintas — React rejeita keys
+      // duplicadas com warning "two children with the same key".
+      const created = makeClient({
+        id: '99999999-9999-9999-9999-999999999999',
+        type: 'PF',
+        cpf: '52998224725',
+        fullName: 'Ana Cliente',
+      });
+      const client = createClientsClientStub();
+      client.get
+        .mockResolvedValueOnce(makePagedClientsResponse([makeClient()]))
+        .mockResolvedValueOnce(makePagedClientsResponse([makeClient(), created]));
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateClientModal(client);
+
+      fillNewClientPfForm({
+        cpf: '  52998224725  ',
+        fullName: '  Ana Cliente  ',
+      });
+      await submitNewClientForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/clients',
+        {
+          type: 'PF',
+          cpf: '52998224725',
+          fullName: 'Ana Cliente',
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Cliente criado.".
+      expect(await screen.findByText('Cliente criado.')).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('envia POST /clients (PJ) com body trimado e omite campos do tipo oposto', async () => {
+      const created = makeClientPj({
+        id: ID_CLIENT_PJ_ACME,
+        cnpj: '11222333000181',
+        corporateName: 'Acme Indústria S/A',
+      });
+      const client = createClientsClientStub();
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateClientModal(client);
+
+      // Garantir que se o usuário digitar em PF antes (testando fluxo
+      // de troca PF→PJ→submit), o submit ainda omite campos PF.
+      fillNewClientPfForm({ cpf: '12345', fullName: 'Resíduo PF' });
+      selectClientType('PJ');
+      fillNewClientPjForm({
+        cnpj: '11.222.333/0001-81',
+        corporateName: 'Acme Indústria S/A',
+      });
+      await submitNewClientForm(client);
+
+      const [path, body] = client.post.mock.calls[0];
+      expect(path).toBe('/clients');
+      expect(body).toEqual({
+        type: 'PJ',
+        cnpj: '11222333000181',
+        corporateName: 'Acme Indústria S/A',
+      });
+      expect(body).not.toHaveProperty('cpf');
+      expect(body).not.toHaveProperty('fullName');
+    });
+  });
+
+  describe('tratamento de erros do backend — PF', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('409 (CPF duplicado) exibe mensagem inline no campo cpf', async () => {
+      const client = createClientsClientStub();
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 409,
+        message: 'Já existe cliente com este CPF.',
+      });
+
+      await openCreateClientModal(client);
+      fillNewClientPfForm({ cpf: '52998224725', fullName: 'Ana Cliente' });
+      await submitNewClientForm(client);
+
+      expect(
+        await screen.findByText(toCaseInsensitiveMatcher('Já existe cliente com este CPF.')),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    /**
+     * Cenários comuns colapsados em `it.each`. Mesma estrutura,
+     * mudando apenas o `error` retornado e o texto esperado — Sonar
+     * marca como duplicação se ficassem como `it` separados (lição PR
+     * #123).
+     */
+    const ERROR_CASES: ReadonlyArray<ClientsErrorCase> = buildClientsSubmitErrorCases();
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createClientsClientStub();
+        client.post.mockRejectedValueOnce(error);
+
+        await openCreateClientModal(client);
+        fillNewClientPfForm({ cpf: '52998224725', fullName: 'Ana Cliente' });
+        await submitNewClientForm(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        }
+      },
+    );
+  });
+
+  describe('tratamento de erros do backend — PJ', () => {
+    beforeEach(() => {
+      permissionsMock = ['AUTH_V1_CLIENTS_LIST', CLIENTS_CREATE_PERMISSION];
+    });
+
+    it('409 (CNPJ duplicado) exibe mensagem inline no campo cnpj', async () => {
+      const client = createClientsClientStub();
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 409,
+        message: 'Já existe cliente com este CNPJ.',
+      });
+
+      await openCreateClientModal(client);
+      selectClientType('PJ');
+      fillNewClientPjForm({
+        cnpj: '11222333000181',
+        corporateName: 'Acme Indústria S/A',
+      });
+      await submitNewClientForm(client);
+
+      expect(
+        await screen.findByText(toCaseInsensitiveMatcher('Já existe cliente com este CNPJ.')),
+      ).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/pages/clients/clientsFormShared.test.ts
+++ b/tests/pages/clients/clientsFormShared.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiError } from '@/shared/api';
+
+import {
+  classifyClientSubmitError,
+  CNPJ_LENGTH,
+  CORPORATE_NAME_MAX,
+  CPF_LENGTH,
+  decideClientBadRequestHandling,
+  digitsOnly,
+  extractClientValidationErrors,
+  FULL_NAME_MAX,
+  INITIAL_CLIENT_FORM_STATE,
+  isValidCnpj,
+  isValidCpf,
+  validateClientForm,
+} from '@/pages/clients/clientsFormShared';
+
+/**
+ * Suíte unitária do `clientsFormShared.ts` (Issue #74). Cobre:
+ *
+ * - `digitsOnly` — normalização para apenas dígitos.
+ * - `isValidCpf`/`isValidCnpj` — algoritmo de DV (espelha o
+ *   backend `IsValidCpf`/`IsValidCnpj`).
+ * - `validateClientForm` — validação por tipo (PF/PJ) com mensagens
+ *   idênticas às do backend.
+ * - `extractClientValidationErrors` — parsing de
+ *   `ValidationProblemDetails` do ASP.NET para chaves do form.
+ * - `decideClientBadRequestHandling` — decisão entre erros por
+ *   campo (mapeáveis) e Alert genérico.
+ * - `classifyClientSubmitError` — classificação de status code +
+ *   field do conflito (cpf/cnpj).
+ */
+
+describe('digitsOnly', () => {
+  it('extrai apenas dígitos', () => {
+    expect(digitsOnly('123.456.789-01')).toBe('12345678901');
+    expect(digitsOnly('11.222.333/0001-81')).toBe('11222333000181');
+  });
+
+  it('devolve string vazia quando não há dígitos', () => {
+    expect(digitsOnly('---')).toBe('');
+    expect(digitsOnly('')).toBe('');
+    expect(digitsOnly('abc')).toBe('');
+  });
+
+  it('preserva ordem dos dígitos', () => {
+    expect(digitsOnly('a1b2c3')).toBe('123');
+  });
+});
+
+describe('isValidCpf', () => {
+  it('aceita CPF válido (DVs corretos)', () => {
+    expect(isValidCpf('52998224725')).toBe(true);
+  });
+
+  it('rejeita comprimento ≠ 11', () => {
+    expect(isValidCpf('1234567890')).toBe(false); // 10 dígitos
+    expect(isValidCpf('123456789012')).toBe(false); // 12 dígitos
+    expect(isValidCpf('')).toBe(false);
+  });
+
+  it('rejeita CPF com todos os dígitos iguais', () => {
+    expect(isValidCpf('11111111111')).toBe(false);
+    expect(isValidCpf('00000000000')).toBe(false);
+    expect(isValidCpf('99999999999')).toBe(false);
+  });
+
+  it('rejeita CPF com DVs incorretos', () => {
+    expect(isValidCpf('12345678900')).toBe(false);
+    expect(isValidCpf('52998224726')).toBe(false); // último DV inválido
+  });
+
+  it(`expõe constante CPF_LENGTH = ${CPF_LENGTH}`, () => {
+    expect(CPF_LENGTH).toBe(11);
+  });
+});
+
+describe('isValidCnpj', () => {
+  it('aceita CNPJ válido (DVs corretos)', () => {
+    expect(isValidCnpj('11222333000181')).toBe(true);
+  });
+
+  it('rejeita comprimento ≠ 14', () => {
+    expect(isValidCnpj('1122233300018')).toBe(false); // 13 dígitos
+    expect(isValidCnpj('112223330001811')).toBe(false); // 15 dígitos
+    expect(isValidCnpj('')).toBe(false);
+  });
+
+  it('rejeita CNPJ com todos os dígitos iguais', () => {
+    expect(isValidCnpj('11111111111111')).toBe(false);
+    expect(isValidCnpj('00000000000000')).toBe(false);
+  });
+
+  it('rejeita CNPJ com DVs incorretos', () => {
+    expect(isValidCnpj('11222333000182')).toBe(false); // último DV inválido
+    expect(isValidCnpj('12345678901234')).toBe(false);
+  });
+
+  it(`expõe constante CNPJ_LENGTH = ${CNPJ_LENGTH}`, () => {
+    expect(CNPJ_LENGTH).toBe(14);
+  });
+});
+
+describe('validateClientForm — PF', () => {
+  it('aceita PF válido (CPF e FullName)', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana Cliente',
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('aceita PF com CPF formatado (digitsOnly aplica antes da validação)', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '529.982.247-25',
+      fullName: 'Ana',
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejeita CPF vazio com mensagem do backend', () => {
+    const result = validateClientForm({
+      ...INITIAL_CLIENT_FORM_STATE,
+      type: 'PF',
+      fullName: 'Ana',
+    });
+    expect(result?.cpf).toBe('CPF é obrigatório.');
+  });
+
+  it('rejeita CPF inválido com mensagem do backend', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '11111111111',
+      fullName: 'Ana',
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result?.cpf).toBe('CPF inválido para cliente PF.');
+  });
+
+  it('rejeita FullName vazio com mensagem do backend', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: '',
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result?.fullName).toBe('FullName é obrigatório para cliente PF.');
+  });
+
+  it('rejeita FullName apenas whitespace', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: '   ',
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result?.fullName).toBe('FullName é obrigatório para cliente PF.');
+  });
+
+  it(`rejeita FullName acima de ${FULL_NAME_MAX} caracteres`, () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'a'.repeat(FULL_NAME_MAX + 1),
+      cnpj: '',
+      corporateName: '',
+    });
+    expect(result?.fullName).toContain(`máximo ${FULL_NAME_MAX}`);
+  });
+
+  it('NÃO valida campos de PJ quando type=PF (preserva o que usuário digitou)', () => {
+    const result = validateClientForm({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana',
+      cnpj: 'lixo',
+      corporateName: 'lixo',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('validateClientForm — PJ', () => {
+  it('aceita PJ válido (CNPJ e CorporateName)', () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: '',
+      fullName: '',
+      cnpj: '11222333000181',
+      corporateName: 'Acme Indústria S/A',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejeita CNPJ vazio', () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: '',
+      fullName: '',
+      cnpj: '',
+      corporateName: 'Acme',
+    });
+    expect(result?.cnpj).toBe('CNPJ é obrigatório.');
+  });
+
+  it('rejeita CNPJ inválido', () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: '',
+      fullName: '',
+      cnpj: '11111111111111',
+      corporateName: 'Acme',
+    });
+    expect(result?.cnpj).toBe('CNPJ inválido para cliente PJ.');
+  });
+
+  it('rejeita CorporateName vazio', () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: '',
+      fullName: '',
+      cnpj: '11222333000181',
+      corporateName: '',
+    });
+    expect(result?.corporateName).toBe('CorporateName é obrigatório para cliente PJ.');
+  });
+
+  it(`rejeita CorporateName acima de ${CORPORATE_NAME_MAX} caracteres`, () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: '',
+      fullName: '',
+      cnpj: '11222333000181',
+      corporateName: 'a'.repeat(CORPORATE_NAME_MAX + 1),
+    });
+    expect(result?.corporateName).toContain(`máximo ${CORPORATE_NAME_MAX}`);
+  });
+
+  it('NÃO valida campos de PF quando type=PJ', () => {
+    const result = validateClientForm({
+      type: 'PJ',
+      cpf: 'lixo',
+      fullName: 'lixo',
+      cnpj: '11222333000181',
+      corporateName: 'Acme',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('extractClientValidationErrors', () => {
+  it('mapeia chaves PascalCase → camelCase', () => {
+    const result = extractClientValidationErrors({
+      errors: {
+        Type: ['Type deve ser PF ou PJ.'],
+        Cpf: ['CPF inválido.'],
+        FullName: ['FullName é obrigatório.'],
+        Cnpj: ['CNPJ inválido.'],
+        CorporateName: ['CorporateName é obrigatório.'],
+      },
+    });
+    expect(result).toEqual({
+      type: 'Type deve ser PF ou PJ.',
+      cpf: 'CPF inválido.',
+      fullName: 'FullName é obrigatório.',
+      cnpj: 'CNPJ inválido.',
+      corporateName: 'CorporateName é obrigatório.',
+    });
+  });
+
+  it('aceita string solta (não-array)', () => {
+    const result = extractClientValidationErrors({
+      errors: { Cpf: 'erro literal' },
+    });
+    expect(result).toEqual({ cpf: 'erro literal' });
+  });
+
+  it('ignora chaves desconhecidas', () => {
+    const result = extractClientValidationErrors({
+      errors: {
+        Cpf: ['ok'],
+        UnknownField: ['lixo'],
+      },
+    });
+    expect(result).toEqual({ cpf: 'ok' });
+  });
+
+  it('retorna null para payloads não-mapeáveis', () => {
+    expect(extractClientValidationErrors(null)).toBeNull();
+    expect(extractClientValidationErrors('string')).toBeNull();
+    expect(extractClientValidationErrors({ noErrors: true })).toBeNull();
+    expect(extractClientValidationErrors({ errors: null })).toBeNull();
+    expect(extractClientValidationErrors({ errors: {} })).toBeNull();
+  });
+});
+
+describe('decideClientBadRequestHandling', () => {
+  it('devolve field-errors quando mapeável', () => {
+    const result = decideClientBadRequestHandling(
+      {
+        errors: {
+          Cpf: ['CPF inválido para cliente PF.'],
+        },
+      },
+      'fallback',
+    );
+    expect(result).toEqual({
+      kind: 'field-errors',
+      errors: { cpf: 'CPF inválido para cliente PF.' },
+    });
+  });
+
+  it('devolve submit-error quando payload não-mapeável', () => {
+    const result = decideClientBadRequestHandling(null, 'mensagem fallback');
+    expect(result).toEqual({
+      kind: 'submit-error',
+      message: 'mensagem fallback',
+    });
+  });
+});
+
+describe('classifyClientSubmitError', () => {
+  const COPY = {
+    conflictDefault: 'Já existe cliente com este documento.',
+    forbiddenTitle: 'Falha ao criar cliente',
+    genericFallback: 'Não foi possível criar o cliente. Tente novamente.',
+  };
+
+  it('classifica 409 com conflictField=cpf (PF)', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 409,
+      message: 'Já existe cliente com este CPF.',
+    };
+    const action = classifyClientSubmitError(error, COPY, 'cpf');
+    expect(action.kind).toBe('conflict');
+    if (action.kind === 'conflict') {
+      expect(action.field).toBe('cpf');
+      expect(action.message).toBe('Já existe cliente com este CPF.');
+    }
+  });
+
+  it('classifica 409 com conflictField=cnpj (PJ)', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 409,
+      message: 'Já existe cliente com este CNPJ.',
+    };
+    const action = classifyClientSubmitError(error, COPY, 'cnpj');
+    expect(action.kind).toBe('conflict');
+    if (action.kind === 'conflict') {
+      expect(action.field).toBe('cnpj');
+    }
+  });
+
+  it('classifica 400 como bad-request', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 400,
+      message: 'Erro de validação.',
+      details: { errors: { Cpf: ['x'] } },
+    };
+    const action = classifyClientSubmitError(error, COPY, 'cpf');
+    expect(action.kind).toBe('bad-request');
+  });
+
+  it('classifica 401 como toast', () => {
+    const error: ApiError = {
+      kind: 'http',
+      status: 401,
+      message: 'Sessão expirada.',
+    };
+    const action = classifyClientSubmitError(error, COPY, 'cpf');
+    expect(action.kind).toBe('toast');
+  });
+
+  it('classifica erro de rede como unhandled', () => {
+    const action = classifyClientSubmitError(
+      { kind: 'network', message: 'falha' },
+      COPY,
+      'cpf',
+    );
+    expect(action.kind).toBe('unhandled');
+  });
+});

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -4,6 +4,7 @@ import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
 
 import {
   clientDisplayName,
+  createClient,
   DEFAULT_CLIENTS_PAGE_SIZE,
   getClientsByIds,
   isClientDto,
@@ -475,5 +476,194 @@ describe('getClientsByIds', () => {
         client as unknown as ApiClient,
       ),
     ).rejects.toBe(networkAbort);
+  });
+});
+
+/* ─── createClient (Issue #74) ──────────────────────────── */
+
+describe('createClient', () => {
+  it('envia POST /clients para PF com cpf+fullName trimados', async () => {
+    const client = makeClientStub();
+    const created = makeRawClientPf();
+    client.post.mockResolvedValueOnce(created);
+
+    const result = await createClient(
+      {
+        type: 'PF',
+        cpf: '  12345678901  ',
+        fullName: '  Ana Cliente  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith(
+      '/clients',
+      {
+        type: 'PF',
+        cpf: '12345678901',
+        fullName: 'Ana Cliente',
+      },
+      undefined,
+    );
+    expect(result).toBe(created);
+  });
+
+  it('envia POST /clients para PJ com cnpj+corporateName trimados', async () => {
+    const client = makeClientStub();
+    const created = makeRawClientPj();
+    client.post.mockResolvedValueOnce(created);
+
+    await createClient(
+      {
+        type: 'PJ',
+        cnpj: '  12345678000190  ',
+        corporateName: '  Acme Indústria S/A  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/clients',
+      {
+        type: 'PJ',
+        cnpj: '12345678000190',
+        corporateName: 'Acme Indústria S/A',
+      },
+      undefined,
+    );
+  });
+
+  it('omite campos do tipo oposto (PF não envia cnpj/corporateName)', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(makeRawClientPf());
+
+    await createClient(
+      {
+        type: 'PF',
+        cpf: '12345678901',
+        fullName: 'Ana',
+        // Caller mal-comportado tenta enviar campos PJ junto. O
+        // helper interno `buildClientMutationBody` os filtra para
+        // evitar 400 do backend ("CNPJ não deve ser informado para
+        // cliente PF.").
+        cnpj: '12345678000190',
+        corporateName: 'Algo',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const [, body] = client.post.mock.calls[0];
+    expect(body).toEqual({
+      type: 'PF',
+      cpf: '12345678901',
+      fullName: 'Ana',
+    });
+    expect(body).not.toHaveProperty('cnpj');
+    expect(body).not.toHaveProperty('corporateName');
+  });
+
+  it('omite campos do tipo oposto (PJ não envia cpf/fullName)', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(makeRawClientPj());
+
+    await createClient(
+      {
+        type: 'PJ',
+        cnpj: '12345678000190',
+        corporateName: 'Acme',
+        cpf: '12345678901',
+        fullName: 'Ana',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const [, body] = client.post.mock.calls[0];
+    expect(body).toEqual({
+      type: 'PJ',
+      cnpj: '12345678000190',
+      corporateName: 'Acme',
+    });
+    expect(body).not.toHaveProperty('cpf');
+    expect(body).not.toHaveProperty('fullName');
+  });
+
+  it('omite campos whitespace-only (PF com fullName apenas espaços)', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(makeRawClientPf());
+
+    await createClient(
+      {
+        type: 'PF',
+        cpf: '12345678901',
+        fullName: '   ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const [, body] = client.post.mock.calls[0];
+    expect(body).toEqual({
+      type: 'PF',
+      cpf: '12345678901',
+    });
+    expect(body).not.toHaveProperty('fullName');
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce({ wrong: 'shape' });
+
+    await expect(
+      createClient(
+        {
+          type: 'PF',
+          cpf: '12345678901',
+          fullName: 'Ana',
+        },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(makeRawClientPf());
+    const controller = new AbortController();
+
+    await createClient(
+      { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/clients',
+      expect.any(Object),
+      { signal: controller.signal },
+    );
+  });
+
+  it('propaga ApiError 409 do backend (CPF/CNPJ duplicado)', async () => {
+    const client = makeClientStub();
+    const conflict = {
+      kind: 'http' as const,
+      status: 409,
+      message: 'Já existe cliente com este CPF.',
+    };
+    client.post.mockRejectedValueOnce(conflict);
+
+    await expect(
+      createClient(
+        { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(conflict);
   });
 });


### PR DESCRIPTION
## Summary

- Implementa `NewClientModal` para criação de cliente PF/PJ via `POST /clients`, com gating por `AUTH_V1_CLIENTS_CREATE`, validação client-side de CPF/CNPJ (algoritmo mod 11 espelhando `IsValidCpf`/`IsValidCnpj` do backend) e mapeamento de erros 409/400/401/403 para inline/Alert/toast.
- Reusa o `useCreateEntitySubmit` extraído pelo PR #155 (sem duplicar a 4ª cópia do switch de erro). Estende `src/shared/api/clients.ts` com `createClient` + `CreateClientPayload` filtrando campos do tipo oposto antes do POST (evita 400 backend).
- Refactors anti-duplicação Sonar: `FormFooter` compartilhado (Cancelar/Submit) consumido por NameCodeDescriptionForm/ClientFormFields/UserFormFields/RouteFormFields; `extractValidationErrorsByField`/`useApplyBadRequest` genéricos em `src/shared/forms/`; `ListingResultArea` shell de listagem em `src/shared/listing/`; `useModalOpenState` hook compartilhado em `src/hooks/`.

## Test plan

- [x] `docker compose run --rm web npm run lint` — 0 erros
- [x] `docker compose run --rm web npm run typecheck` — 0 erros
- [x] `docker compose run --rm web npm test` — **975/975 verde** (cobertura nova: `tests/pages/clients/NewClientModal.test.tsx` com 26 testes; `tests/pages/clients/clientsFormShared.test.ts` com 39 testes; `tests/shared/api/clients.test.ts` ganhou casos de `createClient`)
- [x] `docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10` — **2.21% < 3%**, 0 clones novos causados pelo diff (clones remanescentes em `SystemFormFields`/`RoleFormFields` ↔ `NameCodeDescriptionForm` são pré-existentes do upstream)

Closes #74