### PR TITLE
fix(roles): adicionar systemId opcional ao RoleDto

### DIFF
--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -67,6 +67,14 @@ function makeParseError(): ApiError {
  */
 export interface RoleDto {
   id: string;
+  /**
+   * UUID do sistema dono da role. Após `lfc-authenticator#163` é
+   * obrigatório no model `AppRole`. Tipo `string | null` preserva
+   * compatibilidade com fixtures de teste históricas e payloads de
+   * servidores menos atualizados — quando ausente, a UI cai no grupo
+   * "Sem sistema" do agrupamento por sistema.
+   */
+  systemId: string | null;
   name: string;
   code: string;
   /**
@@ -114,6 +122,9 @@ export function isRoleDto(value: unknown): value is RoleDto {
     typeof record.code === "string" &&
     typeof record.createdAt === "string" &&
     typeof record.updatedAt === "string" &&
+    (record.systemId === null ||
+      record.systemId === undefined ||
+      typeof record.systemId === "string") &&
     (record.description === null ||
       record.description === undefined ||
       typeof record.description === "string") &&


### PR DESCRIPTION
## Summary

Hotfix: PR #156 (Issue #69) removeu acidentalmente `systemId` da interface `RoleDto` ao tomar a versão de `origin/development` como base do rebase manual. Como `tests/pages/__helpers__/rolesTestHelpers.tsx` (criado em PR #152, Issue #68) usa `systemId: ID_SYS_AUTH` no fixture tipado como `RoleDto`, isso quebrou typecheck (`TS2353: 'systemId' does not exist in type 'RoleDto'`).

## Test plan

- [x] `tsc --noEmit` passa
- [x] `isRoleDto` aceita payloads com e sem `systemId`

## Detalhes

- Adiciona `systemId: string | null` ao `RoleDto` (nullable para compatibilidade com fixtures legadas).
- Atualiza `isRoleDto` guard para validar o campo opcional.
