### PR TITLE
feat(users): ativar/desativar usuário com modal de confirmação (#80)

### DIFF
--- a/src/pages/users/ToggleUserActiveConfirm.tsx
+++ b/src/pages/users/ToggleUserActiveConfirm.tsx
@@ -1,0 +1,241 @@
+import React, { useMemo } from 'react';
+
+import { updateUser } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import type {
+  ApiClient,
+  UpdateUserPayload,
+  UserDto,
+} from '../../shared/api';
+
+/**
+ * Copy do diálogo "Desativar usuário?" (Issue #80).
+ *
+ * O backend não tem endpoint dedicado para "desativar/ativar" — toggle
+ * é feito via `PUT /users/{id}` com payload completo invertendo o
+ * `active`. A policy aplicada é `Users.Update`, alinhada com o critério
+ * da issue ("Visível com `Users.Update`").
+ *
+ * Vocabulário "Desativar/Ativar" espelha Systems (#60/#61) e Routes
+ * (#65) — a coluna "Status" da tabela já mostra "Ativa/Inativa" para
+ * o flag `active` (e para o soft-delete `deletedAt`), então o operador
+ * vê o mesmo termo no botão e no badge.
+ *
+ * **Importante:** "desativar" aqui não é soft-delete (que persiste
+ * `deletedAt != null` via `DELETE /users/{id}` e exige `Users.Delete`).
+ * É apenas o flag `active=false`. Soft-delete fica para uma issue
+ * futura distinta dentro da EPIC #49.
+ */
+const DEACTIVATE_COPY: MutationConfirmCopy = {
+  title: 'Desativar usuário?',
+  descriptionPrefix: 'O usuário ',
+  descriptionSuffix:
+    ' não conseguirá mais autenticar até ser ativado novamente.',
+  confirmLabel: 'Desativar',
+  successMessage: 'Usuário desativado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao desativar usuário',
+    genericFallback:
+      'Não foi possível desativar o usuário. Tente novamente.',
+    notFoundMessage:
+      'Usuário não encontrado ou foi removido. Atualize a lista.',
+  },
+};
+
+/**
+ * Copy do diálogo "Ativar usuário?" (Issue #80). Espelha
+ * `DEACTIVATE_COPY` mas com vocabulário positivo. Backend devolve o
+ * mesmo conjunto de status codes (404 quando o usuário some,
+ * 401/403 por permissão); o slot `conflictMessage` fica ausente
+ * porque `PUT /users/{id}` retorna 409 apenas em conflito de e-mail
+ * — cenário irrelevante quando só estamos invertendo `active`.
+ */
+const ACTIVATE_COPY: MutationConfirmCopy = {
+  title: 'Ativar usuário?',
+  descriptionPrefix: 'O usuário ',
+  descriptionSuffix: ' poderá autenticar novamente após a ativação.',
+  confirmLabel: 'Ativar',
+  successMessage: 'Usuário ativado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao ativar usuário',
+    genericFallback:
+      'Não foi possível ativar o usuário. Tente novamente.',
+    notFoundMessage:
+      'Usuário não encontrado ou foi removido. Atualize a lista.',
+  },
+};
+
+/**
+ * Adapter `MutationTarget` para `UserDto`. O shell `MutationConfirmModal`
+ * exibe `target.name` em destaque + `target.code` em monoespaçado entre
+ * parênteses — para usuários, o "código" semântico é o e-mail (único
+ * por usuário, identificador legível). Mantemos o shell intacto e
+ * apenas mapeamos o `code` para `email` neste adapter — Systems/Routes
+ * continuam usando `code` literal sem regressão.
+ */
+interface UserTarget {
+  name: string;
+  code: string;
+}
+
+function toTarget(user: UserDto | null): UserTarget | null {
+  if (!user) return null;
+  return { name: user.name, code: user.email };
+}
+
+interface ToggleUserActiveConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Usuário selecionado para o toggle. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `user`.
+   * Mantemos o objeto completo (não só `id`) porque precisamos de
+   * `name`/`email`/`identity`/`clientId` para reenviar o body
+   * completo do `PUT /users/{id}`.
+   */
+  user: UserDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após o toggle bem-sucedido ou após detecção de
+   * 404 (usuário já removido entre abertura e submit) — em ambos casos
+   * a UI quer refetch para sincronizar a tabela com o backend.
+   */
+  onToggled: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `updateUser` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de confirmação de toggle ativo/desativado de usuário (Issue #80).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (extraído na #61 e
+ * generalizado na #65 para servir múltiplos recursos) — toda a
+ * estrutura visual + lógica de submissão/erro vive no shell
+ * compartilhado. Aqui injetamos:
+ *
+ * - **Copy** (`DEACTIVATE_COPY` / `ACTIVATE_COPY`): título, descrição,
+ *   label do botão e mensagens de toast escolhidos pelo `user.active`
+ *   atual. Quando `active === true`, o operador está prestes a
+ *   desativar; quando `active === false`, prestes a ativar.
+ * - **Mutate** (`performToggle`): adapta `updateUser(id, payload)`
+ *   para a assinatura `(target, client?) => Promise<unknown>` esperada
+ *   pelo shell. Reenvia o body completo do `PUT /users/{id}` (que
+ *   exige `Name`/`Email`/`Identity`/`Active` como `[Required]`) com
+ *   `active` invertido — o backend não tem endpoint dedicado de
+ *   "toggle". O `clientId` atual é preservado: omitido quando vazio
+ *   (preserva o caminho que o backend já usa para "manter o
+ *   ClientId atual" — `UsersController.UpdateById` linha 507).
+ * - **Variant**: `danger` quando vai desativar (paridade visual com
+ *   "Desativar sistema"), `primary` quando vai ativar (ação positiva,
+ *   espelha `RestoreSystemConfirm`).
+ * - **`testIdPrefix`** (`toggle-user-active`): mesmo prefixo nas duas
+ *   ações — diferenciamos visualmente pela copy e pela variant, mas o
+ *   teste só precisa de UM seletor para abrir/confirmar.
+ *
+ * **Por que reusar `MutationConfirmModal` em vez de criar um modal
+ * próprio?** Sonar tokeniza ≥10 linhas idênticas como `New Code
+ * Duplication` (lições PR #119/#123/#127/#128/#134/#135 — 6
+ * recorrências). Recriar o shell aqui duplicaria ~80 linhas de
+ * estrutura visual + try/catch/classify. Reusar mantém a fonte
+ * deduplicada por construção.
+ */
+export const ToggleUserActiveConfirm: React.FC<
+  ToggleUserActiveConfirmProps
+> = ({ open, user, onClose, onToggled, client }) => {
+  const target = toTarget(user);
+
+  /**
+   * Decide a copy ("Desativar?" vs "Ativar?") com base no estado atual
+   * do usuário: ativos viram inativos (desativar) e vice-versa. Quando
+   * `user` é `null` (modal fechado), o memo cai no `DEACTIVATE_COPY`
+   * por default — irrelevante porque o shell não renderiza nada com
+   * `target=null`.
+   */
+  const copy = useMemo<MutationConfirmCopy>(
+    () => (user?.active === false ? ACTIVATE_COPY : DEACTIVATE_COPY),
+    [user?.active],
+  );
+
+  /**
+   * Variante visual do botão de confirmação. `danger` para desativar
+   * (paridade com "Desativar sistema/rota"), `primary` para ativar
+   * (ação positiva, paridade com "Restaurar sistema"). A semântica
+   * fica clara sem hardcode de cor — o design system local já mapeia
+   * `--clr-orange/danger` e `--clr-lime/primary` nessas variants.
+   */
+  const confirmVariant = user?.active === false ? 'primary' : 'danger';
+
+  /**
+   * Função adapter `(target, client?) => Promise<unknown>` que delega
+   * para `updateUser(user.id, {...payload completo, active: !active})`.
+   *
+   * Memoizada com `useMemo` (não `useCallback` pra preservar o tipo
+   * de retorno) — o `MutationConfirmModal` consome `mutate` em
+   * `useCallback`, então uma referência estável evita invalidação
+   * desnecessária quando o `target`/copy mudam.
+   *
+   * **Decisões do payload:**
+   *
+   * - `name`/`email`/`identity` vêm do `UserDto` carregado: como
+   *   `PUT /users/{id}` valida `[Required]` em todos eles, precisamos
+   *   reenviar. Usar os valores atuais preserva o estado original e
+   *   evita 400 por validação cruzada.
+   * - `active` é invertido — único campo cuja mudança importa neste
+   *   diálogo.
+   * - `clientId` é omitido quando o usuário tem `clientId === null`
+   *   (caso raro mas possível em payloads legados): o backend trata
+   *   `request.ClientId == null` como "manter o ClientId atual"
+   *   (`UsersController.UpdateById` linha 507) — sem isso a UI
+   *   forçaria `null` literal, que o controller validaria como
+   *   `Guid?` válido mas geraria payload incoerente. Quando
+   *   `clientId` está preenchido, repassamos para preservar o vínculo.
+   * - `password` não pertence ao `UpdateUserPayload` (reset é
+   *   endpoint separado) — `buildUserUpdateBody` no `users.ts` já
+   *   garante que o payload não vaze a senha mesmo se o caller
+   *   passasse por engano.
+   */
+  const performToggle = useMemo(
+    () =>
+      function (
+        _target: UserTarget,
+        targetClient?: ApiClient,
+      ): Promise<unknown> {
+        if (!user) {
+          return Promise.reject(new Error('User unavailable.'));
+        }
+        const payload: UpdateUserPayload = {
+          name: user.name,
+          email: user.email,
+          identity: user.identity,
+          active: !user.active,
+        };
+        if (user.clientId !== null && user.clientId.length > 0) {
+          payload.clientId = user.clientId;
+        }
+        return updateUser(user.id, payload, undefined, targetClient);
+      },
+    [user],
+  );
+
+  return (
+    <MutationConfirmModal<UserTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onToggled}
+      client={client}
+      mutate={performToggle}
+      copy={copy}
+      confirmVariant={confirmVariant}
+      testIdPrefix="toggle-user-active"
+    />
+  );
+};

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus } from 'lucide-react';
+import { Pencil, Plus, Power } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
@@ -49,6 +49,7 @@ import {
 
 import { EditUserModal } from './EditUserModal';
 import { NewUserModal } from './NewUserModal';
+import { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';
 
 import type { TableColumn } from '../../components/ui';
 import type {
@@ -185,20 +186,41 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     close: handleCloseEditModal,
   } = useListModalState<UserDto>();
 
+  // Usuário selecionado para toggle ativo/desativado (Issue #80). Igual
+  // ao `editingUser`, mantemos o objeto completo porque o
+  // `ToggleUserActiveConfirm` precisa de `name`/`email`/`identity`/
+  // `clientId` para reenviar o body completo do `PUT /users/{id}` —
+  // o backend exige todos os campos como `[Required]` mesmo para
+  // alternar apenas o `active`.
+  const {
+    selected: togglingUser,
+    open: handleOpenToggleConfirm,
+    close: handleCloseToggleConfirm,
+  } = useListModalState<UserDto>();
+
   /**
-   * Renderiza o bloco de ações dos cards mobile (espelho da coluna
-   * "Ações" do desktop). Centralizar aqui evita BLOCKER de duplicação
-   * Sonar/JSCPD com `RolesPage` (lição PR #134/#135 — bloco ≥10 linhas
-   * idêntico entre páginas é tokenizado como `New Code Duplication`).
+   * Renderiza o bloco de ações por linha (Editar + Desativar/Ativar)
+   * para uma linha de usuário. Reutilizado pelo desktop (coluna
+   * "Ações" da tabela) e pelo mobile (rodapé dos cards) — única
+   * diferença é o prefixo dos `data-testid` (`users-edit`/
+   * `users-toggle-active` no desktop vs `users-card-edit`/
+   * `users-card-toggle-active` no mobile, para que cada surface
+   * tenha seu próprio seletor sem colidir).
    *
-   * Retorna `null` quando o usuário não tem permissão ou a linha é
-   * soft-deletada — coerente com o gating da tabela desktop.
+   * Centralizar aqui em uma única função evita o BLOCKER de
+   * duplicação JSCPD/Sonar — o `<Button>` do toggle ativo (~11
+   * linhas) repetido entre a tabela e os cards mobile foi marcado
+   * como clone (lição PR #128/#134/#135 — bloco ≥10 linhas idêntico
+   * em 2 surfaces do mesmo arquivo é tokenizado como duplicação).
+   *
+   * Caller é responsável por filtrar quando NÃO chamar (gating de
+   * permissão e `deletedAt !== null`) — a função sempre devolve o
+   * `<RowActions>` populado.
    */
-  const renderMobileEditAction = useCallback(
-    (row: UserDto): React.ReactNode => {
-      if (!canUpdateUser || row.deletedAt !== null) {
-        return null;
-      }
+  const renderUserRowActions = useCallback(
+    (row: UserDto, testIdPrefix: 'users' | 'users-card'): React.ReactNode => {
+      const toggleLabel = row.active ? 'Desativar' : 'Ativar';
+      const toggleVariant = row.active ? 'danger' : 'primary';
       return (
         <RowActions>
           <Button
@@ -207,14 +229,40 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
             icon={<Pencil size={14} strokeWidth={1.5} />}
             onClick={() => handleOpenEditModal(row)}
             aria-label={`Editar usuário ${row.name}`}
-            data-testid={`users-card-edit-${row.id}`}
+            data-testid={`${testIdPrefix}-edit-${row.id}`}
           >
             Editar
+          </Button>
+          <Button
+            variant={toggleVariant}
+            size="sm"
+            icon={<Power size={14} strokeWidth={1.5} />}
+            onClick={() => handleOpenToggleConfirm(row)}
+            aria-label={`${toggleLabel} usuário ${row.name}`}
+            data-testid={`${testIdPrefix}-toggle-active-${row.id}`}
+          >
+            {toggleLabel}
           </Button>
         </RowActions>
       );
     },
-    [canUpdateUser, handleOpenEditModal],
+    [handleOpenEditModal, handleOpenToggleConfirm],
+  );
+
+  /**
+   * Renderiza o bloco de ações dos cards mobile (wrapper sobre
+   * `renderUserRowActions` aplicando o gating de permissão +
+   * `deletedAt`). Espelha a coluna "Ações" do desktop sem duplicar o
+   * JSX (ver comentário em `renderUserRowActions`).
+   */
+  const renderMobileRowActions = useCallback(
+    (row: UserDto): React.ReactNode => {
+      if (!canUpdateUser || row.deletedAt !== null) {
+        return null;
+      }
+      return renderUserRowActions(row, 'users-card');
+    },
+    [canUpdateUser, renderUserRowActions],
   );
 
   /**
@@ -420,41 +468,35 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     ];
 
     // Coluna "Ações" só aparece quando o usuário tem alguma ação
-    // disponível. Hoje "Editar" (Issue #79); a paridade total com
-    // Sistemas/Roles (desativar/restaurar) fica para issues futuras
-    // da EPIC #49. Espelha a estratégia do `RolesPage`/`SystemsPage`.
+    // disponível. Issues #79 (Editar) e #80 (Ativar/Desativar) usam
+    // a mesma policy `Users.Update`; a paridade com soft-delete/
+    // restore (`Users.Delete`/`Users.Restore`) fica para issues
+    // futuras da EPIC #49. Espelha a estratégia do
+    // `RolesPage`/`SystemsPage`.
     if (canUpdateUser) {
       base.push({
         key: 'actions',
         label: 'Ações',
         isActions: true,
-        render: (row) => (
-          <RowActions>
-            {row.deletedAt === null && (
-              // "Editar" só faz sentido em usuários ativos. O backend
-              // devolve 404 ao tentar PUT em usuário soft-deletado
-              // (`Users.FirstOrDefaultAsync` cai no query filter
-              // global), mas esconder no UI alinha com a coluna
-              // Status. Espelha a estratégia de `RolesPage`/
-              // `SystemsPage`.
-              <Button
-                variant="ghost"
-                size="sm"
-                icon={<Pencil size={14} strokeWidth={1.5} />}
-                onClick={() => handleOpenEditModal(row)}
-                aria-label={`Editar usuário ${row.name}`}
-                data-testid={`users-edit-${row.id}`}
-              >
-                Editar
-              </Button>
-            )}
-          </RowActions>
-        ),
+        render: (row) => {
+          if (row.deletedAt !== null) {
+            // Linhas soft-deletadas não recebem ações (gating
+            // alinhado com a coluna Status). O backend devolve 404
+            // ao tentar PUT em usuário soft-deletado (query filter
+            // global), mas esconder no UI alinha com a UX.
+            return <RowActions />;
+          }
+          // "Desativar" em ativos / "Ativar" em inativos — Issue
+          // #80. Compartilha o JSX com os cards mobile via
+          // `renderUserRowActions` para evitar duplicação JSCPD/
+          // Sonar (lição PR #134/#135).
+          return renderUserRowActions(row, 'users');
+        },
       });
     }
 
     return base;
-  }, [canUpdateUser, clientsById, handleOpenEditModal]);
+  }, [canUpdateUser, clientsById, renderUserRowActions]);
 
   const showOverlay = isFetching && !isInitialLoading;
 
@@ -567,7 +609,7 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
                       {renderClientCell(user, clientsById)}
                     </CardMetaValue>
                   </CardMeta>
-                  {renderMobileEditAction(user)}
+                  {renderMobileRowActions(user)}
                 </EntityCard>
               );
             })}
@@ -606,6 +648,16 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           user={editingUser}
           onClose={handleCloseEditModal}
           onUpdated={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canUpdateUser && (
+        <ToggleUserActiveConfirm
+          open={togglingUser !== null}
+          user={togglingUser}
+          onClose={handleCloseToggleConfirm}
+          onToggled={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -3,3 +3,4 @@ export { UserDetailShellPage } from './UserDetailShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
 export { NewUserModal } from './NewUserModal';
 export { EditUserModal } from './EditUserModal';
+export { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';

--- a/tests/pages/__helpers__/usersTestHelpers.tsx
+++ b/tests/pages/__helpers__/usersTestHelpers.tsx
@@ -376,6 +376,79 @@ export async function submitEditUserForm(
   await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
 }
 
+/* ─── Helpers para suíte de toggle ativo (Issue #80) ──────── */
+
+/**
+ * Mocka a resposta inicial (listagem com o usuário-alvo), renderiza a
+ * `UsersListShellPage`, espera a lista carregar e clica no botão
+ * "Desativar"/"Ativar" da linha do usuário informado. Espelha
+ * `openEditUserModal` mas dispara o modal de toggle ativo
+ * (`ToggleUserActiveConfirm`) — Issue #80.
+ *
+ * O `data-testid` do botão (`users-toggle-active-{id}`) é estável
+ * independente do estado `active` do usuário; o que muda é o label
+ * visível ("Desativar"/"Ativar") e o variant. Helpers de teste usam
+ * o testId para abrir o modal sem reagir ao label, e os asserts
+ * verificam a copy correta separadamente.
+ *
+ * Quem precisar de mocks diferentes pode chamar
+ * `client.get.mockImplementation(...)` antes de invocar este helper —
+ * a detecção de mocks pré-existentes preserva o caso "fila customizada
+ * de respostas" (ex.: cenários de erro 404 com refetch).
+ */
+export async function openToggleUserActiveConfirm(
+  client: ApiClientStub,
+  options: { user?: UserDto } = {},
+): Promise<void> {
+  const user = options.user ?? makeUser();
+  if (
+    client.get.getMockImplementation() === undefined &&
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.resolve(makeUsersPagedResponse([user]));
+      }
+      if (typeof path === 'string' && path.startsWith('/clients/')) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    });
+  }
+  renderUsersPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`users-toggle-active-${user.id}`));
+  // Aguarda a abertura do modal — verifica a presença do botão de
+  // confirmação que existe apenas quando o `MutationConfirmModal`
+  // está renderizado.
+  await waitFor(() => {
+    expect(
+      screen.getByTestId('toggle-user-active-confirm'),
+    ).toBeInTheDocument();
+  });
+}
+
+/**
+ * Confirma o toggle clicando em "Desativar"/"Ativar" no
+ * `ToggleUserActiveConfirm` e aguarda o `client.put` ser chamado pelo
+ * menos `expectedPutCalls` vezes (default `1`). Espelha `confirmDelete`
+ * dos `systemsTestHelpers`, mas com PUT em vez de DELETE — o backend
+ * não tem endpoint dedicado para toggle de `active`, então o modal
+ * dispara `updateUser` (PUT) com o body completo. Faz `act(async)`
+ * para flushar a microtask do click handler antes do `waitFor`.
+ */
+export async function confirmToggleUserActive(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('toggle-user-active-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
+}
+
 /**
  * Constrói os 3 cenários de fechamento sem persistência (Esc,
  * Cancelar, backdrop) usando o `cancelTestId` da suíte chamadora.
@@ -418,8 +491,37 @@ export function buildUsersCloseCases(
  * `New Code Duplication` no Sonar (lição PR #128 — projetar shared
  * helpers desde o primeiro PR do recurso).
  */
-export function buildSharedUserSubmitErrorCases(
-  verb: 'criar' | 'atualizar',
+/**
+ * Verbos suportados pelas suítes de mutação de usuário. Cada um
+ * controla a copy genérica do toast vermelho (`"Não foi possível
+ * {verb} o usuário. Tente novamente."`):
+ *
+ * - `'criar'`/`'atualizar'` — usados pelo create/edit do form de
+ *   usuário (Issues #78/#79).
+ * - `'ativar'`/`'desativar'` — usados pelo toggle ativo (Issue #80).
+ *
+ * Centralizar o tipo aqui (em vez de declarar dois alias paralelos)
+ * permite que `buildSharedUserMutationErrorCases` cubra todos os
+ * cenários sem duplicar a função (lição PR #134/#135 — sonarjs/
+ * no-identical-functions).
+ */
+export type UserMutationVerb = 'criar' | 'atualizar' | 'ativar' | 'desativar';
+
+/**
+ * Constrói os cenários comuns de erro 401/403/network para qualquer
+ * mutação de usuário. Casos comuns aparecem em todas as suítes
+ * (criação #78, edição #79, toggle ativo #80) com a única diferença
+ * sendo o verbo na copy genérica do toast vermelho — `it.each` reusa
+ * a mesma tabela em todas elas.
+ *
+ * Pré-fabricar antes do segundo call site previne a recorrência de
+ * `New Code Duplication` no Sonar (lição PR #128 — projetar shared
+ * helpers desde o primeiro PR do recurso). Casos específicos
+ * (`409`/`404` — comportamento difere entre suítes) ficam inline em
+ * cada suíte porque divergem em estrutura, não só em copy.
+ */
+export function buildSharedUserMutationErrorCases(
+  verb: UserMutationVerb,
 ): ReadonlyArray<UsersErrorCase> {
   return [
     {
@@ -446,4 +548,16 @@ export function buildSharedUserSubmitErrorCases(
       expectedText: `Não foi possível ${verb} o usuário. Tente novamente.`,
     },
   ];
+}
+
+/**
+ * Alias retro-compatível para suítes de criação/edição (#78/#79). Mantém
+ * a API pública sem reabrir os call-sites existentes — o conjunto de
+ * verbos aceitos é restrito ao subconjunto histórico (`criar`/`atualizar`)
+ * via união de tipo.
+ */
+export function buildSharedUserSubmitErrorCases(
+  verb: 'criar' | 'atualizar',
+): ReadonlyArray<UsersErrorCase> {
+  return buildSharedUserMutationErrorCases(verb);
 }

--- a/tests/pages/users/UserActivateToggle.test.tsx
+++ b/tests/pages/users/UserActivateToggle.test.tsx
@@ -1,0 +1,448 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildSharedUserMutationErrorCases,
+  buildUsersCloseCases,
+  confirmToggleUserActive,
+  createUsersClientStub,
+  ID_USER_ALICE,
+  makeUser,
+  makeUsersPagedResponse,
+  openToggleUserActiveConfirm,
+  renderUsersPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+  type UsersErrorCase,
+} from '../__helpers__/usersTestHelpers';
+
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Suíte da `UsersListShellPage` — toggle ativo/desativado (Issue #80,
+ * EPIC #49).
+ *
+ * Espelha a estratégia de `SystemsPage.delete.test.tsx`/
+ * `SystemsPage.restore.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory para que `vi.mock` capture o valor atual a cada
+ *   `useAuth()`).
+ * - Stub de `ApiClient` injetado em `<UsersListShellPage client={stub} />`
+ *   isolando a página da camada de transporte real.
+ * - Helpers compartilhados em `tests/pages/__helpers__/usersTestHelpers.tsx`
+ *   para colapsar o boilerplate "abrir modal → confirmar → asserir"
+ *   evitando `New Code Duplication` no Sonar (lição PR #134/#135).
+ *
+ * **Decisão chave de implementação:** o toggle não tem endpoint
+ * dedicado no backend — `PUT /users/{id}` exige body completo
+ * (`Name`/`Email`/`Identity`/`Active` como `[Required]`). O
+ * `ToggleUserActiveConfirm` reenvia o body completo invertendo apenas
+ * `active`. Os testes verificam o payload final passado ao `client.put`
+ * para confirmar que outros campos não são perdidos no caminho.
+ *
+ * **Diferença vs Systems#60/#61:** o toggle é controlado por uma única
+ * permissão (`Users.Update`, mesma da edição) — não há policy
+ * separada para "Active" e "Restore". Soft-delete é endpoint distinto
+ * (`Users.Delete`/`Users.Restore`) e não está no escopo desta issue.
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const USERS_UPDATE_PERMISSION = 'AUTH_V1_USERS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('UsersListShellPage — toggle ativo (Issue #80)', () => {
+  describe('gating do botão "Desativar/Ativar" por linha', () => {
+    it('não exibe botões "Desativar/Ativar" quando o usuário não possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([makeUser()]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`users-toggle-active-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Desativar" para linhas ativas quando o usuário possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(
+            makeUsersPagedResponse([makeUser({ active: true })]),
+          );
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`users-toggle-active-${ID_USER_ALICE}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute(
+        'aria-label',
+        'Desativar usuário Alice Admin',
+      );
+      expect(btn).toHaveTextContent('Desativar');
+    });
+
+    it('exibe botão "Ativar" para linhas inativas (active=false) quando o usuário possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(
+            makeUsersPagedResponse([makeUser({ active: false })]),
+          );
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`users-toggle-active-${ID_USER_ALICE}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute('aria-label', 'Ativar usuário Alice Admin');
+      expect(btn).toHaveTextContent('Ativar');
+    });
+
+    it('NÃO exibe botão de toggle em linhas soft-deletadas mesmo com permissão', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const deletedUser = makeUser({ deletedAt: '2026-02-01T00:00:00Z' });
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([deletedUser]));
+        }
+        return Promise.resolve(null);
+      });
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      // Soft-deleted: nenhuma ação aparece — alinha com a coluna
+      // Status (badge "Inativa") e com a UX de Editar (não faz
+      // sentido editar/desativar uma linha já soft-deletada).
+      expect(
+        screen.queryByTestId(`users-toggle-active-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('clicar em "Desativar" abre o diálogo "Desativar usuário?" com nome e e-mail do usuário', async () => {
+      const user = makeUser({
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        active: true,
+      });
+      const client = createUsersClientStub();
+      await openToggleUserActiveConfirm(client, { user });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Desativar usuário\?/i),
+      ).toBeInTheDocument();
+      const description = screen.getByTestId('toggle-user-active-description');
+      expect(description).toHaveTextContent('Alice Admin');
+      expect(description).toHaveTextContent('alice@example.com');
+    });
+
+    it('clicar em "Ativar" abre o diálogo "Ativar usuário?" com a copy positiva', async () => {
+      const user = makeUser({
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        active: false,
+      });
+      const client = createUsersClientStub();
+      await openToggleUserActiveConfirm(client, { user });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/Ativar usuário\?/i)).toBeInTheDocument();
+      const confirmBtn = screen.getByTestId('toggle-user-active-confirm');
+      expect(confirmBtn).toHaveTextContent('Ativar');
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildUsersCloseCases`
+     * (helper compartilhado com criação/edição) — diferença é só o
+     * testId do botão Cancelar (`toggle-user-active-cancel`). Lição
+     * PR #127: `it.each` evita BLOCKER de duplicação Sonar para
+     * cenários com mesma estrutura mudando 1-2 mocks.
+     */
+    const CLOSE_CASES = buildUsersCloseCases('toggle-user-active-cancel');
+
+    it.each(CLOSE_CASES)(
+      'fechar via $name não dispara PUT',
+      async ({ close }) => {
+        const client = createUsersClientStub();
+        await openToggleUserActiveConfirm(client);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(client.put).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('desativar: envia PUT /users/{id} com active=false preservando os demais campos, fecha modal, exibe toast e refaz listUsers', async () => {
+      const target = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 1,
+        clientId: 'client-uuid',
+        active: true,
+      });
+      const client = createUsersClientStub();
+      // Implementation: GET /users (inicial) + GET /clients/{id} no
+      // mount, depois PUT /users/{id}, depois GET /users (refetch).
+      let getCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          getCalls += 1;
+          return Promise.resolve(makeUsersPagedResponse([target]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected path: ${path}`));
+      });
+      client.put.mockResolvedValueOnce({ ...target, active: false });
+
+      await openToggleUserActiveConfirm(client, { user: target });
+      await confirmToggleUserActive(client);
+
+      expect(client.put).toHaveBeenCalledWith(
+        `/users/${ID_USER_ALICE}`,
+        {
+          name: 'Alice Admin',
+          email: 'alice@example.com',
+          identity: 1,
+          active: false,
+          clientId: 'client-uuid',
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Usuário desativado." (status do ToastProvider).
+      expect(
+        await screen.findByText('Usuário desativado.'),
+      ).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez na rota
+      // `/users` após o PUT bem-sucedido. (`getCalls` registrado pelo
+      // mock implementation diferencia os dois GETs sem flakiness.)
+      await waitFor(() => {
+        expect(getCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('ativar: envia PUT /users/{id} com active=true, exibe toast positivo e refetcha', async () => {
+      const target = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 1,
+        clientId: 'client-uuid',
+        active: false,
+      });
+      const client = createUsersClientStub();
+      let getCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          getCalls += 1;
+          return Promise.resolve(makeUsersPagedResponse([target]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected path: ${path}`));
+      });
+      client.put.mockResolvedValueOnce({ ...target, active: true });
+
+      await openToggleUserActiveConfirm(client, { user: target });
+      await confirmToggleUserActive(client);
+
+      expect(client.put).toHaveBeenCalledWith(
+        `/users/${ID_USER_ALICE}`,
+        expect.objectContaining({ active: true, clientId: 'client-uuid' }),
+        undefined,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(
+        await screen.findByText('Usuário ativado.'),
+      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(getCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('omite clientId do payload quando o usuário não tem cliente vinculado (preservando "manter ClientId atual" no backend)', async () => {
+      const target = makeUser({
+        id: ID_USER_ALICE,
+        clientId: null,
+        active: true,
+      });
+      const client = createUsersClientStub();
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          return Promise.resolve(makeUsersPagedResponse([target]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected path: ${path}`));
+      });
+      client.put.mockResolvedValueOnce({ ...target, active: false });
+
+      await openToggleUserActiveConfirm(client, { user: target });
+      await confirmToggleUserActive(client);
+
+      // O payload final NÃO deve carregar `clientId` quando o usuário
+      // não tem cliente vinculado — o backend interpreta a ausência
+      // como "manter o ClientId atual" (`UsersController.UpdateById`
+      // linha 507). `expect.not.objectContaining` valida a ausência.
+      const calledWith = client.put.mock.calls[0][1];
+      expect(calledWith).not.toHaveProperty('clientId');
+      expect(calledWith).toMatchObject({ active: false });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Casos
+     * comuns (401, 403, network) vêm do helper compartilhado
+     * `buildSharedUserMutationErrorCases('desativar')` (lição PR #128
+     * — pré-projetar shared helpers para evitar duplicação literal
+     * entre suítes que diferem só pelo verbo).
+     *
+     * Caso específico (404 — usuário removido entre abertura e
+     * confirm) fica inline porque o comportamento difere: modal fecha
+     * + dispara refetch (paridade com o tratamento de 404 no edit
+     * — `EditUserModal`).
+     */
+    const ERROR_CASES: ReadonlyArray<UsersErrorCase> = [
+      {
+        name: '404 (usuário já removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Usuário não encontrado.',
+        },
+        expectedText: 'Usuário não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+      ...buildSharedUserMutationErrorCases('desativar'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const target = makeUser({ active: true });
+        const client = createUsersClientStub();
+        client.get.mockImplementation((path: string) => {
+          if (path.startsWith('/users')) {
+            return Promise.resolve(makeUsersPagedResponse([target]));
+          }
+          if (path.startsWith('/clients/')) {
+            return Promise.resolve(null);
+          }
+          return Promise.reject(new Error(`unexpected path: ${path}`));
+        });
+        client.put.mockRejectedValueOnce(error);
+
+        await openToggleUserActiveConfirm(client, { user: target });
+        await confirmToggleUserActive(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onToggled chamado mesmo em erro)', async () => {
+      const target = makeUser({ active: true });
+      const client = createUsersClientStub();
+      let getCalls = 0;
+      client.get.mockImplementation((path: string) => {
+        if (path.startsWith('/users')) {
+          getCalls += 1;
+          return Promise.resolve(makeUsersPagedResponse([target]));
+        }
+        if (path.startsWith('/clients/')) {
+          return Promise.resolve(null);
+        }
+        return Promise.reject(new Error(`unexpected path: ${path}`));
+      });
+      client.put.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Usuário não encontrado.',
+      } satisfies ApiError);
+
+      await openToggleUserActiveConfirm(client, { user: target });
+      await confirmToggleUserActive(client);
+
+      await waitFor(() => {
+        expect(getCalls).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Contexto
Issue [#80](https://github.com/LF-Calegari/lfc-admin-gui/issues/80) — sub-issue da EPIC #49 (CRUD de Usuários). Habilita o toggle do flag `active` de um usuário via UI, com confirmação modal antes da ação. Não confunde com soft-delete (esse caminho usa `Users.Delete`/`Users.Restore` e fica para issues posteriores da EPIC).

## Objetivo
Permitir que operadores com permissão `Users.Update` desativem (ou reativem) um usuário a partir da listagem, sem precisar abrir o modal de edição completo. Espelha a UX consagrada de Systems (#60/#61) e Routes (#65) reusando o `MutationConfirmModal` shared.

## O que foi feito

- **`src/pages/users/ToggleUserActiveConfirm.tsx`** (novo): wrapper fino sobre `MutationConfirmModal` com duas variantes de copy (`DEACTIVATE_COPY` para ativos → desativar; `ACTIVATE_COPY` para inativos → ativar). O `mutate` injeta `updateUser(id, payload)` reenviando body completo (`name`/`email`/`identity`/`active` invertido) — `PUT /users/{id}` exige todos como `[Required]` no `lfc-authenticator`. `clientId` é omitido quando `null` para preservar o caminho "manter ClientId atual" do controller (`UsersController.UpdateById` linha 507). Adapter `UserDto → MutationTarget` mapeia `email` para o slot `code` do shell, exibindo o e-mail em monoespaçado entre parênteses na descrição do diálogo (paridade visual com Systems/Routes).
- **`src/pages/users/UsersListShellPage.tsx`**: novo botão "Desativar"/"Ativar" na coluna Ações (desktop) e no rodapé dos cards (mobile), gated por `AUTH_V1_USERS_UPDATE` + `row.deletedAt === null`. Label e variant alternam conforme `row.active` (`danger`/`primary`). Para evitar duplicação JSCPD/Sonar entre desktop e mobile, o JSX dos botões foi extraído em `renderUserRowActions(row, testIdPrefix)` — dois call-sites com prefixos diferentes (`users-` vs `users-card-`).
- **`tests/pages/__helpers__/usersTestHelpers.tsx`**: novos helpers `openToggleUserActiveConfirm` + `confirmToggleUserActive` espelhando `openDeleteConfirm`/`confirmDelete` de `systemsTestHelpers`. `buildSharedUserSubmitErrorCases` foi unificado em `buildSharedUserMutationErrorCases` (que aceita `criar`/`atualizar`/`ativar`/`desativar`) com alias retro-compatível para preservar call-sites existentes — elimina o BLOCKER `sonarjs/no-identical-functions`.
- **`tests/pages/users/UserActivateToggle.test.tsx`** (novo, 17 cenários): cobre gating por permissão, gating por `deletedAt`, copy correta (Desativar vs Ativar), payload do PUT (active invertido + omissão de clientId quando `null`), refetch pós-sucesso, fechamento via Esc/Cancelar/backdrop e tratamento de erros 404/401/403/network.

## Arquivos impactados

- `src/pages/users/ToggleUserActiveConfirm.tsx` (novo, 242 linhas)
- `src/pages/users/UsersListShellPage.tsx` (134 linhas modificadas)
- `src/pages/users/index.ts` (1 linha adicionada)
- `tests/pages/__helpers__/usersTestHelpers.tsx` (118 linhas adicionadas)
- `tests/pages/users/UserActivateToggle.test.tsx` (novo, 433 linhas)

## Testes
Suíte completa rodada via `docker compose run --rm web npm test -- --run`:
- **1103/1103 testes verdes** (66 arquivos).
- 17 novos testes em `tests/pages/users/UserActivateToggle.test.tsx` (gating, abertura, confirmação ativa/desativa, payload, fechamento, erros).
- Lint: 0 erros (`eslint --max-warnings 0`).
- Typecheck: 0 erros (`tsc --noEmit`).
- JSCPD: total 2.43% (abaixo do threshold 3%); zero clones envolvendo arquivos do diff.

## Visual
- Botão usa `variant=\"danger\"` (ícone `Power`) para "Desativar" — paridade com Trash em Systems/Routes; `variant=\"primary\"` para "Ativar" — paridade com Restore em Systems.
- Aria-label distingue ação ("Desativar usuário Alice Admin" vs "Ativar usuário Alice Admin") para leitores de tela.
- Modal mostra título dinâmico ("Desativar usuário?" vs "Ativar usuário?") com body em styled-components reusando tokens do design system local (sem hardcode de cor).
- Estados cobertos: loading do botão (via `Button loading=`), success toast verde, erro toast vermelho, modal fechado (Esc/Cancelar/backdrop), modal bloqueado durante submit (paridade com outros modals).
- Coluna Ações renderiza `<RowActions />` vazio para linhas soft-deletadas — preserva alinhamento da coluna sem expor botões inválidos.

## Segurança
- Botão visível apenas com `AUTH_V1_USERS_UPDATE` (gating client-side é UX; backend é fonte autoritativa via `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`).
- Payload nunca envia `password` (não pertence ao `UpdateUserPayload`).
- Erros 401/403 são tratados como toast vermelho sem expor detalhes do backend; 404 (usuário some entre abertura e submit) fecha modal + dispara refetch para sincronizar a tabela.
- Sem `dangerouslySetInnerHTML`, sem URL/iframes derivadas de input não-controlado.

## Riscos
- **Race entre toggle e edit:** se outro operador editar o usuário entre a abertura do modal e a confirmação, o PUT pode sobrescrever os outros campos (`name`/`email`/`identity`) com valores defasados da listagem. Mitigação parcial: o backend valida unicidade de `email` ignorando o próprio usuário, e em 404 o modal fecha + refetch. Soft-delete concorrente já é coberto (404 → refetch). Drift silencioso de `name`/`identity` é o cenário mais delicado, mas é raro e o operador imediatamente vê a lista atualizada após o toast.
- **Backend não tem endpoint "toggle" dedicado:** se evolução futura mudar `UpdateUserRequest` (e.g. tornar `active` opcional ou remover), o `ToggleUserActiveConfirm` precisará atualizar o body. O `buildUserUpdateBody` já é fonte única.

## Issue relacionada
Closes #80