### PR TITLE
feat(clients): editar dados do cliente PF/PJ (#75)

### DIFF
--- a/src/pages/clients/ClientDataTab.tsx
+++ b/src/pages/clients/ClientDataTab.tsx
@@ -1,26 +1,436 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 
-import { ClientEditTabPlaceholder } from './ClientEditTabPlaceholder';
+import { useToast } from '../../components/ui';
+import { getClientById, isApiError, updateClient } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
+import {
+  useEditEntitySubmit,
+  type EditEntitySubmitCopy,
+  type EditSubmitActionCopy,
+} from '../../shared/forms';
+import { ErrorRetryBlock, InitialLoadingSpinner } from '../../shared/listing';
+
+import { ClientFormBody } from './ClientFormFields';
+import {
+  INITIAL_CLIENT_FORM_STATE,
+  stateFromClient,
+  type ClientFieldErrors,
+  type ClientSubmitErrorCopy,
+} from './clientsFormShared';
+import { useClientForm, useClientFormFieldProps } from './useClientForm';
+
+import type { ApiClient, ClientDto, UpdateClientPayload } from '../../shared/api';
 
 /**
- * Aba "Dados" do `ClientEditPage` (Issue #144).
+ * Code de permissão exigido para o submit do form de edição (Issue #75).
  *
- * Atualmente renderiza placeholder porque o conteúdo real (CPF/CNPJ,
- * nome/razão social, tipo imutável) é corpo da Issue #75 — companion
- * desta. Quando #75 for entregue, o conteúdo deste arquivo será
- * substituído pelo formulário real, mantendo a interface
- * (`React.FC` sem props) — o `ClientEditPage` já passa contexto via
- * URL (`useParams<{ id }>`) e hooks próprios da aba.
- *
- * Manter cada aba como componente próprio (em vez de inline no
- * `ClientEditPage`) preserva a fronteira clara entre o **container de
- * abas** (escopo de #144) e o **conteúdo de cada aba** (escopo das
- * sub-issues). Cada aba é "pluggável" — quando #75 ficar pronta,
- * substitui-se este arquivo sem tocar no container.
+ * Espelha o `AUTH_V1_CLIENTS_UPDATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`PUT /clients/{id}` valida via
+ * `[Authorize(Policy = PermissionPolicies.ClientsUpdate)]`); o gating
+ * client-side é apenas UX — desabilitar campos e esconder o botão
+ * "Salvar" quando o usuário não pode persistir é mais claro do que
+ * deixar o submit cair em 401/403.
  */
-export const ClientDataTab: React.FC = () => (
-  <ClientEditTabPlaceholder
-    title="Dados do cliente"
-    description="CPF/CNPJ, nome/razão social e tipo (PF/PJ). Será habilitado pela Issue #75."
-  />
-);
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de edição.
+ * Os literais aqui são os únicos pontos onde "atualizar"/"outro
+ * cliente" diferem do "criar"/"um cliente" do `NewClientModal` —
+ * toda a lógica de classificação é compartilhada via
+ * `classifyApiSubmitError` (lição PR #128/#134/#135).
+ */
+const SUBMIT_ERROR_COPY: ClientSubmitErrorCopy = {
+  conflictDefault: 'Já existe outro cliente com este documento.',
+  forbiddenTitle: 'Falha ao atualizar cliente',
+  genericFallback: 'Não foi possível atualizar o cliente. Tente novamente.',
+};
+
+/**
+ * Texto exibido em toast quando o cliente some entre o carregamento
+ * inicial e o submit (404). UI então redireciona para `/clientes` —
+ * a aba não tem mais entidade para editar.
+ */
+const NOT_FOUND_MESSAGE =
+  'Cliente não encontrado ou foi removido. A listagem foi atualizada.';
+
+/**
+ * Mensagem amigável exibida no `ErrorRetryBlock` quando o fetch
+ * inicial falha (rede, parse, 401/403, etc.). Toast com a mensagem
+ * técnica é responsabilidade do `useToast` quando aplicável; o
+ * `Alert` da página fica curto para não competir com o toast.
+ */
+const FETCH_ERROR_MESSAGE = 'Não foi possível carregar os dados do cliente.';
+
+/**
+ * Cópia textual injetada em `applyEditSubmitAction`. Concentra os
+ * literais que diferem entre o `ClientDataTab` e os demais modals/
+ * tabs de edição sem duplicar a árvore de switch (lição PR #128/
+ * #134/#135 reforçada).
+ */
+const EDIT_SUBMIT_ACTION_COPY: EditSubmitActionCopy = {
+  // `conflictInlineMessage` deixado `undefined` para propagar a
+  // mensagem do backend que já discrimina CPF vs CNPJ ("Já existe
+  // cliente com este CPF." / "Já existe cliente com este CNPJ.") —
+  // mesma estratégia do `NewClientModal`.
+  notFoundMessage: NOT_FOUND_MESSAGE,
+  forbiddenTitle: SUBMIT_ERROR_COPY.forbiddenTitle,
+};
+
+interface ClientDataTabProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `getClientById`/`updateClient` caem no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Container externo do conteúdo da aba — preserva o ar e o
+ * espaçamento do `ClientEditTabPlaceholder` que substituímos.
+ * Usar `<section>` com `aria-labelledby` apontando para o `<h3>`
+ * cria uma landmark identificável por leitores de tela
+ * ("Dados do cliente").
+ */
+const TabSection = styled.section`
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const TabHeading = styled.h3`
+  font-family: var(--font-display);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+`;
+
+const TabIntro = styled.p`
+  margin: 0;
+  color: var(--fg2);
+  font-size: var(--text-sm);
+  line-height: var(--leading-base);
+  max-width: 60ch;
+`;
+
+/**
+ * Aba "Dados" do `ClientEditPage` (Issue #75).
+ *
+ * Substitui o placeholder herdado de #144. Carrega o cliente via
+ * `GET /clients/{id}`, pré-popula o `ClientFormBody` com os dados
+ * persistidos e permite editar via `PUT /clients/{id}`. O `<Select>`
+ * de tipo fica desabilitado porque o backend rejeita mudança de
+ * tipo após criação (`ClientsController.UpdateById` linha 369: 400
+ * `"Tipo do cliente não pode ser alterado após a criação."`).
+ *
+ * **Estados visuais (critério "estados visuais completos"):**
+ *
+ * - `loading` (`InitialLoadingSpinner`) — primeiro fetch.
+ * - `error` (`ErrorRetryBlock`) — falha de rede/parse/401/403.
+ * - `not-found` — toast vermelho + redirect para `/clientes`.
+ * - `loaded` — form renderizado com dados pré-populados.
+ * - `submitting` — campos disabled (via `isSubmitting` em
+ *   `ClientFormBody`) e botão "Salvar" com `loading` state.
+ *
+ * **Gating de permissão (critério "Visível com `Clients.Update`"):**
+ *
+ * Quando o usuário não tem `AUTH_V1_CLIENTS_UPDATE`, o form é
+ * renderizado em modo readonly (campos desabilitados, sem botão
+ * "Salvar"). Mostrar os dados ainda é útil mesmo sem permissão de
+ * update — a página `/clientes/:id` é gateada por
+ * `AUTH_V1_CLIENTS_GET_BY_ID`, não por `UPDATE`. O backend é a
+ * fonte autoritativa (`PUT /clients/{id}` rejeitaria com 401/403);
+ * o gating client-side é apenas UX.
+ *
+ * **Tratamento de erros do submit:**
+ *
+ * - 409 (CPF/CNPJ duplicado) → mensagem inline no campo de unicidade
+ *   correspondente ao tipo (`cpf` para PF, `cnpj` para PJ).
+ * - 400 → `details.errors[Field]` mapeado para `fieldErrors[field]`,
+ *   normalizando capitalização. Quando o backend envia
+ *   `{ message: "Tipo do cliente não pode ser alterado..." }` (sem
+ *   `errors` mapeáveis), cai no fallback (`Alert` no topo do form).
+ * - 404 → toast vermelho + redirect para `/clientes`.
+ * - 401/403 → toast vermelho com mensagem do backend.
+ * - Demais → toast vermelho com mensagem genérica.
+ */
+export const ClientDataTab: React.FC<ClientDataTabProps> = ({ client }) => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { show } = useToast();
+  const { hasPermission } = useAuth();
+  const canUpdate = hasPermission(CLIENTS_UPDATE_PERMISSION);
+
+  const clientForm = useClientForm(INITIAL_CLIENT_FORM_STATE);
+  const {
+    formState,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    prepareUpdateSubmit,
+    applyBadRequest,
+  } = clientForm;
+
+  /**
+   * Estados do fetch inicial. `loaded` guarda o cliente que veio do
+   * backend para que asserts e o submit reusem; `error` carrega a
+   * mensagem amigável do `ErrorRetryBlock` (não a mensagem técnica).
+   */
+  const [fetchState, setFetchState] = useState<'loading' | 'loaded' | 'error'>(
+    'loading',
+  );
+  const [loadedClient, setLoadedClient] = useState<ClientDto | null>(null);
+
+  /**
+   * Carrega o cliente via `GET /clients/{id}`. Cancela request
+   * pendente em unmount via `AbortController` para evitar
+   * `setState` em componente desmontado.
+   *
+   * Reload key (`reloadCounter`) permite que `ErrorRetryBlock`
+   * dispare um novo fetch sem precisar resetar todo o estado da
+   * aba — incrementar o número faz o `useEffect` rodar de novo.
+   */
+  const [reloadCounter, setReloadCounter] = useState<number>(0);
+
+  useEffect(() => {
+    if (id === undefined || id.length === 0) {
+      setFetchState('error');
+      return;
+    }
+
+    const controller = new AbortController();
+    let isCancelled = false;
+
+    setFetchState('loading');
+    setSubmitError(null);
+    setFieldErrors({});
+
+    getClientById(id, { signal: controller.signal }, client)
+      .then((dto) => {
+        if (isCancelled) return;
+        setLoadedClient(dto);
+        setFormState(stateFromClient(dto));
+        setFetchState('loaded');
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return;
+        // Cancelamento explícito (unmount/route change) não vira erro
+        // de UI — silencia para que o próximo render comece limpo.
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        if (isApiError(error) && error.kind === 'http' && error.status === 404) {
+          show(NOT_FOUND_MESSAGE, {
+            variant: 'danger',
+            title: 'Cliente não encontrado',
+          });
+          navigate('/clientes', { replace: true });
+          return;
+        }
+        setFetchState('error');
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [id, client, reloadCounter, navigate, show, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Handler do botão "Tentar novamente" do `ErrorRetryBlock`. Apenas
+   * incrementa o `reloadCounter` para que o `useEffect` re-execute.
+   */
+  const handleRetry = useCallback(() => {
+    setReloadCounter((prev) => prev + 1);
+  }, []);
+
+  /**
+   * Wrapper de `prepareUpdateSubmit` que reprova quando o gate de
+   * `isSubmitting`/`!loadedClient` falhar — preserva o dedupe ao
+   * mover a lógica para dentro de `useEditEntitySubmit` (lição PR
+   * #135).
+   */
+  const prepareSubmitSafe = useCallback((): unknown | null => {
+    if (isSubmitting || loadedClient === null) return null;
+    return prepareUpdateSubmit();
+  }, [isSubmitting, loadedClient, prepareUpdateSubmit]);
+
+  /**
+   * Closure sobre `loadedClient.id` + `client`. Quando `loadedClient`
+   * é `null` o `prepareSubmitSafe` já reprova antes do `mutationFn`
+   * rodar — a checagem inline aqui é defensiva (preserva o tipo
+   * sem `!`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> => {
+      if (loadedClient === null) {
+        return Promise.reject(new Error('Client unavailable.'));
+      }
+      return updateClient(
+        loadedClient.id,
+        payload as UpdateClientPayload,
+        undefined,
+        client,
+      );
+    },
+    [client, loadedClient],
+  );
+
+  /**
+   * Refetch local após sucesso — atualiza `loadedClient` (que rege
+   * `id` no submit e estado pré-populado em re-renders) com o DTO
+   * devolvido pelo backend. Mantém o form em estado "limpo" (sem
+   * resíduo de erros) e segue na mesma aba.
+   *
+   * Em vez de re-disparar `getClientById`, aproveitamos a
+   * resposta do `PUT` (backend devolve `ClientResponse` no 200).
+   * O hook `useEditEntitySubmit` não expõe a resposta diretamente,
+   * então confiamos no estado controlado: o usuário só vê o efeito
+   * via toast "Cliente atualizado." + reset de erros — o
+   * `formState` já reflete o que foi enviado, então não há gap
+   * visível.
+   */
+  const onUpdated = useCallback(() => {
+    // Reload silencioso — incrementa o counter para que o efeito
+    // releia o cliente e sincronize `loadedClient`/`formState`.
+    setReloadCounter((prev) => prev + 1);
+  }, []);
+
+  /**
+   * No-op fechamento — esta aba não fecha como um modal; permanecer
+   * na URL corrente é o comportamento esperado após sucesso.
+   * `useEditEntitySubmit` exige callback, então passamos uma função
+   * que não faz nada. O fluxo de 404 (que normalmente fecharia o
+   * modal) é tratado dentro do `useEffect` do fetch — ali sim
+   * navegamos para `/clientes`.
+   */
+  const onClose = useCallback(() => {
+    // Intencionalmente vazio. Ver doc do callback acima.
+  }, []);
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<EditEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Cliente atualizado.',
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+      editSubmitActionCopy: EDIT_SUBMIT_ACTION_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * O `conflictField` muda em runtime conforme o tipo (`cpf` para
+   * PF, `cnpj` para PJ). Mesma lógica do `NewClientModal` — o
+   * backend valida unicidade global do documento, então o campo
+   * onde o conflito aparece depende do tipo do cliente atual.
+   */
+  const conflictField: keyof ClientFieldErrors = formState.type === 'PF' ? 'cpf' : 'cnpj';
+
+  /**
+   * Custom 404 handler — após o submit detectar 404, redireciona
+   * para `/clientes`. O hook chama `onUpdated() + onClose()` no
+   * default; sobrescrevemos via `applyEditSubmitAction.copy.notFoundMessage`
+   * + interceptação do `onAfterNotFound` no helper compartilhado.
+   *
+   * Como `useEditEntitySubmit` não expõe `onAfterNotFound`
+   * customizável (ele compõe internamente `() => { onUpdated();
+   * onClose(); }`), interceptamos via `onUpdated` callback que
+   * inclui o redirect quando estamos em estado pós-404 — não dá pra
+   * distinguir aqui sem tocar no helper. **Decisão:** o
+   * `useEffect` já trata 404 do fetch inicial; para 404 no submit,
+   * o toast é exibido e a aba simplesmente refaz o GET, que devolve
+   * 404 novamente e dispara o redirect via `useEffect`. Comportamento
+   * coerente sem retoque no helper compartilhado (lição PR #135 —
+   * extrair shared deve ser preservado).
+   */
+  const handleSubmit = useEditEntitySubmit<keyof ClientFieldErrors>({
+    dispatchers: {
+      setFieldErrors: clientForm.setFieldErrors,
+      setSubmitError: clientForm.setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onUpdated,
+      onClose,
+    },
+    conflictField,
+  });
+
+  /**
+   * Handler do botão "Cancelar". Reseta o form para o estado do
+   * cliente carregado (descarta edições não salvas) — comportamento
+   * mais útil em uma aba de página do que no modal de criação
+   * (onde "Cancelar" fecha o modal). Bloqueado durante submit.
+   */
+  const handleCancel = useCallback(() => {
+    if (isSubmitting || loadedClient === null) return;
+    setFormState(stateFromClient(loadedClient));
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [isSubmitting, loadedClient, setFormState, setFieldErrors, setSubmitError]);
+
+  // Hook chamado **antes** do early-return para respeitar a regra
+  // "hooks always called in the same order". Quando o caller decide
+  // não renderizar o form (loading/error), o objeto memoizado fica
+  // descartado — sem efeito colateral.
+  const fieldProps = useClientFormFieldProps(clientForm, handleSubmit, handleCancel);
+
+  if (fetchState === 'loading') {
+    return (
+      <InitialLoadingSpinner
+        testId="client-data-loading"
+        label="Carregando dados do cliente"
+      />
+    );
+  }
+
+  if (fetchState === 'error') {
+    return (
+      <ErrorRetryBlock
+        message={FETCH_ERROR_MESSAGE}
+        onRetry={handleRetry}
+        retryTestId="client-data-retry"
+      />
+    );
+  }
+
+  // `loaded` — render do form com dados pré-populados.
+  return (
+    <TabSection aria-labelledby="client-data-heading">
+      <TabHeading id="client-data-heading">Dados do cliente</TabHeading>
+      <TabIntro>
+        Atualize CPF/CNPJ e nome/razão social. O tipo (PF/PJ) é
+        imutável após a criação.
+      </TabIntro>
+      <ClientFormBody
+        {...fieldProps}
+        idPrefix="client-data"
+        submitLabel="Salvar"
+        typeDisabled
+        readonly={!canUpdate}
+      />
+    </TabSection>
+  );
+};

--- a/src/pages/clients/ClientFormFields.tsx
+++ b/src/pages/clients/ClientFormFields.tsx
@@ -193,10 +193,19 @@ interface ClientFormBodyProps {
   submitLabel: string;
   /**
    * Quando `true`, o `<Select>` de tipo fica desabilitado. Default
-   * `false` (criação). `EditClientModal` (#75) passará `true` —
-   * tipo é imutável após criação.
+   * `false` (criação). `ClientDataTab` (#75) passa `true` — tipo é
+   * imutável após criação.
    */
   typeDisabled?: boolean;
+  /**
+   * Quando `true`, todos os campos do form ficam desabilitados e o
+   * footer (Cancelar/Submit) é ocultado. Usado pelo `ClientDataTab`
+   * (#75) quando o usuário não tem `AUTH_V1_CLIENTS_UPDATE` — o
+   * conteúdo do cliente continua visível (a página `/clientes/:id`
+   * é gateada por `GET_BY_ID`, não por `UPDATE`), mas nenhuma
+   * mutação é possível. Default `false`.
+   */
+  readonly?: boolean;
 }
 
 /**
@@ -219,60 +228,70 @@ export const ClientFormBody: React.FC<ClientFormBodyProps> = ({
   isSubmitting,
   submitLabel,
   typeDisabled = false,
-}) => (
-  <FormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
-    {submitError && (
-      <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
-        {submitError}
-      </Alert>
-    )}
-    <FieldStack>
-      <Select
-        label="Tipo"
-        size="md"
-        value={values.type}
-        onChange={(value) => {
-          // O `<Select>` só emite os literais que listamos como
-          // `<option>`, mas validamos defensivamente para preservar o
-          // tipo estreito `ClientType` no caller.
-          if (value === 'PF' || value === 'PJ') {
-            onChangeType(value);
-          }
-        }}
-        error={errors.type}
-        disabled={isSubmitting || typeDisabled}
-        helperText={typeDisabled ? 'Tipo é imutável após a criação.' : undefined}
-        data-testid={`${idPrefix}-type`}
-        aria-label="Tipo do cliente (PF ou PJ)"
-      >
-        <option value="PF">Pessoa física</option>
-        <option value="PJ">Pessoa jurídica</option>
-      </Select>
-      {values.type === 'PF' ? (
-        <PfFields
+  readonly = false,
+}) => {
+  // `fieldsDisabled` cobre tanto o caminho `isSubmitting` (request em
+  // andamento) quanto `readonly` (sem permissão de update). Centralizar
+  // num único cálculo evita repetir `isSubmitting || readonly` em três
+  // pontos abaixo (`<Select>`, `<PfFields disabled>`, `<PjFields disabled>`).
+  const fieldsDisabled = isSubmitting || readonly;
+  return (
+    <FormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
+      {submitError && (
+        <Alert variant="danger" data-testid={`${idPrefix}-submit-error`}>
+          {submitError}
+        </Alert>
+      )}
+      <FieldStack>
+        <Select
+          label="Tipo"
+          size="md"
+          value={values.type}
+          onChange={(value) => {
+            // O `<Select>` só emite os literais que listamos como
+            // `<option>`, mas validamos defensivamente para preservar o
+            // tipo estreito `ClientType` no caller.
+            if (value === 'PF' || value === 'PJ') {
+              onChangeType(value);
+            }
+          }}
+          error={errors.type}
+          disabled={fieldsDisabled || typeDisabled}
+          helperText={typeDisabled ? 'Tipo é imutável após a criação.' : undefined}
+          data-testid={`${idPrefix}-type`}
+          aria-label="Tipo do cliente (PF ou PJ)"
+        >
+          <option value="PF">Pessoa física</option>
+          <option value="PJ">Pessoa jurídica</option>
+        </Select>
+        {values.type === 'PF' ? (
+          <PfFields
+            idPrefix={idPrefix}
+            values={values}
+            errors={errors}
+            disabled={fieldsDisabled}
+            onChangeCpf={onChangeCpf}
+            onChangeFullName={onChangeFullName}
+          />
+        ) : (
+          <PjFields
+            idPrefix={idPrefix}
+            values={values}
+            errors={errors}
+            disabled={fieldsDisabled}
+            onChangeCnpj={onChangeCnpj}
+            onChangeCorporateName={onChangeCorporateName}
+          />
+        )}
+      </FieldStack>
+      {!readonly && (
+        <FormFooter
           idPrefix={idPrefix}
-          values={values}
-          errors={errors}
-          disabled={isSubmitting}
-          onChangeCpf={onChangeCpf}
-          onChangeFullName={onChangeFullName}
-        />
-      ) : (
-        <PjFields
-          idPrefix={idPrefix}
-          values={values}
-          errors={errors}
-          disabled={isSubmitting}
-          onChangeCnpj={onChangeCnpj}
-          onChangeCorporateName={onChangeCorporateName}
+          onCancel={onCancel}
+          isSubmitting={isSubmitting}
+          submitLabel={submitLabel}
         />
       )}
-    </FieldStack>
-    <FormFooter
-      idPrefix={idPrefix}
-      onCancel={onCancel}
-      isSubmitting={isSubmitting}
-      submitLabel={submitLabel}
-    />
-  </FormShell>
-);
+    </FormShell>
+  );
+};

--- a/src/pages/clients/NewClientModal.tsx
+++ b/src/pages/clients/NewClientModal.tsx
@@ -13,7 +13,7 @@ import {
   type ClientFieldErrors,
   type ClientSubmitErrorCopy,
 } from './clientsFormShared';
-import { useClientForm } from './useClientForm';
+import { useClientForm, useClientFormFieldProps } from './useClientForm';
 
 import type { ApiClient } from '../../shared/api';
 
@@ -94,23 +94,17 @@ export const NewClientModal: React.FC<NewClientModalProps> = ({
   client,
 }) => {
   const { show } = useToast();
+  const clientForm = useClientForm(INITIAL_CLIENT_FORM_STATE);
   const {
     formState,
-    fieldErrors,
-    submitError,
     isSubmitting,
     setFormState,
     setFieldErrors,
     setSubmitError,
     setIsSubmitting,
-    handleTypeChange,
-    handleCpfChange,
-    handleFullNameChange,
-    handleCnpjChange,
-    handleCorporateNameChange,
     prepareSubmit,
     applyBadRequest,
-  } = useClientForm(INITIAL_CLIENT_FORM_STATE);
+  } = clientForm;
 
   /**
    * Reseta tudo ao fechar — handler único para Esc, backdrop, X
@@ -193,8 +187,8 @@ export const NewClientModal: React.FC<NewClientModalProps> = ({
    */
   const handleSubmit = useCreateEntitySubmit<keyof ClientFieldErrors>({
     dispatchers: {
-      setFieldErrors,
-      setSubmitError,
+      setFieldErrors: clientForm.setFieldErrors,
+      setSubmitError: clientForm.setSubmitError,
       setIsSubmitting,
       applyBadRequest,
       showToast: show,
@@ -210,6 +204,14 @@ export const NewClientModal: React.FC<NewClientModalProps> = ({
     conflictField,
   });
 
+  // `useClientFormFieldProps` encapsula as ~12 linhas de spread de
+  // handlers (`onChangeType/Cpf/FullName/...`) que JSCPD/Sonar
+  // tokenizaria como duplicação entre `NewClientModal` e
+  // `ClientDataTab` — lição PR #134/#135 aplicada antecipadamente
+  // (call-sites duplicados também precisam virar hook compartilhado,
+  // não só os helpers internos).
+  const fieldProps = useClientFormFieldProps(clientForm, handleSubmit, handleClose);
+
   return (
     <Modal
       open={open}
@@ -220,18 +222,8 @@ export const NewClientModal: React.FC<NewClientModalProps> = ({
       closeOnBackdrop={!isSubmitting}
     >
       <ClientFormBody
+        {...fieldProps}
         idPrefix="new-client"
-        submitError={submitError}
-        values={formState}
-        errors={fieldErrors}
-        onChangeType={handleTypeChange}
-        onChangeCpf={handleCpfChange}
-        onChangeFullName={handleFullNameChange}
-        onChangeCnpj={handleCnpjChange}
-        onChangeCorporateName={handleCorporateNameChange}
-        onSubmit={handleSubmit}
-        onCancel={handleClose}
-        isSubmitting={isSubmitting}
         submitLabel="Criar cliente"
       />
     </Modal>

--- a/src/pages/clients/clientsFormShared.ts
+++ b/src/pages/clients/clientsFormShared.ts
@@ -5,7 +5,7 @@ import {
   type ApiSubmitErrorCopy,
 } from '../../shared/forms';
 
-import type { ClientType } from '../../shared/api';
+import type { ClientDto, ClientType } from '../../shared/api';
 
 /**
  * Helpers compartilhados pelos formulários de criação (Issue #74) e,
@@ -92,6 +92,37 @@ export const INITIAL_CLIENT_FORM_STATE: ClientFormState = {
   cnpj: '',
   corporateName: '',
 };
+
+/**
+ * Constrói o estado inicial do form de edição (Issue #75) a partir
+ * de um `ClientDto` já carregado pelo backend. Cada campo tem
+ * fallback para string vazia para que o input controlado nunca
+ * receba `null`/`undefined` — o backend devolve `null` nos campos
+ * do tipo oposto (PF → `cnpj`/`corporateName` `null`; PJ inverso),
+ * e o React proíbe inputs alternarem entre controlado e
+ * descontrolado.
+ *
+ * Mantemos os campos do tipo oposto como string vazia para que, se
+ * o usuário trocar para o tipo oposto (cenário improvável porque o
+ * `<Select>` fica disabled em modo edit), o estado já esteja
+ * inicializado. Defesa em profundidade — o backend rejeita a troca
+ * com 400, mas a UI não quebra.
+ *
+ * Espelha `stateFromUser` em `EditUserModal.tsx`. Mantido em
+ * `clientsFormShared.ts` em vez de inline na `ClientDataTab` para
+ * centralizar a lógica de mapeamento DTO → form e permitir reuso
+ * pelas próximas sub-issues (#146/#147 — emails/telefones podem
+ * precisar do mesmo bridge).
+ */
+export function stateFromClient(client: ClientDto): ClientFormState {
+  return {
+    type: client.type,
+    cpf: client.cpf ?? '',
+    fullName: client.fullName ?? '',
+    cnpj: client.cnpj ?? '',
+    corporateName: client.corporateName ?? '',
+  };
+}
 
 /* ─── Validação de documento (espelha o backend) ─────────── */
 

--- a/src/pages/clients/useClientForm.ts
+++ b/src/pages/clients/useClientForm.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState, type FormEvent } from 'react';
 
 import { useApplyBadRequest, useFieldChangeHandlers } from '../../shared/forms';
 
@@ -10,7 +10,11 @@ import {
   type ClientFormState,
 } from './clientsFormShared';
 
-import type { ClientType, CreateClientPayload } from '../../shared/api';
+import type {
+  ClientType,
+  CreateClientPayload,
+  UpdateClientPayload,
+} from '../../shared/api';
 
 /**
  * Hook compartilhado pelo modal de criação (`NewClientModal` —
@@ -62,6 +66,21 @@ export interface UseClientFormReturn {
    */
   prepareSubmit: () => CreateClientPayload | null;
   /**
+   * Roda a validação client-side e, se passar, prepara o
+   * `UpdateClientPayload` trimado/normalizado para o `PUT /clients/{id}`
+   * (Issue #75).
+   *
+   * Hoje o body de update é idêntico ao do create — o backend
+   * reaproveita o `CreateClientRequest` no PUT. Mantemos um método
+   * dedicado em vez de reusar `prepareSubmit` para preservar
+   * paridade conceitual com `useUserForm` (que tem `prepareSubmit`/
+   * `prepareUpdateSubmit` divergentes — o update de user não envia
+   * `password`). Se o backend evoluir e a request de update divergir
+   * (ex.: nunca enviar `type` porque é imutável), basta ajustar
+   * aqui sem tocar no `prepareSubmit` do create.
+   */
+  prepareUpdateSubmit: () => UpdateClientPayload | null;
+  /**
    * Aplica o tratamento de uma resposta 400 do backend: distribui
    * erros por campo quando `ValidationProblemDetails` é mapeável,
    * ou popula `submitError` com a mensagem do backend quando não.
@@ -107,17 +126,16 @@ export function useClientForm(initialState: ClientFormState): UseClientFormRetur
     setFieldErrors((prev) => (prev.type === undefined ? prev : { ...prev, type: undefined }));
   }, []);
 
-  const prepareSubmit = useCallback((): CreateClientPayload | null => {
-    const clientErrors = validateClientForm(formState);
-    if (clientErrors) {
-      setFieldErrors(clientErrors);
-      setSubmitError(null);
-      return null;
-    }
-    setFieldErrors({});
-    setSubmitError(null);
-    setIsSubmitting(true);
-
+  /**
+   * Build do payload trimado/normalizado a partir do `formState`
+   * atual. Compartilhado por `prepareSubmit` (create) e
+   * `prepareUpdateSubmit` (update) — o backend reaproveita o
+   * `CreateClientRequest` no PUT, então o body é idêntico em ambos
+   * os caminhos. Mantemos como helper interno para preservar
+   * tipagem estrita do retorno (`CreateClientPayload`) sem repetir
+   * o `if (type === 'PF') ... else ...` em duas funções.
+   */
+  const buildPayloadFromState = useCallback((): CreateClientPayload => {
     if (formState.type === 'PF') {
       return {
         type: 'PF',
@@ -131,6 +149,42 @@ export function useClientForm(initialState: ClientFormState): UseClientFormRetur
       corporateName: formState.corporateName.trim(),
     };
   }, [formState]);
+
+  /**
+   * Núcleo compartilhado por `prepareSubmit` e `prepareUpdateSubmit`:
+   * roda a validação client-side, distribui erros via `setFieldErrors`/
+   * `setSubmitError` no caminho inválido e marca `isSubmitting=true`
+   * + devolve o payload trimado no caminho válido.
+   *
+   * Centralizado para evitar New Code Duplication detectado pelo
+   * JSCPD/Sonar — o create e o update tinham 13 linhas idênticas
+   * (validar → branch → setState → return), divergindo apenas no
+   * tipo de retorno. Manter o helper interno preserva a inferência
+   * estrita do tipo de retorno em cada call-site (lição PR #128/
+   * #134/#135 — refatorar **antes** do push, não após o BLOCKER).
+   */
+  const prepareValidatedPayload = useCallback((): CreateClientPayload | null => {
+    const clientErrors = validateClientForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+    return buildPayloadFromState();
+  }, [buildPayloadFromState, formState]);
+
+  const prepareSubmit = useCallback(
+    (): CreateClientPayload | null => prepareValidatedPayload(),
+    [prepareValidatedPayload],
+  );
+
+  const prepareUpdateSubmit = useCallback(
+    (): UpdateClientPayload | null => prepareValidatedPayload(),
+    [prepareValidatedPayload],
+  );
 
   // Helper compartilhado em `src/shared/forms/createApplyBadRequest.ts`
   // — encapsula o `if (decision.kind === 'field-errors') {...} else
@@ -155,6 +209,92 @@ export function useClientForm(initialState: ClientFormState): UseClientFormRetur
     handleCnpjChange,
     handleCorporateNameChange,
     prepareSubmit,
+    prepareUpdateSubmit,
     applyBadRequest,
   };
+}
+
+/**
+ * Tipo do conjunto de props consumido por `<ClientFormBody>` —
+ * compartilhado entre `NewClientModal` (Issue #74) e `ClientDataTab`
+ * (Issue #75). Centralizar o tipo aqui (em vez de inferir inline em
+ * cada caller) elimina o bloco de ~12 linhas de
+ * `onChangeType/Cpf/FullName/Cnpj/CorporateName` que JSCPD/Sonar
+ * tokenizam como `New Code Duplication` (lição PR #134/#135 —
+ * call-sites dos helpers também precisam ficar deduplicados).
+ *
+ * Espelha `UserFormFieldProps` em `useUserForm.ts`.
+ */
+export interface ClientFormFieldProps {
+  submitError: string | null;
+  values: ClientFormState;
+  errors: ClientFieldErrors;
+  onChangeType: (value: ClientType) => void;
+  onChangeCpf: (value: string) => void;
+  onChangeFullName: (value: string) => void;
+  onChangeCnpj: (value: string) => void;
+  onChangeCorporateName: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+/**
+ * Constrói o objeto de props para `<ClientFormBody>` a partir de
+ * uma instância de `useClientForm` + `handleSubmit` + `handleCancel`
+ * do caller. Memoizado em `useMemo` para preservar identidade entre
+ * renders quando nada mudou — útil pra spread `{...fieldProps}` sem
+ * causar re-render desnecessário no body.
+ *
+ * Espelha `useUserFormFieldProps` em `useUserForm.ts` (lição PR
+ * #134/#135 reaplicada antecipadamente — quando o segundo caller
+ * aparece, o objeto de props vira candidato a hook próprio para
+ * eliminar a duplicação no nível do call-site, não só do helper
+ * em si).
+ */
+export function useClientFormFieldProps(
+  clientForm: UseClientFormReturn,
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void,
+  onCancel: () => void,
+): ClientFormFieldProps {
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    handleTypeChange,
+    handleCpfChange,
+    handleFullNameChange,
+    handleCnpjChange,
+    handleCorporateNameChange,
+  } = clientForm;
+
+  return useMemo(
+    () => ({
+      submitError,
+      values: formState,
+      errors: fieldErrors,
+      onChangeType: handleTypeChange,
+      onChangeCpf: handleCpfChange,
+      onChangeFullName: handleFullNameChange,
+      onChangeCnpj: handleCnpjChange,
+      onChangeCorporateName: handleCorporateNameChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    }),
+    [
+      submitError,
+      formState,
+      fieldErrors,
+      handleTypeChange,
+      handleCpfChange,
+      handleFullNameChange,
+      handleCnpjChange,
+      handleCorporateNameChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    ],
+  );
 }

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -484,6 +484,12 @@ export async function getClientsByIds(
  * Tenta carregar um cliente individual via `GET /clients/{id}`.
  * Retorna `null` quando o backend devolve corpo vazio; lança
  * `ApiError(parse)` quando o JSON não casa com `isClientDto`.
+ *
+ * Mantemos como helper interno para que o `getClientsByIds` continue
+ * podendo skipar resultados vazios silenciosamente. O caller público
+ * (`getClientById` abaixo) trata `null`/`undefined` como erro de parse
+ * porque o backend nunca devolve corpo vazio em `200 OK` — apenas em
+ * `404 Not Found` (que já vira `ApiError` antes de chegar aqui).
  */
 async function fetchClientById(
   id: string,
@@ -498,6 +504,38 @@ async function fetchClientById(
     throw makeParseError();
   }
   return data;
+}
+
+/**
+ * Carrega um cliente individual via `GET /clients/{id}` (Issue #75).
+ *
+ * Endpoint público usado pela aba "Dados" do `ClientEditPage` para
+ * pré-popular o form de edição. Diferente do helper interno
+ * `fetchClientById` (consumido por `getClientsByIds`), este wrapper
+ * trata corpo vazio como erro de parse — o backend nunca responde
+ * `200 OK` com body `null` em `GET /clients/{id}`; `null` indicaria
+ * proxy malformado ou contrato divergente.
+ *
+ * Retorna o `ClientDto` em sucesso; lança `ApiError` em qualquer
+ * falha. Caller tipicamente trata:
+ *
+ * - 404 → cliente removido entre navegação e fetch (`onAfterNotFound`).
+ * - 401/403 → redirect ou toast (gating de permissão).
+ * - parse → drift de contrato (toast genérico).
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function getClientById(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientDto> {
+  const dto = await fetchClientById(id, options, client);
+  if (dto === null) {
+    throw makeParseError();
+  }
+  return dto;
 }
 
 /**
@@ -571,10 +609,84 @@ export async function createClient(
 }
 
 /**
- * Constrói o body para `POST /clients` aplicando trim defensivo e
- * o filtro de campos por tipo (PF/PJ). Centralizar essa montagem
- * garante que nenhum call site inclua acidentalmente o campo do
- * tipo oposto (que o backend rejeitaria com 400).
+ * Body aceito pelo `PUT /clients/{id}` no `lfc-authenticator`
+ * (`ClientsController.UpdateById` linha 358). O backend reaproveita
+ * o `CreateClientRequest` no PUT, então o shape é idêntico ao do
+ * create. Mantemos um alias dedicado por dois motivos:
+ *
+ * 1. Tipos discriminados no call-site (`updateClient` aceita
+ *    `UpdateClientPayload`, `createClient` aceita `CreateClientPayload`)
+ *    — preserva clareza ao ler o código sem desambiguar pela
+ *    assinatura da função.
+ * 2. Espelho do `UserUpdatePayload`/`UpdateUserPayload` (`users.ts`),
+ *    onde o shape diverge do create (sem `password`) — manter o
+ *    alias hoje, mesmo igual ao create, evita refator destrutivo
+ *    se o backend vier a divergir os dois requests no futuro.
+ *
+ * **Imutabilidade do `type` (Issue #75):** o backend rejeita com 400
+ * `"Tipo do cliente não pode ser alterado após a criação."` quando
+ * o `Type` enviado difere do `Type` persistido. A UI espelha
+ * desabilitando o `<Select>` de tipo no modo edit (`typeDisabled`
+ * em `ClientFormBody`); o body envia o `type` atual do cliente para
+ * que o backend rode a comparação esperada e devolva 200, não 400.
+ */
+export type UpdateClientPayload = CreateClientPayload;
+
+/**
+ * Atualiza um cliente existente via `PUT /clients/{id}` (Issue #75).
+ *
+ * Retorna o `ClientDto` atualizado (`200 OK` com `ClientResponse` no
+ * corpo). Lança `ApiError` em qualquer falha — caller tipicamente
+ * trata:
+ *
+ * - 409 → conflito de unicidade global de `cpf` ou `cnpj`. Backend
+ *   devolve mensagens distintas ("Já existe cliente com este CPF."
+ *   / "Já existe cliente com este CNPJ."); o caller exibe inline no
+ *   campo correspondente ao tipo do cliente.
+ * - 400 → erros de validação por campo em `details` (mesmo shape de
+ *   `ValidationProblemDetails` usado pelos demais recursos) **ou**
+ *   `{ message: "Tipo do cliente não pode ser alterado após a
+ *   criação." }` quando o `type` enviado difere do persistido. O
+ *   segundo caso não tem `details.errors` mapeáveis, então cai no
+ *   fallback do `applyBadRequest` (Alert no topo do form). A UI já
+ *   evita esse cenário desabilitando o `<Select>` de tipo, mas
+ *   preserva o tratamento defensivo.
+ * - 404 → cliente não encontrado (soft-deletado concorrentemente
+ *   entre abertura e submit). UI fecha o tab/redireciona, dispara
+ *   toast e força refetch.
+ * - 401/403 → toast vermelho (gating de permissão).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ *
+ * O response é validado contra `isClientDto` para detectar drift de
+ * contrato precocemente — backend retornando shape inesperado
+ * dispara `ApiError(parse)` em vez de propagar shape inválido para
+ * a UI.
+ */
+export async function updateClient(
+  id: string,
+  payload: UpdateClientPayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientDto> {
+  const body = buildClientMutationBody(payload);
+  const data = await client.put<unknown>(`/clients/${id}`, body, options);
+  if (!isClientDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Constrói o body para `POST /clients` e `PUT /clients/{id}`
+ * aplicando trim defensivo e o filtro de campos por tipo (PF/PJ).
+ * Centralizar essa montagem garante que nenhum call site inclua
+ * acidentalmente o campo do tipo oposto (que o backend rejeitaria
+ * com 400). Compartilhado entre `createClient` (Issue #74) e
+ * `updateClient` (Issue #75) — o backend reaproveita o
+ * `CreateClientRequest` no PUT, então o build do body é idêntico.
  *
  * Para PF: envia `type`, `cpf`, `fullName`. Para PJ: envia `type`,
  * `cnpj`, `corporateName`. Em ambos, qualquer campo whitespace-only

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -133,10 +133,12 @@ export {
   DEFAULT_CLIENTS_INCLUDE_DELETED,
   DEFAULT_CLIENTS_PAGE,
   DEFAULT_CLIENTS_PAGE_SIZE,
+  getClientById,
   getClientsByIds,
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  updateClient,
 } from './clients';
 export type {
   ClientDto,
@@ -146,6 +148,7 @@ export type {
   ClientType,
   CreateClientPayload,
   ListClientsParams,
+  UpdateClientPayload,
 } from './clients';
 export {
   isTokenTypeArray,

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -367,3 +367,121 @@ export function buildClientsSubmitErrorCases(): ReadonlyArray<ClientsErrorCase> 
     },
   ];
 }
+
+/* ─── Helpers de fluxo do `ClientDataTab` (Issue #75) ──── */
+
+/**
+ * Preenche os campos do form do `ClientDataTab` para o caminho PF.
+ * Espelha `fillNewClientPfForm` para o `idPrefix="client-data"`
+ * usado pela aba "Dados". Cada chave é opcional — testes que
+ * validam um único campo passam apenas o relevante.
+ */
+export function fillClientDataPfForm(values: { cpf?: string; fullName?: string }): void {
+  if (values.cpf !== undefined) {
+    fireEvent.change(screen.getByTestId('client-data-cpf'), {
+      target: { value: values.cpf },
+    });
+  }
+  if (values.fullName !== undefined) {
+    fireEvent.change(screen.getByTestId('client-data-fullName'), {
+      target: { value: values.fullName },
+    });
+  }
+}
+
+/**
+ * Preenche os campos do form do `ClientDataTab` para o caminho PJ.
+ * Espelha `fillNewClientPjForm` para o `idPrefix="client-data"`.
+ */
+export function fillClientDataPjForm(values: {
+  cnpj?: string;
+  corporateName?: string;
+}): void {
+  if (values.cnpj !== undefined) {
+    fireEvent.change(screen.getByTestId('client-data-cnpj'), {
+      target: { value: values.cnpj },
+    });
+  }
+  if (values.corporateName !== undefined) {
+    fireEvent.change(screen.getByTestId('client-data-corporateName'), {
+      target: { value: values.corporateName },
+    });
+  }
+}
+
+/**
+ * Submete o form do `ClientDataTab` e aguarda o `client.put` ser
+ * chamado pelo menos `expectedPutCalls` vezes (default `1`). Espelha
+ * `submitNewClientForm` para o caminho de edição (PUT em vez de
+ * POST).
+ */
+export async function submitClientDataForm(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('client-data-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
+}
+
+/**
+ * Constrói os cenários comuns de erro de submit para a suíte de
+ * edição de clientes (Issue #75). A mensagem genérica diverge da
+ * criação ("atualizar" vs "criar") — manter cenários próprios
+ * preserva os asserts ancorados na copy específica de cada caminho.
+ */
+export function buildClientsEditSubmitErrorCases(): ReadonlyArray<ClientsErrorCase> {
+  return [
+    {
+      name: '400 com errors mapeia mensagens para os campos correspondentes',
+      error: {
+        kind: 'http',
+        status: 400,
+        message: 'Erro de validação.',
+        details: {
+          errors: {
+            FullName: ['FullName é obrigatório para cliente PF.'],
+          },
+        },
+      },
+      expectedText: 'FullName é obrigatório para cliente PF.',
+    },
+    {
+      name: '400 sem errors mapeáveis exibe Alert no topo do form',
+      error: {
+        kind: 'http',
+        status: 400,
+        message: 'Tipo do cliente não pode ser alterado após a criação.',
+      },
+      expectedText: 'Tipo do cliente não pode ser alterado após a criação.',
+    },
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      },
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      },
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: {
+        kind: 'network',
+        message: 'Falha de conexão com o servidor.',
+      },
+      expectedText: 'Não foi possível atualizar o cliente. Tente novamente.',
+    },
+  ];
+}

--- a/tests/pages/clients/ClientDataTab.test.tsx
+++ b/tests/pages/clients/ClientDataTab.test.tsx
@@ -1,0 +1,543 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildClientsEditSubmitErrorCases,
+  createClientsClientStub,
+  fillClientDataPfForm,
+  fillClientDataPjForm,
+  ID_CLIENT_PF_ANA,
+  ID_CLIENT_PJ_ACME,
+  makeClient,
+  makeClientPj,
+  submitClientDataForm,
+  toCaseInsensitiveMatcher,
+} from '../__helpers__/clientsTestHelpers';
+import type { ApiClientStub, ClientsErrorCase } from '../__helpers__/clientsTestHelpers';
+import { ToastProvider } from '@/components/ui';
+import { ClientDataTab } from '@/pages/clients/ClientDataTab';
+/* eslint-enable import/order */
+
+/**
+ * Suíte do `ClientDataTab` (Issue #75 — aba "Dados" do
+ * `ClientEditPage`).
+ *
+ * Estratégia espelha `NewClientModal.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory) para alternar a permissão `AUTH_V1_CLIENTS_UPDATE`
+ *   entre testes.
+ * - Stub de `ApiClient` injetado em `<ClientDataTab client={stub} />`,
+ *   isolando a aba da camada de transporte real.
+ * - Helpers em `clientsTestHelpers.tsx` (`fillClientDataPfForm`/
+ *   `fillClientDataPjForm`/`submitClientDataForm`) para colapsar o
+ *   boilerplate "preencher → submeter" e evitar `New Code Duplication`
+ *   no Sonar (lição PR #134 — call-sites duplicados também precisam
+ *   ficar deduplicados, não só os helpers internos).
+ *
+ * Cobre (critérios da issue):
+ *
+ * - Pré-popula CPF/CNPJ + nome/razão social + tipo a partir de
+ *   `getClientById`.
+ * - Tipo (PF/PJ) é renderizado como `<Select>` desabilitado (imutável
+ *   após criação — backend rejeita mudança).
+ * - Mesma validação client-side da criação (CPF/CNPJ inválido,
+ *   FullName/CorporateName vazio).
+ * - Submit com sucesso envia `PUT /clients/{id}` e exibe toast
+ *   verde "Cliente atualizado.".
+ * - 409 (CPF/CNPJ duplicado) exibe mensagem inline no campo de
+ *   unicidade correspondente ao tipo.
+ * - 400 com `errors` mapeia para campos; 400 sem `errors` (ex.: type
+ *   imutável) exibe `Alert` no topo.
+ * - 401/403 disparam toast vermelho.
+ * - 404 dispara toast vermelho + redireciona para `/clientes`.
+ * - Sem `AUTH_V1_CLIENTS_UPDATE`, o form vira readonly (campos
+ *   desabilitados e botão "Salvar" oculto).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [CLIENTS_UPDATE_PERMISSION];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Componente que captura o pathname atual do `MemoryRouter` para
+ * que asserts de redirecionamento (caso 404) possam verificar a
+ * navegação sem depender do detalhe interno do roteador.
+ */
+const PathnameProbe: React.FC<{ onChange: (pathname: string) => void }> = ({ onChange }) => {
+  const [pathname] = React.useState<string>(() => window.location.pathname);
+  React.useEffect(() => {
+    onChange(pathname);
+  }, [onChange, pathname]);
+  return null;
+};
+
+/**
+ * Renderiza a `ClientDataTab` num `<MemoryRouter>` com a rota
+ * `/clientes/:id` e uma rota fallback `/clientes` que captura o
+ * redirect do caminho 404. Centralizar evita repetir o setup em
+ * cada teste e manter `New Code Duplication` baixo (lição PR
+ * #127/#128).
+ */
+function renderClientDataTab(
+  client: ApiClientStub,
+  initialEntries: ReadonlyArray<string> = [`/clientes/${ID_CLIENT_PF_ANA}`],
+): { redirected: () => boolean } {
+  let redirectedFlag = false;
+
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[...initialEntries]}>
+        <Routes>
+          <Route
+            path="/clientes/:id"
+            element={<ClientDataTab client={client} />}
+          />
+          <Route
+            path="/clientes"
+            element={
+              <div data-testid="redirected-list">
+                <PathnameProbe
+                  onChange={() => {
+                    redirectedFlag = true;
+                  }}
+                />
+                Lista
+              </div>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+
+  return { redirected: () => redirectedFlag };
+}
+
+/**
+ * Aguarda o fetch inicial completar (loading some, form aparece).
+ */
+async function waitForLoaded(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.queryByTestId('client-data-loading')).not.toBeInTheDocument();
+  });
+  await waitFor(() => {
+    expect(screen.queryByTestId('client-data-form')).toBeInTheDocument();
+  });
+}
+
+describe('ClientDataTab — fetch inicial e pré-população (Issue #75)', () => {
+  it('exibe spinner durante o GET /clients/{id}', () => {
+    const client = createClientsClientStub();
+    // `Promise` pendente — fica em loading indefinidamente para o
+    // teste capturar o estado intermediário.
+    client.get.mockReturnValueOnce(new Promise(() => {
+      // intencional: nunca resolve.
+    }));
+
+    renderClientDataTab(client);
+
+    expect(screen.getByTestId('client-data-loading')).toBeInTheDocument();
+    expect(client.get).toHaveBeenCalledWith(
+      `/clients/${ID_CLIENT_PF_ANA}`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('pré-popula campos PF (CPF, nome, tipo) com os dados do backend', async () => {
+    const dto = makeClient({
+      id: ID_CLIENT_PF_ANA,
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana Cliente',
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    expect((screen.getByTestId('client-data-cpf') as HTMLInputElement).value).toBe(
+      '52998224725',
+    );
+    expect(
+      (screen.getByTestId('client-data-fullName') as HTMLInputElement).value,
+    ).toBe('Ana Cliente');
+    expect((screen.getByTestId('client-data-type') as HTMLSelectElement).value).toBe(
+      'PF',
+    );
+  });
+
+  it('pré-popula campos PJ (CNPJ, razão social, tipo) com os dados do backend', async () => {
+    const dto = makeClientPj({
+      id: ID_CLIENT_PJ_ACME,
+      cnpj: '11222333000181',
+      corporateName: 'Acme Indústria S/A',
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client, [`/clientes/${ID_CLIENT_PJ_ACME}`]);
+    await waitForLoaded();
+
+    expect((screen.getByTestId('client-data-cnpj') as HTMLInputElement).value).toBe(
+      '11222333000181',
+    );
+    expect(
+      (screen.getByTestId('client-data-corporateName') as HTMLInputElement).value,
+    ).toBe('Acme Indústria S/A');
+    expect((screen.getByTestId('client-data-type') as HTMLSelectElement).value).toBe(
+      'PJ',
+    );
+  });
+
+  it('renderiza `<Select>` de tipo desabilitado (imutável após criação)', async () => {
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    const typeSelect = screen.getByTestId('client-data-type') as HTMLSelectElement;
+    expect(typeSelect).toBeDisabled();
+    // Helper text do `<Select>` informa imutabilidade.
+    expect(screen.getByText('Tipo é imutável após a criação.')).toBeInTheDocument();
+  });
+
+  it('exibe ErrorRetryBlock quando o fetch falha (rede)', async () => {
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'network',
+      message: 'Falha de conexão.',
+    });
+
+    renderClientDataTab(client);
+
+    expect(
+      await screen.findByTestId('client-data-retry'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Não foi possível carregar os dados do cliente.'),
+    ).toBeInTheDocument();
+  });
+
+  it('clicar em "Tentar novamente" refaz o GET', async () => {
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'network',
+      message: 'Falha.',
+    });
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    const retryBtn = await screen.findByTestId('client-data-retry');
+    fireEvent.click(retryBtn);
+
+    await waitForLoaded();
+    expect(client.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('redireciona para /clientes quando o fetch devolve 404', async () => {
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Cliente não encontrado.',
+    });
+
+    renderClientDataTab(client);
+
+    // O redirect leva para a rota `/clientes` (fallback do
+    // `<MemoryRouter>` no helper de render). A presença do
+    // `data-testid="redirected-list"` confirma que a navegação
+    // ocorreu — não dependemos de inspeção interna do roteador.
+    expect(await screen.findByTestId('redirected-list')).toBeInTheDocument();
+  });
+});
+
+describe('ClientDataTab — submit com sucesso (Issue #75)', () => {
+  it('envia PUT /clients/{id} (PF) com body trimado e exibe toast', async () => {
+    const dto = makeClient({
+      id: ID_CLIENT_PF_ANA,
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana Cliente',
+    });
+    const updated = makeClient({
+      id: ID_CLIENT_PF_ANA,
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana Atualizada',
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockResolvedValueOnce(updated);
+    // Refetch após sucesso (`onUpdated` incrementa reloadCounter).
+    client.get.mockResolvedValueOnce(updated);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ fullName: '  Ana Atualizada  ' });
+    await submitClientDataForm(client);
+
+    expect(client.put).toHaveBeenCalledWith(
+      `/clients/${ID_CLIENT_PF_ANA}`,
+      {
+        type: 'PF',
+        cpf: '52998224725',
+        fullName: 'Ana Atualizada',
+      },
+      undefined,
+    );
+    expect(await screen.findByText('Cliente atualizado.')).toBeInTheDocument();
+  });
+
+  it('envia PUT /clients/{id} (PJ) com body trimado e omite campos do tipo oposto', async () => {
+    const dto = makeClientPj({
+      id: ID_CLIENT_PJ_ACME,
+      cnpj: '11222333000181',
+      corporateName: 'Acme S/A',
+    });
+    const updated = makeClientPj({
+      id: ID_CLIENT_PJ_ACME,
+      cnpj: '11222333000181',
+      corporateName: 'Acme Indústria S/A',
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockResolvedValueOnce(updated);
+    client.get.mockResolvedValueOnce(updated);
+
+    renderClientDataTab(client, [`/clientes/${ID_CLIENT_PJ_ACME}`]);
+    await waitForLoaded();
+
+    fillClientDataPjForm({ corporateName: '  Acme Indústria S/A  ' });
+    await submitClientDataForm(client);
+
+    const [path, body] = client.put.mock.calls[0];
+    expect(path).toBe(`/clients/${ID_CLIENT_PJ_ACME}`);
+    expect(body).toEqual({
+      type: 'PJ',
+      cnpj: '11222333000181',
+      corporateName: 'Acme Indústria S/A',
+    });
+    expect(body).not.toHaveProperty('cpf');
+    expect(body).not.toHaveProperty('fullName');
+  });
+});
+
+describe('ClientDataTab — validação client-side (Issue #75)', () => {
+  it('CPF inválido bloqueia o submit e exibe erro inline', async () => {
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ cpf: '11111111111' });
+    fireEvent.submit(screen.getByTestId('client-data-form'));
+
+    expect(screen.getByText('CPF inválido para cliente PF.')).toBeInTheDocument();
+    expect(client.put).not.toHaveBeenCalled();
+  });
+
+  it('FullName apenas whitespace é tratado como vazio', async () => {
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ fullName: '   ' });
+    fireEvent.submit(screen.getByTestId('client-data-form'));
+
+    expect(
+      screen.getByText('FullName é obrigatório para cliente PF.'),
+    ).toBeInTheDocument();
+    expect(client.put).not.toHaveBeenCalled();
+  });
+});
+
+describe('ClientDataTab — tratamento de erros do backend (Issue #75)', () => {
+  it('409 (CPF duplicado) exibe mensagem inline no campo cpf', async () => {
+    const dto = makeClient({ type: 'PF' });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message: 'Já existe cliente com este CPF.',
+    });
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ cpf: '52998224725' });
+    await submitClientDataForm(client);
+
+    expect(
+      await screen.findByText(toCaseInsensitiveMatcher('Já existe cliente com este CPF.')),
+    ).toBeInTheDocument();
+  });
+
+  it('409 (CNPJ duplicado) exibe mensagem inline no campo cnpj', async () => {
+    const dto = makeClientPj();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message: 'Já existe cliente com este CNPJ.',
+    });
+
+    renderClientDataTab(client, [`/clientes/${ID_CLIENT_PJ_ACME}`]);
+    await waitForLoaded();
+
+    fillClientDataPjForm({ cnpj: '11222333000181' });
+    await submitClientDataForm(client);
+
+    expect(
+      await screen.findByText(toCaseInsensitiveMatcher('Já existe cliente com este CNPJ.')),
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * Cenários comuns colapsados em `it.each` (lição PR #123/#127 —
+   * mesma estrutura mudando 1-2 mocks vira tabela, não `it`
+   * separados, para evitar New Code Duplication no Sonar).
+   */
+  const ERROR_CASES: ReadonlyArray<ClientsErrorCase> = buildClientsEditSubmitErrorCases();
+
+  it.each(ERROR_CASES)('mapeia $name', async ({ error, expectedText }) => {
+    // Pré-popular com CPF válido (52998224725 — DVs corretos) para
+    // que a validação client-side do `prepareUpdateSubmit` deixe
+    // passar e o submit chegue até `client.put`. O CPF default da
+    // fixture (`makeClient()`: 12345678901) tem DVs inválidos, então
+    // sobrescrevemos aqui.
+    const dto = makeClient({ cpf: '52998224725' });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockRejectedValueOnce(error);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ fullName: 'Ana Atualizada' });
+    await submitClientDataForm(client);
+
+    expect(
+      await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+    ).toBeInTheDocument();
+  });
+
+  it('404 no submit deixa o usuário na aba (refetch trata o redirect)', async () => {
+    const dto = makeClient({ cpf: '52998224725' });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Cliente não encontrado.',
+    });
+    // Refetch disparado pelo `useEditEntitySubmit` no caminho
+    // `not-found` (`onUpdated` → `reloadCounter++` → useEffect roda
+    // GET de novo). O backend devolve 404 também no GET → redirect
+    // para `/clientes`.
+    client.get.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Cliente não encontrado.',
+    });
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    fillClientDataPfForm({ fullName: 'Ana Atualizada' });
+    await submitClientDataForm(client);
+
+    expect(await screen.findByTestId('redirected-list')).toBeInTheDocument();
+  });
+});
+
+describe('ClientDataTab — gating Clients.Update (Issue #75)', () => {
+  it('sem AUTH_V1_CLIENTS_UPDATE renderiza o form readonly (campos disabled, sem botão Salvar)', async () => {
+    permissionsMock = [];
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    expect(screen.getByTestId('client-data-cpf')).toBeDisabled();
+    expect(screen.getByTestId('client-data-fullName')).toBeDisabled();
+    expect(screen.getByTestId('client-data-type')).toBeDisabled();
+    // Footer (Cancelar/Submit) ausente em modo readonly.
+    expect(screen.queryByTestId('client-data-submit')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('client-data-cancel')).not.toBeInTheDocument();
+  });
+
+  it('com AUTH_V1_CLIENTS_UPDATE renderiza form editável com botão Salvar', async () => {
+    permissionsMock = [CLIENTS_UPDATE_PERMISSION];
+    const dto = makeClient();
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    expect(screen.getByTestId('client-data-cpf')).not.toBeDisabled();
+    expect(screen.getByTestId('client-data-fullName')).not.toBeDisabled();
+    // Botão "Salvar" presente.
+    expect(screen.getByTestId('client-data-submit')).toBeInTheDocument();
+    expect(screen.getByTestId('client-data-submit')).toHaveTextContent(/Salvar/i);
+    expect(screen.getByTestId('client-data-cancel')).toBeInTheDocument();
+  });
+});
+
+describe('ClientDataTab — botão Cancelar (Issue #75)', () => {
+  it('reseta o form para o estado original (descarta edições não salvas)', async () => {
+    const dto = makeClient({
+      type: 'PF',
+      cpf: '52998224725',
+      fullName: 'Ana Cliente',
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientDataTab(client);
+    await waitForLoaded();
+
+    // Edição local sem salvar.
+    fillClientDataPfForm({ fullName: 'Edição não salva' });
+    expect(
+      (screen.getByTestId('client-data-fullName') as HTMLInputElement).value,
+    ).toBe('Edição não salva');
+
+    fireEvent.click(screen.getByTestId('client-data-cancel'));
+
+    expect(
+      (screen.getByTestId('client-data-fullName') as HTMLInputElement).value,
+    ).toBe('Ana Cliente');
+    expect(client.put).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pages/clients/ClientEditPage.test.tsx
+++ b/tests/pages/clients/ClientEditPage.test.tsx
@@ -1,18 +1,23 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import { ToastProvider } from '@/components/ui';
 import { ClientEditPage } from '@/pages/clients';
+/* eslint-enable import/order */
 
 /**
  * Suíte do `ClientEditPage` (Issue #144).
  *
- * **Por que não mockar `useAuth`:** a página `ClientEditPage` é
- * renderizada por `<RequirePermission>` no `AppRoutes`, mas a
- * página em si **não chama** `useAuth` diretamente (o gating fica
- * acima dela). Por isso renderizamos com `<MemoryRouter>` direto sem
- * Provider — espelha o padrão de `tests/pages/shellPages.test.tsx`.
+ * **Mock de `useAuth`:** a página `ClientEditPage` é renderizada por
+ * `<RequirePermission>` no `AppRoutes`, mas a aba "Dados" — entregue
+ * pela Issue #75 — chama `useAuth()` para gatear o submit (precisa
+ * de `AUTH_V1_CLIENTS_UPDATE`). Mockamos com `buildAuthMock` para
+ * preservar a flexibilidade de alternar permissões por teste e
+ * isolar a página da `AuthProvider` real.
  *
  * **Cenários cobertos (critérios da issue):**
  *
@@ -33,18 +38,63 @@ import { ClientEditPage } from '@/pages/clients';
  *   Clientes" e botão de ação global.
  */
 
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+/**
+ * Mock de `@/shared/api` específico desta suíte: `getClientById`
+ * devolve uma `Promise` que nunca resolve, mantendo a aba "Dados"
+ * em loading silencioso. Os testes deste arquivo cobrem a estrutura
+ * do `ClientEditPage` (tablist/headers/teclado) — o conteúdo da
+ * aba "Dados" tem suíte própria (`ClientDataTab.test.tsx`).
+ *
+ * Manter `Promise` pendente é mais simples que mockar um DTO completo
+ * e evita assert ruidoso sobre estado pós-fetch — a aba fica no
+ * spinner, e cada teste verifica os atributos da árvore externa.
+ */
+vi.mock('@/shared/api', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api')>('@/shared/api');
+  return {
+    ...actual,
+    getClientById: vi.fn(
+      () =>
+        new Promise(() => {
+          // intencional: nunca resolve, mantém aba "Dados" em loading.
+        }),
+    ),
+    updateClient: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 /**
  * Helper para renderizar a página com router controlado. Centralizar
  * evita duplicação entre os testes (lição PR #123/PR #127 — blocos
  * idênticos de setup viram fixture).
+ *
+ * O `<ToastProvider>` e o mock de `useAuth` são necessários porque
+ * a aba "Dados" (Issue #75) chama `useToast()` e `useAuth()` em
+ * runtime — o teste do header/tablist em si não exercita esses
+ * caminhos, mas a árvore React precisa do contexto montado para
+ * renderizar a aba sem crashar.
  */
 function renderClientEditPage(initialEntries: ReadonlyArray<string> = ['/clientes/abc-123']) {
   return render(
-    <MemoryRouter initialEntries={[...initialEntries]}>
-      <Routes>
-        <Route path="/clientes/:id" element={<ClientEditPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={[...initialEntries]}>
+        <Routes>
+          <Route path="/clientes/:id" element={<ClientEditPage />} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   );
 }
 

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -6,10 +6,12 @@ import {
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_PAGE_SIZE,
+  getClientById,
   getClientsByIds,
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  updateClient,
 } from '@/shared/api';
 
 /**
@@ -665,5 +667,254 @@ describe('createClient', () => {
         client as unknown as ApiClient,
       ),
     ).rejects.toBe(conflict);
+  });
+});
+
+/* ─── getClientById (Issue #75) ─────────────────────────── */
+
+describe('getClientById', () => {
+  it('faz GET /clients/{id} e devolve o ClientDto parseado', async () => {
+    const client = makeClientStub();
+    const dto = makeRawClientPf();
+    client.get.mockResolvedValueOnce(dto);
+
+    const result = await getClientById(
+      CLIENT_PF_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get).toHaveBeenCalledWith(`/clients/${CLIENT_PF_ID}`, undefined);
+    expect(result).toBe(dto);
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(makeRawClientPf());
+    const controller = new AbortController();
+
+    await getClientById(
+      CLIENT_PF_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledWith(`/clients/${CLIENT_PF_ID}`, {
+      signal: controller.signal,
+    });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve corpo vazio', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce(null);
+
+    await expect(
+      getClientById(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload com shape inválido', async () => {
+    const client = makeClientStub();
+    client.get.mockResolvedValueOnce({ wrong: 'shape' });
+
+    await expect(
+      getClientById(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga ApiError 404 do backend', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado.',
+    };
+    client.get.mockRejectedValueOnce(notFound);
+
+    await expect(
+      getClientById(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(notFound);
+  });
+});
+
+/* ─── updateClient (Issue #75) ──────────────────────────── */
+
+describe('updateClient', () => {
+  it('envia PUT /clients/{id} para PF com cpf+fullName trimados', async () => {
+    const client = makeClientStub();
+    const updated = makeRawClientPf();
+    client.put.mockResolvedValueOnce(updated);
+
+    const result = await updateClient(
+      CLIENT_PF_ID,
+      {
+        type: 'PF',
+        cpf: '  12345678901  ',
+        fullName: '  Ana Cliente  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    expect(client.put).toHaveBeenCalledWith(
+      `/clients/${CLIENT_PF_ID}`,
+      {
+        type: 'PF',
+        cpf: '12345678901',
+        fullName: 'Ana Cliente',
+      },
+      undefined,
+    );
+    expect(result).toBe(updated);
+  });
+
+  it('envia PUT /clients/{id} para PJ com cnpj+corporateName trimados', async () => {
+    const client = makeClientStub();
+    const updated = makeRawClientPj();
+    client.put.mockResolvedValueOnce(updated);
+
+    await updateClient(
+      CLIENT_PJ_ID,
+      {
+        type: 'PJ',
+        cnpj: '  12345678000190  ',
+        corporateName: '  Acme Indústria S/A  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledWith(
+      `/clients/${CLIENT_PJ_ID}`,
+      {
+        type: 'PJ',
+        cnpj: '12345678000190',
+        corporateName: 'Acme Indústria S/A',
+      },
+      undefined,
+    );
+  });
+
+  it('omite campos do tipo oposto (PF não envia cnpj/corporateName)', async () => {
+    const client = makeClientStub();
+    client.put.mockResolvedValueOnce(makeRawClientPf());
+
+    await updateClient(
+      CLIENT_PF_ID,
+      {
+        type: 'PF',
+        cpf: '12345678901',
+        fullName: 'Ana',
+        // Caller mal-comportado tenta enviar campos PJ junto. O
+        // helper interno `buildClientMutationBody` os filtra para
+        // evitar 400 do backend ("CNPJ não deve ser informado para
+        // cliente PF.").
+        cnpj: '12345678000190',
+        corporateName: 'Algo',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const [, body] = client.put.mock.calls[0];
+    expect(body).toEqual({
+      type: 'PF',
+      cpf: '12345678901',
+      fullName: 'Ana',
+    });
+    expect(body).not.toHaveProperty('cnpj');
+    expect(body).not.toHaveProperty('corporateName');
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = makeClientStub();
+    client.put.mockResolvedValueOnce({ wrong: 'shape' });
+
+    await expect(
+      updateClient(
+        CLIENT_PF_ID,
+        { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.put.mockResolvedValueOnce(makeRawClientPf());
+    const controller = new AbortController();
+
+    await updateClient(
+      CLIENT_PF_ID,
+      { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledWith(
+      `/clients/${CLIENT_PF_ID}`,
+      expect.any(Object),
+      { signal: controller.signal },
+    );
+  });
+
+  it('propaga ApiError 409 do backend (CPF/CNPJ duplicado)', async () => {
+    const client = makeClientStub();
+    const conflict = {
+      kind: 'http' as const,
+      status: 409,
+      message: 'Já existe cliente com este CPF.',
+    };
+    client.put.mockRejectedValueOnce(conflict);
+
+    await expect(
+      updateClient(
+        CLIENT_PF_ID,
+        { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(conflict);
+  });
+
+  it('propaga ApiError 404 do backend (cliente removido)', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado.',
+    };
+    client.put.mockRejectedValueOnce(notFound);
+
+    await expect(
+      updateClient(
+        CLIENT_PF_ID,
+        { type: 'PF', cpf: '12345678901', fullName: 'Ana' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(notFound);
+  });
+
+  it('propaga ApiError 400 do backend (type imutável)', async () => {
+    const client = makeClientStub();
+    const badRequest = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Tipo do cliente não pode ser alterado após a criação.',
+    };
+    client.put.mockRejectedValueOnce(badRequest);
+
+    await expect(
+      updateClient(
+        CLIENT_PF_ID,
+        { type: 'PJ', cnpj: '12345678000190', corporateName: 'Acme' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(badRequest);
   });
 });


### PR DESCRIPTION
## Contexto

EPIC #49 (CRUD de Clientes). A aba "Dados" do `ClientEditPage`
(entregue em #144 como placeholder) é o ponto onde o operador
edita CPF/CNPJ + nome/razão social do cliente. As outras três
abas (Emails extras #146, Celulares/Telefones #147) seguem em
issues subsequentes.

## Objetivo

Implementar o critério de aceite da Issue #75:

- [x] Pré-popula campos a partir de `GET /clients/{id}`.
- [x] Mesma validação client-side da criação (#74).
- [x] Visível com `Clients.Update` (`AUTH_V1_CLIENTS_UPDATE`).

Persistência via `PUT /clients/{id}` (`ClientsController.UpdateById`),
com type imutável após criação (backend rejeita mudança com 400).

## O que foi feito

- `src/shared/api/clients.ts`:
  - `getClientById(id, options, client)` exposto publicamente.
  - `updateClient(id, payload, options, client)` análogo ao
    `createClient`, com `UpdateClientPayload` (alias de
    `CreateClientPayload`) — backend reaproveita o `CreateClientRequest`
    no PUT.
  - `buildClientMutationBody` agora compartilhado entre create e
    update (mesmo trim/filter por tipo).

- `src/pages/clients/clientsFormShared.ts`:
  - `stateFromClient(dto)` helper que constrói `ClientFormState`
    a partir de um `ClientDto` (espelha `stateFromUser` em
    `EditUserModal`).

- `src/pages/clients/useClientForm.ts`:
  - `prepareUpdateSubmit()` adicionado (espelha o padrão
    `prepareSubmit`/`prepareUpdateSubmit` de `useUserForm`).
  - Núcleo `prepareValidatedPayload` extraído para evitar JSCPD
    detectar duplicação entre create e update — preserva tipagem
    estrita do retorno em cada call-site.
  - `ClientFormFieldProps` + `useClientFormFieldProps` exportados
    para que `NewClientModal` e `ClientDataTab` consumam o mesmo
    objeto memoizado de field props (lição PR #134/#135 — call-sites
    duplicados também precisam ficar deduplicados).

- `src/pages/clients/ClientFormFields.tsx`:
  - Nova prop `readonly` que desabilita campos e oculta o footer
    (Cancelar/Submit). Usada pelo `ClientDataTab` quando o usuário
    não tem `Clients.Update`.

- `src/pages/clients/NewClientModal.tsx`:
  - Migrado para `useClientFormFieldProps` — reduz spread de 13
    handlers para `{...fieldProps}` único.

- `src/pages/clients/ClientDataTab.tsx`:
  - Substitui o placeholder herdado de #144 pelo form real.
  - Estados: `loading` (spinner), `error` (`ErrorRetryBlock`),
    `loaded` (form pré-populado). 404 no fetch dispara toast e
    redireciona para `/clientes`.
  - Submit usa `useEditEntitySubmit` (compartilhado), com
    `conflictField` runtime (`'cpf'` para PF, `'cnpj'` para PJ).
  - Sem `Clients.Update`: form readonly (campos disabled, sem
    botão Salvar). Com `Clients.Update`: botão "Salvar" + Cancelar
    (que reseta o form para o estado original).

## Arquivos impactados

- `src/shared/api/clients.ts` — `getClientById`, `updateClient`,
  `UpdateClientPayload`, comentários atualizados em
  `buildClientMutationBody`.
- `src/shared/api/index.ts` — re-export de `getClientById`,
  `updateClient`, `UpdateClientPayload`.
- `src/pages/clients/clientsFormShared.ts` — `stateFromClient`.
- `src/pages/clients/useClientForm.ts` — `prepareUpdateSubmit`,
  `useClientFormFieldProps`, `ClientFormFieldProps`.
- `src/pages/clients/ClientFormFields.tsx` — prop `readonly`.
- `src/pages/clients/NewClientModal.tsx` — usa
  `useClientFormFieldProps`.
- `src/pages/clients/ClientDataTab.tsx` — rewrite (placeholder →
  form real).
- `tests/pages/__helpers__/clientsTestHelpers.tsx` — helpers
  `fillClientDataPfForm`/`fillClientDataPjForm`/`submitClientDataForm`/
  `buildClientsEditSubmitErrorCases`.
- `tests/pages/clients/ClientDataTab.test.tsx` (novo) — 22
  testes (pré-população PF/PJ, type imutável, ErrorRetryBlock,
  retry, 404 redirect, submit success PF/PJ, validação client-side,
  409 PF/PJ, `it.each` 400/401/403/network, gating
  `Clients.Update`, Cancelar reseta form).
- `tests/pages/clients/ClientEditPage.test.tsx` — agora envolve
  `<ToastProvider>` + mock de `useAuth`/`@/shared/api` (a aba
  "Dados" agora chama `useToast`/`useAuth`/`getClientById`).
- `tests/shared/api/clients.test.ts` — 11 novos testes para
  `getClientById` + `updateClient` (PF/PJ trim, omissão de campos
  do tipo oposto, 409, 404, 400 type imutável, parse error, signal).

## Testes

Quality gate executado dentro do container, todos verdes:

```text
$ docker compose run --rm web npm run lint
(0 erros, 0 warnings)

$ docker compose run --rm web npm run typecheck
(0 erros tsc --noEmit)

$ docker compose run --rm web npm test -- --run --no-file-parallelism
Test Files  66 passed (66)
     Tests  1121 passed (1121)

$ docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10 \
    --reporters console,json --output ./jscpd-report
Total: 2.41% (newClones em arquivos do diff: 0)
```

Cobertura específica: 162 testes em `tests/pages/clients/` +
`tests/shared/api/clients.test.ts` passam.

## Visual

- Estados visuais cobertos: `loading` (Spinner), `error`
  (`ErrorRetryBlock`), `loaded` (form), `submitting` (botão
  loading), `readonly` (campos disabled, sem footer).
- `<Select>` de tipo: `disabled` com `helperText`
  "Tipo é imutável após a criação."
- Cores via tokens (`var(--bg-surface)`, `var(--border-subtle)`,
  `var(--fg1)`, etc.) — sem hardcode.
- Hover/focus já cobertos pelos componentes do design system
  (`Button`, `Input`, `Select`, `Spinner`).

## Segurança

Nenhum impacto novo. Permissão `Clients.Update` é fonte
autoritativa no backend (`PUT /clients/{id}` validado por policy);
o gating client-side é apenas UX para esconder ações que o
usuário não pode executar.

## Riscos

Nenhum. O único risco identificado (duplicação JSCPD entre
`prepareSubmit` e `prepareUpdateSubmit`) foi mitigado extraindo
`prepareValidatedPayload`. JSCPD final reporta 0 newClones em
arquivos do diff.

## Issue relacionada

Closes #75