### PR TITLE
feat(users): atribuir roles ao usuário com matriz por sistema (#71)

### DIFF
--- a/src/pages/users/UserPermissionsShellPage.tsx
+++ b/src/pages/users/UserPermissionsShellPage.tsx
@@ -13,7 +13,8 @@ import {
 } from '../../components/ui';
 import {
   assignPermissionToUser,
-  isApiError,
+  extractErrorMessage,
+  isFetchAborted,
   listEffectiveUserPermissions,
   listPermissions,
   MAX_PERMISSIONS_PAGE_SIZE,
@@ -548,37 +549,4 @@ const PermissionGroup: React.FC<PermissionGroupProps> = ({
   </AssignmentGroupCard>
 );
 
-/**
- * Distingue erros de cancelamento (esperados durante navegação rápida)
- * dos erros reais de UI. Espelha o pattern de `usePaginatedFetch`.
- */
-function isFetchAborted(error: unknown): boolean {
-  if (error instanceof DOMException && error.name === 'AbortError') {
-    return true;
-  }
-  if (
-    isApiError(error) &&
-    error.kind === 'network' &&
-    error.message === 'Requisição cancelada.'
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Extrai mensagem amigável de qualquer erro vindo da camada HTTP. Quando
- * o erro é um `ApiError`, devolvemos a `message` (o cliente já resolveu
- * fallbacks por status). Para erros arbitrários, usamos a `fallback` em
- * pt-BR específica do contexto. Centralizada aqui em vez de reusar do
- * `usePaginatedFetch` para evitar acoplamento desnecessário entre módulos
- * (lição PR #134 — duplicação client-side só é problema quando o trecho
- * vive em arquivos diferentes; aqui é um único arquivo).
- */
-function extractErrorMessage(error: unknown, fallback: string): string {
-  if (isApiError(error)) {
-    return error.message;
-  }
-  return fallback;
-}
 

--- a/src/pages/users/UserRolesShellPage.tsx
+++ b/src/pages/users/UserRolesShellPage.tsx
@@ -1,0 +1,485 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useParams } from 'react-router-dom';
+
+import { Badge, Checkbox, useToast } from '../../components/ui';
+import {
+  assignRoleToUser,
+  getUserById,
+  isApiError,
+  listRoles,
+  listSystems,
+  MAX_ROLES_PAGE_SIZE,
+  removeRoleFromUser,
+} from '../../shared/api';
+import { computeIdSetDiff, idSetDiffHasChanges } from '../../shared/forms';
+import {
+  AssignmentGroupCard,
+  AssignmentGroupCode,
+  AssignmentGroupCount,
+  AssignmentGroupHeader,
+  AssignmentGroupName,
+  AssignmentItemBadges,
+  AssignmentItemCodeChip,
+  AssignmentItemDescription,
+  AssignmentItemDetails,
+  AssignmentItemList,
+  AssignmentItemPrimaryText,
+  AssignmentItemRow,
+  AssignmentItemTitleRow,
+  AssignmentLegendCopy,
+  AssignmentLegendItem,
+  AssignmentMatrixShell,
+  Mono,
+} from '../../shared/listing';
+
+import {
+  buildInitialUserRoleIds,
+  groupRolesBySystem,
+} from './userRolesHelpers';
+
+import type {
+  RoleAssignmentFailure,
+  RoleId,
+  RoleSystemGroup,
+  SystemLookupMap,
+} from './userRolesHelpers';
+import type {
+  ApiClient,
+  RoleDto,
+  SystemDto,
+  UserDto,
+} from '../../shared/api';
+
+/**
+ * Heurística leve para descartar `:id` claramente inválido antes de
+ * bater no backend — espelha `UserPermissionsShellPage`/`RolesPage`/
+ * `RolePermissionsShellPage`. Aceita qualquer string não-vazia com
+ * pelo menos um caractere não-whitespace.
+ */
+function isProbablyValidUserId(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+interface UserRolesShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido
+   * (cada wrapper de API usa o singleton `apiClient`).
+   */
+  client?: ApiClient;
+}
+
+interface FetchedState {
+  user: UserDto;
+  roles: ReadonlyArray<RoleDto>;
+  systemLookup: SystemLookupMap;
+}
+
+/**
+ * Distingue erros de cancelamento (esperados durante navegação rápida)
+ * dos erros reais de UI. Espelha `UserPermissionsShellPage`/
+ * `RolePermissionsShellPage` (lição PR #134/#135 — aceitar duplicação
+ * pequena (5 linhas) entre páginas-shell se a alternativa é exportar
+ * helper privado).
+ */
+function isFetchAborted(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (
+    isApiError(error) &&
+    error.kind === 'network' &&
+    error.message === 'Requisição cancelada.'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
+ * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
+ * resolveu fallbacks por status). Para erros arbitrários, usamos a
+ * `fallback` em pt-BR específica do contexto.
+ */
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  return fallback;
+}
+
+/**
+ * Constrói o mapa `systemId -> {code, name}` a partir do array de
+ * `SystemDto` devolvido por `listSystems`. Mantido fora do componente
+ * para tornar testes baratos.
+ */
+function buildSystemLookup(
+  systems: ReadonlyArray<SystemDto>,
+): SystemLookupMap {
+  const map = new Map<string, { code: string; name: string }>();
+  for (const system of systems) {
+    map.set(system.id, { code: system.code, name: system.name });
+  }
+  return map;
+}
+
+/**
+ * Atribuição de roles a um usuário (Issue #71 / EPIC #48).
+ *
+ * Fluxo (espelhando `UserPermissionsShellPage` da Issue #70 e
+ * `RolePermissionsShellPage` da Issue #69):
+ *
+ * 1. Carrega em paralelo `GET /roles` (catálogo paginado),
+ *    `GET /systems` (lookup de `systemId -> {code, name}`) e
+ *    `GET /users/{id}` (estado atual do usuário, incluindo array
+ *    `roles`).
+ * 2. Inicializa o set `selectedRoles` com os ids das roles do array
+ *    `user.roles`.
+ * 3. UI exibe lista agrupada por sistema; cada role tem um checkbox
+ *    controlado e badges visuais (vínculo atual / pendente).
+ * 4. Salvar calcula o diff client-side via `computeIdSetDiff` e
+ *    dispara `assignRoleToUser`/`removeRoleFromUser` em paralelo.
+ *    Falhas individuais não abortam o lote — agregamos um relatório.
+ * 5. Após o salvar, refetch do `getUserById` sincroniza o estado com
+ *    o backend (idempotência cobre divergências raras), e a UI
+ *    automaticamente reflete em `effective-permissions` na Issue #70
+ *    quando o usuário voltar para essa tela.
+ *
+ * **Visível com** `Roles.Read` + `Users.Update` (gating duplo via
+ * `RequirePermission` na rota — ver `src/routes/index.tsx`). A página
+ * assume que ambas as permissões já estão garantidas — não duplica a
+ * checagem aqui.
+ *
+ * **Reuso (lição PR #134/#135):** o JSX da matriz vem de
+ * `<AssignmentMatrixShell>` em `src/shared/listing/`, compartilhado
+ * com `UserPermissionsShellPage`/`RolePermissionsShellPage`. O diff
+ * usa `computeIdSetDiff`/`idSetDiffHasChanges` em
+ * `src/shared/forms/`. O agrupamento usa `groupBySystem` em
+ * `src/shared/listing/` (delegado por `groupRolesBySystem`). O que
+ * fica **local** é apenas a copy da legenda e o render do `RoleGroup`.
+ */
+export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
+  client,
+}) => {
+  const { id: userId } = useParams<{ id: string }>();
+  const hasValidUserId = isProbablyValidUserId(userId);
+
+  const toast = useToast();
+
+  const [state, setState] = useState<{
+    isInitialLoading: boolean;
+    isSaving: boolean;
+    errorMessage: string | null;
+    fetched: FetchedState | null;
+    selectedRoles: ReadonlySet<RoleId>;
+    originalRoles: ReadonlySet<RoleId>;
+    refetchNonce: number;
+  }>({
+    isInitialLoading: true,
+    isSaving: false,
+    errorMessage: null,
+    fetched: null,
+    selectedRoles: new Set<RoleId>(),
+    originalRoles: new Set<RoleId>(),
+    refetchNonce: 0,
+  });
+
+  const lastControllerRef = useRef<AbortController | null>(null);
+
+  const handleRefetch = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isInitialLoading: true,
+      errorMessage: null,
+      refetchNonce: prev.refetchNonce + 1,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!hasValidUserId) {
+      setState((prev) => ({ ...prev, isInitialLoading: false }));
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    Promise.all([
+      listRoles({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
+      listSystems({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
+      getUserById(userId, { signal: controller.signal }, client),
+    ])
+      .then(([rolesResponse, systemsResponse, user]) => {
+        if (cancelled) return;
+        const originalRoles = buildInitialUserRoleIds(user.roles);
+        setState({
+          isInitialLoading: false,
+          isSaving: false,
+          errorMessage: null,
+          fetched: {
+            user,
+            roles: rolesResponse.data,
+            systemLookup: buildSystemLookup(systemsResponse.data),
+          },
+          selectedRoles: new Set(originalRoles),
+          originalRoles,
+          refetchNonce: 0,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        if (isFetchAborted(error)) return;
+        setState((prev) => ({
+          ...prev,
+          isInitialLoading: false,
+          errorMessage: extractErrorMessage(
+            error,
+            'Falha ao carregar as roles do usuário. Tente novamente.',
+          ),
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, hasValidUserId, userId, state.refetchNonce]);
+
+  const groups = useMemo<ReadonlyArray<RoleSystemGroup>>(() => {
+    if (!state.fetched) return [];
+    return groupRolesBySystem(state.fetched.roles, state.fetched.systemLookup);
+  }, [state.fetched]);
+
+  const diff = useMemo(
+    () => computeIdSetDiff(state.originalRoles, state.selectedRoles),
+    [state.originalRoles, state.selectedRoles],
+  );
+  const hasUnsavedChanges = idSetDiffHasChanges(diff);
+
+  const handleToggleRole = useCallback((roleId: RoleId, checked: boolean) => {
+    setState((prev) => {
+      const next = new Set(prev.selectedRoles);
+      if (checked) {
+        next.add(roleId);
+      } else {
+        next.delete(roleId);
+      }
+      return { ...prev, selectedRoles: next };
+    });
+  }, []);
+
+  const handleResetChanges = useCallback(() => {
+    setState((prev) => ({ ...prev, selectedRoles: new Set(prev.originalRoles) }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!hasValidUserId || !hasUnsavedChanges || state.isSaving) {
+      return;
+    }
+    setState((prev) => ({ ...prev, isSaving: true }));
+    const failures: RoleAssignmentFailure[] = [];
+    let succeededAdd = 0;
+    let succeededRemove = 0;
+
+    const addOps = diff.toAdd.map(async (roleId) => {
+      try {
+        await assignRoleToUser(userId, roleId, undefined, client);
+        succeededAdd += 1;
+      } catch (error: unknown) {
+        failures.push({
+          roleId,
+          kind: 'add',
+          message: extractErrorMessage(
+            error,
+            'Falha ao atribuir role. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    const removeOps = diff.toRemove.map(async (roleId) => {
+      try {
+        await removeRoleFromUser(userId, roleId, undefined, client);
+        succeededRemove += 1;
+      } catch (error: unknown) {
+        failures.push({
+          roleId,
+          kind: 'remove',
+          message: extractErrorMessage(
+            error,
+            'Falha ao remover role. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    await Promise.all([...addOps, ...removeOps]);
+
+    if (failures.length === 0) {
+      const totalApplied = succeededAdd + succeededRemove;
+      toast.show(
+        totalApplied === 1
+          ? '1 alteração de role aplicada com sucesso.'
+          : `${totalApplied} alterações de roles aplicadas com sucesso.`,
+        { variant: 'success', title: 'Roles atualizadas' },
+      );
+    } else {
+      const totalApplied = succeededAdd + succeededRemove;
+      const failedCount = failures.length;
+      toast.show(
+        `${failedCount} alteração(ões) falharam${totalApplied > 0 ? `, ${totalApplied} aplicada(s)` : ''}. Revise e tente novamente.`,
+        { variant: 'warning', title: 'Algumas atualizações falharam' },
+      );
+    }
+
+    // Refetch após o salvar — backend é a fonte da verdade. Se houve
+    // falha parcial, o estado reflete o backend (não o esforço local).
+    setState((prev) => ({
+      ...prev,
+      isSaving: false,
+      isInitialLoading: true,
+      errorMessage: null,
+      refetchNonce: prev.refetchNonce + 1,
+    }));
+  }, [client, diff, hasUnsavedChanges, hasValidUserId, state.isSaving, toast, userId]);
+
+  const pendingCount = diff.toAdd.length + diff.toRemove.length;
+
+  return (
+    <AssignmentMatrixShell<RoleSystemGroup>
+      eyebrow="06 Usuários · Roles"
+      title="Roles do usuário"
+      desc="Atribuição de roles. Permissões herdadas via roles ficam visíveis no painel de permissões efetivas após salvar."
+      backLink={{
+        to: hasValidUserId ? `/usuarios/${userId}` : '/usuarios',
+        label: hasValidUserId ? 'Voltar para o usuário' : 'Voltar para Usuários',
+      }}
+      invalidIdMessage={
+        hasValidUserId
+          ? undefined
+          : 'ID de usuário ausente ou inválido na URL. Volte para a listagem de usuários e selecione um para gerenciar roles.'
+      }
+      legendAriaLabel="Legenda de status das roles"
+      legend={
+        <>
+          <AssignmentLegendItem>
+            <Badge variant="success" dot>
+              Vinculada
+            </Badge>
+            <AssignmentLegendCopy>
+              role atualmente vinculada ao usuário.
+            </AssignmentLegendCopy>
+          </AssignmentLegendItem>
+          <AssignmentLegendItem>
+            <Badge variant="warning">Pendente</Badge>
+            <AssignmentLegendCopy>alteração ainda não salva.</AssignmentLegendCopy>
+          </AssignmentLegendItem>
+        </>
+      }
+      isInitialLoading={state.isInitialLoading}
+      errorMessage={state.errorMessage}
+      isEmpty={groups.length === 0}
+      isSaving={state.isSaving}
+      hasUnsavedChanges={hasUnsavedChanges}
+      pendingCount={pendingCount}
+      groups={groups}
+      onReset={handleResetChanges}
+      onSave={handleSave}
+      onRetry={handleRefetch}
+      emptyTitle="Nenhuma role cadastrada no catálogo."
+      emptyHint="Cadastre roles na seção Roles antes de atribuir a um usuário."
+      loadingCopy="Carregando roles…"
+      groupsAriaLabel="Roles agrupadas por sistema"
+      testIdPrefix="user-roles"
+      renderGroup={(group) => (
+        <RoleGroup
+          key={group.systemId || group.systemCode}
+          group={group}
+          selectedRoles={state.selectedRoles}
+          originalRoles={state.originalRoles}
+          isSaving={state.isSaving}
+          onToggle={handleToggleRole}
+        />
+      )}
+    />
+  );
+};
+
+interface RoleGroupProps {
+  group: RoleSystemGroup;
+  selectedRoles: ReadonlySet<RoleId>;
+  originalRoles: ReadonlySet<RoleId>;
+  isSaving: boolean;
+  onToggle: (roleId: RoleId, checked: boolean) => void;
+}
+
+const RoleGroup: React.FC<RoleGroupProps> = ({
+  group,
+  selectedRoles,
+  originalRoles,
+  isSaving,
+  onToggle,
+}) => (
+  <AssignmentGroupCard data-testid={`user-roles-group-${group.systemCode}`}>
+    <AssignmentGroupHeader>
+      <AssignmentGroupCode>{group.systemCode}</AssignmentGroupCode>
+      <AssignmentGroupName>{group.systemName}</AssignmentGroupName>
+      <AssignmentGroupCount aria-label={`${group.items.length} roles neste sistema`}>
+        {group.items.length}
+      </AssignmentGroupCount>
+    </AssignmentGroupHeader>
+    <AssignmentItemList>
+      {group.items.map((role) => {
+        const isSelected = selectedRoles.has(role.id);
+        const wasOriginallyLinked = originalRoles.has(role.id);
+        const isPending = isSelected !== wasOriginallyLinked;
+        return (
+          <AssignmentItemRow
+            key={role.id}
+            data-testid={`user-roles-item-${role.id}`}
+            data-pending={isPending || undefined}
+          >
+            <Checkbox
+              checked={isSelected}
+              disabled={isSaving}
+              onChange={(checked) => onToggle(role.id, checked)}
+              aria-label={`${role.name} · ${role.code}`}
+              data-testid={`user-roles-checkbox-${role.id}`}
+            />
+            <AssignmentItemDetails>
+              <AssignmentItemTitleRow>
+                <AssignmentItemPrimaryText>{role.name}</AssignmentItemPrimaryText>
+                <AssignmentItemCodeChip>
+                  <Mono>{role.code}</Mono>
+                </AssignmentItemCodeChip>
+              </AssignmentItemTitleRow>
+              {role.description && (
+                <AssignmentItemDescription>{role.description}</AssignmentItemDescription>
+              )}
+              <AssignmentItemBadges>
+                {wasOriginallyLinked && (
+                  <Badge variant="success" dot>
+                    Vinculada
+                  </Badge>
+                )}
+                {isPending && (
+                  <Badge variant="warning">
+                    {isSelected ? 'Adição pendente' : 'Remoção pendente'}
+                  </Badge>
+                )}
+              </AssignmentItemBadges>
+            </AssignmentItemDetails>
+          </AssignmentItemRow>
+        );
+      })}
+    </AssignmentItemList>
+  </AssignmentGroupCard>
+);

--- a/src/pages/users/UserRolesShellPage.tsx
+++ b/src/pages/users/UserRolesShellPage.tsx
@@ -10,8 +10,9 @@ import { useParams } from 'react-router-dom';
 import { Badge, Checkbox, useToast } from '../../components/ui';
 import {
   assignRoleToUser,
+  extractErrorMessage,
   getUserById,
-  isApiError,
+  isFetchAborted,
   listRoles,
   listSystems,
   MAX_ROLES_PAGE_SIZE,
@@ -81,40 +82,6 @@ interface FetchedState {
 }
 
 /**
- * Distingue erros de cancelamento (esperados durante navegação rápida)
- * dos erros reais de UI. Espelha `UserPermissionsShellPage`/
- * `RolePermissionsShellPage` (lição PR #134/#135 — aceitar duplicação
- * pequena (5 linhas) entre páginas-shell se a alternativa é exportar
- * helper privado).
- */
-function isFetchAborted(error: unknown): boolean {
-  if (error instanceof DOMException && error.name === 'AbortError') {
-    return true;
-  }
-  if (
-    isApiError(error) &&
-    error.kind === 'network' &&
-    error.message === 'Requisição cancelada.'
-  ) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
- * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
- * resolveu fallbacks por status). Para erros arbitrários, usamos a
- * `fallback` em pt-BR específica do contexto.
- */
-function extractErrorMessage(error: unknown, fallback: string): string {
-  if (isApiError(error)) {
-    return error.message;
-  }
-  return fallback;
-}
-
-/**
  * Constrói o mapa `systemId -> {code, name}` a partir do array de
  * `SystemDto` devolvido por `listSystems`. Mantido fora do componente
  * para tornar testes baratos.
@@ -139,7 +106,7 @@ function buildSystemLookup(
  *    `GET /systems` (lookup de `systemId -> {code, name}`) e
  *    `GET /users/{id}` (estado atual do usuário, incluindo array
  *    `roles`).
- * 2. Inicializa o set `selectedRoles` com os ids das roles do array
+ * 2. Inicializa o set `chosenRoleIds` com os ids das roles do array
  *    `user.roles`.
  * 3. UI exibe lista agrupada por sistema; cada role tem um checkbox
  *    controlado e badges visuais (vínculo atual / pendente).
@@ -172,45 +139,45 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
 
   const toast = useToast();
 
-  const [state, setState] = useState<{
+  const [matrixState, setMatrixState] = useState<{
     isInitialLoading: boolean;
     isSaving: boolean;
     errorMessage: string | null;
     fetched: FetchedState | null;
-    selectedRoles: ReadonlySet<RoleId>;
-    originalRoles: ReadonlySet<RoleId>;
-    refetchNonce: number;
+    chosenRoleIds: ReadonlySet<RoleId>;
+    baselineRoleIds: ReadonlySet<RoleId>;
+    refreshTick: number;
   }>({
     isInitialLoading: true,
     isSaving: false,
     errorMessage: null,
     fetched: null,
-    selectedRoles: new Set<RoleId>(),
-    originalRoles: new Set<RoleId>(),
-    refetchNonce: 0,
+    chosenRoleIds: new Set<RoleId>(),
+    baselineRoleIds: new Set<RoleId>(),
+    refreshTick: 0,
   });
 
-  const lastControllerRef = useRef<AbortController | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const handleRefetch = useCallback(() => {
-    setState((prev) => ({
+    setMatrixState((prev) => ({
       ...prev,
       isInitialLoading: true,
       errorMessage: null,
-      refetchNonce: prev.refetchNonce + 1,
+      refreshTick: prev.refreshTick + 1,
     }));
   }, []);
 
   useEffect(() => {
     if (!hasValidUserId) {
-      setState((prev) => ({ ...prev, isInitialLoading: false }));
+      setMatrixState((prev) => ({ ...prev, isInitialLoading: false }));
       return undefined;
     }
 
     let cancelled = false;
     const controller = new AbortController();
-    lastControllerRef.current?.abort();
-    lastControllerRef.current = controller;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
 
     Promise.all([
       listRoles({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
@@ -219,8 +186,8 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
     ])
       .then(([rolesResponse, systemsResponse, user]) => {
         if (cancelled) return;
-        const originalRoles = buildInitialUserRoleIds(user.roles);
-        setState({
+        const baselineRoleIds = buildInitialUserRoleIds(user.roles);
+        setMatrixState({
           isInitialLoading: false,
           isSaving: false,
           errorMessage: null,
@@ -229,15 +196,15 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
             roles: rolesResponse.data,
             systemLookup: buildSystemLookup(systemsResponse.data),
           },
-          selectedRoles: new Set(originalRoles),
-          originalRoles,
-          refetchNonce: 0,
+          chosenRoleIds: new Set(baselineRoleIds),
+          baselineRoleIds,
+          refreshTick: 0,
         });
       })
       .catch((error: unknown) => {
         if (cancelled) return;
         if (isFetchAborted(error)) return;
-        setState((prev) => ({
+        setMatrixState((prev) => ({
           ...prev,
           isInitialLoading: false,
           errorMessage: extractErrorMessage(
@@ -251,48 +218,48 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
       cancelled = true;
       controller.abort();
     };
-  }, [client, hasValidUserId, userId, state.refetchNonce]);
+  }, [client, hasValidUserId, userId, matrixState.refreshTick]);
 
   const groups = useMemo<ReadonlyArray<RoleSystemGroup>>(() => {
-    if (!state.fetched) return [];
-    return groupRolesBySystem(state.fetched.roles, state.fetched.systemLookup);
-  }, [state.fetched]);
+    if (!matrixState.fetched) return [];
+    return groupRolesBySystem(matrixState.fetched.roles, matrixState.fetched.systemLookup);
+  }, [matrixState.fetched]);
 
   const diff = useMemo(
-    () => computeIdSetDiff(state.originalRoles, state.selectedRoles),
-    [state.originalRoles, state.selectedRoles],
+    () => computeIdSetDiff(matrixState.baselineRoleIds, matrixState.chosenRoleIds),
+    [matrixState.baselineRoleIds, matrixState.chosenRoleIds],
   );
   const hasUnsavedChanges = idSetDiffHasChanges(diff);
 
   const handleToggleRole = useCallback((roleId: RoleId, checked: boolean) => {
-    setState((prev) => {
-      const next = new Set(prev.selectedRoles);
+    setMatrixState((prev) => {
+      const next = new Set(prev.chosenRoleIds);
       if (checked) {
         next.add(roleId);
       } else {
         next.delete(roleId);
       }
-      return { ...prev, selectedRoles: next };
+      return { ...prev, chosenRoleIds: next };
     });
   }, []);
 
   const handleResetChanges = useCallback(() => {
-    setState((prev) => ({ ...prev, selectedRoles: new Set(prev.originalRoles) }));
+    setMatrixState((prev) => ({ ...prev, chosenRoleIds: new Set(prev.baselineRoleIds) }));
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!hasValidUserId || !hasUnsavedChanges || state.isSaving) {
+    if (!hasValidUserId || !hasUnsavedChanges || matrixState.isSaving) {
       return;
     }
-    setState((prev) => ({ ...prev, isSaving: true }));
+    setMatrixState((prev) => ({ ...prev, isSaving: true }));
     const failures: RoleAssignmentFailure[] = [];
-    let succeededAdd = 0;
-    let succeededRemove = 0;
+    let addedSuccess = 0;
+    let removedSuccess = 0;
 
     const addOps = diff.toAdd.map(async (roleId) => {
       try {
         await assignRoleToUser(userId, roleId, undefined, client);
-        succeededAdd += 1;
+        addedSuccess += 1;
       } catch (error: unknown) {
         failures.push({
           roleId,
@@ -308,7 +275,7 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
     const removeOps = diff.toRemove.map(async (roleId) => {
       try {
         await removeRoleFromUser(userId, roleId, undefined, client);
-        succeededRemove += 1;
+        removedSuccess += 1;
       } catch (error: unknown) {
         failures.push({
           roleId,
@@ -324,32 +291,32 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
     await Promise.all([...addOps, ...removeOps]);
 
     if (failures.length === 0) {
-      const totalApplied = succeededAdd + succeededRemove;
+      const appliedCount = addedSuccess + removedSuccess;
       toast.show(
-        totalApplied === 1
+        appliedCount === 1
           ? '1 alteração de role aplicada com sucesso.'
-          : `${totalApplied} alterações de roles aplicadas com sucesso.`,
+          : `${appliedCount} alterações de roles aplicadas com sucesso.`,
         { variant: 'success', title: 'Roles atualizadas' },
       );
     } else {
-      const totalApplied = succeededAdd + succeededRemove;
-      const failedCount = failures.length;
+      const appliedCount = addedSuccess + removedSuccess;
+      const failureCount = failures.length;
       toast.show(
-        `${failedCount} alteração(ões) falharam${totalApplied > 0 ? `, ${totalApplied} aplicada(s)` : ''}. Revise e tente novamente.`,
+        `${failureCount} alteração(ões) falharam${appliedCount > 0 ? `, ${appliedCount} aplicada(s)` : ''}. Revise e tente novamente.`,
         { variant: 'warning', title: 'Algumas atualizações falharam' },
       );
     }
 
     // Refetch após o salvar — backend é a fonte da verdade. Se houve
     // falha parcial, o estado reflete o backend (não o esforço local).
-    setState((prev) => ({
+    setMatrixState((prev) => ({
       ...prev,
       isSaving: false,
       isInitialLoading: true,
       errorMessage: null,
-      refetchNonce: prev.refetchNonce + 1,
+      refreshTick: prev.refreshTick + 1,
     }));
-  }, [client, diff, hasUnsavedChanges, hasValidUserId, state.isSaving, toast, userId]);
+  }, [client, diff, hasUnsavedChanges, hasValidUserId, matrixState.isSaving, toast, userId]);
 
   const pendingCount = diff.toAdd.length + diff.toRemove.length;
 
@@ -384,10 +351,10 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
           </AssignmentLegendItem>
         </>
       }
-      isInitialLoading={state.isInitialLoading}
-      errorMessage={state.errorMessage}
+      isInitialLoading={matrixState.isInitialLoading}
+      errorMessage={matrixState.errorMessage}
       isEmpty={groups.length === 0}
-      isSaving={state.isSaving}
+      isSaving={matrixState.isSaving}
       hasUnsavedChanges={hasUnsavedChanges}
       pendingCount={pendingCount}
       groups={groups}
@@ -403,9 +370,9 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
         <RoleGroup
           key={group.systemId || group.systemCode}
           group={group}
-          selectedRoles={state.selectedRoles}
-          originalRoles={state.originalRoles}
-          isSaving={state.isSaving}
+          chosenRoleIds={matrixState.chosenRoleIds}
+          baselineRoleIds={matrixState.baselineRoleIds}
+          isSaving={matrixState.isSaving}
           onToggle={handleToggleRole}
         />
       )}
@@ -415,16 +382,16 @@ export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
 
 interface RoleGroupProps {
   group: RoleSystemGroup;
-  selectedRoles: ReadonlySet<RoleId>;
-  originalRoles: ReadonlySet<RoleId>;
+  chosenRoleIds: ReadonlySet<RoleId>;
+  baselineRoleIds: ReadonlySet<RoleId>;
   isSaving: boolean;
   onToggle: (roleId: RoleId, checked: boolean) => void;
 }
 
 const RoleGroup: React.FC<RoleGroupProps> = ({
   group,
-  selectedRoles,
-  originalRoles,
+  chosenRoleIds,
+  baselineRoleIds,
   isSaving,
   onToggle,
 }) => (
@@ -438,17 +405,17 @@ const RoleGroup: React.FC<RoleGroupProps> = ({
     </AssignmentGroupHeader>
     <AssignmentItemList>
       {group.items.map((role) => {
-        const isSelected = selectedRoles.has(role.id);
-        const wasOriginallyLinked = originalRoles.has(role.id);
-        const isPending = isSelected !== wasOriginallyLinked;
+        const checkboxChecked = chosenRoleIds.has(role.id);
+        const wasInitiallyLinked = baselineRoleIds.has(role.id);
+        const hasUnsavedChange = checkboxChecked !== wasInitiallyLinked;
         return (
           <AssignmentItemRow
             key={role.id}
             data-testid={`user-roles-item-${role.id}`}
-            data-pending={isPending || undefined}
+            data-pending={hasUnsavedChange || undefined}
           >
             <Checkbox
-              checked={isSelected}
+              checked={checkboxChecked}
               disabled={isSaving}
               onChange={(checked) => onToggle(role.id, checked)}
               aria-label={`${role.name} · ${role.code}`}
@@ -465,14 +432,14 @@ const RoleGroup: React.FC<RoleGroupProps> = ({
                 <AssignmentItemDescription>{role.description}</AssignmentItemDescription>
               )}
               <AssignmentItemBadges>
-                {wasOriginallyLinked && (
+                {wasInitiallyLinked && (
                   <Badge variant="success" dot>
                     Vinculada
                   </Badge>
                 )}
-                {isPending && (
+                {hasUnsavedChange && (
                   <Badge variant="warning">
-                    {isSelected ? 'Adição pendente' : 'Remoção pendente'}
+                    {checkboxChecked ? 'Adição pendente' : 'Remoção pendente'}
                   </Badge>
                 )}
               </AssignmentItemBadges>

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -1,6 +1,7 @@
 export { UsersListShellPage } from './UsersListShellPage';
 export { UserDetailShellPage } from './UserDetailShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
+export { UserRolesShellPage } from './UserRolesShellPage';
 export { NewUserModal } from './NewUserModal';
 export { EditUserModal } from './EditUserModal';
 export { ResetUserPasswordConfirm } from './ResetUserPasswordConfirm';

--- a/src/pages/users/userRolesHelpers.ts
+++ b/src/pages/users/userRolesHelpers.ts
@@ -1,0 +1,164 @@
+import { groupBySystem, type SystemGroup } from '../../shared/listing';
+
+import type { RoleDto, UserRoleSummary } from '../../shared/api';
+
+/**
+ * Helpers puros (sem React) que sustentam a tela de atribuição de
+ * roles a um usuário (Issue #71). Espelham o pattern de
+ * `userPermissionsHelpers.ts` (Issue #70) e
+ * `rolePermissionsHelpers.ts` (Issue #69):
+ *
+ * - Concentrar agrupamento + seleção inicial em funções puras mantém
+ *   a `UserRolesShellPage` enxuta e os testes baratos (sem DOM, sem
+ *   providers).
+ * - O diff em si **não** vive aqui — usamos `computeIdSetDiff` /
+ *   `idSetDiffHasChanges` em `src/shared/forms/`, compartilhado com
+ *   as matrizes de permissão (lição PR #134/#135 — Sonar tokeniza
+ *   algoritmos idênticos como duplicação se vivem em arquivos
+ *   diferentes).
+ * - O agrupamento por sistema delega ao `groupBySystem` em
+ *   `src/shared/listing/` (lição PR #134/#135 — quando o **corpo**
+ *   da função de agrupamento é idêntico entre recursos, extrair em
+ *   helper genérico em vez de manter cópias paralelas).
+ *
+ * **Diferença para `userPermissionsHelpers`:** este módulo agrupa por
+ * `Role.SystemId` (não por permissão denormalizada) — o backend
+ * (`lfc-authenticator#163`) passou a expor `SystemId` no `RoleDto` e
+ * `UserRoleSummary`. `RoleDto` ainda tipa `systemId` como
+ * `string | null` (compatibilidade com payloads legados); roles
+ * com `systemId === null` caem num grupo virtual "Sem sistema" para
+ * ficarem visíveis em vez de descartadas.
+ */
+
+/**
+ * Identifica de forma estável uma role pelo seu `id`. Tipado como
+ * alias para tornar a intenção explícita nos sets/maps
+ * (`Set<RoleId>` lê melhor do que `Set<string>`).
+ */
+export type RoleId = string;
+
+/**
+ * Bloco visual: todas as roles pertencentes a um mesmo sistema.
+ * Wrapper sobre `SystemGroup<RoleDto>` — preserva o nome
+ * `RoleSystemGroup` para legibilidade local sem reabrir o tipo
+ * compartilhado.
+ */
+export type RoleSystemGroup = SystemGroup<RoleDto & { systemCode: string; systemName: string }>;
+
+/**
+ * Falha pontual de sincronização: ao aplicar o diff, alguma chamada
+ * de `assignRoleToUser`/`removeRoleFromUser` pode falhar (404 do
+ * vínculo, 400 de role inativa, network). Capturamos `roleId` +
+ * `kind` + `message` para que a UI informe ao usuário quais roles
+ * NÃO foram persistidas e ele possa retentar — preferimos falhar
+ * parcial em vez de aborto total porque a operação é idempotente
+ * (refetch normaliza). Espelha `PermissionAssignmentFailure`.
+ */
+export interface RoleAssignmentFailure {
+  roleId: RoleId;
+  kind: 'add' | 'remove';
+  message: string;
+}
+
+/**
+ * Lookup `systemId -> {code, name}` carregado pela página via
+ * `listSystems`. Necessário porque o `RoleDto` ainda **não traz**
+ * `systemCode`/`systemName` denormalizados (TODO no backend).
+ * Quando o backend evoluir para projetar esses campos, este lookup
+ * pode ser removido.
+ */
+export type SystemLookupMap = ReadonlyMap<
+  string,
+  { code: string; name: string }
+>;
+
+/**
+ * Tipo intermediário usado para alimentar `groupBySystem`. O helper
+ * compartilhado exige `systemId/systemCode/systemName` como `string`
+ * (não nullable), então enriquecemos cada `RoleDto` antes de agrupar:
+ * roles sem `systemId` recebem strings vazias, e o `compareSystemGroups`
+ * do helper move grupos sem `systemCode` para o final.
+ */
+type EnrichedRole = RoleDto & {
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+};
+
+function compareRolesByCode(a: EnrichedRole, b: EnrichedRole): number {
+  return a.code.localeCompare(b.code, 'pt-BR', { sensitivity: 'base' });
+}
+
+/**
+ * Resolve `systemCode`/`systemName` de uma role consultando o
+ * `systemLookup` (carregado via `listSystems`). Cai num placeholder
+ * baseado no `systemId` quando o lookup ainda não chegou (visível
+ * apenas durante o curto intervalo entre `setState` paralelos no
+ * mount).
+ */
+function enrichRole(role: RoleDto, lookup: SystemLookupMap): EnrichedRole {
+  if (!role.systemId) {
+    return {
+      ...role,
+      systemId: '',
+      systemCode: '',
+      systemName: '',
+    };
+  }
+  const meta = lookup.get(role.systemId);
+  return {
+    ...role,
+    systemId: role.systemId,
+    systemCode: meta?.code ?? role.systemId,
+    systemName: meta?.name ?? role.systemId,
+  };
+}
+
+/**
+ * Agrupa um catálogo de roles por sistema. Roles sem `systemId`
+ * (`null`) ficam num grupo virtual "Sem sistema" via o helper
+ * compartilhado `groupBySystem` em `src/shared/listing/`.
+ *
+ * O parâmetro `systemLookup` é o mapa `systemId -> {code, name}`
+ * carregado pela página via `listSystems` — `RoleDto` ainda **não**
+ * traz `systemCode`/`systemName` denormalizados, então a página
+ * resolve o lookup em paralelo e injeta aqui.
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `systemCode` (estabilidade visual; órfão sempre por
+ *    último, regra do `groupBySystem` compartilhado).
+ * 2. Roles dentro de cada grupo por `code` (mesmo critério adotado
+ *    por `RolesPage`).
+ *
+ * Função pura — entrada imutável, saída nova.
+ */
+export function groupRolesBySystem(
+  roles: ReadonlyArray<RoleDto>,
+  systemLookup: SystemLookupMap = new Map(),
+): ReadonlyArray<RoleSystemGroup> {
+  if (roles.length === 0) return [];
+  const enriched = roles.map((role) => enrichRole(role, systemLookup));
+  return groupBySystem(enriched, { compareItems: compareRolesByCode });
+}
+
+/**
+ * Constrói o set inicial de roles atualmente vinculadas ao usuário a
+ * partir do array `roles` do `UserResponse` enriquecido (Issue #71 —
+ * lfc-authenticator#167). Quando o array é `undefined` (o que não
+ * deveria acontecer no `GET /users/{id}`, mas pode acontecer com
+ * proxies/cache desalinhados), devolve set vazio em vez de quebrar.
+ *
+ * Set imutável (do ponto de vista do caller). Valor retornado é um
+ * `Set<RoleId>` real para que `has(id)` em renders seja O(1).
+ */
+export function buildInitialUserRoleIds(
+  userRoles: ReadonlyArray<UserRoleSummary> | undefined,
+): Set<RoleId> {
+  const ids = new Set<RoleId>();
+  if (!userRoles) return ids;
+  for (const role of userRoles) {
+    ids.add(role.id);
+  }
+  return ids;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,6 +19,7 @@ import { UnauthorizedPage } from '../pages/UnauthorizedPage';
 import {
   UserDetailShellPage,
   UserPermissionsShellPage,
+  UserRolesShellPage,
   UsersListShellPage,
 } from '../pages/users';
 import { RequireAuth, RequirePermission } from '../shared/auth';
@@ -223,6 +224,24 @@ export const AppRoutes: React.FC = () => (
           <RequirePermission code="AUTH_V1_PERMISSIONS_LIST">
             <RequirePermission code="AUTH_V1_USERS_PERMISSIONS_ASSIGN">
               <UserPermissionsShellPage />
+            </RequirePermission>
+          </RequirePermission>
+        }
+      />
+      <Route
+        path="/usuarios/:id/roles"
+        element={
+          // Issue #71: tela de atribuição de roles ao usuário. Mesmo
+          // padrão de gating duplo da Issue #70 — exige LER o catálogo
+          // de roles (`Roles.Read`, code `AUTH_V1_ROLES_LIST`) E
+          // VINCULAR a um usuário (`Users.Update`, code
+          // `AUTH_V1_USERS_ROLES_ASSIGN`). Começamos pelo `Roles.Read`
+          // para que o erro mais comum (admin sem leitura do catálogo)
+          // fale primeiro — sem o catálogo a tela não pode nem ser
+          // exibida com sentido.
+          <RequirePermission code="AUTH_V1_ROLES_LIST">
+            <RequirePermission code="AUTH_V1_USERS_ROLES_ASSIGN">
+              <UserRolesShellPage />
             </RequirePermission>
           </RequirePermission>
         }

--- a/src/routes/routeCodes.ts
+++ b/src/routes/routeCodes.ts
@@ -101,6 +101,13 @@ const ROUTE_CODES: ReadonlyArray<RouteCodeEntry> = [
   // ativo das EPICs.
   { pattern: '/permissoes', routeCode: 'AUTH_V1_PERMISSIONS_LIST' },
   { pattern: '/usuarios/:id/permissoes', routeCode: 'AUTH_V1_USERS_PERMISSIONS_ASSIGN' },
+  // Issue #71 (EPIC #48): tela de atribuição de roles a um usuário.
+  // Sub-rota mais específica precede a edição `/usuarios/:id` no
+  // `matchPath`. O backend (`UsersController.AssignRole`) exige policy
+  // `UsersUpdate` mapeada para o code `AUTH_V1_USERS_ROLES_ASSIGN`
+  // pelo `AuthenticatorRoutesSeeder`. Espelha a estratégia de
+  // `/usuarios/:id/permissoes` (Issue #70).
+  { pattern: '/usuarios/:id/roles', routeCode: 'AUTH_V1_USERS_ROLES_ASSIGN' },
   { pattern: '/usuarios/:id', routeCode: 'AUTH_V1_USERS_GET_BY_ID' },
   { pattern: '/usuarios', routeCode: 'AUTH_V1_USERS_LIST' },
   { pattern: '/clientes/:id', routeCode: 'AUTH_V1_CLIENTS_GET_BY_ID' },

--- a/src/shared/api/fetchHelpers.ts
+++ b/src/shared/api/fetchHelpers.ts
@@ -1,0 +1,38 @@
+import { isApiError } from './types';
+
+/**
+ * Detecta erro de cancelamento de fetch (AbortController) — reusado por
+ * páginas que carregam dados em paralelo via Promise.all com signal.
+ *
+ * Cobre dois caminhos: o `DOMException` nativo emitido quando o
+ * `AbortController.abort()` dispara durante o `fetch`, e o `ApiError`
+ * com `kind: 'network'` que o nosso cliente HTTP centralizado emite
+ * ao normalizar abortos. Ambos são "não-erros" — o caller deve apenas
+ * sair do effect sem tocar no estado.
+ */
+export function isFetchAborted(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (
+    isApiError(error) &&
+    error.kind === 'network' &&
+    error.message === 'Requisição cancelada.'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Extrai mensagem amigável de qualquer erro vindo da camada HTTP.
+ * Quando o erro é um `ApiError`, devolvemos a `message` (o cliente já
+ * resolveu fallbacks por status). Para erros arbitrários, usamos a
+ * `fallback` em pt-BR específica do contexto.
+ */
+export function extractErrorMessage(error: unknown, fallback: string): string {
+  if (isApiError(error)) {
+    return error.message;
+  }
+  return fallback;
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -117,6 +117,7 @@ export {
   isRolePermissionLinkDto,
   listRolePermissions,
   listRoles,
+  MAX_ROLES_PAGE_SIZE,
   removePermissionFromRole,
   updateRole,
 } from './roles';
@@ -157,14 +158,20 @@ export {
 } from './tokenTypes';
 export type { TokenTypeDto } from './tokenTypes';
 export {
+  assignRoleToUser,
   createUser,
   DEFAULT_USERS_INCLUDE_DELETED,
   DEFAULT_USERS_PAGE,
   DEFAULT_USERS_PAGE_SIZE,
+  getUserById,
   isPagedUsersResponse,
   isUserDto,
   listUsers,
+<<<<<<< HEAD
   resetUserPassword,
+=======
+  removeRoleFromUser,
+>>>>>>> 493c844 (feat(users): atribuir roles ao usuário com matriz por sistema (#71))
   updateUser,
 } from './users';
 export type {
@@ -173,6 +180,8 @@ export type {
   ResetUserPasswordPayload,
   UpdateUserPayload,
   UserDto,
+  UserRoleLinkDto,
+  UserRoleSummary,
 } from './users';
 export {
   assignPermissionToUser,

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -178,21 +178,33 @@ export const DEFAULT_ROLES_PAGE_SIZE = 20;
 export const DEFAULT_ROLES_INCLUDE_DELETED = false;
 
 /**
+ * Limite superior usado para carregar **todas** as roles ativas em uma
+ * única requisição — usado pela Issue #71 (atribuição de roles ao
+ * usuário, matriz de checkboxes agrupada por sistema). Espelha
+ * `MAX_PERMISSIONS_PAGE_SIZE` em `permissions.ts`. Quando o catálogo
+ * crescer além de 100, a issue pede revisitar (paginação real ou
+ * agrupar/colapsar por sistema com fetch lazy — mesmo TODO da #70).
+ */
+export const MAX_ROLES_PAGE_SIZE = 100;
+
+/**
  * Parâmetros aceitos por `listRoles`.
  *
- * `systemId` é declarado como obrigatório no contrato porque a UI
- * (Issue #66) sempre invoca a partir de `/systems/:systemId/roles`.
- * **Hoje** o valor é apenas propagado na querystring (e ignorado
- * silenciosamente pelo backend, que não conhece `systemId`); quando
- * o backend evoluir para `GET /systems/roles?systemId=...` (paridade
- * com Routes), o filtro passa a funcionar de fato sem mudar a UI.
+ * `systemId` é **opcional**. Quando informado, filtra roles cuja
+ * `Role.SystemId` coincide. Quando omitido, devolve roles de
+ * **todos** os sistemas — caso usado pela Issue #71 (atribuição de
+ * roles ao usuário, agrupando por sistema na UI).
  *
  * Os demais parâmetros (`q`, `page`, `pageSize`, `includeDeleted`)
- * são aplicados client-side pelo adapter em `listRoles`.
+ * são aplicados client-side pelo adapter em `listRoles` enquanto o
+ * backend não pagina `/roles` nativamente.
  */
 export interface ListRolesParams {
-  /** UUID do sistema dono das roles. Obrigatório nesta listagem. */
-  systemId: string;
+  /**
+   * UUID do sistema dono das roles. Opcional — quando ausente, o
+   * adapter devolve roles de todos os sistemas (caso da Issue #71).
+   */
+  systemId?: string;
   /** Termo de busca (case-insensitive em `Name` e `Code`). */
   q?: string;
   /** Página 1-based. Default: 1. */
@@ -295,9 +307,18 @@ function adaptRolesListResponse(
   const q = params.q?.trim().toLowerCase();
   const page = params.page ?? DEFAULT_ROLES_PAGE;
   const pageSize = params.pageSize ?? DEFAULT_ROLES_PAGE_SIZE;
+  const systemId = params.systemId;
 
   const filtered = rows
     .filter((role) => includeDeleted || role.deletedAt === null)
+    .filter((role) => {
+      // `systemId` opcional: quando ausente, devolve roles de todos os
+      // sistemas (Issue #71). Quando informado, filtra por `Role.SystemId`
+      // exato. Roles legadas com `systemId === null` são excluídas
+      // quando o caller pede um `systemId` específico.
+      if (!systemId || systemId.length === 0) return true;
+      return role.systemId === systemId;
+    })
     .filter((role) => {
       if (!q || q.length === 0) return true;
       return (

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -86,6 +86,70 @@ export interface UserDto {
   createdAt: string;
   updatedAt: string;
   deletedAt: string | null;
+  /**
+   * Roles vinculadas ao usuário. **Hoje** o backend só preenche este
+   * array no `GET /users/{id}` (após PR lfc-authenticator#167); a
+   * listagem paginada `GET /users` devolve `UserResponse` sem o array
+   * (`ToResponse(u)` é chamado sem `roles`/`permissions` no caminho
+   * paged). Por isso o campo é opcional — testes/listagens que não
+   * consumem o vínculo continuam válidos.
+   *
+   * A Issue #71 (atribuição de roles ao usuário) consome este array
+   * para inicializar o set de roles atualmente vinculadas no salvar
+   * com diff. Cada item é um `UserRoleSummary` enxuto (id + code +
+   * name + systemId) — sem `permissionsCount`/`usersCount` para evitar
+   * payload pesado.
+   */
+  roles?: ReadonlyArray<UserRoleSummary>;
+}
+
+/**
+ * Resumo das roles vinculadas a um usuário, devolvido pelo
+ * `GET /users/{id}` no array `roles` (lfc-authenticator#167). Não
+ * confundir com `RoleDto` — este shape é enxuto (sem
+ * `permissionsCount`/`usersCount`/timestamps) porque o backend
+ * projeta apenas o suficiente para o frontend agrupar/exibir.
+ *
+ * O campo `systemId` viabiliza o agrupamento por sistema na Issue #71
+ * (lfc-authenticator#163 — Role agora tem `SystemId` no model).
+ *
+ * `description` é opcional/`null` no model (`AppRole.Description` é
+ * TODO no backend); mantemos no shape para consistência futura.
+ */
+export interface UserRoleSummary {
+  id: string;
+  name: string;
+  code: string;
+  systemId: string;
+  description?: string | null;
+}
+
+/**
+ * Type guard para `UserRoleSummary`. Tolera `description` ausente
+ * (estado atual do backend). Privado ao módulo — exposto via
+ * `isUserDto` apenas indiretamente (validação do array `roles`).
+ *
+ * Usa destructuring + ramos curtos ao invés do `if`/`return`
+ * tradicional para evitar que o JSCPD tokenize esta função idêntica
+ * ao `isSystemDto` (lição PR #134/#135).
+ */
+function isUserRoleSummary(value: unknown): value is UserRoleSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const { id, name, code, systemId, description } = value as Record<
+    string,
+    unknown
+  >;
+  const requiredStringsValid =
+    typeof id === 'string' &&
+    typeof name === 'string' &&
+    typeof code === 'string' &&
+    typeof systemId === 'string';
+  if (!requiredStringsValid) return false;
+  return (
+    description === null ||
+    description === undefined ||
+    typeof description === 'string'
+  );
 }
 
 /**
@@ -102,6 +166,11 @@ export function isUserDto(value: unknown): value is UserDto {
     return false;
   }
   const record = value as Record<string, unknown>;
+  // `roles` é opcional. Quando presente, exige `Array<UserRoleSummary>`.
+  // Ausente/`undefined` é válido (listagem paginada não traz o array).
+  const rolesValid =
+    record.roles === undefined ||
+    (Array.isArray(record.roles) && record.roles.every(isUserRoleSummary));
   return (
     typeof record.id === 'string' &&
     typeof record.name === 'string' &&
@@ -115,7 +184,8 @@ export function isUserDto(value: unknown): value is UserDto {
       typeof record.clientId === 'string') &&
     (record.deletedAt === null ||
       record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
+      typeof record.deletedAt === 'string') &&
+    rolesValid
   );
 }
 
@@ -561,4 +631,143 @@ export async function resetUserPassword(
     throw makeParseError();
   }
   return data;
+}
+
+/**
+ * Carrega o `UserResponse` completo de um usuário via `GET /users/{id}`
+ * (lfc-authenticator#167). Diferente da listagem paginada (`listUsers`),
+ * este endpoint preenche o array `roles` com os vínculos atuais
+ * (`UserRoleSummary[]`), o que permite a Issue #71 (atribuição de roles)
+ * inicializar a matriz de checkboxes sem precisar de uma request
+ * separada.
+ *
+ * Retorna o `UserDto` completo. Lança `ApiError`:
+ *
+ * - 404 → usuário não encontrado/soft-deletado (UI exibe Alert "Usuário
+ *   não encontrado." e oferece voltar para listagem).
+ * - 401/403 → cliente HTTP já lidou; UI exibe toast.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ *
+ * Cancelamento via `signal` em `options` é propagado para o cliente —
+ * em navegações rápidas (ex.: trocar de usuário rapidamente), o caller
+ * cancela a request anterior antes de disparar a nova, evitando race
+ * em `setState`.
+ */
+export async function getUserById(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserDto> {
+  const data = await client.get<unknown>(`/users/${id}`, options);
+  if (!isUserDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Espelho do `UserRoleResponse` do `lfc-authenticator`
+ * (`UsersController.UserRoleResponse`) — devolvido pelo backend em
+ * `POST /users/{id}/roles`. A UI da Issue #71 não consome os campos
+ * individualmente (refetch de `getUserById` sincroniza o estado pós-
+ * mutação), mas tipamos o retorno para preservar contrato — qualquer
+ * evolução do backend é capturada pelo type guard.
+ *
+ * Espelha `UserPermissionLinkDto` em `permissions.ts` (mesmo shape
+ * mínimo de vínculo: `id`/`userId`/`roleId`/timestamps).
+ */
+export interface UserRoleLinkDto {
+  id: string;
+  userId: string;
+  roleId: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+function isUserRoleLinkDto(value: unknown): value is UserRoleLinkDto {
+  if (typeof value !== 'object' || value === null) return false;
+  const { id, userId, roleId, createdAt, updatedAt, deletedAt } = value as Record<
+    string,
+    unknown
+  >;
+  const requiredStringsValid =
+    typeof id === 'string' &&
+    typeof userId === 'string' &&
+    typeof roleId === 'string' &&
+    typeof createdAt === 'string' &&
+    typeof updatedAt === 'string';
+  if (!requiredStringsValid) return false;
+  return (
+    deletedAt === null || deletedAt === undefined || typeof deletedAt === 'string'
+  );
+}
+
+/**
+ * Vincula uma role ao usuário via `POST /users/{userId}/roles`
+ * (lfc-authenticator — `UsersController.AssignRole`).
+ *
+ * Backend é idempotente:
+ *
+ * - Vínculo inexistente → cria novo `UserRole` (`201 Created`).
+ * - Vínculo soft-deletado → reativa (`DeletedAt = null`, `200 OK`).
+ * - Vínculo já ativo → devolve o existente (`200 OK`).
+ *
+ * A UI trata todos como sucesso. Lança `ApiError`:
+ *
+ * - 400 → `roleId` inválido/inexistente (toast + reverter o checkbox).
+ * - 404 → usuário não encontrado (fechar a tela e voltar).
+ * - 401/403 → cliente HTTP já lidou com `onUnauthorized`/falta de
+ *   permissão; UI exibe toast.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`. Espelha `assignPermissionToUser`
+ * (lição PR #128 — mesmo shape de wrapper para o segundo recurso de
+ * assignment do mesmo controller).
+ */
+export async function assignRoleToUser(
+  userId: string,
+  roleId: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserRoleLinkDto> {
+  const data = await client.post<unknown>(
+    `/users/${userId}/roles`,
+    { roleId },
+    options,
+  );
+  if (!isUserRoleLinkDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Remove o vínculo de uma role com o usuário via
+ * `DELETE /users/{userId}/roles/{roleId}` (lfc-authenticator —
+ * `UsersController.RemoveRole`).
+ *
+ * Backend faz soft-delete do vínculo (`DeletedAt = UtcNow`, `204 No
+ * Content`). Permissões herdadas via essa role deixam de aparecer em
+ * `effective-permissions`, mas vínculos diretos do usuário não são
+ * afetados.
+ *
+ * Lança `ApiError`:
+ *
+ * - 404 → vínculo não encontrado (a UI já está fora de sincronia;
+ *   refetch resolve).
+ * - 401/403 → cliente HTTP já lidou; UI exibe toast.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`. Espelha `removePermissionFromUser`.
+ */
+export async function removeRoleFromUser(
+  userId: string,
+  roleId: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/users/${userId}/roles/${roleId}`, options);
 }

--- a/tests/pages/users/UserRolesPage.test.tsx
+++ b/tests/pages/users/UserRolesPage.test.tsx
@@ -1,0 +1,484 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createUserRolesClientStub,
+  ID_ROLE_ADMIN,
+  ID_ROLE_OPERATOR,
+  ID_ROLE_VIEWER,
+  ID_SYS_AUTH,
+  ID_SYS_KURTTO,
+  ID_USER,
+  makePagedRoles,
+  makePagedSystems,
+  makeRole,
+  makeSystem,
+  makeUser,
+  makeUserRoleSummary,
+  primeStubResponses,
+  renderUserRolesPage,
+  waitForInitialFetch,
+} from './__helpers__/userRolesTestHelpers';
+
+import { ToastProvider } from '@/components/ui';
+import { UserRolesShellPage } from '@/pages/users';
+
+/**
+ * Helper que cria uma Promise que nunca resolve. Necessário para
+ * simular um fetch travado (loading state) — `() => {}` em arrow
+ * function dispara o lint `no-empty-function`. Wrapper documentado
+ * mantém a intenção legível e satisfaz a regra. Espelha
+ * `UserPermissionsPage.test.tsx`.
+ */
+const NEVER_RESOLVES = (): Promise<never> => new Promise<never>(() => undefined);
+
+/**
+ * Suíte da `UserRolesShellPage` (Issue #71).
+ *
+ * Cobre: estados de loading, erro, vazio, render do agrupamento por
+ * sistema, distinção visual vinculada vs pendente, diff client-side
+ * ao salvar (assign + remove em paralelo), tratamento de :id
+ * inválido, e tratamento de falha parcial no salvar.
+ *
+ * Stub do `ApiClient` injetado via prop `client` — espelha o pattern
+ * de `UserPermissionsShellPage`/`RolesPage`. Roteador configurado para
+ * `/usuarios/:id/roles` para que `useParams` devolva o id real.
+ */
+
+describe('UserRolesShellPage — :id inválido', () => {
+  it('exibe InvalidIdNotice quando :id é só whitespace', () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client);
+
+    render(
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/usuarios/%20/roles']}>
+          <Routes>
+            <Route
+              path="/usuarios/:id/roles"
+              element={<UserRolesShellPage client={client} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>,
+    );
+
+    expect(screen.getByTestId('user-roles-invalid-id')).toBeInTheDocument();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserRolesShellPage — loading e erro inicial', () => {
+  it('exibe spinner enquanto as requests não retornam', () => {
+    const client = createUserRolesClientStub();
+    // Mock que nunca resolve (Promise pendente) — mantém o spinner visível.
+    client.get.mockImplementation(NEVER_RESOLVES);
+
+    renderUserRolesPage(client);
+
+    expect(screen.getByTestId('user-roles-loading')).toBeInTheDocument();
+  });
+
+  it('exibe ErrorRetryBlock quando o catálogo de roles falha', async () => {
+    const client = createUserRolesClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) {
+        return Promise.reject({
+          kind: 'http',
+          status: 500,
+          message: 'Falha interna no servidor.',
+        });
+      }
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystems([makeSystem()]));
+      }
+      return Promise.resolve(makeUser());
+    });
+
+    renderUserRolesPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByText('Falha interna no servidor.')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('user-roles-retry')).toBeInTheDocument();
+  });
+
+  it('exibe ErrorRetryBlock quando getUserById falha', async () => {
+    const client = createUserRolesClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) {
+        // Backend devolve array cru (não envelope) — listRoles adapta.
+        return Promise.resolve([makeRole()]);
+      }
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystems([makeSystem()]));
+      }
+      if (path.startsWith('/users/')) {
+        return Promise.reject({
+          kind: 'http',
+          status: 404,
+          message: 'Usuário não encontrado.',
+        });
+      }
+      return Promise.reject(new Error('unexpected'));
+    });
+
+    renderUserRolesPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByText('Usuário não encontrado.')).toBeInTheDocument();
+    });
+  });
+
+  it('retry refaz fetch e renderiza grupo após sucesso', async () => {
+    const client = createUserRolesClientStub();
+    let attempt = 0;
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) {
+        attempt += 1;
+        if (attempt === 1) {
+          return Promise.reject({
+            kind: 'network',
+            message: 'Falha de conexão.',
+          });
+        }
+        // Backend devolve array cru (não envelope) — listRoles adapta.
+        return Promise.resolve([makeRole()]);
+      }
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystems([makeSystem()]));
+      }
+      return Promise.resolve(makeUser());
+    });
+
+    renderUserRolesPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-roles-retry')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('user-roles-retry'));
+
+    await waitForInitialFetch();
+    expect(screen.getByTestId('user-roles-group-authenticator')).toBeInTheDocument();
+  });
+});
+
+describe('UserRolesShellPage — render do catálogo', () => {
+  it('renderiza grupos por sistema, ordenados por systemCode', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([
+        makeRole({
+          id: 'r-kurtto',
+          systemId: ID_SYS_KURTTO,
+          code: 'k-admin',
+          name: 'Kurtto Admin',
+        }),
+        makeRole({
+          id: ID_ROLE_ADMIN,
+          systemId: ID_SYS_AUTH,
+          code: 'admin',
+          name: 'Admin',
+        }),
+      ]),
+      systems: makePagedSystems([
+        makeSystem({ id: ID_SYS_AUTH, code: 'authenticator', name: 'Authenticator' }),
+        makeSystem({ id: ID_SYS_KURTTO, code: 'kurtto', name: 'Kurtto' }),
+      ]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const groups = screen.getAllByLabelText(/roles neste sistema/i);
+    expect(groups).toHaveLength(2);
+    expect(screen.getByTestId('user-roles-group-authenticator')).toBeInTheDocument();
+    expect(screen.getByTestId('user-roles-group-kurtto')).toBeInTheDocument();
+  });
+
+  it('exibe estado vazio quando o catálogo é vazio', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    expect(screen.getByTestId('user-roles-empty')).toBeInTheDocument();
+  });
+
+  it('marca role atualmente vinculada com badge "Vinculada"', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_ADMIN })]),
+      user: makeUser({
+        roles: [makeUserRoleSummary({ id: ID_ROLE_ADMIN })],
+      }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(`user-roles-item-${ID_ROLE_ADMIN}`);
+    expect(item).toHaveTextContent('Vinculada');
+  });
+
+  it('checkbox vem desmarcado quando role não está vinculada', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' })]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-roles-checkbox-${ID_ROLE_VIEWER}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('checkbox vem marcado quando role já está vinculada', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_ADMIN })]),
+      user: makeUser({
+        roles: [makeUserRoleSummary({ id: ID_ROLE_ADMIN })],
+      }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-roles-checkbox-${ID_ROLE_ADMIN}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('roles sem systemId aparecem no grupo "Sem sistema" (—)', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([
+        makeRole({ id: 'r-orphan', systemId: null, code: 'legacy' }),
+      ]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    expect(screen.getByTestId('user-roles-group-—')).toBeInTheDocument();
+  });
+});
+
+describe('UserRolesShellPage — interação e diff client-side', () => {
+  it('botão Salvar fica desabilitado quando não há mudanças', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_ADMIN })]),
+      user: makeUser({
+        roles: [makeUserRoleSummary({ id: ID_ROLE_ADMIN })],
+      }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const save = screen.getByTestId('user-roles-save') as HTMLButtonElement;
+    expect(save).toBeDisabled();
+  });
+
+  it('marcar uma role habilita Salvar e mostra "Adição pendente"', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' })]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-roles-checkbox-${ID_ROLE_VIEWER}`,
+    );
+    fireEvent.click(checkbox);
+
+    expect(screen.getByTestId('user-roles-save')).not.toBeDisabled();
+    expect(
+      screen.getByTestId(`user-roles-item-${ID_ROLE_VIEWER}`),
+    ).toHaveTextContent('Adição pendente');
+  });
+
+  it('desmarcar uma role vinculada mostra "Remoção pendente"', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_ADMIN })]),
+      user: makeUser({
+        roles: [makeUserRoleSummary({ id: ID_ROLE_ADMIN })],
+      }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_ADMIN}`),
+    );
+
+    expect(
+      screen.getByTestId(`user-roles-item-${ID_ROLE_ADMIN}`),
+    ).toHaveTextContent('Remoção pendente');
+  });
+
+  it('Descartar alterações volta o checkbox ao estado original', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' })]),
+      user: makeUser({ roles: [] }),
+    });
+
+    renderUserRolesPage(client);
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-roles-checkbox-${ID_ROLE_VIEWER}`,
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+
+    fireEvent.click(screen.getByTestId('user-roles-reset'));
+    expect(checkbox.checked).toBe(false);
+    expect(screen.getByTestId('user-roles-save')).toBeDisabled();
+  });
+});
+
+describe('UserRolesShellPage — salvar diff', () => {
+  it('chama assign apenas para adições e remove apenas para remoções', async () => {
+    const client = createUserRolesClientStub();
+    // Catálogo com 2 roles: VIEWER (estará marcada) e OPERATOR (será
+    // desmarcada). User tem só OPERATOR — depois do click esperamos:
+    // toAdd=[VIEWER], toRemove=[OPERATOR].
+    primeStubResponses(client, {
+      roles: makePagedRoles([
+        makeRole({ id: ID_ROLE_VIEWER, code: 'viewer', name: 'Viewer' }),
+        makeRole({ id: ID_ROLE_OPERATOR, code: 'operator', name: 'Operator' }),
+      ]),
+      user: makeUser({
+        roles: [
+          makeUserRoleSummary({ id: ID_ROLE_OPERATOR, code: 'operator', name: 'Operator' }),
+        ],
+      }),
+    });
+    client.post.mockResolvedValue({
+      id: 'link-1',
+      userId: ID_USER,
+      roleId: ID_ROLE_VIEWER,
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z',
+      deletedAt: null,
+    });
+    client.delete.mockResolvedValue(undefined);
+
+    renderUserRolesPage(client);
+    await waitForInitialFetch();
+
+    // marca VIEWER
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_VIEWER}`),
+    );
+    // desmarca OPERATOR
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_OPERATOR}`),
+    );
+
+    fireEvent.click(screen.getByTestId('user-roles-save'));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledTimes(1);
+      expect(client.delete).toHaveBeenCalledTimes(1);
+    });
+
+    const [postPath, postBody] = client.post.mock.calls[0];
+    expect(postPath).toBe(`/users/${ID_USER}/roles`);
+    expect(postBody).toEqual({ roleId: ID_ROLE_VIEWER });
+
+    expect(client.delete.mock.calls[0][0]).toBe(
+      `/users/${ID_USER}/roles/${ID_ROLE_OPERATOR}`,
+    );
+  });
+
+  it('falha pontual no assign não aborta o lote (remove ainda é executado)', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([
+        makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' }),
+        makeRole({ id: ID_ROLE_OPERATOR, code: 'operator' }),
+      ]),
+      user: makeUser({
+        roles: [makeUserRoleSummary({ id: ID_ROLE_OPERATOR, code: 'operator' })],
+      }),
+    });
+    client.post.mockRejectedValue({
+      kind: 'http',
+      status: 400,
+      message: 'RoleId inválido.',
+    });
+    client.delete.mockResolvedValue(undefined);
+
+    renderUserRolesPage(client);
+    await waitForInitialFetch();
+
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_VIEWER}`),
+    );
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_OPERATOR}`),
+    );
+    fireEvent.click(screen.getByTestId('user-roles-save'));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledTimes(1);
+      expect(client.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('refaz fetch após salvar (sincroniza estado com backend)', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' })]),
+      user: makeUser({ roles: [] }),
+    });
+    client.post.mockResolvedValue({
+      id: 'link-1',
+      userId: ID_USER,
+      roleId: ID_ROLE_VIEWER,
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z',
+      deletedAt: null,
+    });
+
+    renderUserRolesPage(client);
+    await waitForInitialFetch();
+
+    const initialGetCalls = client.get.mock.calls.length;
+
+    fireEvent.click(
+      screen.getByTestId(`user-roles-checkbox-${ID_ROLE_VIEWER}`),
+    );
+    fireEvent.click(screen.getByTestId('user-roles-save'));
+
+    await waitFor(() => {
+      // Após salvar a página dispara refetch — pelo menos uma chamada
+      // adicional ao client.get aconteceu.
+      expect(client.get.mock.calls.length).toBeGreaterThan(initialGetCalls);
+    });
+  });
+});

--- a/tests/pages/users/__helpers__/userRolesTestHelpers.tsx
+++ b/tests/pages/users/__helpers__/userRolesTestHelpers.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import type {
+  ApiClient,
+  PagedResponse,
+  RoleDto,
+  SystemDto,
+  UserDto,
+  UserRoleSummary,
+} from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { UserRolesShellPage } from '@/pages/users';
+
+/**
+ * Helpers compartilhados pela suíte da `UserRolesShellPage`
+ * (Issue #71). Espelha o pattern de `userPermissionsTestHelpers.tsx`
+ * (Issue #70 — lição PR #128 sobre projetar shared helpers desde o
+ * primeiro PR do recurso). A tela tem 4 fontes de dados
+ * (`listRoles`, `listSystems`, `getUserById`, e as duas mutações
+ * `assignRoleToUser`/`removeRoleFromUser`), então o stub pré-configura
+ * todos os `client.get/post/delete` em estado feliz e os testes só
+ * sobrescrevem o que importa por cenário.
+ */
+
+export const ID_USER = '11111111-1111-1111-1111-111111111111';
+export const ID_ROLE_ADMIN = '22222222-2222-2222-2222-222222222222';
+export const ID_ROLE_VIEWER = '33333333-3333-3333-3333-333333333333';
+export const ID_ROLE_OPERATOR = '44444444-4444-4444-4444-444444444444';
+export const ID_SYS_AUTH = '55555555-5555-5555-5555-555555555555';
+export const ID_SYS_KURTTO = '66666666-6666-6666-6666-666666666666';
+
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createUserRolesClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+export function makeRole(overrides: Partial<RoleDto> = {}): RoleDto {
+  return {
+    id: ID_ROLE_ADMIN,
+    name: 'Administrator',
+    code: 'admin',
+    systemId: ID_SYS_AUTH,
+    description: null,
+    permissionsCount: null,
+    usersCount: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+export function makeSystem(overrides: Partial<SystemDto> = {}): SystemDto {
+  return {
+    id: ID_SYS_AUTH,
+    name: 'Authenticator',
+    code: 'authenticator',
+    description: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+export function makeUserRoleSummary(
+  overrides: Partial<UserRoleSummary> = {},
+): UserRoleSummary {
+  return {
+    id: ID_ROLE_ADMIN,
+    name: 'Administrator',
+    code: 'admin',
+    systemId: ID_SYS_AUTH,
+    ...overrides,
+  };
+}
+
+export function makeUser(overrides: Partial<UserDto> = {}): UserDto {
+  return {
+    id: ID_USER,
+    name: 'Alice Admin',
+    email: 'alice@example.com',
+    clientId: null,
+    identity: 1,
+    active: true,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    roles: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói um envelope `PagedResponse<T>` com defaults de página
+ * coerentes com o catálogo carregado em uma única request
+ * (`pageSize=100`, `page=1`). Genérico evita duplicação entre
+ * `makePagedRoles` e `makePagedSystems` que o lint
+ * `sonarjs/no-identical-functions` capturaria.
+ */
+function makePagedResponse<T>(
+  items: ReadonlyArray<T>,
+  overrides: Partial<PagedResponse<T>> = {},
+): PagedResponse<T> {
+  return {
+    data: items,
+    page: 1,
+    pageSize: 100,
+    total: items.length,
+    ...overrides,
+  };
+}
+
+export function makePagedRoles(
+  items: ReadonlyArray<RoleDto>,
+  overrides: Partial<PagedResponse<RoleDto>> = {},
+): PagedResponse<RoleDto> {
+  return makePagedResponse(items, overrides);
+}
+
+export function makePagedSystems(
+  items: ReadonlyArray<SystemDto>,
+  overrides: Partial<PagedResponse<SystemDto>> = {},
+): PagedResponse<SystemDto> {
+  return makePagedResponse(items, overrides);
+}
+
+interface SetupOptions {
+  /**
+   * Catálogo devolvido pelo `listRoles`. **Importante:** o backend
+   * `/roles` ainda devolve um array cru (não envelope paginado);
+   * `listRoles` adapta client-side. O stub deve mocar o array, e o
+   * `makePagedRoles` aqui é apenas conveniência para testes que
+   * queiram passar o envelope explicitamente — a normalização no
+   * `primeStubResponses` aceita ambos.
+   */
+  roles?: PagedResponse<RoleDto> | ReadonlyArray<RoleDto>;
+  /** Sistemas devolvidos pelo `listSystems` (lookup, envelope paginado). */
+  systems?: PagedResponse<SystemDto>;
+  /** Usuário devolvido pelo `getUserById`. */
+  user?: UserDto;
+}
+
+/**
+ * Configura o stub para retornar roles + sistemas + user em estado
+ * feliz. A página dispara as três requests em paralelo no mount; este
+ * helper resolve todas via `mockImplementation` baseado na URL para
+ * evitar acoplar o teste à ordem de chamadas.
+ */
+export function primeStubResponses(
+  client: ApiClientStub,
+  options: SetupOptions = {},
+): void {
+  // Backend hoje devolve `/roles` como array cru — o adapter
+  // `listRoles` paginia/filtra client-side. O stub aqui sempre devolve
+  // o array (extraído do envelope se o caller passou `PagedResponse`).
+  const rolesInput = options.roles ?? [makeRole()];
+  const rolesArray = Array.isArray(rolesInput)
+    ? (rolesInput as ReadonlyArray<RoleDto>)
+    : (rolesInput as PagedResponse<RoleDto>).data;
+  const systems = options.systems ?? makePagedSystems([makeSystem()]);
+  const user = options.user ?? makeUser();
+
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith('/roles')) {
+      return Promise.resolve(rolesArray);
+    }
+    if (path.startsWith('/systems')) {
+      return Promise.resolve(systems);
+    }
+    if (path.startsWith('/users/')) {
+      return Promise.resolve(user);
+    }
+    return Promise.reject(
+      Object.assign(new Error('URL stub não esperada: ' + path), {
+        kind: 'http',
+        status: 404,
+      }),
+    );
+  });
+}
+
+export function renderUserRolesPage(
+  client: ApiClientStub,
+  userId: string = ID_USER,
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[`/usuarios/${userId}/roles`]}>
+        <Routes>
+          <Route
+            path="/usuarios/:id/roles"
+            element={<UserRolesShellPage client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a finalização do mount: o spinner de loading desaparece
+ * quando todas as promises (roles + sistemas + user) resolvem.
+ * Centraliza o pattern para reduzir boilerplate por teste.
+ */
+export async function waitForInitialFetch(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.queryByTestId('user-roles-loading')).not.toBeInTheDocument();
+  });
+}

--- a/tests/pages/users/userRolesHelpers.test.ts
+++ b/tests/pages/users/userRolesHelpers.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RoleDto, UserRoleSummary } from '@/shared/api';
+
+import {
+  buildInitialUserRoleIds,
+  groupRolesBySystem,
+} from '@/pages/users/userRolesHelpers';
+
+/**
+ * Suíte dos helpers puros que sustentam a tela de atribuição de
+ * roles a um usuário (Issue #71). Espelha o pattern de
+ * `userPermissionsHelpers.test.ts` (Issue #70). Helpers vivem fora
+ * do componente para que a cobertura seja barata (sem DOM, sem
+ * providers) — lição PR #128 sobre projetar shared helpers desde o
+ * primeiro PR do recurso.
+ */
+
+const SYS_AUTH = '11111111-1111-1111-1111-111111111111';
+const SYS_KURTTO = '22222222-2222-2222-2222-222222222222';
+
+function makeRole(overrides: Partial<RoleDto> = {}): RoleDto {
+  return {
+    id: 'r-1',
+    name: 'Root',
+    code: 'root',
+    systemId: SYS_AUTH,
+    description: null,
+    permissionsCount: null,
+    usersCount: null,
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+const SYSTEM_LOOKUP = new Map([
+  [SYS_AUTH, { code: 'authenticator', name: 'Authenticator' }],
+  [SYS_KURTTO, { code: 'kurtto', name: 'Kurtto' }],
+]);
+
+describe('groupRolesBySystem', () => {
+  it('agrupa por systemId e ordena por systemCode (lookup)', () => {
+    const result = groupRolesBySystem(
+      [
+        makeRole({ id: 'r-k', systemId: SYS_KURTTO, code: 'k-admin' }),
+        makeRole({ id: 'r-a', systemId: SYS_AUTH, code: 'a-admin' }),
+      ],
+      SYSTEM_LOOKUP,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].systemCode).toBe('authenticator');
+    expect(result[1].systemCode).toBe('kurtto');
+  });
+
+  it('ordena roles por code dentro do grupo', () => {
+    const result = groupRolesBySystem(
+      [
+        makeRole({ id: 'r-3', code: 'charlie' }),
+        makeRole({ id: 'r-1', code: 'alpha' }),
+        makeRole({ id: 'r-2', code: 'bravo' }),
+      ],
+      SYSTEM_LOOKUP,
+    );
+    const [group] = result;
+    // O grupo segue o shape de `SystemGroup<T>` (campo `items`,
+    // herdado de `src/shared/listing/groupBySystem`).
+    expect(group.items.map((r) => r.id)).toEqual(['r-1', 'r-2', 'r-3']);
+  });
+
+  it('move roles com systemId null para o final ("Sem sistema")', () => {
+    const result = groupRolesBySystem(
+      [
+        makeRole({ id: 'r-orphan', systemId: null }),
+        makeRole({ id: 'r-auth', systemId: SYS_AUTH, code: 'admin' }),
+      ],
+      SYSTEM_LOOKUP,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].systemCode).toBe('authenticator');
+    expect(result[1].systemCode).toBe('—');
+    expect(result[1].systemName).toBe('Sem sistema');
+  });
+
+  it('move roles com systemId vazio (string) para o grupo órfão', () => {
+    const result = groupRolesBySystem(
+      [makeRole({ id: 'r-orphan', systemId: '' as unknown as string })],
+      SYSTEM_LOOKUP,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].systemCode).toBe('—');
+  });
+
+  it('quando lookup não tem o systemId, usa o id como fallback de code/name', () => {
+    const customLookup = new Map<string, { code: string; name: string }>();
+    const result = groupRolesBySystem(
+      [makeRole({ id: 'r-1', systemId: SYS_AUTH })],
+      customLookup,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].systemCode).toBe(SYS_AUTH);
+    expect(result[0].systemName).toBe(SYS_AUTH);
+  });
+
+  it('lista vazia devolve array vazio', () => {
+    expect(groupRolesBySystem([], SYSTEM_LOOKUP)).toEqual([]);
+  });
+
+  it('lookup default (Map vazio) ainda agrupa, usando id como fallback', () => {
+    const result = groupRolesBySystem([
+      makeRole({ id: 'r-1', systemId: SYS_AUTH }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].systemId).toBe(SYS_AUTH);
+    expect(result[0].systemCode).toBe(SYS_AUTH);
+  });
+});
+
+describe('buildInitialUserRoleIds', () => {
+  function makeUserRole(overrides: Partial<UserRoleSummary> = {}): UserRoleSummary {
+    return {
+      id: 'r-1',
+      name: 'Root',
+      code: 'root',
+      systemId: SYS_AUTH,
+      ...overrides,
+    };
+  }
+
+  it('captura todos os ids do array roles do user', () => {
+    const set = buildInitialUserRoleIds([
+      makeUserRole({ id: 'a' }),
+      makeUserRole({ id: 'b' }),
+      makeUserRole({ id: 'c' }),
+    ]);
+    expect(set.size).toBe(3);
+    expect(set.has('a')).toBe(true);
+    expect(set.has('b')).toBe(true);
+    expect(set.has('c')).toBe(true);
+  });
+
+  it('lista vazia devolve set vazio', () => {
+    expect(buildInitialUserRoleIds([]).size).toBe(0);
+  });
+
+  it('undefined (array ausente) devolve set vazio', () => {
+    expect(buildInitialUserRoleIds(undefined).size).toBe(0);
+  });
+});

--- a/tests/routes/routeCodes.test.ts
+++ b/tests/routes/routeCodes.test.ts
@@ -46,6 +46,10 @@ const POSITIVE_CASES: ReadonlyArray<ResolveCase> = [
   { pathname: '/usuarios', expected: 'AUTH_V1_USERS_LIST' },
   { pathname: '/usuarios/42', expected: 'AUTH_V1_USERS_GET_BY_ID' },
   { pathname: '/usuarios/42/permissoes', expected: 'AUTH_V1_USERS_PERMISSIONS_ASSIGN' },
+  // Issue #71: tela de atribuição de roles ao usuário. Sub-rota mais
+  // específica vence `/usuarios/:id` no `matchPath` — backend exige
+  // policy `UsersUpdate`, code `AUTH_V1_USERS_ROLES_ASSIGN`.
+  { pathname: '/usuarios/42/roles', expected: 'AUTH_V1_USERS_ROLES_ASSIGN' },
   { pathname: '/tokens', expected: 'AUTH_V1_TOKEN_TYPES_LIST' },
 ];
 

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -5,15 +5,19 @@ import type {
   CreateUserPayload,
   UpdateUserPayload,
   UserDto,
+  UserRoleSummary,
 } from '@/shared/api';
 
 import {
+  assignRoleToUser,
   createUser,
   DEFAULT_USERS_PAGE_SIZE,
+  getUserById,
   isPagedUsersResponse,
   isUserDto,
   listUsers,
   resetUserPassword,
+  removeRoleFromUser,
   updateUser,
 } from '@/shared/api';
 
@@ -122,6 +126,37 @@ describe('isUserDto', () => {
     ).toBe(false);
     expect(
       isUserDto(makeUserDto({ clientId: 0 as unknown as string })),
+    ).toBe(false);
+  });
+
+  it('aceita roles ausente (listagem paginada não traz)', () => {
+    expect(isUserDto(makeUserDto())).toBe(true);
+  });
+
+  it('aceita roles populado (GET /users/{id})', () => {
+    expect(
+      isUserDto(
+        makeUserDto({
+          roles: [
+            {
+              id: '99999999-9999-9999-9999-999999999999',
+              name: 'Admin',
+              code: 'admin',
+              systemId: '88888888-8888-8888-8888-888888888888',
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejeita roles com item de shape inválido', () => {
+    expect(
+      isUserDto(
+        makeUserDto({
+          roles: [{ broken: true }] as unknown as UserRoleSummary[],
+        }),
+      ),
     ).toBe(false);
   });
 });
@@ -846,6 +881,35 @@ describe('resetUserPassword — body e path', () => {
     await resetUserPassword(
       USER_ID,
       '  senha-com-espacos  ',
+/**
+ * Suíte do `getUserById` (Issue #71). Cobre a chamada do endpoint
+ * `GET /users/{id}`, a propagação do array `roles`
+ * (lfc-authenticator#167) e os erros típicos (404 quando o usuário
+ * não existe, parse quando o shape diverge).
+ */
+describe('getUserById', () => {
+  const ROLE_ID = '99999999-9999-9999-9999-999999999999';
+  const SYSTEM_ID_FOR_ROLE = '88888888-8888-8888-8888-888888888888';
+
+  function makeUserRoleSummary(
+    overrides: Partial<UserRoleSummary> = {},
+  ): UserRoleSummary {
+    return {
+      id: ROLE_ID,
+      name: 'Administrator',
+      code: 'admin',
+      systemId: SYSTEM_ID_FOR_ROLE,
+      ...overrides,
+    };
+  }
+
+  it('emite GET /users/{id} e devolve UserDto com roles preenchidas', async () => {
+    const client = createStub();
+    const userWithRoles = makeUserDto({ roles: [makeUserRoleSummary()] });
+    client.get.mockResolvedValueOnce(userWithRoles);
+
+    const result = await getUserById(
+      USER_ID,
       undefined,
       client as unknown as ApiClient,
     );
@@ -869,6 +933,33 @@ describe('resetUserPassword — body e path', () => {
     await resetUserPassword(
       USER_ID,
       'nova-senha',
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe(`/users/${USER_ID}`);
+    expect(result).toEqual(userWithRoles);
+    expect(result.roles).toHaveLength(1);
+    expect(result.roles?.[0].id).toBe(ROLE_ID);
+  });
+
+  it('aceita UserDto sem array roles (payload legado)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makeUserDto());
+
+    const result = await getUserById(
+      USER_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.roles).toBeUndefined();
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makeUserDto());
+    const controller = new AbortController();
+
+    await getUserById(
+      USER_ID,
       { signal: controller.signal },
       client as unknown as ApiClient,
     );
@@ -937,6 +1028,35 @@ describe('resetUserPassword — response e erros', () => {
   });
 
   it('propaga 404 do backend (usuário removido) sem traduzir', async () => {
+    expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      getUserById(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    });
+  });
+
+  it('lança ApiError(parse) quando algum item de roles não é UserRoleSummary', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(
+      makeUserDto({
+        roles: [{ broken: true }] as unknown as UserRoleSummary[],
+      }),
+    );
+
+    await expect(
+      getUserById(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 404 do backend (usuário não encontrado) sem traduzir', async () => {
     const client = createStub();
     const apiError = {
       kind: 'http',
@@ -947,12 +1067,17 @@ describe('resetUserPassword — response e erros', () => {
 
     await expect(
       resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+    client.get.mockRejectedValueOnce(apiError);
+
+    await expect(
+      getUserById(USER_ID, undefined, client as unknown as ApiClient),
     ).rejects.toEqual(apiError);
   });
 
   it('propaga 401/403 sem traduzir', async () => {
     const client = createStub();
     client.put.mockRejectedValueOnce({
+    client.get.mockRejectedValueOnce({
       kind: 'http',
       status: 403,
       message: 'Sem permissão.',
@@ -960,6 +1085,209 @@ describe('resetUserPassword — response e erros', () => {
 
     await expect(
       resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+      getUserById(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
+  });
+});
+
+/**
+ * Suíte do `assignRoleToUser` (Issue #71). Cobre a chamada do
+ * endpoint `POST /users/{userId}/roles` com body `{ roleId }`,
+ * validação do response (`UserRoleLinkDto`) e propagação de erros
+ * tipados (`ApiError`). Espelha `assignPermissionToUser` (lição
+ * PR #128 — mesmo shape de wrapper para o segundo recurso de
+ * assignment do mesmo controller).
+ */
+describe('assignRoleToUser', () => {
+  const ROLE_ID = '99999999-9999-9999-9999-999999999999';
+  const LINK_ID = '00000000-1111-2222-3333-444444444444';
+
+  function makeLink() {
+    return {
+      id: LINK_ID,
+      userId: USER_ID,
+      roleId: ROLE_ID,
+      createdAt: '2026-05-01T10:00:00Z',
+      updatedAt: '2026-05-01T10:00:00Z',
+      deletedAt: null,
+    };
+  }
+
+  it('emite POST /users/{userId}/roles com body { roleId }', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeLink());
+
+    await assignRoleToUser(
+      USER_ID,
+      ROLE_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post.mock.calls[0][0]).toBe(`/users/${USER_ID}/roles`);
+    expect(client.post.mock.calls[0][1]).toEqual({ roleId: ROLE_ID });
+  });
+
+  it('devolve UserRoleLinkDto válido', async () => {
+    const client = createStub();
+    const link = makeLink();
+    client.post.mockResolvedValueOnce(link);
+
+    const result = await assignRoleToUser(
+      USER_ID,
+      ROLE_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(link);
+  });
+
+  it('lança ApiError(parse) quando o response não é UserRoleLinkDto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      assignRoleToUser(
+        USER_ID,
+        ROLE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 400 (roleId inválido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'RoleId inválido.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      assignRoleToUser(
+        USER_ID,
+        ROLE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 404 (usuário não encontrado) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Usuário não encontrado.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      assignRoleToUser(
+        USER_ID,
+        ROLE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toEqual(apiError);
+  });
+});
+
+/**
+ * Suíte do `removeRoleFromUser` (Issue #71). Cobre a chamada do
+ * endpoint `DELETE /users/{userId}/roles/{roleId}`, ausência de
+ * corpo no retorno (`204 No Content`) e propagação de erros tipados.
+ * Espelha `removePermissionFromUser`.
+ */
+describe('removeRoleFromUser', () => {
+  const ROLE_ID = '99999999-9999-9999-9999-999999999999';
+
+  it('emite DELETE /users/{userId}/roles/{roleId}', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    await removeRoleFromUser(
+      USER_ID,
+      ROLE_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete.mock.calls[0][0]).toBe(
+      `/users/${USER_ID}/roles/${ROLE_ID}`,
+    );
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+
+    await removeRoleFromUser(
+      USER_ID,
+      ROLE_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete.mock.calls[0][1]).toEqual({
+      signal: controller.signal,
+    });
+  });
+
+  it('resolve void em sucesso (204 No Content)', async () => {
+    const client = createStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    const result = await removeRoleFromUser(
+      USER_ID,
+      ROLE_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('propaga 404 (vínculo não encontrado) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Vínculo não encontrado.',
+    };
+    client.delete.mockRejectedValueOnce(apiError);
+
+    await expect(
+      removeRoleFromUser(
+        USER_ID,
+        ROLE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.delete.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      removeRoleFromUser(
+        USER_ID,
+        ROLE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
     ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
 });


### PR DESCRIPTION
## Contexto

Issue [#71](https://github.com/LF-Calegari/lfc-admin-gui/issues/71) (EPIC #48) — Permissões via role, atribuição de roles ao usuário.

A tela vincula/desvincula roles ao usuário usando uma matriz de checkboxes agrupada por sistema. Após salvar, a UI sincroniza com o backend (refetch) e a Issue #70 (`UserPermissionsShellPage`) reflete automaticamente as permissões herdadas via role.

## Dependências externas (já mergeadas)

- `lfc-authenticator#163` — `AppRole.SystemId` no model.
- `lfc-authenticator#167` — `GET /users/{id}` retorna `UserResponse` enriquecido (com `Roles[]`) + endpoints `POST /users/{id}/roles` e `DELETE /users/{id}/roles/{roleId}`.

## O que foi feito

### Tela `/usuarios/:id/roles` (`UserRolesShellPage`)

- Fetch paralelo: `listRoles({pageSize: 100})` + `listSystems({pageSize: 100})` + `getUserById(:id)` no mount; `AbortController` cobre navegação rápida entre `:id`s.
- Lista de roles agrupadas por sistema, ordenadas por `code` dentro do grupo (delega ao `groupBySystem` compartilhado em `src/shared/listing/`). Roles legadas com `systemId === null` caem num grupo virtual `'—' Sem sistema`.
- Multi-select com diff client-side via `computeIdSetDiff` (`src/shared/forms/`); botão Salvar fica desabilitado quando não há mudanças e exibe contador (`SaveCounter`).
- Salvar dispara `assignRoleToUser`/`removeRoleFromUser` em paralelo (`Promise.all`); falhas individuais não abortam o lote — toast de aviso lista quantas falharam vs aplicaram.
- Refetch pós-mutação garante sincronização com o backend (idempotência cobre divergências raras).
- Visível com `Roles.Read` + `Users.Update` (gating duplo via `RequirePermission` aninhado em `src/routes/index.tsx`).
- Estados visuais completos: invalid-id, loading, error+retry, empty, hover, focus-visible, badges \"Vinculada\" (estado salvo) / \"Adição pendente\" / \"Remoção pendente\".

### API (`src/shared/api/`)

- `users.ts`: adiciona `UserRoleSummary`, `UserRoleLinkDto`, `getUserById`, `assignRoleToUser`, `removeRoleFromUser`. Estende `UserDto` com `roles?: ReadonlyArray<UserRoleSummary>` (opcional — listagem paginada não traz; só `GET /users/{id}` preenche).
- `roles.ts`: torna `ListRolesParams.systemId` opcional, adiciona `MAX_ROLES_PAGE_SIZE = 100` e filtra por `systemId` no adapter client-side.
- Type guards estritos em runtime para detectar drift de contrato.

### Reuso (lições PR #128/#134/#135)

- `AssignmentMatrixShell` em `src/shared/listing/` (introduzido pela Issue #69) — JSX da matriz, ações, legenda, loading/error/empty/groups.
- `groupBySystem` em `src/shared/listing/` — agrupamento por sistema com fallback órfão.
- `computeIdSetDiff` em `src/shared/forms/` — diff `selected \\ original` + `original \\ selected`.

## Arquivos impactados

**Novos** (5):
- `src/pages/users/UserRolesShellPage.tsx`
- `src/pages/users/userRolesHelpers.ts`
- `tests/pages/users/UserRolesPage.test.tsx` (18 cenários)
- `tests/pages/users/userRolesHelpers.test.ts` (10 cenários)
- `tests/pages/users/__helpers__/userRolesTestHelpers.tsx`

**Modificados** (8):
- `src/shared/api/users.ts` — `getUserById`/`assignRoleToUser`/`removeRoleFromUser`/`UserRoleSummary`/`UserRoleLinkDto`/`isUserDto` validando `roles[]`.
- `src/shared/api/roles.ts` — `MAX_ROLES_PAGE_SIZE`, `systemId` opcional + filtro no adapter.
- `src/shared/api/index.ts` — re-exports.
- `src/pages/users/index.ts` — export do novo shell.
- `src/routes/index.tsx` — rota `/usuarios/:id/roles` com gating duplo.
- `src/routes/routeCodes.ts` — mapeamento `AUTH_V1_USERS_ROLES_ASSIGN`.
- `tests/routes/routeCodes.test.ts` — caso positivo para a nova rota.
- `tests/shared/api/users.test.ts` — +21 testes para os novos wrappers e validação do `roles[]`.

## Testes

```text
docker compose run --rm web npm run lint
  → 0 erros, 0 warnings.

docker compose run --rm web npm run typecheck
  → 0 erros.

docker compose run --rm web npm test
  → Test Files  68 passed (69) | 1 failed
  → Tests  1186 passed (1187) | 1 failed
  (a falha é flake de container em teste pré-existente; o teste passa
   isoladamente: \`docker compose run --rm web npm test -- <arquivo>\`
   resulta em 100% verde. Os 313 testes dos arquivos tocados pelo
   diff passam todos em isolamento.)

docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10
  → Total: 2.69% (baseline pré-diff: 2.71%; threshold: 3%)
  → 0 novas duplicações ≥10 linhas em arquivos do diff que não tenham
    contrapartida no `AssignmentMatrixShell`/`groupBySystem` já
    compartilhados pela Issue #69.
```

## Visual

- Tokens (`var(--space-*)`, `var(--bg-*)`, `var(--border-*)`, `var(--accent-ink)` etc.) — sem hardcode.
- Hover/focus/disabled cobertos via primitives compartilhados em `src/shared/listing/AssignmentMatrixStyles.ts` (introduzidos pela Issue #69).
- Badges com `variant=\"success\"` (Vinculada) e `variant=\"warning\"` (Pendente) reusam o design system.
- Layout responsivo herdado do `AssignmentMatrixShell` (já validado nas Issues #69/#70).

## Segurança

- Sem `dangerouslySetInnerHTML`, sem URLs dinâmicas para iframes.
- Tokens HTTP injetados via `apiClient.setAuth(...)` no boot — wrapper não expõe.
- Erros do backend são exibidos via Alert/Toast com mensagens canônicas; nenhum `console.log` de sensíveis.
- Cancelamento via `AbortController` evita race em mudanças rápidas de `:id`.

## Riscos / Pendências

- O backend ainda não denormaliza `systemCode`/`systemName` no `RoleResponse` (TODO documentado); enquanto isso, a UI carrega `listSystems` em paralelo para resolver os labels. Quando o backend evoluir, basta remover o `systemLookup` do helper.
- Os testes flaky em containers compartilham recursos com lints/typechecks paralelos; a CI do GitHub Actions roda em runners isolados e tipicamente não exibe esse comportamento.

## Issue relacionada

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)