### PR TITLE
feat(users): reset de senha por linha (#81)

### DIFF
--- a/src/pages/users/ResetUserPasswordConfirm.tsx
+++ b/src/pages/users/ResetUserPasswordConfirm.tsx
@@ -1,0 +1,457 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { Alert, Input, Modal, useToast } from '../../components/ui';
+import { resetUserPassword } from '../../shared/api';
+import {
+  FormFooter as SharedFormFooter,
+  useEditEntitySubmit,
+  type EditEntitySubmitCopy,
+  type EditSubmitActionCopy,
+} from '../../shared/forms';
+
+import {
+  PASSWORD_MAX,
+  PASSWORD_MIN,
+  type UserSubmitErrorCopy,
+} from './userFormShared';
+
+import type { ApiClient, UserDto } from '../../shared/api';
+
+/**
+ * Field key do form de reset de senha — usada pelo helper genérico
+ * `useEditEntitySubmit<TField>` para tipar `setFieldErrors`. O único
+ * campo do contrato `UpdatePasswordRequest` é `Password`.
+ */
+type ResetPasswordField = 'password';
+
+/* ─── Copy ────────────────────────────────────────────────── */
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o reset de senha
+ * (Issue #81). Espelha o padrão de `EditUserModal`/`NewUserModal` mas
+ * com vocabulário "redefinir" — `conflictDefault` fica vazio porque o
+ * backend nunca devolve 409 em `PUT /users/{id}/password` (não há
+ * unicidade de senha entre usuários).
+ *
+ * O `forbiddenTitle` aparece em toasts vermelhos (401/403) e no
+ * fallback genérico de 404; coerente com a ação que o operador
+ * acabou de tentar ("Falha ao redefinir senha").
+ */
+const SUBMIT_ERROR_COPY: UserSubmitErrorCopy = {
+  conflictDefault: '',
+  forbiddenTitle: 'Falha ao redefinir senha',
+  genericFallback:
+    'Não foi possível redefinir a senha. Tente novamente.',
+};
+
+/**
+ * Copy injetada em `applyEditSubmitAction`. O backend nunca devolve 409
+ * neste endpoint (não há unicidade), então `conflictInlineMessage` fica
+ * `undefined` — o switch do helper passa pelo branch `conflict` apenas
+ * defensivamente caso o contrato evolua, e ainda assim a copy do
+ * próprio backend (`action.message`) seria exibida sem que o frontend
+ * regrida.
+ *
+ * `notFoundMessage` cobre o cenário "operador abriu o modal e o
+ * usuário-alvo foi soft-deletado por outra sessão antes do submit" —
+ * UX paritária com `EditUserModal` (modal fecha + toast + refetch).
+ */
+const EDIT_SUBMIT_ACTION_COPY: EditSubmitActionCopy = {
+  notFoundMessage:
+    'Usuário não encontrado ou foi removido. Atualize a lista.',
+  forbiddenTitle: SUBMIT_ERROR_COPY.forbiddenTitle,
+};
+
+/**
+ * Mensagem do toast verde após sucesso. Não interpolamos o nome
+ * porque a tabela ainda não muda visualmente após o reset (apenas
+ * `updatedAt` é atualizado no backend, não exibido na UI) — manter
+ * a copy curta e direta.
+ */
+const SUCCESS_MESSAGE = 'Senha redefinida.';
+
+/* ─── Validação client-side ───────────────────────────────── */
+
+/**
+ * Replica as regras do backend (`UpdatePasswordRequest`):
+ *
+ * - `password` é obrigatório (`Required`) e não pode ser apenas
+ *   espaços (validado server-side via `IsNullOrWhiteSpace` após trim).
+ * - Tamanho máximo 60 chars (`MaxLength(60)`).
+ *
+ * Mantemos o **mesmo mínimo client-side** dos demais forms de
+ * usuário (`PASSWORD_MIN = 8`) — UX defensiva para senhas iniciais
+ * administrativas, espelha `userFormShared.validateUserForm`. O
+ * backend não exige mínimo, mas reset implica nova senha que o
+ * usuário-alvo vai usar imediatamente; aplicar o mesmo guard
+ * preserva consistência entre o caminho de criação (#78) e o de
+ * reset (#81).
+ *
+ * Validação client-side **não trima** — espaços laterais podem ser
+ * intencionais para senhas geradas em gerenciadores. O backend
+ * trima com `request.Password.Trim()` e refaz o
+ * `IsNullOrWhiteSpace` depois (rejeita senha de só espaços).
+ *
+ * Devolve `null` quando válido, ou string com a mensagem do erro.
+ */
+function validateResetPassword(password: string): string | null {
+  if (password.length === 0) {
+    return 'Nova senha é obrigatória.';
+  }
+  // O backend rejeita senhas formadas apenas por espaços — espelhar
+  // client-side evita round-trip por digitação acidental do operador
+  // (ex.: copy/paste de uma string em branco).
+  if (password.trim().length === 0) {
+    return 'Nova senha não pode ser apenas espaços.';
+  }
+  if (password.length < PASSWORD_MIN) {
+    return `Nova senha deve ter ao menos ${PASSWORD_MIN} caracteres.`;
+  }
+  if (password.length > PASSWORD_MAX) {
+    return `Nova senha deve ter no máximo ${PASSWORD_MAX} caracteres.`;
+  }
+  return null;
+}
+
+/* ─── Styled primitives ───────────────────────────────────── */
+
+/**
+ * Wrapper do `<form>` do reset. Espelha `UserFormShell` em
+ * `UserFormFields.tsx` — mesmo `display: flex` com `gap:
+ * var(--space-4)` para coerência visual entre os modals do user
+ * (criar/editar/desativar/reset).
+ */
+const ResetFormShell = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+/**
+ * Bloco "contexto" — quem está prestes a ter a senha redefinida.
+ * Espelha o padrão visual de `MutationConfirmModal` (descrição com
+ * `<strong>name</strong> (<Mono>email</Mono>)`) sem reusar o shell
+ * porque aqui temos campo de form. Mantemos a hierarquia visual
+ * coerente.
+ */
+const ContextBlock = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg1);
+  background: var(--bg-elevated);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+`;
+
+/* ─── Component ───────────────────────────────────────────── */
+
+interface ResetUserPasswordConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Usuário selecionado para o reset. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `user`.
+   * Mantemos o objeto completo (não só `id`) para que a copy do
+   * diálogo exiba `name`/`email` sem precisar de re-fetch.
+   */
+  user: UserDto | null;
+  /** Fecha o modal sem persistir. Chamada também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após reset bem-sucedido ou após detecção de
+   * 404 (usuário já removido entre abertura e submit) — em ambos os
+   * casos a UI quer refetch para sincronizar a tabela com o backend
+   * (paridade com `EditUserModal`).
+   */
+  onResetCompleted: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `resetUserPassword` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para reset de senha de usuário (Issue #81).
+ *
+ * Diferenças vs `EditUserModal`/`NewUserModal`:
+ *
+ * - Mostra apenas **um** campo (nova senha) em vez do form completo
+ *   — o backend tem endpoint dedicado (`PUT /users/{id}/password`)
+ *   que aceita só `Password`.
+ * - Copy "Redefinir senha" e contexto destacando `name` + `email`
+ *   do usuário-alvo (paridade visual com `MutationConfirmModal`
+ *   usado pelo toggle ativo).
+ * - **Sem 409** — não há unicidade de senha entre usuários.
+ * - **Sem reset de form pós-sucesso** — caller já vai fechar o modal
+ *   imediatamente após o sucesso; a próxima abertura zera o estado
+ *   via `useEffect` do `open` (mesma estratégia do `EditUserModal`).
+ *
+ * Diferenças vs `ToggleUserActiveConfirm`/`MutationConfirmModal`:
+ *
+ * - Tem campo de input — `MutationConfirmModal` é estritamente sem
+ *   form, então não cabe reusar como wrapper aqui. Usamos `Modal` +
+ *   `<form>` + `Alert` + `FormFooter` (mesma combinação dos demais
+ *   form modals do recurso) para preservar consistência visual.
+ * - Submit usa `useEditEntitySubmit<'password'>` — o helper genérico
+ *   já encapsula `try/catch/finally` + `classifyApiSubmitError` +
+ *   `applyEditSubmitAction` (lição PR #135). Usar aqui evita
+ *   duplicação ≥10 linhas com `EditUserModal` na mesma pasta.
+ *
+ * **Visibilidade:** o caller (`UsersListShellPage`) só renderiza este
+ * modal quando o operador tem `Users.Update` (mesma policy do edit/
+ * toggle, alinhada com o backend
+ * `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`).
+ */
+export const ResetUserPasswordConfirm: React.FC<
+  ResetUserPasswordConfirmProps
+> = ({ open, user, onClose, onResetCompleted, client }) => {
+  const { show } = useToast();
+
+  // Estado controlado do campo "Nova senha". Mantemos string vazia
+  // como inicial — `useEffect` do `open` zera entre aberturas.
+  const [password, setPassword] = useState<string>('');
+  // Erro inline do campo "Nova senha" — alimentado pela validação
+  // client-side e pelo parsing de `ValidationProblemDetails` (via
+  // `applyBadRequest`).
+  const [fieldError, setFieldError] = useState<string | undefined>(undefined);
+  // Erro genérico exibido em `<Alert>` no topo do form quando o
+  // backend devolve 400 sem `details.errors` mapeáveis.
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  // Flag de submissão. Bloqueia Esc/backdrop/cancelar e desabilita
+  // os controles enquanto a request está em voo.
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  /**
+   * Reseta o estado entre aberturas (ou quando o `user` selecionado
+   * muda). Espelha o `useEffect` do `EditUserModal` — preferimos
+   * limpar no `open=true` em vez de no `onClose` para evitar
+   * "flicker" de erro residual quando o operador reabre o modal
+   * imediatamente após uma falha.
+   */
+  useEffect(() => {
+    if (!open || !user) return;
+    setPassword('');
+    setFieldError(undefined);
+    setSubmitError(null);
+  }, [open, user]);
+
+  /**
+   * Handler de mudança do campo "Nova senha". Limpa o erro inline
+   * em qualquer alteração para que o operador veja feedback
+   * imediato — espelha `useFieldChangeHandlers` do form completo
+   * mas inline aqui porque é apenas um campo (factory genérica
+   * não compensa em LOC).
+   */
+  const handlePasswordChange = useCallback((value: string) => {
+    setPassword(value);
+    setFieldError(undefined);
+  }, []);
+
+  /**
+   * Fecha o modal sem persistir. Bloqueado durante submit para
+   * evitar request órfã. Único handler para Esc/backdrop/X/Cancelar
+   * (mesmo padrão dos demais modals do recurso).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    onClose();
+  }, [isSubmitting, onClose]);
+
+  /**
+   * Roda a validação client-side e, se passar, marca submitting +
+   * limpa erros + devolve a senha pronta para envio. Devolve `null`
+   * quando há erro client-side (já tendo populado `fieldError`).
+   *
+   * Tipado como `() => unknown | null` para casar com o contrato do
+   * `useEditEntitySubmit` (que aceita `unknown` no payload). O hook
+   * filtra `null` antes de chamar `mutationFn`, então o cast é seguro.
+   */
+  const prepareSubmit = useCallback((): string | null => {
+    if (isSubmitting || !user) return null;
+    const error = validateResetPassword(password);
+    if (error) {
+      setFieldError(error);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldError(undefined);
+    setSubmitError(null);
+    setIsSubmitting(true);
+    return password;
+  }, [isSubmitting, password, user]);
+
+  /**
+   * Aplica decisão de 400 do backend: se o `ValidationProblemDetails`
+   * tem `errors.Password`, exibe inline; caso contrário, mostra a
+   * mensagem do backend no `<Alert>` no topo (caso defensivo — o
+   * backend só devolve `errors.Password` neste endpoint).
+   *
+   * Mantemos inline aqui (em vez de reusar `applyUserBadRequest`)
+   * porque o shape de erro é específico — só uma chave (`Password`).
+   */
+  const applyBadRequest = useCallback(
+    (details: unknown, fallbackMessage: string) => {
+      if (!details || typeof details !== 'object') {
+        setSubmitError(fallbackMessage);
+        return;
+      }
+      const errors = (details as Record<string, unknown>).errors;
+      if (!errors || typeof errors !== 'object') {
+        setSubmitError(fallbackMessage);
+        return;
+      }
+      // O backend manda `Password` em PascalCase; checamos
+      // case-insensitive para preservar resiliência contra mudanças
+      // mecânicas no contrato.
+      for (const [serverField, raw] of Object.entries(errors)) {
+        if (serverField.toLowerCase() !== 'password') continue;
+        if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+          setFieldError(raw[0]);
+          setSubmitError(null);
+          return;
+        }
+        if (typeof raw === 'string') {
+          setFieldError(raw);
+          setSubmitError(null);
+          return;
+        }
+      }
+      // Não havia chave `Password` mapeável — fallback no Alert.
+      setSubmitError(fallbackMessage);
+    },
+    [],
+  );
+
+  /**
+   * Adapter `setFieldErrors` para o helper genérico — recebe um
+   * `Partial<Record<'password', string>>` e despacha para o setter
+   * local. Centralizar na assinatura do helper preserva a
+   * generalização (`useEditEntitySubmit<TField>`).
+   */
+  const setFieldErrorsAdapter = useCallback(
+    (errors: Partial<Record<ResetPasswordField, string>>) => {
+      setFieldError(errors.password ?? undefined);
+    },
+    [],
+  );
+
+  /**
+   * Closure sobre `user.id` + `client`. Quando `user` é `null` o
+   * `prepareSubmit` já reprova antes do `mutationFn` rodar — a
+   * checagem inline aqui é defensiva (preserva o tipo sem `!`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> => {
+      if (!user) {
+        return Promise.reject(new Error('User unavailable.'));
+      }
+      return resetUserPassword(user.id, payload as string, undefined, client);
+    },
+    [client, user],
+  );
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<EditEntitySubmitCopy>(
+    () => ({
+      successMessage: SUCCESS_MESSAGE,
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+      editSubmitActionCopy: EDIT_SUBMIT_ACTION_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * `handleSubmit` orquestrado pelo hook compartilhado — encapsula
+   * o `try/catch/finally` + `classifyApiSubmitError` +
+   * `applyEditSubmitAction` que vivia inline em outros modals
+   * antes da extração (lição PR #134/#135). Reusar aqui mantém a
+   * dedupe de blocos ≥10 linhas com `EditUserModal`.
+   *
+   * `conflictField: 'password'` é simbólico — backend nunca devolve
+   * 409 neste endpoint, mas o tipo do helper exige um `TField` para
+   * o caso `conflict` do switch. Se o contrato evoluir, a copy do
+   * backend é exibida inline no campo (degradação aceitável).
+   */
+  const handleSubmit = useEditEntitySubmit<ResetPasswordField>({
+    dispatchers: {
+      setFieldErrors: setFieldErrorsAdapter,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit,
+      mutationFn,
+      onUpdated: onResetCompleted,
+      onClose,
+    },
+    conflictField: 'password',
+  });
+
+  // Não renderiza nada quando não houver `user` selecionado — o pai
+  // controla `open` em conjunto com o `user`, mas cobrimos o caso
+  // defensivo de `open=true && user=null` para não quebrar o submit.
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Redefinir senha"
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <ResetFormShell
+        onSubmit={handleSubmit}
+        noValidate
+        data-testid="reset-user-password-form"
+      >
+        <ContextBlock data-testid="reset-user-password-description">
+          Defina uma nova senha para o usuário{' '}
+          <strong>{user.name}</strong> (<Mono>{user.email}</Mono>). O
+          usuário precisará usá-la no próximo login.
+        </ContextBlock>
+        {submitError && (
+          <Alert variant="danger" data-testid="reset-user-password-submit-error">
+            {submitError}
+          </Alert>
+        )}
+        <Input
+          label="Nova senha"
+          type="password"
+          placeholder="Nova senha — o usuário poderá alterar depois."
+          value={password}
+          onChange={handlePasswordChange}
+          error={fieldError}
+          maxLength={PASSWORD_MAX}
+          autoComplete="new-password"
+          required
+          disabled={isSubmitting}
+          data-testid="reset-user-password-input"
+          data-modal-initial-focus
+        />
+        <SharedFormFooter
+          idPrefix="reset-user-password"
+          onCancel={handleClose}
+          isSubmitting={isSubmitting}
+          submitLabel="Redefinir senha"
+        />
+      </ResetFormShell>
+    </Modal>
+  );
+};

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus, Power } from 'lucide-react';
+import { KeyRound, Pencil, Plus, Power } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
@@ -49,6 +49,7 @@ import {
 
 import { EditUserModal } from './EditUserModal';
 import { NewUserModal } from './NewUserModal';
+import { ResetUserPasswordConfirm } from './ResetUserPasswordConfirm';
 import { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';
 
 import type { TableColumn } from '../../components/ui';
@@ -198,6 +199,18 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     close: handleCloseToggleConfirm,
   } = useListModalState<UserDto>();
 
+  // Usuário selecionado para reset de senha (Issue #81). Mantemos o
+  // objeto completo (não só `id`) para que o `ResetUserPasswordConfirm`
+  // possa exibir `name`/`email` no contexto do diálogo sem re-fetch.
+  // O endpoint dedicado (`PUT /users/{id}/password`) só consome `id` +
+  // a nova senha — outros campos do `UserDto` ficam inertes mas a
+  // copy do diálogo se beneficia.
+  const {
+    selected: resettingUser,
+    open: handleOpenResetPassword,
+    close: handleCloseResetPassword,
+  } = useListModalState<UserDto>();
+
   /**
    * Renderiza o bloco de ações por linha (Editar + Desativar/Ativar)
    * para uma linha de usuário. Reutilizado pelo desktop (coluna
@@ -234,6 +247,16 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
             Editar
           </Button>
           <Button
+            variant="ghost"
+            size="sm"
+            icon={<KeyRound size={14} strokeWidth={1.5} />}
+            onClick={() => handleOpenResetPassword(row)}
+            aria-label={`Redefinir senha do usuário ${row.name}`}
+            data-testid={`${testIdPrefix}-reset-password-${row.id}`}
+          >
+            Redefinir senha
+          </Button>
+          <Button
             variant={toggleVariant}
             size="sm"
             icon={<Power size={14} strokeWidth={1.5} />}
@@ -246,7 +269,7 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
         </RowActions>
       );
     },
-    [handleOpenEditModal, handleOpenToggleConfirm],
+    [handleOpenEditModal, handleOpenResetPassword, handleOpenToggleConfirm],
   );
 
   /**
@@ -658,6 +681,16 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           user={togglingUser}
           onClose={handleCloseToggleConfirm}
           onToggled={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canUpdateUser && (
+        <ResetUserPasswordConfirm
+          open={resettingUser !== null}
+          user={resettingUser}
+          onClose={handleCloseResetPassword}
+          onResetCompleted={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -3,4 +3,5 @@ export { UserDetailShellPage } from './UserDetailShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
 export { NewUserModal } from './NewUserModal';
 export { EditUserModal } from './EditUserModal';
+export { ResetUserPasswordConfirm } from './ResetUserPasswordConfirm';
 export { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -164,11 +164,13 @@ export {
   isPagedUsersResponse,
   isUserDto,
   listUsers,
+  resetUserPassword,
   updateUser,
 } from './users';
 export type {
   CreateUserPayload,
   ListUsersParams,
+  ResetUserPasswordPayload,
   UpdateUserPayload,
   UserDto,
 } from './users';

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -479,3 +479,86 @@ export async function updateUser(
   }
   return data;
 }
+
+/**
+ * Body aceito pelo `PUT /users/{id}/password` no `lfc-authenticator`
+ * (`UsersController.UpdatePasswordRequest`).
+ *
+ * Issue #81 (EPIC #49) — fluxo dedicado de reset de senha do operador
+ * sobre outro usuário. O backend mantém este endpoint **separado** do
+ * `PUT /users/{id}` para preservar simetria com o contrato:
+ *
+ * - `Password` (obrigatório, máx. 60 chars) — senha em texto plano que
+ *   o backend trima e hasheia via
+ *   `UserPasswordHasher.HashPlainPassword` antes de persistir. Frontend
+ *   nunca grava em log/storage e o body **não** é serializado em URL.
+ *
+ * Permissão: `Users.Update` — mesma do `PUT /users/{id}`. Backend
+ * valida via `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`.
+ *
+ * Status codes esperados:
+ *
+ * - `200` com `UserResponse` no body (idêntico ao `updateUser`).
+ * - `400` com `ValidationProblemDetails` quando a senha é vazia/só
+ *   espaços/longa demais.
+ * - `404` (`{ message: "Usuário não encontrado." }`) quando o id
+ *   referenciado foi soft-deletado entre abertura e submit.
+ * - `401`/`403` por gating de permissão.
+ *
+ * Mantemos exportável (em vez de `string` literal inline) para que o
+ * teste unitário e o modal compartilhem a mesma fonte de verdade.
+ */
+export interface ResetUserPasswordPayload {
+  password: string;
+}
+
+/**
+ * Reset de senha de um usuário via `PUT /users/{id}/password` (Issue #81).
+ *
+ * Retorna o `UserDto` atualizado (`200 OK` com `UserResponse` no body —
+ * mesmo shape do `updateUser`). Lança `ApiError` em qualquer falha — o
+ * caller tipicamente trata:
+ *
+ * - 400 → validação de campo (`ValidationProblemDetails` com chave
+ *   `Password`). Caller exibe inline no campo "Nova senha".
+ * - 404 → usuário não encontrado (soft-deletado entre abertura e
+ *   submit). UI fecha o modal, dispara toast e força refetch.
+ * - 401/403 → toast vermelho (gating de permissão).
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ *
+ * **Por que `password` é parâmetro literal e não `ResetUserPasswordPayload`?**
+ * O endpoint só aceita esse campo — exigir um objeto wrapper
+ * adicionaria boilerplate sem benefício de tipagem (a única chave já
+ * está nomeada). Mantemos a assinatura `(id, password)` simétrica com a
+ * percepção semântica do reset ("resetar senha do usuário X para Y") e
+ * evita o teste tipo `expect.objectContaining({ password: 'x' })` que
+ * seria menos legível.
+ *
+ * O response é validado contra `isUserDto` para detectar drift de
+ * contrato precocemente — backend retornando shape inesperado dispara
+ * `ApiError(parse)` em vez de propagar shape inválido para a UI.
+ *
+ * Espelha o padrão de `updateUser`/`createUser` mas sem `buildBody`
+ * dedicado — o body é trivial (`{ password }`) e o trim acontece no
+ * backend (`request.Password.Trim()` em `UpdatePassword`). Trimar
+ * client-side aqui daria comportamento divergente do que o operador
+ * vê: se ele digitar `"  abc  "`, o backend salvaria `"abc"` mesmo —
+ * preservar literal preserva paridade visual com a senha exibida no
+ * input.
+ */
+export async function resetUserPassword(
+  id: string,
+  password: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<UserDto> {
+  const body: ResetUserPasswordPayload = { password };
+  const data = await client.put<unknown>(`/users/${id}/password`, body, options);
+  if (!isUserDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}

--- a/tests/pages/__helpers__/usersTestHelpers.tsx
+++ b/tests/pages/__helpers__/usersTestHelpers.tsx
@@ -113,6 +113,60 @@ export function renderUsersPage(client: ApiClientStub): void {
 }
 
 /**
+ * Mocka `client.get` para responder à listagem de usuários e ao
+ * lookup de clientes (que a página dispara em paralelo) com defaults
+ * sensatos. Centralizar evita repetir o mesmo `mockImplementation`
+ * (`/users` → page, `/clients/{id}` → null) em vários testes de
+ * gating/listagem (lição PR #127/#134/#135 — bloco ≥10 linhas
+ * idêntico vira clone JSCPD).
+ *
+ * O caller passa apenas a lista de usuários para a página corrente —
+ * o helper monta o `PagedResponse<UserDto>` via `makeUsersPagedResponse`
+ * e define o lookup de clientes como "best-effort missing" (`null`).
+ *
+ * Quem precisar de comportamento diferente (ex.: cenários de erro)
+ * pode chamar `client.get.mockImplementation(...)` antes de invocar
+ * — esta função sobrescreve apenas se o caller não tiver definido
+ * implementação prévia.
+ */
+export function mockUserListResponse(
+  client: ApiClientStub,
+  users: ReadonlyArray<UserDto>,
+): void {
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith('/users')) {
+      return Promise.resolve(makeUsersPagedResponse(users));
+    }
+    return Promise.resolve(null);
+  });
+}
+
+/**
+ * Variante de `mockUserListResponse` que retorna um getter para o
+ * número de chamadas em `/users`. Usado pelos testes que precisam
+ * asserir refetch (`getCalls >= 2` após a mutação) sem repetir o
+ * boilerplate do `let getCalls = 0; client.get.mockImplementation(...)`
+ * em cada teste.
+ *
+ * O getter é uma closure sobre uma variável local — chamar
+ * `getUserListCallCount()` devolve o contador atual a cada momento.
+ */
+export function mockUserListResponseWithCounter(
+  client: ApiClientStub,
+  users: ReadonlyArray<UserDto>,
+): () => number {
+  let count = 0;
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith('/users')) {
+      count += 1;
+      return Promise.resolve(makeUsersPagedResponse(users));
+    }
+    return Promise.resolve(null);
+  });
+  return () => count;
+}
+
+/**
  * Aguarda a primeira renderização da listagem (a `UsersListShellPage`
  * faz `listUsers` no mount). Centraliza o "esperar listagem" para que
  * cada teste comece em estado estável sem precisar replicar `waitFor`
@@ -494,18 +548,30 @@ export function buildUsersCloseCases(
 /**
  * Verbos suportados pelas suítes de mutação de usuário. Cada um
  * controla a copy genérica do toast vermelho (`"Não foi possível
- * {verb} o usuário. Tente novamente."`):
+ * {verb} o usuário. Tente novamente."` ou — no caso do reset de senha
+ * — `"Não foi possível redefinir a senha. Tente novamente."`).
  *
  * - `'criar'`/`'atualizar'` — usados pelo create/edit do form de
  *   usuário (Issues #78/#79).
  * - `'ativar'`/`'desativar'` — usados pelo toggle ativo (Issue #80).
+ * - `'redefinir senha do'` — usado pelo reset de senha (Issue #81).
+ *   O sufixo "do" preserva concordância: a copy fica
+ *   `"Não foi possível redefinir senha do o usuário..."` — o helper
+ *   ignora a copy do verbo e usa o fallback exato do
+ *   `ResetUserPasswordConfirm` (`'Não foi possível redefinir a senha.
+ *   Tente novamente.'`), preservando a UX coerente.
  *
  * Centralizar o tipo aqui (em vez de declarar dois alias paralelos)
  * permite que `buildSharedUserMutationErrorCases` cubra todos os
  * cenários sem duplicar a função (lição PR #134/#135 — sonarjs/
  * no-identical-functions).
  */
-export type UserMutationVerb = 'criar' | 'atualizar' | 'ativar' | 'desativar';
+export type UserMutationVerb =
+  | 'criar'
+  | 'atualizar'
+  | 'ativar'
+  | 'desativar'
+  | 'redefinir senha do';
 
 /**
  * Constrói os cenários comuns de erro 401/403/network para qualquer
@@ -523,6 +589,14 @@ export type UserMutationVerb = 'criar' | 'atualizar' | 'ativar' | 'desativar';
 export function buildSharedUserMutationErrorCases(
   verb: UserMutationVerb,
 ): ReadonlyArray<UsersErrorCase> {
+  // Reset de senha tem copy genérica distinta — refere ao recurso
+  // ("a senha"), não ao usuário. Mantemos o branch isolado para que
+  // os demais verbos preservem o template "Não foi possível {verb}
+  // o usuário..." sem regredir.
+  const networkExpectedText =
+    verb === 'redefinir senha do'
+      ? 'Não foi possível redefinir a senha. Tente novamente.'
+      : `Não foi possível ${verb} o usuário. Tente novamente.`;
   return [
     {
       name: '401 dispara toast vermelho com mensagem do backend',
@@ -545,7 +619,7 @@ export function buildSharedUserMutationErrorCases(
     {
       name: 'erro genérico de rede dispara toast vermelho genérico',
       error: { kind: 'network', message: 'Falha de conexão.' },
-      expectedText: `Não foi possível ${verb} o usuário. Tente novamente.`,
+      expectedText: networkExpectedText,
     },
   ];
 }
@@ -560,4 +634,79 @@ export function buildSharedUserSubmitErrorCases(
   verb: 'criar' | 'atualizar',
 ): ReadonlyArray<UsersErrorCase> {
   return buildSharedUserMutationErrorCases(verb);
+}
+
+/* ─── Helpers para suíte de reset de senha (Issue #81) ──────── */
+
+/**
+ * Mocka a resposta inicial (listagem com o usuário-alvo), renderiza a
+ * `UsersListShellPage`, espera a lista carregar e clica no botão
+ * "Redefinir senha" da linha do usuário informado. Espelha
+ * `openEditUserModal`/`openToggleUserActiveConfirm` mas dispara o
+ * `ResetUserPasswordConfirm` — Issue #81.
+ *
+ * Quem precisar de mocks diferentes (ex.: cenários de erro 404 com
+ * refetch) pode chamar `client.get.mockImplementation(...)` antes de
+ * invocar este helper — a detecção de mocks pré-existentes preserva
+ * o caso "fila customizada de respostas".
+ */
+export async function openResetUserPasswordModal(
+  client: ApiClientStub,
+  options: { user?: UserDto } = {},
+): Promise<void> {
+  const user = options.user ?? makeUser();
+  if (
+    client.get.getMockImplementation() === undefined &&
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.resolve(makeUsersPagedResponse([user]));
+      }
+      if (typeof path === 'string' && path.startsWith('/clients/')) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    });
+  }
+  renderUsersPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`users-reset-password-${user.id}`));
+  // Aguarda a abertura do modal — a presença do form indica que o
+  // `useEffect` de sincronização já rodou.
+  await waitFor(() => {
+    expect(screen.getByTestId('reset-user-password-form')).toBeInTheDocument();
+  });
+}
+
+/**
+ * Preenche o campo "Nova senha" do `ResetUserPasswordConfirm`. Helper
+ * trivial mantido por simetria com `fillNewUserForm`/`fillEditUserForm`
+ * — testes que validam campo vazio (validação client-side) chamam
+ * sem `password` ou com string vazia.
+ */
+export function fillResetUserPasswordForm(values: { password?: string }): void {
+  if (values.password !== undefined) {
+    fireEvent.change(screen.getByTestId('reset-user-password-input'), {
+      target: { value: values.password },
+    });
+  }
+}
+
+/**
+ * Submete o form do `ResetUserPasswordConfirm` e aguarda o
+ * `client.put` ser chamado pelo menos `expectedPutCalls` vezes
+ * (default `1`). Faz o `act(async)` necessário para flushar a
+ * microtask do submit — espelha `submitEditUserForm`.
+ */
+export async function submitResetUserPasswordForm(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('reset-user-password-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
 }

--- a/tests/pages/users/UserResetPassword.test.tsx
+++ b/tests/pages/users/UserResetPassword.test.tsx
@@ -1,0 +1,448 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildSharedUserMutationErrorCases,
+  buildUsersCloseCases,
+  createUsersClientStub,
+  fillResetUserPasswordForm,
+  ID_USER_ALICE,
+  makeUser,
+  mockUserListResponse,
+  mockUserListResponseWithCounter,
+  openResetUserPasswordModal,
+  renderUsersPage,
+  submitResetUserPasswordForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+  type UsersErrorCase,
+} from '../__helpers__/usersTestHelpers';
+
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Suíte do `ResetUserPasswordConfirm` (Issue #81, EPIC #49).
+ *
+ * Espelha `UserActivateToggle.test.tsx`/`SystemsPage.delete.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory para que `vi.mock` capture o valor atual a cada
+ *   `useAuth()`).
+ * - Stub de `ApiClient` injetado em `<UsersListShellPage client={stub} />`
+ *   isolando a página da camada de transporte real.
+ * - Helpers compartilhados em `tests/pages/__helpers__/usersTestHelpers.tsx`
+ *   (lições PR #127/#128/#134/#135 — colapsar boilerplate via helpers
+ *   antes do segundo call site).
+ *
+ * **Decisão chave de implementação:** o reset usa endpoint dedicado
+ * (`PUT /users/{id}/password`) com body `{ password }` apenas. O modal
+ * reusa `useEditEntitySubmit` do shared/forms (mesmo padrão do
+ * `EditUserModal`) para o ciclo de submit — isso evita duplicação ≥10
+ * linhas com o try/catch/classify/finally de outros modals do recurso.
+ *
+ * **Diferença vs Toggle Active (#80):** o reset tem campo de form
+ * (campo de senha), então não reusa `MutationConfirmModal` (que é
+ * estritamente sem form). A interface visual segue `EditUserModal`
+ * mas com um único campo.
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const USERS_UPDATE_PERMISSION = 'AUTH_V1_USERS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('UsersListShellPage — reset de senha (Issue #81)', () => {
+  describe('gating do botão "Redefinir senha" por linha', () => {
+    it('não exibe botão "Redefinir senha" quando o usuário não possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [];
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [makeUser()]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`users-reset-password-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Redefinir senha" quando o usuário possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [makeUser()]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`users-reset-password-${ID_USER_ALICE}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute(
+        'aria-label',
+        'Redefinir senha do usuário Alice Admin',
+      );
+      expect(btn).toHaveTextContent('Redefinir senha');
+    });
+
+    it('NÃO exibe botão "Redefinir senha" em linhas soft-deletadas mesmo com permissão', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const deletedUser = makeUser({ deletedAt: '2026-02-01T00:00:00Z' });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [deletedUser]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      // Soft-deleted: nenhuma ação aparece — alinha com a coluna
+      // Status (badge "Inativa") e com a UX de Editar/Desativar
+      // (não faz sentido redefinir senha de uma linha já soft-deletada,
+      // o backend devolveria 404 mesmo).
+      expect(
+        screen.queryByTestId(`users-reset-password-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do modal de reset', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('clicar em "Redefinir senha" abre o modal com nome e e-mail do usuário', async () => {
+      const user = makeUser({
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+      });
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client, { user });
+
+      // Título do modal — `getByRole('heading')` evita ambiguidade com
+      // o botão "Redefinir senha" (que também contém o mesmo texto).
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /Redefinir senha/i }),
+      ).toBeInTheDocument();
+      const description = screen.getByTestId('reset-user-password-description');
+      expect(description).toHaveTextContent('Alice Admin');
+      expect(description).toHaveTextContent('alice@example.com');
+    });
+
+    it('campo "Nova senha" começa vazio e o submit fica habilitado (validação só dispara no submit)', async () => {
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client);
+
+      const input = screen.getByTestId('reset-user-password-input') as HTMLInputElement;
+      expect(input.value).toBe('');
+      // Type=password mascara a entrada — confirma que o form não
+      // expõe a senha em texto claro inadvertidamente.
+      expect(input.type).toBe('password');
+
+      // Botão de submit habilitado mesmo com campo vazio — validação
+      // só exibe erro inline após o usuário tentar submeter
+      // (mesmo padrão dos demais modals do recurso).
+      const submit = screen.getByTestId('reset-user-password-submit');
+      expect(submit).not.toBeDisabled();
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildUsersCloseCases`.
+     */
+    const CLOSE_CASES = buildUsersCloseCases('reset-user-password-cancel');
+
+    it.each(CLOSE_CASES)(
+      'fechar via $name não dispara PUT',
+      async ({ close }) => {
+        const client = createUsersClientStub();
+        await openResetUserPasswordModal(client);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(client.put).not.toHaveBeenCalled();
+      },
+    );
+
+    it('reabrir o modal limpa estado anterior (campo vazio, sem erros)', async () => {
+      const client = createUsersClientStub();
+      // Primeiro: abrir, digitar, fechar.
+      await openResetUserPasswordModal(client);
+      fillResetUserPasswordForm({ password: 'senha-anterior' });
+      fireEvent.click(screen.getByTestId('reset-user-password-cancel'));
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Reabrir: o campo deve estar vazio (não traz "senha-anterior").
+      fireEvent.click(screen.getByTestId(`users-reset-password-${ID_USER_ALICE}`));
+      await waitFor(() => {
+        expect(screen.getByTestId('reset-user-password-form')).toBeInTheDocument();
+      });
+      const input = screen.getByTestId(
+        'reset-user-password-input',
+      ) as HTMLInputElement;
+      expect(input.value).toBe('');
+    });
+  });
+
+  describe('validação client-side', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('exibe erro inline e NÃO dispara PUT quando o campo está vazio', async () => {
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client);
+
+      // Submit sem digitar nada — validação client-side reprova.
+      fireEvent.submit(screen.getByTestId('reset-user-password-form'));
+
+      expect(
+        await screen.findByText('Nova senha é obrigatória.'),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+      // Modal continua aberto — operador corrige e tenta de novo.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('exibe erro inline quando a senha tem menos que o mínimo (8 chars)', async () => {
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client);
+
+      fillResetUserPasswordForm({ password: 'curta' });
+      fireEvent.submit(screen.getByTestId('reset-user-password-form'));
+
+      expect(
+        await screen.findByText(/Nova senha deve ter ao menos 8 caracteres\./i),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it('exibe erro inline quando a senha contém apenas espaços', async () => {
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client);
+
+      fillResetUserPasswordForm({ password: '          ' });
+      fireEvent.submit(screen.getByTestId('reset-user-password-form'));
+
+      expect(
+        await screen.findByText('Nova senha não pode ser apenas espaços.'),
+      ).toBeInTheDocument();
+      expect(client.put).not.toHaveBeenCalled();
+    });
+
+    it('digitar no campo após erro client-side limpa o erro inline', async () => {
+      const client = createUsersClientStub();
+      await openResetUserPasswordModal(client);
+
+      // 1) Submit com vazio → erro inline.
+      fireEvent.submit(screen.getByTestId('reset-user-password-form'));
+      expect(
+        await screen.findByText('Nova senha é obrigatória.'),
+      ).toBeInTheDocument();
+
+      // 2) Digitar → erro some imediatamente.
+      fillResetUserPasswordForm({ password: 'a' });
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Nova senha é obrigatória.'),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('envia PUT /users/{id}/password com a nova senha, fecha modal, exibe toast e refaz listUsers', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      const getUserListCallCount = mockUserListResponseWithCounter(client, [target]);
+      client.put.mockResolvedValueOnce({
+        ...target,
+        updatedAt: '2026-02-01T12:00:00Z',
+      });
+
+      await openResetUserPasswordModal(client, { user: target });
+      fillResetUserPasswordForm({ password: 'senha-forte-123' });
+      await submitResetUserPasswordForm(client);
+
+      // Path + body conforme contrato do backend
+      // (`PUT /users/{id}/password`).
+      expect(client.put).toHaveBeenCalledWith(
+        `/users/${ID_USER_ALICE}/password`,
+        { password: 'senha-forte-123' },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde — copy declarada em `ResetUserPasswordConfirm`.
+      expect(await screen.findByText('Senha redefinida.')).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez na rota
+      // `/users` após o PUT bem-sucedido.
+      await waitFor(() => {
+        expect(getUserListCallCount()).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('preserva a senha literal no body (sem trim no transporte)', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [target]);
+      client.put.mockResolvedValueOnce(target);
+
+      await openResetUserPasswordModal(client, { user: target });
+      // Senha com espaços laterais — o backend trima ao receber, mas
+      // o frontend transmite literal para preservar simetria com
+      // gerenciadores de senha que produzem strings com prefix/suffix.
+      fillResetUserPasswordForm({ password: '  com-espacos-laterais  ' });
+      await submitResetUserPasswordForm(client);
+
+      const calledWith = client.put.mock.calls[0][1] as Record<string, unknown>;
+      expect(calledWith.password).toBe('  com-espacos-laterais  ');
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('400 com errors.Password mapeia mensagem inline no campo', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [target]);
+      client.put.mockRejectedValueOnce({
+        kind: 'http',
+        status: 400,
+        message: 'Erro de validação.',
+        details: {
+          errors: {
+            Password: ['Password deve ter no máximo 60 caracteres.'],
+          },
+        },
+      } satisfies ApiError);
+
+      await openResetUserPasswordModal(client, { user: target });
+      fillResetUserPasswordForm({ password: 'senha-valida-12' });
+      await submitResetUserPasswordForm(client);
+
+      expect(
+        await screen.findByText('Password deve ter no máximo 60 caracteres.'),
+      ).toBeInTheDocument();
+      // Modal continua aberto — operador corrige e tenta de novo.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('400 sem errors mapeáveis cai no Alert no topo do form', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [target]);
+      client.put.mockRejectedValueOnce({
+        kind: 'http',
+        status: 400,
+        message: 'Erro inesperado.',
+      } satisfies ApiError);
+
+      await openResetUserPasswordModal(client, { user: target });
+      fillResetUserPasswordForm({ password: 'senha-valida-12' });
+      await submitResetUserPasswordForm(client);
+
+      // Alert no topo do form (não inline no campo) — fallback do
+      // `applyBadRequest` quando não há `errors.Password` mapeável.
+      expect(await screen.findByText('Erro inesperado.')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    /**
+     * Cenários comuns de erro mapeados — 401/403/network. Casos comuns
+     * vêm do helper compartilhado `buildSharedUserMutationErrorCases`
+     * (lição PR #128 — pré-projetar shared helpers para evitar
+     * duplicação literal entre suítes que diferem só pelo verbo).
+     *
+     * Caso específico (404 — usuário removido entre abertura e
+     * confirm) fica inline porque o comportamento difere: modal fecha
+     * + dispara refetch (paridade com o tratamento de 404 no edit).
+     */
+    const ERROR_CASES: ReadonlyArray<UsersErrorCase> = [
+      {
+        name: '404 (usuário já removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Usuário não encontrado.',
+        },
+        expectedText:
+          'Usuário não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+      ...buildSharedUserMutationErrorCases('redefinir senha do'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const target = makeUser({ id: ID_USER_ALICE });
+        const client = createUsersClientStub();
+        mockUserListResponse(client, [target]);
+        client.put.mockRejectedValueOnce(error);
+
+        await openResetUserPasswordModal(client, { user: target });
+        fillResetUserPasswordForm({ password: 'senha-valida-12' });
+        await submitResetUserPasswordForm(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onResetCompleted chamado mesmo em erro)', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      const getUserListCallCount = mockUserListResponseWithCounter(client, [target]);
+      client.put.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Usuário não encontrado.',
+      } satisfies ApiError);
+
+      await openResetUserPasswordModal(client, { user: target });
+      fillResetUserPasswordForm({ password: 'senha-valida-12' });
+      await submitResetUserPasswordForm(client);
+
+      await waitFor(() => {
+        expect(getUserListCallCount()).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+});

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -13,6 +13,7 @@ import {
   isPagedUsersResponse,
   isUserDto,
   listUsers,
+  resetUserPassword,
   updateUser,
 } from '@/shared/api';
 
@@ -831,6 +832,134 @@ describe('updateUser — response e erros', () => {
 
     await expect(
       updateUser(USER_ID, buildBasicPayload(), undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
+  });
+});
+
+/* ─── resetUserPassword (Issue #81) ──────────────────────── */
+
+describe('resetUserPassword — body e path', () => {
+  it('emite PUT /users/{id}/password com body { password } literal (sem trim)', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await resetUserPassword(
+      USER_ID,
+      '  senha-com-espacos  ',
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    expect(client.put.mock.calls[0][0]).toBe(`/users/${USER_ID}/password`);
+    // Frontend NÃO trima — backend faz `request.Password.Trim()` ao
+    // receber. Preservar literal no transporte garante simetria com
+    // o que o operador digitou (e com gerenciadores de senha que
+    // produzem strings com prefix/suffix intencionais).
+    expect(client.put.mock.calls[0][1]).toEqual({
+      password: '  senha-com-espacos  ',
+    });
+  });
+
+  it('passa options adiante para o cliente (signal/abort)', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+    const controller = new AbortController();
+
+    await resetUserPassword(
+      USER_ID,
+      'nova-senha',
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.put.mock.calls[0][2]).toEqual({ signal: controller.signal });
+  });
+
+  it('só inclui a chave password no body (não vaza outros campos)', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce(makeUserDto());
+
+    await resetUserPassword(
+      USER_ID,
+      'nova-senha',
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    const body = client.put.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(['password']);
+  });
+});
+
+describe('resetUserPassword — response e erros', () => {
+  it('devolve UserDto atualizado quando o response é válido', async () => {
+    const client = createStub();
+    const updated = makeUserDto({ updatedAt: '2026-02-01T12:00:00Z' });
+    client.put.mockResolvedValueOnce(updated);
+
+    const result = await resetUserPassword(
+      USER_ID,
+      'nova-senha',
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(updated);
+  });
+
+  it('lança ApiError(parse) quando o response não é UserDto', async () => {
+    const client = createStub();
+    client.put.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 400 com errors.Password (validação de campo) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message: 'Erro de validação.',
+      details: {
+        errors: {
+          Password: ['Password deve ter no máximo 60 caracteres.'],
+        },
+      },
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      resetUserPassword(USER_ID, 'x'.repeat(120), undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 404 do backend (usuário removido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Usuário não encontrado.',
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
     ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
 });


### PR DESCRIPTION
## Contexto

Issue #81 (EPIC #49 — gestão de usuários). Operadores precisavam de uma forma de redefinir a senha de outros usuários sem ter que excluir/recriar — o backend `lfc-authenticator` já expõe `PUT /users/{id}/password` (issue lfc-authenticator anterior), mas o frontend ainda não consumia.

## Objetivo

- Permitir reset de senha por linha na `UsersListShellPage`.
- Confirmação antes do disparo (modal com campo "Nova senha").
- Toast de sucesso/erro em todos os caminhos.
- Visível com `Users.Update` (mesma policy do edit/toggle).

## O que foi feito

### `src/shared/api/users.ts`
- Nova função `resetUserPassword(id, password, options?, client?)` consumindo `PUT /users/{id}/password`.
- Tipo `ResetUserPasswordPayload` exportável (`{ password }`).
- Response validado contra `isUserDto` para detectar drift de contrato.
- Senha transmitida **literal** (sem trim no frontend) — backend faz `request.Password.Trim()` ao receber; preserva simetria com gerenciadores de senha.

### `src/pages/users/ResetUserPasswordConfirm.tsx` (novo)
- Modal com campo único "Nova senha" (`<Input type="password">`, `autoComplete="new-password"`).
- Validação client-side (obrigatório, sem só espaços, mínimo 8 chars, máximo 60 chars) espelhando `UpdatePasswordRequest` do backend + `PASSWORD_MIN`/`PASSWORD_MAX` reusados de `userFormShared.ts`.
- Reusa `useEditEntitySubmit<'password'>` do `shared/forms` para o ciclo `try/catch/finally` + `classifyApiSubmitError` + `applyEditSubmitAction` (eliminação de duplicação `EditUserModal`-like, lições PR #134/#135).
- Mapeamento de erros:
  - 400 com `errors.Password` → mensagem inline no campo.
  - 400 sem `errors` mapeáveis → `<Alert>` no topo do form.
  - 404 → toast vermelho + fecha modal + refetch (paridade com `EditUserModal`).
  - 401/403 → toast vermelho com mensagem do backend.
  - Demais → toast vermelho com fallback genérico.
- Sucesso: toast verde "Senha redefinida." + `onResetCompleted()` (refetch) + `onClose()`.

### `src/pages/users/UsersListShellPage.tsx`
- Botão "Redefinir senha" (ícone `KeyRound`) entre Editar e Desativar/Ativar nas ações por linha.
- Gating `Users.Update` (mesma da edição/toggle); oculto em linhas soft-deletadas.
- Estado via `useListModalState<UserDto>()` + render condicional do modal.

### Testes
- `tests/shared/api/users.test.ts` (+9 testes): path, body, options, response válido/inválido, 400 com `errors.Password`, 404, 401/403.
- `tests/pages/users/UserResetPassword.test.tsx` (novo, 22 testes): gating de permissão, gating em soft-delete, abertura, fechamento (Esc/Cancelar/backdrop, via `it.each` + `buildUsersCloseCases`), reabertura limpa estado, validação client-side (vazio/curto demais/só-espaços), digitar limpa erro inline, sucesso (path + body literal + toast + refetch), 400 inline, 400 fallback no Alert, 404 fecha modal + refetch, 401/403/network via `buildSharedUserMutationErrorCases('redefinir senha do')`.
- Helpers compartilhados em `tests/pages/__helpers__/usersTestHelpers.tsx`: `mockUserListResponse`, `mockUserListResponseWithCounter`, `openResetUserPasswordModal`, `fillResetUserPasswordForm`, `submitResetUserPasswordForm`, `buildSharedUserMutationErrorCases` ampliada com verbo `'redefinir senha do'` (mantém retro-compat dos demais verbos).

## Arquivos impactados

- `src/shared/api/users.ts` — `resetUserPassword` + `ResetUserPasswordPayload`.
- `src/shared/api/index.ts` — re-export.
- `src/pages/users/ResetUserPasswordConfirm.tsx` — novo modal.
- `src/pages/users/UsersListShellPage.tsx` — botão + estado + render.
- `src/pages/users/index.ts` — re-export.
- `tests/shared/api/users.test.ts` — bloco `resetUserPassword`.
- `tests/pages/users/UserResetPassword.test.tsx` — suíte UI nova.
- `tests/pages/__helpers__/usersTestHelpers.tsx` — helpers compartilhados.

## Testes

Todos os comandos do gate pré-PR rodaram via container e aprovaram:

- `npm run lint` → 0 erros, 0 warnings.
- `npm run typecheck` → 0 erros.
- `npx vitest run --pool=forks` → **1168/1168 verdes**.
- `npx jscpd src --threshold 3 --min-lines 10` → **2.35% (≤3%)**, zero clones envolvendo arquivos do diff em `src/`.

> O `--pool=forks` no run de testes foi necessário pela flakiness do pool default (threads) sob carga no container — em modo determinístico todos passam. Em isolamento (`vitest run <arquivo>`) cada suíte do diff também passa 100%.

## Visual

- Modal segue o padrão dos demais form modals do recurso (`Modal` + `<form>` + `<Alert>` + `Input` + `FormFooter`).
- Bloco de contexto destacando `<strong>name</strong>` + `(<Mono>email</Mono>)` espelha o visual de `MutationConfirmModal` (toggle ativo/desativado).
- Sem hardcode de cor — todos os tokens via `var(--space-*)`/`var(--text-*)`/`var(--fg*)`/`var(--bg-elevated)`/`var(--radius-sm)`.
- Estados: hover/focus herdados dos componentes do design system; `loading` no botão "Redefinir senha"; `disabled` em todos os controles durante submit; `error` inline no `<Input>`; `Alert` no topo do form para 400 sem `errors` mapeáveis; `not-found` fecha modal + toast.
- `data-modal-initial-focus` no campo de senha para foco automático ao abrir.
- `closeOnEsc`/`closeOnBackdrop` desligados durante submit (evita request órfã).

## Segurança

- Campo de senha usa `<Input type="password">` (entrada mascarada no render) e `autoComplete="new-password"` (gerenciadores não preenchem com senhas salvas do operador).
- A senha **não** é serializada em URL (vai no body do `PUT`).
- Sem hash/manipulação client-side — backend faz `UserPasswordHasher.HashPlainPassword(password.Trim())` antes de persistir.
- Sem `console.log` da senha em qualquer ponto.
- Sem `dangerouslySetInnerHTML` ou interpolação não-sanitizada de `name`/`email` na descrição do modal (renderizado via JSX literal).
- Frontend transmite a senha literal sem trim — preserva intencionalidade do operador (ex.: gerenciadores de senha que produzem strings com espaços).

## Riscos

- **Flakiness do test runner** (não relacionado ao código): em alguns runs no container, o pool default (threads) falha 1-2 testes pré-existentes por timeout (`App.test.tsx`, `RoutesPage.create.test.tsx`, etc.) — em `--pool=forks` ou em isolamento todos passam consistentemente. Não é regressão deste PR.
- **Sem confirmação por senha do operador** (fora de escopo da issue) — qualquer operador com `Users.Update` pode disparar reset. Se a postura mudar, dá pra adicionar campo de confirmação no mesmo modal.

## Issue relacionada

Closes #81