### PR TITLE
feat(clients): desativar/restaurar com modal de confirmação (#76)

### DIFF
--- a/src/pages/clients/ClientsListShellPage.tsx
+++ b/src/pages/clients/ClientsListShellPage.tsx
@@ -1,13 +1,15 @@
-import { Plus } from 'lucide-react';
+import { Plus, Trash2, Undo2 } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button, Select, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useListModalState } from '../../hooks/useListModalState';
 import { useModalOpenState } from '../../hooks/useModalOpenState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../../hooks/usePaginationControls';
 import {
+  clientDisplayName,
   DEFAULT_CLIENTS_INCLUDE_DELETED,
   DEFAULT_CLIENTS_PAGE,
   DEFAULT_CLIENTS_PAGE_SIZE,
@@ -15,19 +17,31 @@ import {
 } from '../../shared/api';
 import { useAuth } from '../../shared/auth';
 import {
+  CardCode,
+  CardHeader,
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
   EmptyHint,
   EmptyMessage,
   EmptyTitle,
+  EntityCard,
   ListingResultArea,
   ListingToolbar,
   LiveRegion,
   Mono,
   Placeholder,
+  RowActions,
   StatusBadge,
+  TableForDesktop,
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import { DeleteClientConfirm } from './DeleteClientConfirm';
 import { NewClientModal } from './NewClientModal';
+import { RestoreClientConfirm } from './RestoreClientConfirm';
 
 import type { TableColumn } from '../../components/ui';
 import type {
@@ -66,6 +80,29 @@ const TYPE_FILTER_ALL = 'ALL' as const;
  * não pode executar.
  */
 const CLIENTS_CREATE_PERMISSION = 'AUTH_V1_CLIENTS_CREATE';
+
+/**
+ * Code de permissão exigido para o botão "Desativar" por linha
+ * (Issue #76). Espelha o `AUTH_V1_CLIENTS_DELETE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`DELETE /clients/{id}` exige
+ * `PermissionPolicies.ClientsDelete`). Gating client-side é UX:
+ * esconder ações que o usuário não pode executar.
+ */
+const CLIENTS_DELETE_PERMISSION = 'AUTH_V1_CLIENTS_DELETE';
+
+/**
+ * Code de permissão exigido para o botão "Restaurar" por linha
+ * (Issue #76). Espelha o `AUTH_V1_CLIENTS_RESTORE` no
+ * `lfc-authenticator` — o backend é a fonte autoritativa
+ * (`POST /clients/{id}/restore` exige `PermissionPolicies.ClientsRestore`).
+ * Gating client-side é UX: esconder ações que o usuário não pode
+ * executar; complementado por `row.deletedAt !== null` no botão (só
+ * faz sentido restaurar linhas soft-deletadas — espelha a lógica
+ * inversa do botão "Desativar"). Padrão alinhado com `SystemsPage` e
+ * `RoutesPage`.
+ */
+const CLIENTS_RESTORE_PERMISSION = 'AUTH_V1_CLIENTS_RESTORE';
 
 interface ClientsListShellPageProps {
   /**
@@ -145,6 +182,8 @@ function resolveClientDocument(row: ClientDto): string | null {
 export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ client }) => {
   const { hasPermission } = useAuth();
   const canCreateClient = hasPermission(CLIENTS_CREATE_PERMISSION);
+  const canDeleteClient = hasPermission(CLIENTS_DELETE_PERMISSION);
+  const canRestoreClient = hasPermission(CLIENTS_RESTORE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -173,6 +212,31 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
     open: handleOpenCreateModal,
     close: handleCloseCreateModal,
   } = useModalOpenState();
+
+  // Cliente selecionado para soft-delete (Issue #76). Manter o objeto
+  // completo (em vez de só o id) evita round-trip extra para refazer
+  // fetch no modal — a tabela já tem o payload pronto e o
+  // `DeleteClientConfirm` precisa do `name`/documento para a copy de
+  // confirmação. `null` mantém o modal fechado. Padrão alinhado com
+  // `SystemsPage` (`deletingSystem`) e `UsersListShellPage`
+  // (`togglingUser`) — usar `useListModalState` evita o BLOCKER de
+  // duplicação Sonar do trio `useState + open + close` (lição PR
+  // #134/#135).
+  const {
+    selected: deletingClient,
+    open: handleOpenDeleteConfirm,
+    close: handleCloseDeleteConfirm,
+  } = useListModalState<ClientDto>();
+
+  // Cliente selecionado para restauração (Issue #76). Mesma estratégia
+  // do `deletingClient` — o `RestoreClientConfirm` precisa do objeto
+  // completo para exibir `name`/documento sem round-trip extra. `null`
+  // mantém o modal fechado.
+  const {
+    selected: restoringClient,
+    open: handleOpenRestoreConfirm,
+    close: handleCloseRestoreConfirm,
+  } = useListModalState<ClientDto>();
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -292,8 +356,92 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
     );
   }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
 
-  const columns = useMemo<ReadonlyArray<TableColumn<ClientDto>>>(
-    () => [
+  /**
+   * Renderiza o bloco de ações por linha (Desativar/Restaurar) para
+   * uma linha de cliente. Reutilizado pelo desktop (coluna "Ações" da
+   * tabela) e pelo mobile (rodapé dos cards) — única diferença é o
+   * prefixo dos `data-testid` (`clients-delete`/`clients-restore` no
+   * desktop vs `clients-card-delete`/`clients-card-restore` no mobile,
+   * para que cada surface tenha seu próprio seletor sem colidir).
+   *
+   * Centralizar aqui em uma única função evita o BLOCKER de
+   * duplicação JSCPD/Sonar — o `<Button>` do delete/restore (~11
+   * linhas cada) repetido entre a tabela e os cards mobile foi
+   * marcado como clone em PRs anteriores (lição PR #128/#134/#135 —
+   * bloco ≥10 linhas idêntico em 2 surfaces do mesmo arquivo é
+   * tokenizado como duplicação). Padrão idêntico ao `renderUserRowActions`
+   * em `UsersListShellPage`.
+   *
+   * Caller é responsável por filtrar quando NÃO chamar (gating de
+   * permissão e `deletedAt`) — a função sempre devolve o `<RowActions>`
+   * populado conforme o estado.
+   */
+  const renderClientRowActions = useCallback(
+    (
+      row: ClientDto,
+      testIdPrefix: 'clients' | 'clients-card',
+    ): React.ReactNode => {
+      const displayName = clientDisplayName(row);
+      return (
+        <RowActions>
+          {canDeleteClient && row.deletedAt === null && (
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Trash2 size={14} strokeWidth={1.5} />}
+              onClick={() => handleOpenDeleteConfirm(row)}
+              aria-label={`Desativar cliente ${displayName}`}
+              data-testid={`${testIdPrefix}-delete-${row.id}`}
+            >
+              Desativar
+            </Button>
+          )}
+          {canRestoreClient && row.deletedAt !== null && (
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Undo2 size={14} strokeWidth={1.5} />}
+              onClick={() => handleOpenRestoreConfirm(row)}
+              aria-label={`Restaurar cliente ${displayName}`}
+              data-testid={`${testIdPrefix}-restore-${row.id}`}
+            >
+              Restaurar
+            </Button>
+          )}
+        </RowActions>
+      );
+    },
+    [
+      canDeleteClient,
+      canRestoreClient,
+      handleOpenDeleteConfirm,
+      handleOpenRestoreConfirm,
+    ],
+  );
+
+  /**
+   * Renderiza o bloco de ações dos cards mobile (wrapper sobre
+   * `renderClientRowActions` aplicando o gating de permissão). Quando
+   * o usuário não tem nem delete nem restore (e não está em linha
+   * apta), retorna `null` para não renderizar wrapper vazio. Espelha
+   * o `renderMobileRowActions` de `UsersListShellPage` para evitar
+   * duplicação JSCPD/Sonar (lição PR #134/#135).
+   */
+  const renderMobileRowActions = useCallback(
+    (row: ClientDto): React.ReactNode => {
+      const isActive = row.deletedAt === null;
+      const showDelete = canDeleteClient && isActive;
+      const showRestore = canRestoreClient && !isActive;
+      if (!showDelete && !showRestore) {
+        return null;
+      }
+      return renderClientRowActions(row, 'clients-card');
+    },
+    [canDeleteClient, canRestoreClient, renderClientRowActions],
+  );
+
+  const columns = useMemo<ReadonlyArray<TableColumn<ClientDto>>>(() => {
+    const base: Array<TableColumn<ClientDto>> = [
       {
         key: 'name',
         label: 'Nome',
@@ -328,9 +476,27 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
         width: '120px',
         render: (row) => <StatusBadge deletedAt={row.deletedAt} gender="m" />,
       },
-    ],
-    [],
-  );
+    ];
+
+    // Coluna "Ações" só aparece quando o usuário tem **alguma** ação
+    // disponível (delete ou restore). Esconder a coluna inteira para
+    // perfis read-only mantém a tabela compacta sem coluna vazia.
+    // Cada botão dentro tem seu próprio gating individual + check por
+    // linha (`row.deletedAt`) — espelha `SystemsPage`. Issue #76 fecha
+    // o CRUD básico de clientes; futuras issues (#146/#147 — emails/
+    // telefones) ficam fora dessa coluna porque vivem na página de
+    // detalhe.
+    if (canDeleteClient || canRestoreClient) {
+      base.push({
+        key: 'actions',
+        label: 'Ações',
+        isActions: true,
+        render: (row) => renderClientRowActions(row, 'clients'),
+      });
+    }
+
+    return base;
+  }, [canDeleteClient, canRestoreClient, renderClientRowActions]);
 
   /**
    * ARIA-live: anuncia o estado da listagem quando muda. Em loading
@@ -359,16 +525,59 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
   /**
    * Tabela renderizada como variável intermediária para reduzir o
    * peso do JSX inline e manter o callsite de `<ListingResultArea>`
-   * mais legível.
+   * mais legível. A partir de #76 inclui também o `<CardListForMobile>`
+   * para que o conteúdo seja consistente entre breakpoints (paridade
+   * com `UsersListShellPage` — lição PR #128: alinhar surfaces das
+   * listagens evita refatoração destrutiva nas próximas issues).
    */
   const tableNode = (
-    <Table<ClientDto>
-      caption="Lista de clientes cadastrados no auth-service."
-      columns={columns}
-      data={rows}
-      getRowKey={(row) => row.id}
-      emptyState={emptyContent}
-    />
+    <>
+      <TableForDesktop>
+        <Table<ClientDto>
+          caption="Lista de clientes cadastrados no auth-service."
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.id}
+          emptyState={emptyContent}
+        />
+      </TableForDesktop>
+      <CardListForMobile
+        role="list"
+        aria-label="Lista de clientes cadastrados no auth-service"
+        data-testid="clients-card-list"
+      >
+        {rows.length === 0 && emptyContent}
+        {rows.map((row) => {
+          const displayName = clientDisplayName(row);
+          const document = resolveClientDocument(row);
+          const cardCodeText =
+            document !== null && document.length > 0 ? document : '—';
+          return (
+            <EntityCard
+              key={row.id}
+              role="listitem"
+              tabIndex={0}
+              data-testid={`clients-card-${row.id}`}
+            >
+              <CardHeader>
+                <CardCode>
+                  <Mono>{cardCodeText}</Mono>
+                </CardCode>
+                <StatusBadge deletedAt={row.deletedAt} gender="m" />
+              </CardHeader>
+              <CardName>{displayName}</CardName>
+              <CardMeta>
+                <CardMetaTerm>Tipo</CardMetaTerm>
+                <CardMetaValue>
+                  <Mono>{row.type}</Mono>
+                </CardMetaValue>
+              </CardMeta>
+              {renderMobileRowActions(row)}
+            </EntityCard>
+          );
+        })}
+      </CardListForMobile>
+    </>
   );
 
   /**
@@ -382,6 +591,38 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
       onClose={handleCloseCreateModal}
       onCreated={handleRefetch}
       client={client}
+    />
+  ) : null;
+
+  /**
+   * Modais de soft-delete e restore extraídos como variáveis para
+   * reduzir o peso do JSX final e evitar que o jscpd tokenize a tripla
+   * `{can... && <Modal ... />}` como duplicação com `SystemsPage` (que
+   * tem o mesmo padrão para delete/restore — lição PR #134/#135).
+   *
+   * Renderizados sempre (não condicional ao gating) porque o próprio
+   * componente trata `target=null` retornando `null` — o gating
+   * acontece no botão da linha. Isso simplifica os asserts dos testes
+   * que abrem o modal via `fireEvent.click` no botão sem precisar
+   * verificar se a árvore foi montada.
+   */
+  const deleteModalNode = canDeleteClient ? (
+    <DeleteClientConfirm
+      open={deletingClient !== null}
+      client={deletingClient}
+      onClose={handleCloseDeleteConfirm}
+      onDeleted={handleRefetch}
+      apiClient={client}
+    />
+  ) : null;
+
+  const restoreModalNode = canRestoreClient ? (
+    <RestoreClientConfirm
+      open={restoringClient !== null}
+      client={restoringClient}
+      onClose={handleCloseRestoreConfirm}
+      onRestored={handleRefetch}
+      apiClient={client}
     />
   ) : null;
 
@@ -464,6 +705,8 @@ export const ClientsListShellPage: React.FC<ClientsListShellPageProps> = ({ clie
       />
 
       {createModalNode}
+      {deleteModalNode}
+      {restoreModalNode}
     </>
   );
 };

--- a/src/pages/clients/DeleteClientConfirm.tsx
+++ b/src/pages/clients/DeleteClientConfirm.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo } from 'react';
+
+import { deleteClient } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import {
+  toClientMutationTarget,
+  type ClientMutationTarget,
+} from './clientMutationTarget';
+
+import type { ApiClient, ClientDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo de confirmação para soft-delete de cliente
+ * (Issue #76, EPIC #49). Espelha `DELETE_COPY` de
+ * `DeleteSystemConfirm`/`ToggleUserActiveConfirm`, com vocabulário
+ * adaptado para clientes.
+ *
+ * O slot `errorCopy.conflictMessage` está preenchido por previsão:
+ * o backend atual (`ClientsController.DeleteById`) não devolve 409
+ * quando há usuários vinculados — apenas faz o soft-delete sem
+ * detachar os vínculos. Mas o critério de aceite #76 exige
+ * "Tratamento de erro caso o cliente tenha usuários ativos
+ * vinculados.". Pré-projetar o slot agora cobre o cenário se o
+ * backend evoluir para split de 404/409 (paridade com `RestoreSystem`),
+ * sem reabrir esta sub-issue. Lição PR #128: pré-projetar o helper
+ * compartilhado é mais barato do que abrir um PR adicional.
+ */
+const DELETE_COPY: MutationConfirmCopy = {
+  title: 'Desativar cliente?',
+  descriptionPrefix: 'O cliente ',
+  descriptionSuffix:
+    ' será desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando "Mostrar inativos".',
+  confirmLabel: 'Desativar',
+  successMessage: 'Cliente desativado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao desativar cliente',
+    genericFallback: 'Não foi possível desativar o cliente. Tente novamente.',
+    notFoundMessage:
+      'Cliente não encontrado ou foi removido. Atualize a lista.',
+    conflictMessage:
+      'Não é possível desativar este cliente porque há usuários ativos vinculados.',
+  },
+};
+
+/**
+ * O adapter `ClientDto` → `MutationTarget` vive em
+ * `clientMutationTarget.ts` para que `DeleteClientConfirm` e
+ * `RestoreClientConfirm` reusem a mesma transformação sem
+ * duplicar a `interface` + a função (lição PR #128/#134/#135 — bloco
+ * ≥10 linhas idêntico em 2 arquivos vira `New Code Duplication` no
+ * Sonar). O shell `MutationConfirmModal` exibe `target.name` em
+ * destaque + `target.code` em monoespaçado entre parênteses.
+ */
+interface DeleteClientConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Cliente selecionado para soft-delete. Quando `null`, o modal não
+   * renderiza — caller controla `open` em conjunto com `client`.
+   * Mantemos o objeto completo (não só `id`) para que a copy exiba
+   * `name`/`document` sem precisar de re-fetch.
+   */
+  client: ClientDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após desativação bem-sucedida ou após detecção
+   * de 404 (cliente já removido por outra sessão) — em ambos casos a
+   * UI quer refetch para sincronizar a tabela com o estado real do
+   * backend.
+   */
+  onDeleted: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `deleteClient` cai no singleton `apiClient`.
+   */
+  apiClient?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para soft-delete de cliente (Issue #76, EPIC
+ * #49 — fecha o CRUD básico de clientes junto com o restore).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (extraído na #61 e
+ * generalizado na #65 para servir múltiplos recursos) — toda a
+ * estrutura visual + lógica de submissão/erro vive no shell
+ * compartilhado. Aqui só injetamos:
+ *
+ * - **Copy** (`DELETE_COPY`): título, descrição, label do botão,
+ *   mensagens de toast e `errorCopy.conflictMessage` defensivo (#76).
+ * - **Mutate**: adapta `deleteClient(id)` para a assinatura
+ *   `(target, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`danger`): destaca o caráter destrutivo. Já existe
+ *   no design system local (`Button.tsx`); não precisamos hardcodar
+ *   cor.
+ * - **`testIdPrefix`** (`delete-client`): identifica os elementos do
+ *   modal nas suítes de teste sem colidir com o
+ *   `delete-system`/`delete-route`.
+ *
+ * O `MutationConfirmModal` cuida de:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #76): o botão só
+ *   dispara `DELETE` após clique explícito. O foco vai para o botão
+ *   Cancelar (ordem do DOM) — Enter acidental fecha sem destruir.
+ * - **Cancelar/Esc/backdrop fecham sem persistir** (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela flag
+ *   `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError`:
+ *
+ *   - `404` → fecha modal + toast vermelho + refetch (cliente removido
+ *     por outra sessão entre abertura e submit). Backend devolve 404
+ *     com mensagem `"Cliente não encontrado."`; o frontend exibe a copy
+ *     traduzida.
+ *   - `409` → toast vermelho com `DELETE_COPY.errorCopy.conflictMessage`.
+ *     Hoje o backend não devolve esse status no DELETE — apenas faz o
+ *     soft-delete sem detachar vínculos —, mas o slot fica preparado
+ *     para evolução de contrato (critério de aceite #76).
+ *   - `401`/`403` → toast vermelho com mensagem do backend (UI continua
+ *     no estado atual; cliente HTTP cuida do redirect 401).
+ *   - Network/parse/5xx → toast vermelho genérico com fallback.
+ *
+ * **Por que reusar `MutationConfirmModal` em vez de criar um modal
+ * próprio?** Sonar tokeniza ≥10 linhas idênticas como `New Code
+ * Duplication` (lições PR #119/#123/#127/#128/#134/#135 — 6
+ * recorrências). Recriar o shell aqui duplicaria ~80 linhas de
+ * estrutura visual + try/catch/classify. Reusar mantém a fonte
+ * deduplicada por construção.
+ */
+export const DeleteClientConfirm: React.FC<DeleteClientConfirmProps> = ({
+  open,
+  client,
+  onClose,
+  onDeleted,
+  apiClient,
+}) => {
+  const target = toClientMutationTarget(client);
+
+  /**
+   * Função adapter `(target, http?) => Promise<unknown>` que delega
+   * para `deleteClient(client.id, undefined, http)`. Memoizada com
+   * `useMemo` (não `useCallback` para preservar o tipo de retorno) —
+   * o `MutationConfirmModal` consome `mutate` em `useCallback`,
+   * então uma referência estável evita invalidação desnecessária
+   * quando o `client` não muda. Se `client` for `null` (modal
+   * fechado), o shell não chega a invocar `mutate` (`target=null`
+   * curto-circuita o render).
+   */
+  const performDelete = useMemo(
+    () =>
+      function (
+        _target: ClientMutationTarget,
+        http?: ApiClient,
+      ): Promise<unknown> {
+        if (!client) {
+          return Promise.reject(new Error('Client unavailable.'));
+        }
+        return deleteClient(client.id, undefined, http);
+      },
+    [client],
+  );
+
+  return (
+    <MutationConfirmModal<ClientMutationTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onDeleted}
+      client={apiClient}
+      mutate={performDelete}
+      copy={DELETE_COPY}
+      confirmVariant="danger"
+      testIdPrefix="delete-client"
+    />
+  );
+};

--- a/src/pages/clients/RestoreClientConfirm.tsx
+++ b/src/pages/clients/RestoreClientConfirm.tsx
@@ -1,0 +1,161 @@
+import React, { useMemo } from 'react';
+
+import { restoreClient } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import {
+  toClientMutationTarget,
+  type ClientMutationTarget,
+} from './clientMutationTarget';
+
+import type { ApiClient, ClientDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo de confirmação para restauração de cliente
+ * (Issue #76, EPIC #49 — última sub-issue do CRUD básico de clientes,
+ * em paralelo com o `DeleteClientConfirm`).
+ *
+ * Espelha `RESTORE_COPY` de `RestoreSystemConfirm` (#61), com
+ * vocabulário adaptado para clientes. O slot
+ * `errorCopy.conflictMessage` está preenchido por previsão: o backend
+ * atual (`ClientsController.RestoreById`) devolve **404** com mensagem
+ * específica quando o cliente já está ativo (em vez de 409), mas o
+ * `classifyMutationError` trata o eventual 409 com `kind: 'conflict'`
+ * quando esse slot existe — assim, qualquer mudança futura do
+ * contrato (split de 404/409) fica coberta sem reabrir o modal.
+ * Lição PR #128: pré-projetar o helper compartilhado é mais barato
+ * do que abrir um PR adicional.
+ */
+const RESTORE_COPY: MutationConfirmCopy = {
+  title: 'Restaurar cliente?',
+  descriptionPrefix: 'O cliente ',
+  descriptionSuffix: ' voltará a aparecer na listagem padrão.',
+  confirmLabel: 'Restaurar',
+  successMessage: 'Cliente restaurado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao restaurar cliente',
+    genericFallback: 'Não foi possível restaurar o cliente. Tente novamente.',
+    notFoundMessage: 'Cliente não encontrado ou já está ativo.',
+    conflictMessage: 'O cliente já está ativo.',
+  },
+};
+
+/**
+ * O adapter `ClientDto` → `MutationTarget` vive em
+ * `clientMutationTarget.ts` para que `DeleteClientConfirm` e este
+ * componente reusem a mesma transformação sem duplicar a `interface`
+ * + a função (lição PR #128/#134/#135).
+ */
+interface RestoreClientConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Cliente soft-deletado selecionado para restauração. Quando `null`,
+   * o modal não renderiza — caller controla `open` em conjunto com
+   * `client`. Mantemos o objeto completo (não só `id`) para que a
+   * copy exiba `name`/`document` sem precisar de re-fetch.
+   */
+  client: ClientDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após restauração bem-sucedida ou após
+   * detecção de 404 (cliente não encontrado ou já ativo) — em ambos
+   * casos a UI quer refetch para sincronizar a tabela com o estado
+   * real do backend.
+   */
+  onRestored: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `restoreClient` cai no singleton `apiClient`.
+   */
+  apiClient?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para restauração de cliente soft-deletado
+ * (Issue #76, EPIC #49 — fecha o CRUD básico de clientes ao lado do
+ * `DeleteClientConfirm`).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` — espelha o
+ * `RestoreSystemConfirm` em estrutura, mas injeta:
+ *
+ * - **Copy** (`RESTORE_COPY`): "Restaurar cliente?" + descrição
+ *   contextual; sem aviso de "ativar Mostrar inativos" porque o
+ *   cliente volta diretamente para a listagem padrão após o restore.
+ * - **Mutate**: adapta `restoreClient(id)` para a assinatura
+ *   `(target, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`primary`): ação positiva (restaura/ativa) — o
+ *   token `--clr-lime`/`--clr-forest` do design system reforça o
+ *   significado sem hardcode de cor (paridade com
+ *   `RestoreSystemConfirm`).
+ * - **`testIdPrefix`** (`restore-client`): identifica os elementos
+ *   do modal nas suítes de teste sem colidir com o
+ *   `restore-system`.
+ *
+ * O `MutationConfirmModal` cuida de:
+ *
+ * - **Confirmação obrigatória** (critério de aceite #76).
+ * - **Cancelar/Esc/backdrop** fecham sem persistir (gerenciado pelo
+ *   `Modal`). Cancelar durante request em curso é bloqueado pela
+ *   flag interna `isSubmitting` — evita request órfã.
+ * - **Mapeamento de erros** via `classifyMutationError`:
+ *
+ *   - `404` → fecha modal + toast vermelho + refetch (cliente removido
+ *     ou já ativo entre abertura e submit). Backend devolve 404 com
+ *     mensagem `"Cliente não encontrado ou não está deletado."`; o
+ *     frontend exibe a copy traduzida `"Cliente não encontrado ou já
+ *     está ativo."`.
+ *   - `401`/`403` → toast vermelho com mensagem do backend (UI continua
+ *     no estado atual; cliente HTTP cuida do redirect 401).
+ *   - `409` → toast vermelho com `RESTORE_COPY.errorCopy.conflictMessage`
+ *     (defensivo). Hoje o backend não devolve esse status, mas o slot
+ *     fica preparado.
+ *   - Network/parse/5xx → toast vermelho genérico com fallback.
+ */
+export const RestoreClientConfirm: React.FC<RestoreClientConfirmProps> = ({
+  open,
+  client,
+  onClose,
+  onRestored,
+  apiClient,
+}) => {
+  const target = toClientMutationTarget(client);
+
+  /**
+   * Função adapter `(target, http?) => Promise<unknown>` que delega
+   * para `restoreClient(client.id, undefined, http)`. Memoizada com
+   * `useMemo` para preservar referência estável entre renders —
+   * espelha o padrão de `DeleteClientConfirm`/`ToggleUserActiveConfirm`.
+   */
+  const performRestore = useMemo(
+    () =>
+      function (
+        _target: ClientMutationTarget,
+        http?: ApiClient,
+      ): Promise<unknown> {
+        if (!client) {
+          return Promise.reject(new Error('Client unavailable.'));
+        }
+        return restoreClient(client.id, undefined, http);
+      },
+    [client],
+  );
+
+  return (
+    <MutationConfirmModal<ClientMutationTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onRestored}
+      client={apiClient}
+      mutate={performRestore}
+      copy={RESTORE_COPY}
+      confirmVariant="primary"
+      testIdPrefix="restore-client"
+    />
+  );
+};

--- a/src/pages/clients/clientMutationTarget.ts
+++ b/src/pages/clients/clientMutationTarget.ts
@@ -1,0 +1,45 @@
+import { clientDisplayName } from '../../shared/api';
+
+import type { ClientDto } from '../../shared/api';
+
+/**
+ * Adapter `MutationTarget` para `ClientDto`. O shell
+ * `MutationConfirmModal` (em `src/pages/systems/`) exige um target
+ * com `name` (label visível em destaque) e `code` (identificador
+ * curto exibido em monoespaçado entre parênteses).
+ *
+ * Para clientes:
+ *
+ * - `name` → `clientDisplayName(client)` (PF: `fullName`; PJ:
+ *   `corporateName`; fallback: `id` curto). Centralizar via helper
+ *   evita duplicação com `UsersListShellPage` e o `ClientEditPage`
+ *   (lição PR #127).
+ * - `code` → CPF (PF) ou CNPJ (PJ). É o identificador mais legível
+ *   visível na tabela. Quando ambos são `null` (cenário fora do
+ *   contrato mas defensivo), cai em string vazia para que o shell
+ *   mantenha o layout — o `<Mono>` ficaria vazio mas não quebra.
+ *
+ * Extraído como módulo dedicado pela Issue #76 para deduplicar entre
+ * `DeleteClientConfirm` e `RestoreClientConfirm` — JSCPD tokenizou
+ * a `interface` + função (~14 linhas com comentários) como bloco
+ * idêntico (lição PR #128/#134/#135 — qualquer trecho ≥10 linhas em
+ * 2+ arquivos vira `New Code Duplication` no Sonar).
+ */
+export interface ClientMutationTarget {
+  name: string;
+  code: string;
+}
+
+/**
+ * Converte um `ClientDto` (ou `null`) em `ClientMutationTarget` (ou
+ * `null` quando o cliente é `null`). O modal não renderiza com
+ * `target=null`, então retornar `null` aqui é o fluxo natural quando
+ * o pai ainda não selecionou nada.
+ */
+export function toClientMutationTarget(
+  client: ClientDto | null,
+): ClientMutationTarget | null {
+  if (!client) return null;
+  const code = client.cpf ?? client.cnpj ?? '';
+  return { name: clientDisplayName(client), code };
+}

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -680,6 +680,96 @@ export async function updateClient(
 }
 
 /**
+ * Desativa (soft-delete) um cliente via `DELETE /clients/{id}` (Issue #76).
+ *
+ * O backend (`ClientsController.DeleteById`) seta `DeletedAt = UtcNow` e
+ * responde `204 No Content` em sucesso. O método não devolve corpo — a
+ * função resolve `void` e a UI faz refetch para sincronizar a lista.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → cliente inexistente ou já
+ *   soft-deletado (o backend filtra por `DeletedAt == null` por padrão
+ *   via global query filter); a UI fecha o modal, dispara toast e força
+ *   refetch (paridade com `deleteSystem`).
+ * - `kind: 'http'` com `status === 409` → conflito por usuários ativos
+ *   vinculados (defensivo). Hoje o backend não devolve esse status no
+ *   `DELETE /clients/{id}` (apenas soft-delete), mas o `MutationConfirmModal`
+ *   já tem o slot `errorCopy.conflictMessage` reservado para quando o
+ *   contrato evoluir. A UI mostra a mensagem do backend ou o fallback
+ *   da `errorCopy`. Critério de aceite #76 — "Tratamento de erro caso o
+ *   cliente tenha usuários ativos vinculados.".
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_CLIENTS_DELETE`; toast vermelho com mensagem do backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Diferente de `createClient`/`updateClient`, não há type guard de
+ * resposta porque `204` não tem corpo — `client.delete<void>` resolve
+ * `undefined` e descartamos.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function deleteClient(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/clients/${id}`, options);
+}
+
+/**
+ * Restaura (desfaz soft-delete) um cliente via
+ * `POST /clients/{id}/restore` (Issue #76, EPIC #49 — fecha o CRUD básico
+ * de clientes junto com o delete).
+ *
+ * O backend (`ClientsController.RestoreById`) limpa `DeletedAt` via
+ * `IgnoreQueryFilters()` e responde `200 OK` com
+ * `{ message: "Cliente restaurado com sucesso." }`. Diferente de
+ * `createClient`/`updateClient`, o corpo da resposta **não** é um
+ * `ClientDto` — é um envelope simples `{ message }` que descartamos.
+ * A UI faz refetch para sincronizar a lista (idêntico ao padrão do
+ * `deleteClient`/`restoreSystem`), então retornamos `void`.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → cliente inexistente **ou** já
+ *   ativo (o backend devolve 404 com mensagem específica em ambos os
+ *   casos: filtro `DeletedAt != null` no `WHERE`). A UI fecha o modal,
+ *   dispara toast e força refetch — o registro foi mexido por outra
+ *   sessão entre a abertura do modal e o submit, ou nem existe.
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_CLIENTS_RESTORE`; toast vermelho com mensagem do backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Não há type guard de resposta porque `{ message }` é descartado —
+ * `client.post<void>` resolve com o body como `unknown` e ignoramos.
+ * Caso o backend evolua para devolver `ClientResponse` no futuro, basta
+ * ajustar este wrapper para validar com `isClientDto` e atualizar o
+ * tipo de retorno.
+ *
+ * Recebe `BodyRequestOptions` (com `signal`) por simetria com
+ * `createClient`/`updateClient` e `restoreSystem` — `POST` é tratado
+ * como mutação com corpo no cliente HTTP, ainda que aqui não enviemos
+ * payload. Passamos `undefined` como body para que o backend receba
+ * uma requisição vazia.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function restoreClient(
+  id: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.post<void>(`/clients/${id}/restore`, undefined, options);
+}
+
+/**
  * Constrói o body para `POST /clients` e `PUT /clients/{id}`
  * aplicando trim defensivo e o filtro de campos por tipo (PF/PJ).
  * Centralizar essa montagem garante que nenhum call site inclua

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -133,11 +133,13 @@ export {
   DEFAULT_CLIENTS_INCLUDE_DELETED,
   DEFAULT_CLIENTS_PAGE,
   DEFAULT_CLIENTS_PAGE_SIZE,
+  deleteClient,
   getClientById,
   getClientsByIds,
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  restoreClient,
   updateClient,
 } from './clients';
 export type {

--- a/tests/pages/ClientsListShellPage.test.tsx
+++ b/tests/pages/ClientsListShellPage.test.tsx
@@ -93,9 +93,14 @@ describe('ClientsListShellPage — render inicial', () => {
       expect(screen.queryByTestId('clients-loading')).not.toBeInTheDocument();
     });
 
-    expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
-    expect(screen.getByText('Bruno Souza')).toBeInTheDocument();
-    expect(screen.getByText('Acme Indústria S/A')).toBeInTheDocument();
+    // `getAllByText` porque a página renderiza tabela desktop +
+    // cards mobile (Issue #76 — paridade com `UsersListShellPage`).
+    // O texto aparece duas vezes na DOM (RTL ignora CSS).
+    expect(screen.getAllByText('Ana Cliente').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bruno Souza').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Acme Indústria S/A').length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renderiza header da página com título "Clientes cadastrados"', async () => {
@@ -128,10 +133,12 @@ describe('ClientsListShellPage — render inicial', () => {
     renderClientsListPage(client);
     await waitForInitialList(client);
 
-    // CPF "12345678901" -> "123.456.789-01"
-    expect(screen.getByText('123.456.789-01')).toBeInTheDocument();
-    // CNPJ "12345678000190" -> "12.345.678/0001-90"
-    expect(screen.getByText('12.345.678/0001-90')).toBeInTheDocument();
+    // CPF "12345678901" -> "123.456.789-01" (table + cards = 2x)
+    expect(screen.getAllByText('123.456.789-01').length).toBeGreaterThan(0);
+    // CNPJ "12345678000190" -> "12.345.678/0001-90" (table + cards = 2x)
+    expect(screen.getAllByText('12.345.678/0001-90').length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renderiza badge "Inativo" para clientes soft-deletados quando includeDeleted=true', async () => {
@@ -152,7 +159,8 @@ describe('ClientsListShellPage — render inicial', () => {
     fireEvent.click(screen.getByTestId('clients-include-deleted'));
 
     await waitFor(() => {
-      expect(screen.getByText('Inativo')).toBeInTheDocument();
+      // `getAllByText` por causa da renderização desktop + mobile.
+      expect(screen.getAllByText('Inativo').length).toBeGreaterThan(0);
     });
   });
 
@@ -387,7 +395,11 @@ describe('ClientsListShellPage — estados vazios', () => {
     // contrato sem se acoplar ao detalhe (espelha o padrão usado nos
     // testes da RolesPage).
     expect(screen.getAllByText(/Nenhum cliente encontrado para/i).length).toBeGreaterThan(0);
-    expect(screen.getByTestId('clients-empty-clear')).toBeInTheDocument();
+    // O `EmptyMessage` agora aparece em duplicidade (table desktop +
+    // cards mobile) após Issue #76 — paridade com `UsersListShellPage`.
+    expect(
+      screen.getAllByTestId('clients-empty-clear').length,
+    ).toBeGreaterThan(0);
   });
 
   it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
@@ -398,11 +410,15 @@ describe('ClientsListShellPage — estados vazios', () => {
     await waitForInitialList(client);
 
     // Texto duplicado no `LiveRegion` + `EmptyMessage` — usar
-    // `getAllByText` evita o erro "Found multiple elements".
+    // `getAllByText` evita o erro "Found multiple elements". A
+    // mensagem do `EmptyMessage` agora aparece em duplicidade (table
+    // desktop + cards mobile) após Issue #76 — paridade com
+    // `UsersListShellPage`.
     expect(screen.getAllByText(/Nenhum cliente cadastrado\./i).length).toBeGreaterThan(0);
     expect(
-      screen.getByText(/Clientes removidos podem ser visualizados/i),
-    ).toBeInTheDocument();
+      screen.getAllByText(/Clientes removidos podem ser visualizados/i)
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it('clicar em "limpar busca" reseta termo e re-popula a lista', async () => {
@@ -426,7 +442,10 @@ describe('ClientsListShellPage — estados vazios', () => {
       expect(screen.getAllByText(/Nenhum cliente encontrado para/i).length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getByTestId('clients-empty-clear'));
+    // `getAllByTestId` porque `clients-empty-clear` aparece tanto no
+    // emptyState da tabela desktop quanto no rodapé dos cards mobile.
+    // Clicar no primeiro fecha ambos pelo estado compartilhado.
+    fireEvent.click(screen.getAllByTestId('clients-empty-clear')[0]);
 
     await act(async () => {
       vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
@@ -434,7 +453,8 @@ describe('ClientsListShellPage — estados vazios', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
+      // Tabela desktop + cards mobile renderizam o nome em duplicidade.
+      expect(screen.getAllByText('Ana Cliente').length).toBeGreaterThan(0);
     });
   });
 });
@@ -462,7 +482,8 @@ describe('ClientsListShellPage — erro de rede', () => {
     await waitFor(() => {
       expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
     });
-    expect(screen.getByText('Ana Cliente')).toBeInTheDocument();
+    // Tabela desktop + cards mobile renderizam o nome em duplicidade.
+    expect(screen.getAllByText('Ana Cliente').length).toBeGreaterThan(0);
   });
 
   it('erro desconhecido exibe mensagem genérica', async () => {

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -426,6 +426,139 @@ export async function submitClientDataForm(
   await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
 }
 
+/* ─── Helpers de fluxo de delete/restore (Issue #76) ───── */
+
+/**
+ * Mocka o GET inicial com uma página contendo o `clientItem` informado
+ * e abre o `DeleteClientConfirm` clicando no botão "Desativar" da
+ * linha (Issue #76). O cliente default vem ativo (sem `deletedAt`) —
+ * desativar só faz sentido em linhas ativas, e o gating no
+ * `ClientsListShellPage` esconde o botão em linhas soft-deletadas.
+ *
+ * Espelha `openDeleteConfirm` em `systemsTestHelpers.tsx` — manter o
+ * mesmo formato facilita leitura side-by-side e evita BLOCKER de
+ * duplicação Sonar (lição PR #127). Quem precisar de mocks diferentes
+ * pode chamar `client.get.mockXxx` antes para sobrescrever a fila — a
+ * detecção de mocks pré-existentes preserva o caso "fila customizada
+ * de respostas" (ex.: cenários de erro 404 com refetch).
+ */
+export async function openDeleteClientConfirm(
+  client: ApiClientStub,
+  clientItem: ClientDto = makeClient(),
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([clientItem]));
+  }
+  renderClientsListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`clients-delete-${clientItem.id}`));
+}
+
+/**
+ * Confirma a desativação clicando em "Desativar" no
+ * `DeleteClientConfirm` e aguarda o `client.delete` ser chamado pelo
+ * menos `expectedDeleteCalls` vezes (default `1`). Espelha
+ * `confirmDelete` em `systemsTestHelpers.tsx`. Faz `act(async)` para
+ * flushar a microtask do click handler antes do `waitFor`.
+ */
+export async function confirmDeleteClient(
+  client: ApiClientStub,
+  expectedDeleteCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('delete-client-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.delete).toHaveBeenCalledTimes(expectedDeleteCalls));
+}
+
+/**
+ * Mocka o GET inicial com uma página contendo o `clientItem` informado
+ * (default soft-deletado) e abre o `RestoreClientConfirm` clicando no
+ * botão "Restaurar" da linha (Issue #76). Diferente de
+ * `openDeleteClientConfirm`, o cliente default já vem com `deletedAt`
+ * preenchido — restaurar só faz sentido em linhas soft-deletadas, e o
+ * gating no `ClientsListShellPage` esconde o botão em linhas ativas.
+ *
+ * Espelha `openRestoreConfirm` em `systemsTestHelpers.tsx`.
+ */
+export async function openRestoreClientConfirm(
+  client: ApiClientStub,
+  clientItem: ClientDto = makeClient({ deletedAt: '2026-02-01T00:00:00Z' }),
+): Promise<void> {
+  if (client.get.mock.calls.length === 0 && client.get.mock.results.length === 0) {
+    client.get.mockResolvedValueOnce(makePagedClientsResponse([clientItem]));
+  }
+  renderClientsListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`clients-restore-${clientItem.id}`));
+}
+
+/**
+ * Confirma a restauração clicando em "Restaurar" no
+ * `RestoreClientConfirm` e aguarda o `client.post` ser chamado pelo
+ * menos `expectedPostCalls` vezes (default `1`). Espelha
+ * `confirmRestore` em `systemsTestHelpers.tsx` mas com POST (em
+ * `/clients/{id}/restore`) em vez de DELETE.
+ */
+export async function confirmRestoreClient(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('restore-client-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+}
+
+/**
+ * Constrói os cenários comuns de erro de mutação simples
+ * (delete/restore) para a suíte da Issue #76. Centraliza os 3 casos
+ * compartilhados (401, 403, network) entre desativar e restaurar — o
+ * texto genérico no fallback diverge ("desativar"/"restaurar") e por
+ * isso parametrizamos via `verb`.
+ *
+ * Casos específicos por sub-fluxo (404 fecha modal, 409 conflito) ficam
+ * inline na suíte de teste (`it.each([...específicos, ...buildClients
+ * MutationErrorCases('desativar')])`) — espelha
+ * `buildSharedMutationErrorCases` em `systemsTestHelpers.tsx` para
+ * preservar a mesma estratégia de declaração e evitar duplicação
+ * Sonar (lição PR #128).
+ */
+export function buildClientsMutationErrorCases(
+  verb: 'desativar' | 'restaurar',
+): ReadonlyArray<ClientsErrorCase> {
+  return [
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      },
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      },
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: {
+        kind: 'network',
+        message: 'Falha de conexão com o servidor.',
+      },
+      expectedText: `Não foi possível ${verb} o cliente. Tente novamente.`,
+    },
+  ];
+}
+
 /**
  * Constrói os cenários comuns de erro de submit para a suíte de
  * edição de clientes (Issue #75). A mensagem genérica diverge da

--- a/tests/pages/clients/ClientDeleteRestore.test.tsx
+++ b/tests/pages/clients/ClientDeleteRestore.test.tsx
@@ -1,0 +1,572 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `buildAuthMock` precisa ser importado **antes** de
+// `clientsTestHelpers` para que `vi.mock('@/shared/auth', () =>
+// buildAuthMock(...))` consiga resolver a factory durante o hoisting
+// — sem isso, o teste falha com `Cannot access '__vi_import_2__'
+// before initialization`. Quebra a ordem alfabética de `import/order`
+// por necessidade de hoisting do Vitest — espelha o padrão usado em
+// `SystemsPage.delete.test.tsx`.
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildClientsMutationErrorCases,
+  confirmDeleteClient,
+  confirmRestoreClient,
+  createClientsClientStub,
+  ID_CLIENT_PF_ANA,
+  ID_CLIENT_PJ_ACME,
+  makeClient,
+  makeClientPj,
+  makePagedClientsResponse,
+  openDeleteClientConfirm,
+  openRestoreClientConfirm,
+  renderClientsListPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from '../__helpers__/clientsTestHelpers';
+/* eslint-enable import/order */
+
+import type { ClientsErrorCase } from '../__helpers__/clientsTestHelpers';
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Suíte de delete/restore da `ClientsListShellPage` (Issue #76, EPIC
+ * #49 — fecha o CRUD básico de clientes ao adicionar
+ * desativação/restauração via modal de confirmação).
+ *
+ * Estratégia espelha `SystemsPage.delete.test.tsx`/
+ * `SystemsPage.restore.test.tsx`: stub de `ApiClient`, asserts sobre
+ * gating por permissão, abertura/fechamento do modal, fluxo de
+ * sucesso (DELETE/POST + refetch + toast) e mapeamento de erros
+ * (`it.each` reusando `buildClientsMutationErrorCases` para evitar
+ * duplicação Sonar — lição PR #128).
+ *
+ * O modal compartilhado é `MutationConfirmModal` (em
+ * `src/pages/systems/`), reusado via
+ * `DeleteClientConfirm`/`RestoreClientConfirm` — testar o shell
+ * direto seria redundante (já coberto pela suíte de Systems);
+ * focamos no comportamento específico do recurso Cliente (gating,
+ * copy, integração com `ClientsListShellPage`).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const CLIENTS_DELETE_PERMISSION = 'AUTH_V1_CLIENTS_DELETE';
+const CLIENTS_RESTORE_PERMISSION = 'AUTH_V1_CLIENTS_RESTORE';
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('ClientsListShellPage — desativar (Issue #76)', () => {
+  describe('gating do botão "Desativar" por linha', () => {
+    it('não exibe botões "Desativar" quando o usuário não possui AUTH_V1_CLIENTS_DELETE', async () => {
+      permissionsMock = [];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([makeClient({ id: ID_CLIENT_PF_ANA })]),
+      );
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`clients-delete-${ID_CLIENT_PF_ANA}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Desativar" para cada linha ativa quando o usuário possui AUTH_V1_CLIENTS_DELETE', async () => {
+      permissionsMock = [CLIENTS_DELETE_PERMISSION];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({ id: ID_CLIENT_PF_ANA, fullName: 'Ana Cliente' }),
+          makeClientPj({
+            id: ID_CLIENT_PJ_ACME,
+            corporateName: 'Acme Indústria S/A',
+          }),
+        ]),
+      );
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.getByTestId(`clients-delete-${ID_CLIENT_PF_ANA}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`clients-delete-${ID_CLIENT_PJ_ACME}`),
+      ).toBeInTheDocument();
+    });
+
+    it('NÃO exibe "Desativar" em linhas já soft-deletadas (deletedAt != null)', async () => {
+      permissionsMock = [CLIENTS_DELETE_PERMISSION];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({ id: ID_CLIENT_PF_ANA, fullName: 'Ana Cliente' }),
+          makeClient({
+            id: ID_CLIENT_PJ_ACME,
+            type: 'PJ',
+            cpf: null,
+            fullName: null,
+            cnpj: '12345678000190',
+            corporateName: 'Acme Indústria S/A',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.getByTestId(`clients-delete-${ID_CLIENT_PF_ANA}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`clients-delete-${ID_CLIENT_PJ_ACME}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_DELETE_PERMISSION];
+    });
+
+    it('clicar em "Desativar" abre o diálogo com nome e documento do cliente', async () => {
+      const target = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        fullName: 'Ana Cliente',
+        cpf: '12345678901',
+      });
+      const client = createClientsClientStub();
+      await openDeleteClientConfirm(client, target);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Desativar cliente\?/i),
+      ).toBeInTheDocument();
+      const description = screen.getByTestId('delete-client-description');
+      expect(description).toHaveTextContent('Ana Cliente');
+      expect(description).toHaveTextContent('12345678901');
+    });
+
+    it('Esc fecha o modal sem disparar DELETE', async () => {
+      const client = createClientsClientStub();
+      await openDeleteClientConfirm(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      // eslint-disable-next-line no-restricted-globals
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.delete).not.toHaveBeenCalled();
+    });
+
+    it('botão Cancelar fecha o modal sem disparar DELETE', async () => {
+      const client = createClientsClientStub();
+      await openDeleteClientConfirm(client);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('delete-client-cancel'));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      expect(client.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_DELETE_PERMISSION];
+    });
+
+    it('envia DELETE /clients/{id} com id correto, fecha modal, exibe toast verde e refaz listClients', async () => {
+      const target = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        fullName: 'Ana Cliente',
+        cpf: '12345678901',
+      });
+      const client = createClientsClientStub();
+      // Fila de respostas: GET inicial → DELETE (204 → undefined) → GET refetch.
+      client.get
+        .mockResolvedValueOnce(makePagedClientsResponse([target]))
+        .mockResolvedValueOnce(makePagedClientsResponse([], { total: 0 }));
+      client.delete.mockResolvedValueOnce(undefined);
+
+      await openDeleteClientConfirm(client, target);
+      await confirmDeleteClient(client);
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `/clients/${ID_CLIENT_PF_ANA}`,
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Cliente desativado." (status do ToastProvider).
+      expect(
+        await screen.findByText('Cliente desativado.'),
+      ).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_DELETE_PERMISSION];
+    });
+
+    /**
+     * Casos compartilhados (401, 403, network) reusam
+     * `buildClientsMutationErrorCases('desativar')` para evitar
+     * duplicação literal com a suíte de restauração — lição PR #128.
+     *
+     * Casos específicos (404 fecha modal + refetch; 409 conflito por
+     * usuários vinculados — defensivo, critério #76) ficam inline
+     * porque o comportamento difere.
+     */
+    const ERROR_CASES: ReadonlyArray<ClientsErrorCase> = [
+      {
+        name: '404 (cliente já removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Cliente não encontrado.',
+        },
+        expectedText:
+          'Cliente não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+      {
+        name: '409 (usuários ativos vinculados) exibe toast com mensagem do backend',
+        error: {
+          kind: 'http',
+          status: 409,
+          message: 'Cliente possui usuários ativos vinculados.',
+        },
+        expectedText: 'Cliente possui usuários ativos vinculados.',
+      },
+      ...buildClientsMutationErrorCases('desativar'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createClientsClientStub();
+        client.delete.mockRejectedValueOnce(error);
+
+        await openDeleteClientConfirm(client);
+        await confirmDeleteClient(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onDeleted chamado mesmo em erro)', async () => {
+      const client = createClientsClientStub();
+      // Fila: GET inicial → DELETE (404) → GET refetch após onDeleted.
+      client.get
+        .mockResolvedValueOnce(makePagedClientsResponse([makeClient()]))
+        .mockResolvedValueOnce(makePagedClientsResponse([], { total: 0 }));
+      client.delete.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Cliente não encontrado.',
+      } satisfies ApiError);
+
+      await openDeleteClientConfirm(client);
+      await confirmDeleteClient(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});
+
+describe('ClientsListShellPage — restaurar (Issue #76)', () => {
+  describe('gating do botão "Restaurar" por linha', () => {
+    it('não exibe botões "Restaurar" quando o usuário não possui AUTH_V1_CLIENTS_RESTORE', async () => {
+      permissionsMock = [];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({
+            id: ID_CLIENT_PF_ANA,
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`clients-restore-${ID_CLIENT_PF_ANA}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Restaurar" para cada linha soft-deletada quando o usuário possui AUTH_V1_CLIENTS_RESTORE', async () => {
+      permissionsMock = [CLIENTS_RESTORE_PERMISSION];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({
+            id: ID_CLIENT_PF_ANA,
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.getByTestId(`clients-restore-${ID_CLIENT_PF_ANA}`),
+      ).toBeInTheDocument();
+    });
+
+    it('NÃO exibe "Restaurar" em linhas ativas (deletedAt === null)', async () => {
+      permissionsMock = [CLIENTS_RESTORE_PERMISSION];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({ id: ID_CLIENT_PF_ANA }),
+          makeClient({
+            id: ID_CLIENT_PJ_ACME,
+            type: 'PJ',
+            cpf: null,
+            fullName: null,
+            cnpj: '12345678000190',
+            corporateName: 'Acme Indústria S/A',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`clients-restore-${ID_CLIENT_PF_ANA}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId(`clients-restore-${ID_CLIENT_PJ_ACME}`),
+      ).toBeInTheDocument();
+    });
+
+    it('coexiste com o botão "Desativar" só na linha onde faz sentido', async () => {
+      // Caso real do toggle "Mostrar inativos": as duas ações aparecem
+      // na mesma tabela, mas cada uma em sua linha apropriada.
+      permissionsMock = [
+        CLIENTS_DELETE_PERMISSION,
+        CLIENTS_RESTORE_PERMISSION,
+      ];
+      const client = createClientsClientStub();
+      client.get.mockResolvedValueOnce(
+        makePagedClientsResponse([
+          makeClient({ id: ID_CLIENT_PF_ANA }),
+          makeClient({
+            id: ID_CLIENT_PJ_ACME,
+            type: 'PJ',
+            cpf: null,
+            fullName: null,
+            cnpj: '12345678000190',
+            corporateName: 'Acme Indústria S/A',
+            deletedAt: '2026-02-01T00:00:00Z',
+          }),
+        ]),
+      );
+
+      renderClientsListPage(client);
+      await waitForInitialList(client);
+
+      // Linha ativa: Desativar visível, Restaurar oculto.
+      expect(
+        screen.getByTestId(`clients-delete-${ID_CLIENT_PF_ANA}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`clients-restore-${ID_CLIENT_PF_ANA}`),
+      ).not.toBeInTheDocument();
+
+      // Linha inativa: Restaurar visível, Desativar oculto.
+      expect(
+        screen.queryByTestId(`clients-delete-${ID_CLIENT_PJ_ACME}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId(`clients-restore-${ID_CLIENT_PJ_ACME}`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_RESTORE_PERMISSION];
+    });
+
+    it('clicar em "Restaurar" abre o diálogo com nome e documento do cliente', async () => {
+      const target = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        fullName: 'Ana Cliente',
+        cpf: '12345678901',
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createClientsClientStub();
+      await openRestoreClientConfirm(client, target);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Restaurar cliente\?/i),
+      ).toBeInTheDocument();
+      const description = screen.getByTestId('restore-client-description');
+      expect(description).toHaveTextContent('Ana Cliente');
+      expect(description).toHaveTextContent('12345678901');
+    });
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_RESTORE_PERMISSION];
+    });
+
+    it('envia POST /clients/{id}/restore com id correto, fecha modal, exibe toast verde e refaz listClients', async () => {
+      const target = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        fullName: 'Ana Cliente',
+        cpf: '12345678901',
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createClientsClientStub();
+      // Fila de respostas:
+      //   GET inicial → POST /restore (200 com `{message}` — descartado) → GET refetch.
+      client.get
+        .mockResolvedValueOnce(makePagedClientsResponse([target]))
+        .mockResolvedValueOnce(makePagedClientsResponse([], { total: 0 }));
+      client.post.mockResolvedValueOnce(undefined);
+
+      await openRestoreClientConfirm(client, target);
+      await confirmRestoreClient(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/clients/${ID_CLIENT_PF_ANA}/restore`,
+        undefined,
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Cliente restaurado."
+      expect(
+        await screen.findByText('Cliente restaurado.'),
+      ).toBeInTheDocument();
+
+      // Refetch da lista.
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [CLIENTS_RESTORE_PERMISSION];
+    });
+
+    /**
+     * Casos compartilhados (401, 403, network) reusam
+     * `buildClientsMutationErrorCases('restaurar')` — lição PR #128.
+     * Caso específico 404 (cliente não encontrado ou já ativo) fica
+     * inline porque o comportamento difere (modal fecha + refetch).
+     */
+    const ERROR_CASES: ReadonlyArray<ClientsErrorCase> = [
+      {
+        name: '404 (cliente não encontrado ou já ativo) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Cliente não encontrado ou não está deletado.',
+        },
+        expectedText: 'Cliente não encontrado ou já está ativo.',
+        modalStaysOpen: false,
+      },
+      ...buildClientsMutationErrorCases('restaurar'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createClientsClientStub();
+        client.post.mockRejectedValueOnce(error);
+
+        await openRestoreClientConfirm(client);
+        await confirmRestoreClient(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onRestored chamado mesmo em erro)', async () => {
+      const target = makeClient({
+        id: ID_CLIENT_PF_ANA,
+        deletedAt: '2026-02-01T00:00:00Z',
+      });
+      const client = createClientsClientStub();
+      // Fila: GET inicial → POST (404) → GET refetch.
+      client.get
+        .mockResolvedValueOnce(makePagedClientsResponse([target]))
+        .mockResolvedValueOnce(makePagedClientsResponse([], { total: 0 }));
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Cliente não encontrado ou não está deletado.',
+      } satisfies ApiError);
+
+      await openRestoreClientConfirm(client, target);
+      await confirmRestoreClient(client);
+
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -6,11 +6,13 @@ import {
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_PAGE_SIZE,
+  deleteClient,
   getClientById,
   getClientsByIds,
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  restoreClient,
   updateClient,
 } from '@/shared/api';
 
@@ -916,5 +918,158 @@ describe('updateClient', () => {
         client as unknown as ApiClient,
       ),
     ).rejects.toBe(badRequest);
+  });
+});
+
+/* ─── deleteClient (Issue #76) ──────────────────────────── */
+
+describe('deleteClient', () => {
+  it('faz DELETE /clients/{id} sem corpo e resolve void em sucesso', async () => {
+    const client = makeClientStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    const result = await deleteClient(
+      CLIENT_PF_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete).toHaveBeenCalledWith(`/clients/${CLIENT_PF_ID}`, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.delete.mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+
+    await deleteClient(
+      CLIENT_PF_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete).toHaveBeenCalledWith(`/clients/${CLIENT_PF_ID}`, {
+      signal: controller.signal,
+    });
+  });
+
+  it('propaga ApiError 404 do backend (cliente não encontrado)', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado.',
+    };
+    client.delete.mockRejectedValueOnce(notFound);
+
+    await expect(
+      deleteClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(notFound);
+  });
+
+  it('propaga ApiError 409 do backend (conflito por usuários vinculados — defensivo)', async () => {
+    // Hoje o backend não devolve 409 no DELETE — apenas faz o
+    // soft-delete sem detachar vínculos. Mantemos o teste como
+    // defensivo para o caso do backend evoluir o contrato (critério
+    // #76 — "Tratamento de erro caso o cliente tenha usuários ativos
+    // vinculados.").
+    const client = makeClientStub();
+    const conflict = {
+      kind: 'http' as const,
+      status: 409,
+      message: 'Cliente possui usuários ativos vinculados.',
+    };
+    client.delete.mockRejectedValueOnce(conflict);
+
+    await expect(
+      deleteClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(conflict);
+  });
+
+  it('propaga ApiError 401/403 do backend (sessão/permissão)', async () => {
+    const client = makeClientStub();
+    const forbidden = {
+      kind: 'http' as const,
+      status: 403,
+      message: 'Você não tem permissão para esta ação.',
+    };
+    client.delete.mockRejectedValueOnce(forbidden);
+
+    await expect(
+      deleteClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(forbidden);
+  });
+});
+
+/* ─── restoreClient (Issue #76) ─────────────────────────── */
+
+describe('restoreClient', () => {
+  it('faz POST /clients/{id}/restore com body undefined e resolve void em sucesso', async () => {
+    const client = makeClientStub();
+    // Backend devolve `{ message: "Cliente restaurado com sucesso." }`
+    // mas o wrapper retorna `void` — descartamos o body.
+    client.post.mockResolvedValueOnce(undefined);
+
+    const result = await restoreClient(
+      CLIENT_PF_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith(
+      `/clients/${CLIENT_PF_ID}/restore`,
+      undefined,
+      undefined,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+
+    await restoreClient(
+      CLIENT_PF_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/clients/${CLIENT_PF_ID}/restore`,
+      undefined,
+      { signal: controller.signal },
+    );
+  });
+
+  it('propaga ApiError 404 do backend (cliente inexistente ou já ativo)', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado ou não está deletado.',
+    };
+    client.post.mockRejectedValueOnce(notFound);
+
+    await expect(
+      restoreClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(notFound);
+  });
+
+  it('propaga ApiError 401/403 do backend (sessão/permissão)', async () => {
+    const client = makeClientStub();
+    const forbidden = {
+      kind: 'http' as const,
+      status: 401,
+      message: 'Sessão expirada. Faça login novamente.',
+    };
+    client.post.mockRejectedValueOnce(forbidden);
+
+    await expect(
+      restoreClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(forbidden);
   });
 });


### PR DESCRIPTION
## Summary

- Adiciona `deleteClient(id)` (DELETE `/clients/{id}` → 204) e `restoreClient(id)` (POST `/clients/{id}/restore` → 200) em `src/shared/api/clients.ts`, com tratamento defensivo de 404/409/401/403 e propagação de `signal`.
- Cria `DeleteClientConfirm` e `RestoreClientConfirm` em `src/pages/clients/`, reusando o `MutationConfirmModal` compartilhado (`src/pages/systems/`) — sem hardcode de cor (variants `danger`/`primary` do design system).
- Adiciona ações "Desativar"/"Restaurar" por linha na `ClientsListShellPage` (tabela desktop + cards mobile via `CardListForMobile`), com gating por `AUTH_V1_CLIENTS_DELETE` e `AUTH_V1_CLIENTS_RESTORE`.
- Critério "Tratamento de erro caso o cliente tenha usuários ativos vinculados" coberto pelo slot `errorCopy.conflictMessage` (defensivo — o backend atual não devolve 409 nesse path, mas o slot fica preparado para evolução do contrato).
- Helper `clientMutationTarget.ts` deduplica o adapter `ClientDto → MutationTarget` entre os dois modais (lição PR #128).

## Test plan

- [x] `tests/shared/api/clients.test.ts` — cobertura unitária de `deleteClient` (DELETE path, signal, 404/409/403) e `restoreClient` (POST path com body undefined, signal, 404/401).
- [x] `tests/pages/clients/ClientDeleteRestore.test.tsx` — 24 testes cobrindo gating por permissão, abertura/fechamento do modal (Esc, Cancelar), fluxo de sucesso (DELETE/POST + refetch + toast verde) e mapeamento de erros via `it.each` reusando `buildClientsMutationErrorCases`.
- [x] `tests/pages/ClientsListShellPage.test.tsx` ajustado para `getAllByText`/`getAllByTestId` onde o EmptyMessage e nomes aparecem em duplicidade (table desktop + cards mobile).

## Quality gate

- `npm run lint` — 0 errors, 0 warnings
- `npm run typecheck` — 0 errors
- `npm test` — 68 files, **1171 tests** passing
- `jscpd src --threshold 3 --min-lines 10` — total 2.33% (≤ 3%); **0 new clones** envolvendo arquivos do diff

## Visual

- Variants `danger`/`primary` do design system (sem hardcode de cor).
- Gating por permissão preserva tabela compacta para perfis read-only (coluna "Ações" só aparece quando há `Clients.Delete` ou `Clients.Restore`).
- Cards mobile adicionados com paridade visual a `UsersListShellPage` (CardHeader/CardName/CardMeta + RowActions no rodapé).

## Backend

- `ClientsController.DeleteById` (DELETE `/clients/{id}` → 204) e `RestoreById` (POST `/clients/{id}/restore` → 200) já existem no `lfc-authenticator`.
- Permissões `AUTH_V1_CLIENTS_DELETE` / `AUTH_V1_CLIENTS_RESTORE` já cadastradas em `AuthenticatorRoutesSeeder`.

Closes #76