### PR TITLE
feat(users): logout remoto incrementando tokenVersion (#82)

### DIFF
--- a/src/pages/users/ForceLogoutUserConfirm.tsx
+++ b/src/pages/users/ForceLogoutUserConfirm.tsx
@@ -1,0 +1,167 @@
+import React, { useMemo } from 'react';
+
+import { forceLogoutUser } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import { toUserTarget, type UserTarget } from './userMutationTarget';
+
+import type { ApiClient, UserDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo "Forçar logout?" (Issue #82).
+ *
+ * O backend `lfc-authenticator#168` expõe `POST /users/{id}/force-logout`
+ * que incrementa o `TokenVersion` do usuário-alvo, derrubando todos os
+ * JWTs ativos no próximo `verify-token`/`/auth/permissions`. Aplica-se
+ * a cenários de comprometimento de credencial, troca de cargo ou
+ * encerramento de vínculo onde a operadoria precisa invalidar a sessão
+ * imediatamente sem aguardar a expiração natural do token.
+ *
+ * A copy reforça o caráter destrutivo (variant `danger` no botão) e a
+ * consequência prática: o usuário-alvo precisará fazer login novamente.
+ *
+ * **Importante:** "forçar logout" não soft-deleta o usuário nem mexe em
+ * `active` — apenas invalida sessões. Distinção explícita da copy de
+ * "Desativar usuário" (`ToggleUserActiveConfirm`) onde o usuário não
+ * consegue mais autenticar até ser reativado. Aqui, ele consegue logar
+ * de novo imediatamente; só perde as sessões em curso.
+ */
+const FORCE_LOGOUT_COPY: MutationConfirmCopy = {
+  title: 'Forçar logout?',
+  descriptionPrefix: 'Todas as sessões ativas do usuário ',
+  descriptionSuffix:
+    ' serão invalidadas. O usuário precisará fazer login novamente para acessar o sistema.',
+  confirmLabel: 'Forçar logout',
+  successMessage:
+    'Sessões invalidadas. Usuário precisará fazer login novamente.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao forçar logout',
+    genericFallback:
+      'Não foi possível forçar logout do usuário. Tente novamente.',
+    notFoundMessage:
+      'Usuário não encontrado ou foi removido. Atualize a lista.',
+  },
+};
+
+interface ForceLogoutUserConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Usuário selecionado para a invalidação de sessões. Quando `null`, o
+   * modal não renderiza — caller controla `open` em conjunto com `user`.
+   * Mantemos o objeto completo (não só `id`) porque a copy do diálogo
+   * cita `name` + `email` para contexto visual.
+   */
+  user: UserDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após o force-logout bem-sucedido ou após
+   * detecção de 404 (usuário já removido entre abertura e submit) — em
+   * ambos os casos a UI quer refetch para sincronizar a tabela com o
+   * backend (paridade com `ToggleUserActiveConfirm`/`EditUserModal`).
+   */
+  onLoggedOut: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `forceLogoutUser` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de confirmação de logout remoto de usuário (Issue #82).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (extraído na #61 e
+ * generalizado na #65 para servir múltiplos recursos) — toda a
+ * estrutura visual + lógica de submissão/erro vive no shell
+ * compartilhado. Aqui injetamos:
+ *
+ * - **Copy** (`FORCE_LOGOUT_COPY`): título, descrição reforçando a
+ *   ação destrutiva e o impacto (perda de sessão) em pt-BR.
+ * - **Mutate** (`performForceLogout`): adapta `forceLogoutUser(id)` para
+ *   a assinatura `(target, client?) => Promise<unknown>` esperada pelo
+ *   shell. O backend não exige body — `forceLogoutUser` envia POST
+ *   sem payload. Resposta `ForceLogoutResponse` é descartada (a UI só
+ *   reage ao sucesso/erro, não ao `newTokenVersion`).
+ * - **Variant** `danger`: ação destrutiva (paridade visual com
+ *   "Desativar sistema/rota/usuário"). O design system local mapeia
+ *   `--clr-orange/danger` na variant — sem hardcode de cor.
+ * - **`testIdPrefix`** (`force-logout-user`): seletor estável para
+ *   abrir/confirmar/cancelar; espelha o padrão de
+ *   `toggle-user-active`.
+ *
+ * **Visibilidade:** o caller (`UsersListShellPage`) só renderiza este
+ * modal quando o operador tem `Users.Update` (mesma policy de
+ * edit/toggle/reset, alinhada com o backend
+ * `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`). Adicionalmente,
+ * o caller esconde a ação na linha do **próprio** usuário corrente —
+ * o backend rejeita self-target com `400` (ver controller, mensagem
+ * "Não é possível forçar logout de si mesmo por este endpoint. Utilize
+ * GET /auth/logout."). Manter o gating no UI evita cliques que sempre
+ * falhariam e preserva UX coerente.
+ *
+ * **Por que reusar `MutationConfirmModal` em vez de criar um modal
+ * próprio?** Sonar tokeniza ≥10 linhas idênticas como `New Code
+ * Duplication` (lições PR #119/#123/#127/#128/#134/#135 — 6
+ * recorrências). Recriar o shell aqui duplicaria ~80 linhas de
+ * estrutura visual + try/catch/classify. Reusar mantém a fonte
+ * deduplicada por construção (mesma estratégia do
+ * `ToggleUserActiveConfirm` — Issue #80).
+ */
+export const ForceLogoutUserConfirm: React.FC<ForceLogoutUserConfirmProps> = ({
+  open,
+  user,
+  onClose,
+  onLoggedOut,
+  client,
+}) => {
+  const target = toUserTarget(user);
+
+  /**
+   * Função adapter `(target, client?) => Promise<unknown>` que delega
+   * para `forceLogoutUser(user.id)`.
+   *
+   * Memoizada com `useMemo` (não `useCallback` pra preservar o tipo de
+   * retorno) — o `MutationConfirmModal` consome `mutate` em
+   * `useCallback`, então uma referência estável evita invalidação
+   * desnecessária quando o `target`/copy mudam.
+   *
+   * **Por que ignorar `_target` e usar `user.id` diretamente?**
+   * O `target` aqui é o `UserTarget` adaptado (sem `id`). O id real
+   * vive no `UserDto` capturado pela closure. Espelha a estratégia de
+   * `ToggleUserActiveConfirm.performToggle`: o shell trabalha com o
+   * shape mínimo (`name`/`code`), mas o adapter conhece o objeto
+   * completo do recurso.
+   */
+  const performForceLogout = useMemo(
+    () =>
+      function (
+        _target: UserTarget,
+        targetClient?: ApiClient,
+      ): Promise<unknown> {
+        if (!user) {
+          return Promise.reject(new Error('User unavailable.'));
+        }
+        return forceLogoutUser(user.id, undefined, targetClient);
+      },
+    [user],
+  );
+
+  return (
+    <MutationConfirmModal<UserTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onLoggedOut}
+      client={client}
+      mutate={performForceLogout}
+      copy={FORCE_LOGOUT_COPY}
+      confirmVariant="danger"
+      testIdPrefix="force-logout-user"
+    />
+  );
+};

--- a/src/pages/users/ToggleUserActiveConfirm.tsx
+++ b/src/pages/users/ToggleUserActiveConfirm.tsx
@@ -6,6 +6,8 @@ import {
   type MutationConfirmCopy,
 } from '../systems/MutationConfirmModal';
 
+import { toUserTarget, type UserTarget } from './userMutationTarget';
+
 import type {
   ApiClient,
   UpdateUserPayload,
@@ -68,24 +70,6 @@ const ACTIVATE_COPY: MutationConfirmCopy = {
       'Usuário não encontrado ou foi removido. Atualize a lista.',
   },
 };
-
-/**
- * Adapter `MutationTarget` para `UserDto`. O shell `MutationConfirmModal`
- * exibe `target.name` em destaque + `target.code` em monoespaçado entre
- * parênteses — para usuários, o "código" semântico é o e-mail (único
- * por usuário, identificador legível). Mantemos o shell intacto e
- * apenas mapeamos o `code` para `email` neste adapter — Systems/Routes
- * continuam usando `code` literal sem regressão.
- */
-interface UserTarget {
-  name: string;
-  code: string;
-}
-
-function toTarget(user: UserDto | null): UserTarget | null {
-  if (!user) return null;
-  return { name: user.name, code: user.email };
-}
 
 interface ToggleUserActiveConfirmProps {
   /** Estado de visibilidade controlado pelo pai. */
@@ -150,7 +134,7 @@ interface ToggleUserActiveConfirmProps {
 export const ToggleUserActiveConfirm: React.FC<
   ToggleUserActiveConfirmProps
 > = ({ open, user, onClose, onToggled, client }) => {
-  const target = toTarget(user);
+  const target = toUserTarget(user);
 
   /**
    * Decide a copy ("Desativar?" vs "Ativar?") com base no estado atual

--- a/src/pages/users/UsersListShellPage.tsx
+++ b/src/pages/users/UsersListShellPage.tsx
@@ -1,4 +1,4 @@
-import { KeyRound, Pencil, Plus, Power } from 'lucide-react';
+import { KeyRound, LogOut, Pencil, Plus, Power } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { PageHeader } from '../../components/layout/PageHeader';
@@ -48,6 +48,7 @@ import {
 } from '../../shared/listing';
 
 import { EditUserModal } from './EditUserModal';
+import { ForceLogoutUserConfirm } from './ForceLogoutUserConfirm';
 import { NewUserModal } from './NewUserModal';
 import { ResetUserPasswordConfirm } from './ResetUserPasswordConfirm';
 import { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';
@@ -155,9 +156,19 @@ function deriveStatusDeletedAt(user: UserDto): string | null {
 export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
   client,
 }) => {
-  const { hasPermission } = useAuth();
+  const { hasPermission, user: currentUser } = useAuth();
   const canCreateUser = hasPermission(USERS_CREATE_PERMISSION);
   const canUpdateUser = hasPermission(USERS_UPDATE_PERMISSION);
+  /**
+   * Id do usuário autenticado — usado para esconder a ação "Forçar
+   * logout" na própria linha (Issue #82). O backend rejeita self-target
+   * com 400 (`UsersController.ForceLogout`, mensagem
+   * "Não é possível forçar logout de si mesmo por este endpoint."), e
+   * orientar o operador a usar `GET /auth/logout` para encerrar a
+   * própria sessão. Esconder a ação preventivamente preserva UX
+   * coerente — clique nunca cai no servidor para receber 400.
+   */
+  const currentUserId = currentUser?.id ?? null;
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -211,20 +222,40 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     close: handleCloseResetPassword,
   } = useListModalState<UserDto>();
 
+  // Usuário selecionado para forçar logout remoto (Issue #82). Mantemos
+  // o objeto completo para que o `ForceLogoutUserConfirm` exiba
+  // `name`/`email` na descrição do diálogo. O endpoint dedicado
+  // (`POST /users/{id}/force-logout`) consome apenas o `id` no path —
+  // demais campos servem de contexto visual para o operador confirmar
+  // a ação destrutiva.
+  const {
+    selected: forceLoggingOutUser,
+    open: handleOpenForceLogout,
+    close: handleCloseForceLogout,
+  } = useListModalState<UserDto>();
+
   /**
-   * Renderiza o bloco de ações por linha (Editar + Desativar/Ativar)
-   * para uma linha de usuário. Reutilizado pelo desktop (coluna
-   * "Ações" da tabela) e pelo mobile (rodapé dos cards) — única
-   * diferença é o prefixo dos `data-testid` (`users-edit`/
-   * `users-toggle-active` no desktop vs `users-card-edit`/
-   * `users-card-toggle-active` no mobile, para que cada surface
-   * tenha seu próprio seletor sem colidir).
+   * Renderiza o bloco de ações por linha (Editar + Redefinir senha +
+   * Forçar logout + Desativar/Ativar) para uma linha de usuário.
+   * Reutilizado pelo desktop (coluna "Ações" da tabela) e pelo mobile
+   * (rodapé dos cards) — única diferença é o prefixo dos `data-testid`
+   * (`users-edit`/`users-toggle-active`/`users-force-logout` no
+   * desktop vs `users-card-edit`/`users-card-toggle-active`/
+   * `users-card-force-logout` no mobile, para que cada surface tenha
+   * seu próprio seletor sem colidir).
    *
    * Centralizar aqui em uma única função evita o BLOCKER de
-   * duplicação JSCPD/Sonar — o `<Button>` do toggle ativo (~11
-   * linhas) repetido entre a tabela e os cards mobile foi marcado
-   * como clone (lição PR #128/#134/#135 — bloco ≥10 linhas idêntico
-   * em 2 surfaces do mesmo arquivo é tokenizado como duplicação).
+   * duplicação JSCPD/Sonar — cada `<Button>` (~7 linhas) repetido entre
+   * a tabela e os cards mobile seria marcado como clone (lição PR
+   * #128/#134/#135 — bloco ≥10 linhas idêntico em 2 surfaces do
+   * mesmo arquivo é tokenizado como duplicação).
+   *
+   * **Issue #82 — gating de "Forçar logout":** o botão é escondido na
+   * linha do **próprio** usuário corrente porque o backend rejeita
+   * self-target com 400 (orienta uso de `GET /auth/logout`). Comparar
+   * `currentUserId === row.id` evita clique inútil e preserva UX
+   * coerente. O gating de permissão (`Users.Update`) é responsabilidade
+   * do caller (mesmo critério de Editar/Toggle/Reset).
    *
    * Caller é responsável por filtrar quando NÃO chamar (gating de
    * permissão e `deletedAt !== null`) — a função sempre devolve o
@@ -234,6 +265,7 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
     (row: UserDto, testIdPrefix: 'users' | 'users-card'): React.ReactNode => {
       const toggleLabel = row.active ? 'Desativar' : 'Ativar';
       const toggleVariant = row.active ? 'danger' : 'primary';
+      const isSelf = currentUserId !== null && currentUserId === row.id;
       return (
         <RowActions>
           <Button
@@ -256,6 +288,18 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           >
             Redefinir senha
           </Button>
+          {!isSelf && (
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<LogOut size={14} strokeWidth={1.5} />}
+              onClick={() => handleOpenForceLogout(row)}
+              aria-label={`Forçar logout do usuário ${row.name}`}
+              data-testid={`${testIdPrefix}-force-logout-${row.id}`}
+            >
+              Forçar logout
+            </Button>
+          )}
           <Button
             variant={toggleVariant}
             size="sm"
@@ -269,7 +313,13 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
         </RowActions>
       );
     },
-    [handleOpenEditModal, handleOpenResetPassword, handleOpenToggleConfirm],
+    [
+      currentUserId,
+      handleOpenEditModal,
+      handleOpenForceLogout,
+      handleOpenResetPassword,
+      handleOpenToggleConfirm,
+    ],
   );
 
   /**
@@ -691,6 +741,16 @@ export const UsersListShellPage: React.FC<UsersListShellPageProps> = ({
           user={resettingUser}
           onClose={handleCloseResetPassword}
           onResetCompleted={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canUpdateUser && (
+        <ForceLogoutUserConfirm
+          open={forceLoggingOutUser !== null}
+          user={forceLoggingOutUser}
+          onClose={handleCloseForceLogout}
+          onLoggedOut={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -4,5 +4,6 @@ export { UserPermissionsShellPage } from './UserPermissionsShellPage';
 export { UserRolesShellPage } from './UserRolesShellPage';
 export { NewUserModal } from './NewUserModal';
 export { EditUserModal } from './EditUserModal';
+export { ForceLogoutUserConfirm } from './ForceLogoutUserConfirm';
 export { ResetUserPasswordConfirm } from './ResetUserPasswordConfirm';
 export { ToggleUserActiveConfirm } from './ToggleUserActiveConfirm';

--- a/src/pages/users/userMutationTarget.ts
+++ b/src/pages/users/userMutationTarget.ts
@@ -1,0 +1,40 @@
+import type { UserDto } from '../../shared/api';
+
+/**
+ * Adapter `MutationTarget` para `UserDto` reusado pelos wrappers de
+ * `MutationConfirmModal` no recurso de usuários (ToggleUserActiveConfirm
+ * #80, ForceLogoutUserConfirm #82, e futuros confirm-only modals).
+ *
+ * O shell `MutationConfirmModal` exibe `target.name` em destaque +
+ * `target.code` em monoespaçado entre parênteses — para usuários, o
+ * "código" semântico é o e-mail (único por usuário, identificador
+ * legível). Mantemos o shell genérico intacto (Systems/Routes continuam
+ * usando `code` literal sem regressão) e apenas mapeamos `code` para
+ * `email` neste adapter.
+ *
+ * **Por que extrair em módulo compartilhado?**
+ *
+ * Sonar/JSCPD tokeniza ≥10 linhas idênticas como duplicação (lições
+ * PR #134/#135 — `New Code Duplication > 3%` é BLOCKER). O bloco
+ * `UserTarget` interface + `toTarget` function (~11 linhas com
+ * comentário) era idêntico entre `ToggleUserActiveConfirm` e
+ * `ForceLogoutUserConfirm`. Extrair de uma vez evita a 7ª recorrência
+ * de duplicação Sonar e centraliza qualquer evolução futura (ex.: se
+ * a UX decidir mostrar `identity` em vez de `email` no `code`, muda
+ * em um único lugar).
+ */
+export interface UserTarget {
+  name: string;
+  code: string;
+}
+
+/**
+ * Converte um `UserDto | null` em `UserTarget | null` para alimentar
+ * o `MutationConfirmModal`. Retorna `null` quando `user` é `null` —
+ * o shell não renderiza nada nesse caso (caller controla `open` em
+ * conjunto com `target`).
+ */
+export function toUserTarget(user: UserDto | null): UserTarget | null {
+  if (!user) return null;
+  return { name: user.name, code: user.email };
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -55,6 +55,7 @@ const systemId: string = resolveSystemId();
 export const apiClient: ApiClient = createApiClient({ baseUrl, systemId });
 
 export { createApiClient } from './client';
+export { extractErrorMessage, isFetchAborted } from './fetchHelpers';
 export { isApiError } from './types';
 export type {
   ApiClient,
@@ -165,19 +166,18 @@ export {
   DEFAULT_USERS_INCLUDE_DELETED,
   DEFAULT_USERS_PAGE,
   DEFAULT_USERS_PAGE_SIZE,
+  forceLogoutUser,
   getUserById,
   isPagedUsersResponse,
   isUserDto,
   listUsers,
-<<<<<<< HEAD
-  resetUserPassword,
-=======
   removeRoleFromUser,
->>>>>>> 493c844 (feat(users): atribuir roles ao usuário com matriz por sistema (#71))
+  resetUserPassword,
   updateUser,
 } from './users';
 export type {
   CreateUserPayload,
+  ForceLogoutResponse,
   ListUsersParams,
   ResetUserPasswordPayload,
   UpdateUserPayload,

--- a/src/shared/api/users.ts
+++ b/src/shared/api/users.ts
@@ -771,3 +771,100 @@ export async function removeRoleFromUser(
 ): Promise<void> {
   await client.delete<void>(`/users/${userId}/roles/${roleId}`, options);
 }
+
+/**
+ * Espelho do `ForceLogoutResponse` do `lfc-authenticator`
+ * (`UsersController.ForceLogoutResponse`).
+ *
+ * Issue #82 (EPIC #49) — invalidação remota de sessões. Após o backend
+ * incrementar o `TokenVersion` do usuário-alvo, todos os JWTs emitidos
+ * com a versão anterior passam a falhar a verificação no próximo
+ * `verify-token`. A UI consome apenas a confirmação da operação (toast
+ * verde), mas mantemos o shape completo em tipo para preservar contrato
+ * — qualquer evolução do backend (ex.: incluir `expiresAt` ou
+ * `affectedSessions`) é capturada pelo type guard antes de propagar
+ * shape inesperado para o caller.
+ *
+ * - `message`: cópia em pt-BR confirmando o sucesso
+ *   (`"Sessões do usuário invalidadas com sucesso."`).
+ * - `userId`: id do usuário-alvo (eco do path param) — usado para
+ *   diagnóstico em logs do operador, não exibido.
+ * - `newTokenVersion`: novo `TokenVersion` após o incremento. Útil em
+ *   testes de integração e auditoria; UI atual ignora.
+ */
+export interface ForceLogoutResponse {
+  message: string;
+  userId: string;
+  newTokenVersion: number;
+}
+
+/**
+ * Type guard para `ForceLogoutResponse`. Espelha `isUserDto`/
+ * `isUserRoleLinkDto`: tolera campos extras no payload (forward-compat
+ * com backend), mas exige os três campos obrigatórios com tipos
+ * corretos. Retornar `false` causa `ApiError(parse)` no caller, que
+ * traduz para "Resposta inválida do servidor." — mesmo padrão dos
+ * demais wrappers do recurso.
+ */
+function isForceLogoutResponse(value: unknown): value is ForceLogoutResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const { message, userId, newTokenVersion } = value as Record<string, unknown>;
+  return (
+    typeof message === 'string' &&
+    typeof userId === 'string' &&
+    typeof newTokenVersion === 'number'
+  );
+}
+
+/**
+ * Invalida todas as sessões ativas de um usuário via
+ * `POST /users/{id}/force-logout` (lfc-authenticator#168).
+ *
+ * O backend incrementa o `TokenVersion` do usuário-alvo: tokens antigos
+ * passam a falhar no próximo `verify-token`/`/auth/permissions`,
+ * derrubando a sessão sem precisar invalidar o JWT no servidor.
+ *
+ * Endpoint requer `Users.Update` — mesma policy de `PUT /users/{id}` e
+ * `PUT /users/{id}/password`. Backend valida via
+ * `[Authorize(Policy = PermissionPolicies.UsersUpdate)]`.
+ *
+ * **Self-target é rejeitado**: o backend retorna `400` com
+ * `{ message: "Não é possível forçar logout de si mesmo por este
+ * endpoint. Utilize GET /auth/logout." }`. A UI bloqueia
+ * preventivamente escondendo a ação na linha do próprio usuário
+ * corrente, mas mantemos a tradução do 400 como defesa em profundidade.
+ *
+ * Status codes esperados:
+ *
+ * - `200 OK` com `ForceLogoutResponse` no body.
+ * - `400 Bad Request` quando self-target (caller deve esconder a ação).
+ * - `404 Not Found` quando o usuário foi soft-deletado entre abertura
+ *   do modal e submit (caller fecha modal + dispara refetch).
+ * - `401`/`403` por gating de permissão — cliente HTTP já lidou com
+ *   `onUnauthorized`; UI exibe toast.
+ *
+ * **Por que `POST` sem body?** O backend não espera payload — o id já
+ * vem no path. Passamos `null` literal para o `client.post` porque o
+ * cliente HTTP serializa `null` como body vazio (corpo zero-length); a
+ * alternativa (`{}`) enviaria `{}` no body e o backend ignoraria, mas
+ * preservar o contrato exato facilita auditoria de logs.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ */
+export async function forceLogoutUser(
+  id: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ForceLogoutResponse> {
+  const data = await client.post<unknown>(
+    `/users/${id}/force-logout`,
+    null,
+    options,
+  );
+  if (!isForceLogoutResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}

--- a/tests/pages/__helpers__/mockUseAuth.ts
+++ b/tests/pages/__helpers__/mockUseAuth.ts
@@ -1,8 +1,22 @@
 import { vi } from 'vitest';
 
 /**
+ * Shape mínimo do `User` consumido por componentes que diferenciam o
+ * usuário corrente (ex.: `UsersListShellPage` na Issue #82, que esconde
+ * a ação "Forçar logout" na própria linha). Espelha o `User` de
+ * `@/shared/auth/types` mas mantemos local para não acoplar testes ao
+ * shape exato (basta `id` para os cenários atuais).
+ */
+export interface MockAuthUser {
+  id: string;
+  name: string;
+  email: string;
+  identity: number;
+}
+
+/**
  * Factory compartilhada do mock de `useAuth` consumido pelas páginas
- * `SystemsPage` (suítes de listagem e criação — Issue #58).
+ * (`SystemsPage`, `UsersListShellPage`, etc.) durante os testes.
  *
  * Como `vi.mock` é içado pelo Vitest **antes** dos imports do módulo de
  * teste, não é possível passar valores mutáveis diretamente para a
@@ -22,12 +36,24 @@ import { vi } from 'vitest';
  * dentro do componente — garantindo que os testes possam alternar
  * permissões dentro da mesma suíte sem reordenar imports.
  *
+ * **Issue #82:** acrescentamos um segundo getter opcional (`getUser`)
+ * para que componentes que diferenciam o usuário corrente (ex.:
+ * gating de "Forçar logout" — Issue #82, esconde a ação na linha do
+ * próprio operador para evitar 400 self-target do backend) possam
+ * exercitar o cenário sem reescrever o mock global. Quando ausente, o
+ * default permanece `user: null` (compatível com os call sites
+ * existentes — sistemas, rotas, roles, clients, e demais suítes de
+ * users que não exercem o gating).
+ *
  * Extraído para evitar duplicação entre suítes (lição PR #123 — Sonar
  * conta blocos de 10+ linhas como duplicação independente da intenção).
  */
-export function buildAuthMock(getPermissions: () => ReadonlyArray<string>): {
+export function buildAuthMock(
+  getPermissions: () => ReadonlyArray<string>,
+  getUser?: () => MockAuthUser | null,
+): {
   useAuth: () => {
-    user: null;
+    user: MockAuthUser | null;
     permissions: ReadonlyArray<string>;
     isAuthenticated: boolean;
     isLoading: boolean;
@@ -39,7 +65,7 @@ export function buildAuthMock(getPermissions: () => ReadonlyArray<string>): {
 } {
   return {
     useAuth: () => ({
-      user: null,
+      user: getUser ? getUser() : null,
       permissions: getPermissions(),
       isAuthenticated: true,
       isLoading: false,

--- a/tests/pages/__helpers__/usersTestHelpers.tsx
+++ b/tests/pages/__helpers__/usersTestHelpers.tsx
@@ -560,6 +560,11 @@ export function buildUsersCloseCases(
  *   ignora a copy do verbo e usa o fallback exato do
  *   `ResetUserPasswordConfirm` (`'Não foi possível redefinir a senha.
  *   Tente novamente.'`), preservando a UX coerente.
+ * - `'forçar logout do'` — usado pelo logout remoto (Issue #82).
+ *   Mesma estratégia: o sufixo "do" gera concordância quebrada se
+ *   concatenado com " o usuário", então o helper faz override e usa o
+ *   fallback exato do `ForceLogoutUserConfirm` (`'Não foi possível
+ *   forçar logout do usuário. Tente novamente.'`).
  *
  * Centralizar o tipo aqui (em vez de declarar dois alias paralelos)
  * permite que `buildSharedUserMutationErrorCases` cubra todos os
@@ -571,7 +576,8 @@ export type UserMutationVerb =
   | 'atualizar'
   | 'ativar'
   | 'desativar'
-  | 'redefinir senha do';
+  | 'redefinir senha do'
+  | 'forçar logout do';
 
 /**
  * Constrói os cenários comuns de erro 401/403/network para qualquer
@@ -590,13 +596,21 @@ export function buildSharedUserMutationErrorCases(
   verb: UserMutationVerb,
 ): ReadonlyArray<UsersErrorCase> {
   // Reset de senha tem copy genérica distinta — refere ao recurso
-  // ("a senha"), não ao usuário. Mantemos o branch isolado para que
-  // os demais verbos preservem o template "Não foi possível {verb}
-  // o usuário..." sem regredir.
-  const networkExpectedText =
-    verb === 'redefinir senha do'
-      ? 'Não foi possível redefinir a senha. Tente novamente.'
-      : `Não foi possível ${verb} o usuário. Tente novamente.`;
+  // ("a senha"), não ao usuário. Force logout idem (sufixo "do" no
+  // verbo geraria "Não foi possível forçar logout do o usuário..." —
+  // gramática quebrada). Mantemos branches isolados para que os demais
+  // verbos preservem o template "Não foi possível {verb} o usuário..."
+  // sem regredir.
+  let networkExpectedText: string;
+  if (verb === 'redefinir senha do') {
+    networkExpectedText =
+      'Não foi possível redefinir a senha. Tente novamente.';
+  } else if (verb === 'forçar logout do') {
+    networkExpectedText =
+      'Não foi possível forçar logout do usuário. Tente novamente.';
+  } else {
+    networkExpectedText = `Não foi possível ${verb} o usuário. Tente novamente.`;
+  }
   return [
     {
       name: '401 dispara toast vermelho com mensagem do backend',
@@ -709,4 +723,73 @@ export async function submitResetUserPasswordForm(
     await Promise.resolve();
   });
   await waitFor(() => expect(client.put).toHaveBeenCalledTimes(expectedPutCalls));
+}
+
+/* ─── Helpers para suíte de force logout (Issue #82) ────── */
+
+/**
+ * Mocka a resposta inicial (listagem com o usuário-alvo), renderiza a
+ * `UsersListShellPage`, espera a lista carregar e clica no botão
+ * "Forçar logout" da linha do usuário informado. Espelha
+ * `openToggleUserActiveConfirm` mas dispara o
+ * `ForceLogoutUserConfirm` — Issue #82. Reusa a mesma estratégia
+ * de mocks pré-existentes (`getMockImplementation()` check) para
+ * preservar fila customizada de respostas em cenários de erro.
+ *
+ * Observação: o gating do botão "Forçar logout" depende de
+ * `currentUserId !== row.id` (defesa contra self-target). Por padrão
+ * o `buildAuthMock` devolve `user: null`, ou seja, `currentUserId` é
+ * `null` e o botão aparece em todas as linhas. Cenários que precisam
+ * exercitar o gating de self-target devem mockar
+ * `useAuth().user = { id: row.id, ... }` antes de renderizar.
+ */
+export async function openForceLogoutConfirm(
+  client: ApiClientStub,
+  options: { user?: UserDto } = {},
+): Promise<void> {
+  const user = options.user ?? makeUser();
+  if (
+    client.get.getMockImplementation() === undefined &&
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockImplementation((path: string) => {
+      if (typeof path === 'string' && path.startsWith('/users')) {
+        return Promise.resolve(makeUsersPagedResponse([user]));
+      }
+      if (typeof path === 'string' && path.startsWith('/clients/')) {
+        return Promise.resolve(null);
+      }
+      return Promise.reject(new Error(`unexpected path: ${String(path)}`));
+    });
+  }
+  renderUsersPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`users-force-logout-${user.id}`));
+  // Aguarda a abertura do modal — verifica a presença do botão de
+  // confirmação que existe apenas quando o `MutationConfirmModal`
+  // está renderizado.
+  await waitFor(() => {
+    expect(screen.getByTestId('force-logout-user-confirm')).toBeInTheDocument();
+  });
+}
+
+/**
+ * Confirma o force logout clicando em "Forçar logout" no
+ * `ForceLogoutUserConfirm` e aguarda o `client.post` ser chamado pelo
+ * menos `expectedPostCalls` vezes (default `1`). Espelha
+ * `confirmToggleUserActive` mas com POST em vez de PUT — o endpoint
+ * dedicado (`POST /users/{id}/force-logout`) não exige body. Faz
+ * `act(async)` para flushar a microtask do click handler antes do
+ * `waitFor`.
+ */
+export async function confirmForceLogout(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('force-logout-user-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
 }

--- a/tests/pages/users/UserForceLogout.test.tsx
+++ b/tests/pages/users/UserForceLogout.test.tsx
@@ -1,0 +1,379 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildAuthMock, type MockAuthUser } from '../__helpers__/mockUseAuth';
+import {
+  buildSharedUserMutationErrorCases,
+  buildUsersCloseCases,
+  confirmForceLogout,
+  createUsersClientStub,
+  ID_USER_ALICE,
+  ID_USER_BOB,
+  makeUser,
+  mockUserListResponse,
+  mockUserListResponseWithCounter,
+  openForceLogoutConfirm,
+  renderUsersPage,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+  type UsersErrorCase,
+} from '../__helpers__/usersTestHelpers';
+
+import type { ApiError } from '@/shared/api';
+
+/**
+ * Suíte da `UsersListShellPage` — logout remoto (Issue #82, EPIC #49).
+ *
+ * Espelha a estratégia de `UserActivateToggle.test.tsx` (Issue #80) e
+ * `UserResetPassword.test.tsx` (#81): mock controlável de `useAuth`
+ * (`permissionsMock` + getter que vi.mock captura a cada
+ * `useAuth()`), stub de `ApiClient` injetado em
+ * `<UsersListShellPage client={stub} />`, helpers compartilhados em
+ * `tests/pages/__helpers__/usersTestHelpers.tsx` para colapsar
+ * boilerplate (lição PR #134/#135).
+ *
+ * **Decisão chave de implementação:** o backend
+ * (`lfc-authenticator#168`) expõe endpoint dedicado
+ * `POST /users/{id}/force-logout` sem body. O wrapper
+ * `forceLogoutUser` envia POST com `body=null` (cliente HTTP omite o
+ * payload) e devolve `ForceLogoutResponse`. A UI só reage a sucesso/
+ * erro — `newTokenVersion` no payload é descartado.
+ *
+ * **Self-target:** o backend rejeita com 400
+ * (`{message: "Não é possível forçar logout de si mesmo..."}`). A UI
+ * bloqueia preventivamente escondendo a ação na linha do próprio
+ * usuário corrente — testes validam ambas as defesas:
+ *
+ * 1. Botão escondido quando `currentUserId === row.id` (gating
+ *    preventivo no UI).
+ * 2. Caso o gating falhe (cenário defensivo cobre a lacuna),
+ *    `forceLogoutUser` propaga o `ApiError` 400 e o
+ *    `MutationConfirmModal` cai no `unhandled` mostrando a copy
+ *    genérica — sem regressão silenciosa.
+ *
+ * **Diferença vs Toggle (#80) e Reset (#81):** policy é a mesma
+ * (`Users.Update`), mas a ação é destrutiva de **sessão**, não de
+ * estado do usuário (`active=false`) ou credencial (`password`).
+ * `tokenVersion` no backend é incrementado, derrubando JWTs antigos
+ * no próximo `verify-token` — usuário consegue fazer login normalmente
+ * imediatamente depois.
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+let currentUserMock: MockAuthUser | null = null;
+
+vi.mock('@/shared/auth', () =>
+  buildAuthMock(
+    () => permissionsMock,
+    () => currentUserMock,
+  ),
+);
+
+const USERS_UPDATE_PERMISSION = 'AUTH_V1_USERS_UPDATE';
+
+beforeEach(() => {
+  permissionsMock = [];
+  currentUserMock = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = '';
+});
+
+describe('UsersListShellPage — forçar logout (Issue #82)', () => {
+  describe('gating do botão "Forçar logout" por linha', () => {
+    it('não exibe botão "Forçar logout" quando o usuário não possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [];
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [makeUser()]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      expect(
+        screen.queryByTestId(`users-force-logout-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe botão "Forçar logout" para outras linhas quando o usuário possui AUTH_V1_USERS_UPDATE', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      // Sessão como Bob: a linha de Alice deve mostrar o botão.
+      currentUserMock = {
+        id: ID_USER_BOB,
+        name: 'Bob Operator',
+        email: 'bob@example.com',
+        identity: 1,
+      };
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [makeUser()]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId(`users-force-logout-${ID_USER_ALICE}`);
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute(
+        'aria-label',
+        'Forçar logout do usuário Alice Admin',
+      );
+      expect(btn).toHaveTextContent('Forçar logout');
+    });
+
+    it('NÃO exibe botão "Forçar logout" na linha do próprio usuário corrente (defesa contra self-target 400 do backend)', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      // Sessão como Alice: a linha de Alice NÃO deve mostrar o botão.
+      currentUserMock = {
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+        identity: 1,
+      };
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [makeUser()]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      // Outras ações continuam visíveis (Editar, Redefinir senha,
+      // Desativar) — só "Forçar logout" some.
+      expect(
+        screen.getByTestId(`users-edit-${ID_USER_ALICE}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`users-force-logout-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+
+    it('NÃO exibe botão "Forçar logout" em linhas soft-deletadas mesmo com permissão', async () => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+      const deletedUser = makeUser({ deletedAt: '2026-02-01T00:00:00Z' });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [deletedUser]);
+
+      renderUsersPage(client);
+      await waitForInitialList(client);
+
+      // Soft-deleted: nenhuma ação aparece — alinha com a coluna
+      // Status (badge "Inativa") e com a UX dos demais botões.
+      expect(
+        screen.queryByTestId(`users-force-logout-${ID_USER_ALICE}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('abertura do diálogo de confirmação', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('clicar em "Forçar logout" abre o diálogo "Forçar logout?" com nome e e-mail do usuário', async () => {
+      const user = makeUser({
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+      });
+      const client = createUsersClientStub();
+      await openForceLogoutConfirm(client, { user });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText(/Forçar logout\?/i)).toBeInTheDocument();
+      const description = screen.getByTestId('force-logout-user-description');
+      expect(description).toHaveTextContent('Alice Admin');
+      expect(description).toHaveTextContent('alice@example.com');
+      expect(description).toHaveTextContent(
+        /precisará fazer login novamente/i,
+      );
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, Cancelar e clique no
+     * backdrop. Colapsados em `it.each` reusando `buildUsersCloseCases`
+     * (helper compartilhado com criação/edição/toggle/reset) — diferença
+     * é só o testId do botão Cancelar (`force-logout-user-cancel`).
+     * Lição PR #127: `it.each` evita BLOCKER de duplicação Sonar para
+     * cenários com mesma estrutura mudando 1-2 mocks.
+     */
+    const CLOSE_CASES = buildUsersCloseCases('force-logout-user-cancel');
+
+    it.each(CLOSE_CASES)(
+      'fechar via $name não dispara POST',
+      async ({ close }) => {
+        const client = createUsersClientStub();
+        await openForceLogoutConfirm(client);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(client.post).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('confirmação bem-sucedida', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    it('envia POST /users/{id}/force-logout sem body, fecha modal, exibe toast e refaz listUsers', async () => {
+      const target = makeUser({
+        id: ID_USER_ALICE,
+        name: 'Alice Admin',
+        email: 'alice@example.com',
+      });
+      const client = createUsersClientStub();
+      const getCallCount = mockUserListResponseWithCounter(client, [target]);
+      client.post.mockResolvedValueOnce({
+        message: 'Sessões do usuário invalidadas com sucesso.',
+        userId: ID_USER_ALICE,
+        newTokenVersion: 7,
+      });
+
+      await openForceLogoutConfirm(client, { user: target });
+      await confirmForceLogout(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/users/${ID_USER_ALICE}/force-logout`,
+        null,
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde com a copy esperada (status do ToastProvider).
+      expect(
+        await screen.findByText(
+          'Sessões invalidadas. Usuário precisará fazer login novamente.',
+        ),
+      ).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez na rota
+      // `/users` após o POST bem-sucedido.
+      await waitFor(() => {
+        expect(getCallCount()).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    it('lança ApiError(parse) quando o backend devolve payload sem campos esperados (defesa contra drift de contrato)', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      mockUserListResponse(client, [target]);
+      // Backend devolveu shape inesperado (faltando newTokenVersion) —
+      // wrapper traduz para ApiError(parse), e o
+      // `MutationConfirmModal` cai no branch `unhandled` exibindo a
+      // copy genérica de erro (validamos que a UI não regride
+      // silenciosamente).
+      client.post.mockResolvedValueOnce({ message: 'oi', userId: 'x' });
+
+      await openForceLogoutConfirm(client, { user: target });
+      await confirmForceLogout(client);
+
+      expect(
+        await screen.findByText(
+          toCaseInsensitiveMatcher(
+            'Não foi possível forçar logout do usuário. Tente novamente.',
+          ),
+        ),
+      ).toBeInTheDocument();
+      // Modal permanece aberto para o operador tentar novamente.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('tratamento de erros do backend', () => {
+    beforeEach(() => {
+      permissionsMock = [USERS_UPDATE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Casos
+     * comuns (401, 403, network) vêm do helper compartilhado
+     * `buildSharedUserMutationErrorCases('forçar logout do')` (lição
+     * PR #128 — pré-projetar shared helpers para evitar duplicação
+     * literal entre suítes que diferem só pelo verbo).
+     *
+     * Casos específicos:
+     *
+     * - **404** — usuário removido entre abertura e confirm: modal
+     *   fecha + dispara refetch (paridade com o tratamento de 404 no
+     *   toggle/edit).
+     * - **400** — defesa em profundidade: a UI deveria ter escondido
+     *   o botão na linha do próprio operador, mas se o gating falhar
+     *   (ou se outro erro do backend devolver 400), o classificador
+     *   cai em `unhandled` e mostra a copy genérica. Validamos esse
+     *   caminho para garantir que não há regressão silenciosa.
+     */
+    const ERROR_CASES: ReadonlyArray<UsersErrorCase> = [
+      {
+        name: '404 (usuário já removido) fecha modal, exibe toast e dispara refetch',
+        error: {
+          kind: 'http',
+          status: 404,
+          message: 'Usuário não encontrado.',
+        },
+        expectedText: 'Usuário não encontrado ou foi removido. Atualize a lista.',
+        modalStaysOpen: false,
+      },
+      {
+        name: '400 (self-target, defesa em profundidade) cai em unhandled e exibe copy genérica',
+        error: {
+          kind: 'http',
+          status: 400,
+          message:
+            'Não é possível forçar logout de si mesmo por este endpoint. Utilize GET /auth/logout.',
+        },
+        expectedText:
+          'Não foi possível forçar logout do usuário. Tente novamente.',
+      },
+      ...buildSharedUserMutationErrorCases('forçar logout do'),
+    ];
+
+    it.each(ERROR_CASES)(
+      'mapeia $name',
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const target = makeUser({ id: ID_USER_ALICE });
+        const client = createUsersClientStub();
+        mockUserListResponse(client, [target]);
+        client.post.mockRejectedValueOnce(error);
+
+        await openForceLogoutConfirm(client, { user: target });
+        await confirmForceLogout(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole('dialog')).toBeInTheDocument();
+        } else {
+          await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+          });
+        }
+      },
+    );
+
+    it('404 dispara refetch (onLoggedOut chamado mesmo em erro)', async () => {
+      const target = makeUser({ id: ID_USER_ALICE });
+      const client = createUsersClientStub();
+      const getCallCount = mockUserListResponseWithCounter(client, [target]);
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 404,
+        message: 'Usuário não encontrado.',
+      } satisfies ApiError);
+
+      await openForceLogoutConfirm(client, { user: target });
+      await confirmForceLogout(client);
+
+      await waitFor(() => {
+        expect(getCallCount()).toBeGreaterThanOrEqual(2);
+      });
+    });
+  });
+});

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -12,6 +12,7 @@ import {
   assignRoleToUser,
   createUser,
   DEFAULT_USERS_PAGE_SIZE,
+  forceLogoutUser,
   getUserById,
   isPagedUsersResponse,
   isUserDto,
@@ -881,35 +882,6 @@ describe('resetUserPassword — body e path', () => {
     await resetUserPassword(
       USER_ID,
       '  senha-com-espacos  ',
-/**
- * Suíte do `getUserById` (Issue #71). Cobre a chamada do endpoint
- * `GET /users/{id}`, a propagação do array `roles`
- * (lfc-authenticator#167) e os erros típicos (404 quando o usuário
- * não existe, parse quando o shape diverge).
- */
-describe('getUserById', () => {
-  const ROLE_ID = '99999999-9999-9999-9999-999999999999';
-  const SYSTEM_ID_FOR_ROLE = '88888888-8888-8888-8888-888888888888';
-
-  function makeUserRoleSummary(
-    overrides: Partial<UserRoleSummary> = {},
-  ): UserRoleSummary {
-    return {
-      id: ROLE_ID,
-      name: 'Administrator',
-      code: 'admin',
-      systemId: SYSTEM_ID_FOR_ROLE,
-      ...overrides,
-    };
-  }
-
-  it('emite GET /users/{id} e devolve UserDto com roles preenchidas', async () => {
-    const client = createStub();
-    const userWithRoles = makeUserDto({ roles: [makeUserRoleSummary()] });
-    client.get.mockResolvedValueOnce(userWithRoles);
-
-    const result = await getUserById(
-      USER_ID,
       undefined,
       client as unknown as ApiClient,
     );
@@ -933,33 +905,6 @@ describe('getUserById', () => {
     await resetUserPassword(
       USER_ID,
       'nova-senha',
-    expect(client.get).toHaveBeenCalledTimes(1);
-    expect(client.get.mock.calls[0][0]).toBe(`/users/${USER_ID}`);
-    expect(result).toEqual(userWithRoles);
-    expect(result.roles).toHaveLength(1);
-    expect(result.roles?.[0].id).toBe(ROLE_ID);
-  });
-
-  it('aceita UserDto sem array roles (payload legado)', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce(makeUserDto());
-
-    const result = await getUserById(
-      USER_ID,
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.roles).toBeUndefined();
-  });
-
-  it('passa signal/options adiante para o cliente', async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce(makeUserDto());
-    const controller = new AbortController();
-
-    await getUserById(
-      USER_ID,
       { signal: controller.signal },
       client as unknown as ApiClient,
     );
@@ -1028,6 +973,104 @@ describe('resetUserPassword — response e erros', () => {
   });
 
   it('propaga 404 do backend (usuário removido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Usuário não encontrado.',
+    };
+    client.put.mockRejectedValueOnce(apiError);
+
+    await expect(
+      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
+  });
+});
+
+/**
+ * Suíte do `getUserById` (Issue #71). Cobre a chamada do endpoint
+ * `GET /users/{id}`, a propagação do array `roles`
+ * (lfc-authenticator#167) e os erros típicos (404 quando o usuário
+ * não existe, parse quando o shape diverge).
+ *
+ * **Fix incidental (Issue #82):** o merge do PR #163 (atribuir roles)
+ * com o PR #164 (reset de senha) deixou esta suíte quebrada com
+ * fragmentos enxertados dentro de `resetUserPassword`. Reescrita aqui
+ * de forma limpa para destravar o `tsc --noEmit` (e por consequência o
+ * gate pré-PR) — sem alterar a cobertura semântica original (assertion
+ * de path, propagação de roles, ApiError parse e propagação de 404).
+ */
+describe('getUserById', () => {
+  const ROLE_ID = '99999999-9999-9999-9999-999999999999';
+  const SYSTEM_ID_FOR_ROLE = '88888888-8888-8888-8888-888888888888';
+
+  function makeUserRoleSummary(
+    overrides: Partial<UserRoleSummary> = {},
+  ): UserRoleSummary {
+    return {
+      id: ROLE_ID,
+      name: 'Administrator',
+      code: 'admin',
+      systemId: SYSTEM_ID_FOR_ROLE,
+      ...overrides,
+    };
+  }
+
+  it('emite GET /users/{id} e devolve UserDto com roles preenchidas', async () => {
+    const client = createStub();
+    const userWithRoles = makeUserDto({ roles: [makeUserRoleSummary()] });
+    client.get.mockResolvedValueOnce(userWithRoles);
+
+    const result = await getUserById(
+      USER_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe(`/users/${USER_ID}`);
+    expect(result).toEqual(userWithRoles);
+    expect(result.roles).toHaveLength(1);
+    expect(result.roles?.[0].id).toBe(ROLE_ID);
+  });
+
+  it('aceita UserDto sem array roles (payload legado)', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makeUserDto());
+
+    const result = await getUserById(
+      USER_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result.roles).toBeUndefined();
+  });
+
+  it('passa signal/options adiante para o cliente', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makeUserDto());
+    const controller = new AbortController();
+
+    await getUserById(
+      USER_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
     expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
   });
 
@@ -1063,10 +1106,6 @@ describe('resetUserPassword — response e erros', () => {
       status: 404,
       message: 'Usuário não encontrado.',
     };
-    client.put.mockRejectedValueOnce(apiError);
-
-    await expect(
-      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
     client.get.mockRejectedValueOnce(apiError);
 
     await expect(
@@ -1076,7 +1115,6 @@ describe('resetUserPassword — response e erros', () => {
 
   it('propaga 401/403 sem traduzir', async () => {
     const client = createStub();
-    client.put.mockRejectedValueOnce({
     client.get.mockRejectedValueOnce({
       kind: 'http',
       status: 403,
@@ -1084,7 +1122,6 @@ describe('resetUserPassword — response e erros', () => {
     });
 
     await expect(
-      resetUserPassword(USER_ID, 'nova-senha', undefined, client as unknown as ApiClient),
       getUserById(USER_ID, undefined, client as unknown as ApiClient),
     ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
@@ -1288,6 +1325,149 @@ describe('removeRoleFromUser', () => {
         undefined,
         client as unknown as ApiClient,
       ),
+    ).rejects.toMatchObject({ kind: 'http', status: 403 });
+  });
+});
+
+/**
+ * Suíte do `forceLogoutUser` (Issue #82). Cobre a chamada do endpoint
+ * `POST /users/{id}/force-logout` (lfc-authenticator#168), validação do
+ * shape `ForceLogoutResponse` (`message`/`userId`/`newTokenVersion`) e
+ * propagação de erros tipados (`ApiError`):
+ *
+ * - 200 OK → devolve `ForceLogoutResponse` válido.
+ * - 200 OK com payload mal formatado → `ApiError(parse)`.
+ * - 400 (self-target) → propagado sem traduzir; UI bloqueia
+ *   preventivamente o botão na linha do próprio operador.
+ * - 401/403 → propagado sem traduzir; cliente HTTP já lidou com
+ *   `onUnauthorized`.
+ * - 404 (usuário soft-deletado entre abertura e submit) → propagado
+ *   sem traduzir; UI fecha modal + dispara refetch.
+ *
+ * Espelha o padrão de `assignRoleToUser`/`removeRoleFromUser` —
+ * stubamos o `ApiClient` injetável e validamos path/body/options sem
+ * bater na camada de transporte (responsabilidade de `client.test.ts`).
+ */
+describe('forceLogoutUser', () => {
+  function makeForceLogoutResponse() {
+    return {
+      message: 'Sessões do usuário invalidadas com sucesso.',
+      userId: USER_ID,
+      newTokenVersion: 5,
+    };
+  }
+
+  it('emite POST /users/{id}/force-logout sem body (null)', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeForceLogoutResponse());
+
+    await forceLogoutUser(
+      USER_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post.mock.calls[0][0]).toBe(
+      `/users/${USER_ID}/force-logout`,
+    );
+    // Body literal `null` para o cliente HTTP omitir o payload no
+    // request — o backend rejeita Content-Length > 0 num endpoint
+    // sem body declarado. Garantir `null` (não `undefined`,
+    // não `{}`) preserva paridade com o contrato.
+    expect(client.post.mock.calls[0][1]).toBeNull();
+  });
+
+  it('passa options adiante para o cliente (signal/abort)', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makeForceLogoutResponse());
+    const controller = new AbortController();
+
+    await forceLogoutUser(
+      USER_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][2]).toEqual({ signal: controller.signal });
+  });
+
+  it('devolve ForceLogoutResponse válido', async () => {
+    const client = createStub();
+    const response = makeForceLogoutResponse();
+    client.post.mockResolvedValueOnce(response);
+
+    const result = await forceLogoutUser(
+      USER_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual(response);
+    expect(result.newTokenVersion).toBe(5);
+  });
+
+  it('lança ApiError(parse) quando o response não é ForceLogoutResponse', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      forceLogoutUser(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('lança ApiError(parse) quando newTokenVersion não é number', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({
+      message: 'ok',
+      userId: USER_ID,
+      newTokenVersion: '5', // string ao invés de number — drift de contrato
+    });
+
+    await expect(
+      forceLogoutUser(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+
+  it('propaga 400 (self-target) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 400,
+      message:
+        'Não é possível forçar logout de si mesmo por este endpoint. Utilize GET /auth/logout.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      forceLogoutUser(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 404 (usuário não encontrado/removido) sem traduzir', async () => {
+    const client = createStub();
+    const apiError = {
+      kind: 'http',
+      status: 404,
+      message: 'Usuário não encontrado.',
+    };
+    client.post.mockRejectedValueOnce(apiError);
+
+    await expect(
+      forceLogoutUser(USER_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toEqual(apiError);
+  });
+
+  it('propaga 401/403 sem traduzir', async () => {
+    const client = createStub();
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão.',
+    });
+
+    await expect(
+      forceLogoutUser(USER_ID, undefined, client as unknown as ApiClient),
     ).rejects.toMatchObject({ kind: 'http', status: 403 });
   });
 });


### PR DESCRIPTION
## Contexto

Issue #82 (parte da EPIC #49 — CRUD de Usuários no painel administrativo).

Operadores precisam invalidar todas as sessões ativas de um usuário em cenários como comprometimento de credencial, troca de cargo ou encerramento de vínculo, sem aguardar a expiração natural dos tokens.

Backend (lfc-authenticator#168) expõe `POST /users/{id}/force-logout` que incrementa o `TokenVersion` do usuário-alvo — todos os JWTs antigos passam a falhar no próximo `verify-token`/`/auth/permissions`.

## Objetivo

Adicionar ação destrutiva "Forçar logout" por linha em `UsersListShellPage`, com modal de confirmação claramente diferenciado (variant `danger` + ícone `LogOut`) e feedback de sucesso/erro coerente.

## O que foi feito

### API (`src/shared/api/users.ts`)

- `forceLogoutUser(id, options?, client?): Promise<ForceLogoutResponse>` — POST sem body (`null` literal para o cliente HTTP omitir o payload).
- `ForceLogoutResponse { message, userId, newTokenVersion }` espelhando o backend.
- Type guard `isForceLogoutResponse` estrito (defesa contra drift de contrato — payload inesperado vira `ApiError(parse)`).
- Exports adicionados em `src/shared/api/index.ts`.

### UI (`src/pages/users/`)

- **`ForceLogoutUserConfirm.tsx`** — wrapper fino sobre `MutationConfirmModal` (extraído na #61, generalizado na #65) com:
  - Copy destrutiva: título "Forçar logout?", descrição "Todas as sessões ativas do usuário **X** (`email@…`) serão invalidadas. O usuário precisará fazer login novamente para acessar o sistema."
  - `confirmVariant="danger"` (paridade com Desativar — `--clr-orange/danger` no design system, sem hardcode).
  - Toast verde: "Sessões invalidadas. Usuário precisará fazer login novamente."
- **`userMutationTarget.ts`** — extrai `UserTarget` + `toUserTarget()` compartilhado entre `ToggleUserActiveConfirm` (#80) e `ForceLogoutUserConfirm` (#82). Refatoração simultânea no `ToggleUserActiveConfirm` para usar o helper — zera duplicação JSCPD entre os dois wrappers (lições PR #128/#134/#135).
- **`UsersListShellPage.tsx`** — nova ação na coluna "Ações" (desktop) e cards mobile, posicionada antes de "Desativar/Ativar". Visível com `Users.Update`. **Esconde na linha do próprio usuário corrente** (`currentUserId === row.id`) como defesa preventiva contra o 400 self-target do backend.

### Testes (24 novos)

- **`tests/shared/api/users.test.ts`** (8 novos): suíte de `forceLogoutUser` cobre path/body, propagação de 400 (self-target)/404 (não encontrado)/401/403, parse de `ForceLogoutResponse` válido e malformado.
- **`tests/pages/users/UserForceLogout.test.tsx`** (16 novos): gating de permissão, gating de self-target, abertura/fechamento (Esc/Cancel/backdrop), confirmação bem-sucedida (POST + toast + refetch), drift de contrato (parse fallback), erros (404/400/401/403/network) via `it.each` reusando `buildSharedUserMutationErrorCases('forçar logout do')`.
- Helpers compartilhados estendidos: `mockUseAuth.ts` agora aceita opcional `getUser` (necessário para gating self-target sem reescrever mock global); `usersTestHelpers.tsx` ganha `openForceLogoutConfirm` + `confirmForceLogout` + verbo `'forçar logout do'` em `UserMutationVerb` com branch dedicado para a copy de network error.

## Fix incidental

`src/shared/api/index.ts` e `tests/shared/api/users.test.ts` estavam quebrados em `origin/development` com merge conflict markers literais (`<<<<<<< HEAD` ... `>>>>>>>`) e blocos de teste embaralhados — resíduo do PR #163 mal mergeado (similar ao caso resolvido em PR #160 mas que escapou em outro arquivo).

Sintoma: `tsc --noEmit` falhava com 11 erros antes de qualquer modificação minha. Reescrita mínima e cirúrgica para destravar o gate pré-PR sem alterar a cobertura semântica original (mesmos asserts de path/propagação de roles/parse/404). Sem essa correção, **nenhum** PR poderia ser aberto contra `development`.

## Arquivos impactados

- `src/shared/api/users.ts` (+97 linhas)
- `src/shared/api/index.ts` (corrige merge markers + adiciona exports)
- `src/pages/users/ForceLogoutUserConfirm.tsx` (novo)
- `src/pages/users/userMutationTarget.ts` (novo)
- `src/pages/users/UsersListShellPage.tsx` (nova ação + estado + gating)
- `src/pages/users/ToggleUserActiveConfirm.tsx` (consome `userMutationTarget` extraído)
- `src/pages/users/index.ts` (export do novo componente)
- `tests/shared/api/users.test.ts` (fix incidental + suíte `forceLogoutUser`)
- `tests/pages/users/UserForceLogout.test.tsx` (novo)
- `tests/pages/__helpers__/usersTestHelpers.tsx` (helpers + verbo)
- `tests/pages/__helpers__/mockUseAuth.ts` (suporte opcional a `getUser`)

## Testes

- **Lint:** 0 erros, 0 warnings.
- **Typecheck:** 0 erros (`tsc --noEmit`).
- **Suíte completa:** 1274/1274 passed (24 novos).
- **JSCPD `src/`:** 2.22% (≤ 3%) — 0 clones envolvendo os arquivos do diff.

## Visual

- Botão "Forçar logout" usa `variant="danger"` + ícone `<LogOut size={14}>` (lucide-react, já no projeto).
- Modal segue exatamente o shell do `MutationConfirmModal` (mesmo layout/spacing dos modais "Desativar sistema/usuário", "Restaurar sistema") — preserva consistência visual entre ações destrutivas do produto.
- Hover/focus/disabled herdados do `<Button>` shared (já validados em PRs anteriores).
- Sem hardcode de cor — todas as superfícies via tokens (`--clr-orange/danger`, `--space-*`, `--radius-*`, `--text-*`).
- Loading state durante submit: botão fica em `loading=true`, Esc/backdrop bloqueados (controle do shell).
- Empty state, error state, refetch overlay: já tratados pela `UsersListShellPage` existente — nenhuma regressão.

## Segurança

- Não há renderização de HTML não sanitizado (`dangerouslySetInnerHTML` não usado).
- Nenhum dado sensível em log/console.
- Token JWT permanece gerenciado pelo `apiClient` singleton; chamada do `forceLogoutUser` não expõe credenciais.
- Self-target tem **dupla defesa**: gating preventivo no UI (esconde botão) + propagação do 400 do backend caso o gating falhe (cai em `unhandled` mostrando copy genérica, sem regressão silenciosa).

## Riscos

- O `UsersListShellPage` agora exibe 4 botões na coluna "Ações" (Editar, Redefinir senha, Forçar logout, Desativar/Ativar). Em viewport desktop padrão isso cabe sem overflow; em larguras intermediárias pode espremer. `RowActions` é `inline-flex` sem `flex-wrap` — alinhado com o padrão atual do projeto e fora do escopo desta issue. Se for necessário ajuste, fica para uma issue de ergonomia de coluna.

## Issue relacionada

Closes #82