### PR TITLE
feat(users): visualização read-only de permissões efetivas (#72)

### DIFF
--- a/src/hooks/useSingleFetchWithAbort.ts
+++ b/src/hooks/useSingleFetchWithAbort.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { extractErrorMessage, isFetchAborted } from '../shared/api';
+
+import type { SafeRequestOptions } from '../shared/api';
+
+/**
+ * Função de fetch consumida pelo hook. Recebe `options` com `signal`
+ * para cancelamento e devolve uma `Promise` do recurso (não-paginado).
+ *
+ * Genérico em `T` — o caller define o tipo do recurso devolvido pelo
+ * backend (ex.: `ReadonlyArray<EffectivePermissionDto>` para o painel
+ * de permissões efetivas, `UserDto` para um detalhe).
+ */
+export type SingleFetcher<T> = (options: SafeRequestOptions) => Promise<T>;
+
+/**
+ * Estado retornado por `useSingleFetchWithAbort` para o componente
+ * consumir.
+ *
+ * - `data` — payload da última request bem-sucedida (`null` em
+ *   loading inicial / erro).
+ * - `isInitialLoading` — `true` enquanto a primeira request não
+ *   completou (sucesso OU erro).
+ * - `errorMessage` — mensagem amigável quando o fetch falhou; `null`
+ *   em sucesso ou cancelamento.
+ * - `refetch` — força reexecutar o fetch (usado pelo botão "Tentar
+ *   novamente" e por callbacks pós-mutação).
+ */
+export interface UseSingleFetchWithAbortResult<T> {
+  data: T | null;
+  isInitialLoading: boolean;
+  errorMessage: string | null;
+  refetch: () => void;
+}
+
+interface UseSingleFetchWithAbortConfig<T> {
+  /**
+   * Função que executa a request — recebe `signal` para cancelamento e
+   * devolve o payload tipado. **Crucial:** o caller deve memoizar com
+   * `useCallback` (com dependências sobre os params reais) para que o
+   * hook saiba quando refazer fetch. Toda vez que `fetcher` mudar de
+   * identidade, o effect dispara nova request.
+   */
+  fetcher: SingleFetcher<T>;
+  /**
+   * Mensagem genérica usada quando o erro não é um `ApiError` reconhecido
+   * pelo `extractErrorMessage`. Cada página passa sua própria copy em
+   * pt-BR (ex.: "Falha ao carregar as permissões efetivas...").
+   */
+  fallbackErrorMessage: string;
+  /**
+   * Quando `true`, o effect skipa a request e desliga `isInitialLoading`.
+   * Usado por páginas que recebem `:id` da URL e querem evitar bater no
+   * backend quando o id é claramente inválido (validação client-side).
+   */
+  skip?: boolean;
+}
+
+/**
+ * Hook compartilhado que encapsula o pattern de fetch único de um
+ * recurso (não-paginado) com cancelamento via AbortController,
+ * tratamento padrão de erro e bumper de retry.
+ *
+ * **Por que existe (lições PR #134/#135):** as páginas
+ * `UserPermissionsShellPage` (Issue #70) e
+ * `UserEffectivePermissionsShellPage` (Issue #72) repetiam ~38 linhas
+ * de orquestração idêntica:
+ *
+ * 1. `useState` com `{ isInitialLoading, errorMessage, fetched, refetchNonce }`.
+ * 2. `useRef<AbortController>` para cancelar requests anteriores.
+ * 3. `handleRefetch` callback bumpando o nonce.
+ * 4. `useEffect` que cria controller, chama fetcher, trata erros
+ *    genericamente via `extractErrorMessage` + `isFetchAborted`.
+ *
+ * JSCPD tokeniza esse bloco como duplicado mesmo com call-sites em
+ * páginas diferentes — extrair em hook genérico parametrizado por
+ * `TData` mantém a fonte única e elimina o clone.
+ *
+ * **Diferença vs `usePaginatedFetch`:**
+ *
+ * - `usePaginatedFetch` lida com `PagedResponse<T>` (envelope com
+ *   `page`/`pageSize`/`total`/`data`) e expõe `rows` em vez de `data`.
+ * - Este hook lida com qualquer payload (`T`) e expõe `data` direto.
+ *
+ * Páginas que carregam **um único recurso** (efetivas, detalhe de
+ * usuário, role com permissões) usam este; páginas que carregam **uma
+ * página de lista** usam `usePaginatedFetch`.
+ */
+export function useSingleFetchWithAbort<T>(
+  config: UseSingleFetchWithAbortConfig<T>,
+): UseSingleFetchWithAbortResult<T> {
+  const { fetcher, fallbackErrorMessage, skip = false } = config;
+
+  const [state, setState] = useState<{
+    data: T | null;
+    isInitialLoading: boolean;
+    errorMessage: string | null;
+    refetchNonce: number;
+  }>({
+    data: null,
+    isInitialLoading: true,
+    errorMessage: null,
+    refetchNonce: 0,
+  });
+
+  const lastControllerRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isInitialLoading: true,
+      errorMessage: null,
+      refetchNonce: prev.refetchNonce + 1,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (skip) {
+      setState((prev) => ({ ...prev, isInitialLoading: false }));
+      return undefined;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    lastControllerRef.current?.abort();
+    lastControllerRef.current = controller;
+
+    setState((prev) => ({ ...prev, isInitialLoading: true, errorMessage: null }));
+
+    fetcher({ signal: controller.signal })
+      .then((data) => {
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          data,
+          isInitialLoading: false,
+          errorMessage: null,
+        }));
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        if (isFetchAborted(error)) return;
+        setState((prev) => ({
+          ...prev,
+          isInitialLoading: false,
+          errorMessage: extractErrorMessage(error, fallbackErrorMessage),
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [fetcher, fallbackErrorMessage, skip, state.refetchNonce]);
+
+  return {
+    data: state.data,
+    isInitialLoading: state.isInitialLoading,
+    errorMessage: state.errorMessage,
+    refetch,
+  };
+}

--- a/src/pages/roles/RolePermissionsShellPage.tsx
+++ b/src/pages/roles/RolePermissionsShellPage.tsx
@@ -30,11 +30,8 @@ import {
   AssignmentEmptyShell,
   AssignmentEmptyTitle,
   AssignmentGroupCard,
-  AssignmentGroupCode,
-  AssignmentGroupCount,
-  AssignmentGroupHeader,
+  AssignmentGroupHeaderRow,
   AssignmentGroupList,
-  AssignmentGroupName,
   AssignmentItemBadges,
   AssignmentItemCodeChip,
   AssignmentItemDescription,
@@ -539,15 +536,12 @@ const PermissionGroup: React.FC<PermissionGroupProps> = ({
   <AssignmentGroupCard
     data-testid={`role-permissions-group-${group.systemCode}`}
   >
-    <AssignmentGroupHeader>
-      <AssignmentGroupCode>{group.systemCode}</AssignmentGroupCode>
-      <AssignmentGroupName>{group.systemName}</AssignmentGroupName>
-      <AssignmentGroupCount
-        aria-label={`${group.permissions.length} permissões neste sistema`}
-      >
-        {group.permissions.length}
-      </AssignmentGroupCount>
-    </AssignmentGroupHeader>
+    <AssignmentGroupHeaderRow
+      systemCode={group.systemCode}
+      systemName={group.systemName}
+      count={group.permissions.length}
+      countAriaLabel={`${group.permissions.length} permissões neste sistema`}
+    />
     <AssignmentItemList>
       {group.permissions.map((perm) => {
         const isSelected = selectedAssigned.has(perm.id);

--- a/src/pages/users/UserEffectivePermissionsShellPage.tsx
+++ b/src/pages/users/UserEffectivePermissionsShellPage.tsx
@@ -1,0 +1,430 @@
+import { ArrowLeft, Info } from 'lucide-react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Alert, Badge, Select, Spinner } from '../../components/ui';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import { listEffectiveUserPermissions } from '../../shared/api';
+import {
+  AssignmentEmptyHint,
+  AssignmentEmptyShell,
+  AssignmentEmptyTitle,
+  AssignmentGroupCard,
+  AssignmentGroupHeaderRow,
+  AssignmentGroupList,
+  AssignmentItemBadges,
+  AssignmentItemCodeChip,
+  AssignmentItemDetails,
+  AssignmentItemList,
+  AssignmentItemMetaRow,
+  AssignmentItemPrimaryText,
+  AssignmentItemRow,
+  AssignmentItemTitleRow,
+  AssignmentLegendBar,
+  AssignmentLegendCopy,
+  AssignmentLegendItem,
+  AssignmentLoadingCopy,
+  AssignmentLoadingShell,
+  BackLink,
+  ErrorRetryBlock,
+  InvalidIdNotice,
+  Mono,
+} from '../../shared/listing';
+
+import {
+  breakdownPermissionOrigin,
+  deriveSystemOptionsFromEffective,
+  groupEffectivePermissionsBySystem,
+} from './userEffectivePermissionsHelpers';
+
+import type {
+  EffectivePermissionRoleSource,
+  EffectivePermissionSystemGroup,
+  EffectivePermissionSystemOption,
+} from './userEffectivePermissionsHelpers';
+import type { ApiClient, EffectivePermissionDto } from '../../shared/api';
+
+/**
+ * Heurística leve para descartar `:id` claramente inválido antes de
+ * bater no backend — espelha `UserPermissionsShellPage`/
+ * `UserRolesShellPage`. Aceita qualquer string não-vazia com pelo menos
+ * um caractere não-whitespace.
+ */
+function isProbablyValidUserId(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Valor especial do `<Select>` que representa "sem filtro" (mostrar
+ * permissões de todos os sistemas). Mantemos como constante para que o
+ * comparador (`selectedSystemId === ALL_SYSTEMS_OPTION_VALUE`) seja
+ * explícito e o teste possa importar a constante em vez de duplicar
+ * o literal.
+ */
+export const ALL_SYSTEMS_OPTION_VALUE = '__all__';
+
+interface UserEffectivePermissionsShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido
+   * (cada wrapper de API usa o singleton `apiClient`).
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Painel **read-only** consolidado das permissões efetivas de um
+ * usuário (Issue #72 / EPIC #48).
+ *
+ * Conceito: enquanto a `UserPermissionsShellPage` (Issue #70) edita
+ * apenas vínculos diretos e a `UserRolesShellPage` (Issue #71) edita
+ * apenas vínculos via role, esta página **mostra a união consolidada**
+ * — uma única lista agrupada por sistema com badges de origem por
+ * permissão. Sem checkbox, sem botão "Salvar"; o operador entende o
+ * impacto efetivo das atribuições e, se quiser alterar, navega para a
+ * tela dedicada (link no header e backlink padrão).
+ *
+ * Fluxo:
+ *
+ * 1. Carrega `GET /users/{id}/effective-permissions` via
+ *    `useSingleFetchWithAbort` (sem filtro no primeiro fetch).
+ * 2. Deriva a lista de sistemas únicos do payload (cache em
+ *    `cachedSystemOptions`) para popular o `<Select>` de filtro —
+ *    apenas sistemas com permissões efetivas aparecem como opção,
+ *    reduzindo ruído no dropdown. O cache é preservado entre filtros
+ *    para que o operador possa voltar para "Todos" ou trocar de
+ *    sistema sem que a lista de opções encolha.
+ * 3. Quando o operador escolhe um sistema, o `useCallback` do `fetcher`
+ *    muda de identidade e o hook refaz a request com `?systemId=`
+ *    (server-side filtering — alinhado com o contrato do backend).
+ * 4. Renderiza grupos por sistema; cada permissão exibe a badge "Direta"
+ *    (variant success) e/ou uma badge "Role: <Nome>" por origem `role`.
+ *
+ * **Visível com** `Permissions.Read` + `Users.Read`. O gating
+ * client-side fica na rota (`RequirePermission` aninhado em
+ * `src/routes/index.tsx`); a página assume que ambas as permissões já
+ * estão garantidas — não duplica a checagem aqui.
+ *
+ * **Reuso (lições PR #134/#135):** primitivos visuais
+ * (`AssignmentLegendBar`, `AssignmentGroupCard`, `AssignmentItemRow`,
+ * `AssignmentGroupHeaderRow`) vêm de `src/shared/listing/`,
+ * compartilhados com Issue #69/#70/#71. Orquestração de fetch
+ * (cancelamento + handleRefetch + state de loading/error) vem de
+ * `useSingleFetchWithAbort` em `src/hooks/`. Não usamos
+ * `AssignmentMatrixShell` porque ele inclui Save/Reset/contador —
+ * elementos exclusivos das telas de mutação. Esta página tem layout
+ * próprio (header sem actions, sem legenda Pendente, lista mais
+ * enxuta).
+ */
+export const UserEffectivePermissionsShellPage: React.FC<
+  UserEffectivePermissionsShellPageProps
+> = ({ client }) => {
+  const { id: userId } = useParams<{ id: string }>();
+  const hasValidUserId = isProbablyValidUserId(userId);
+
+  const [selectedSystemId, setSelectedSystemId] = useState<string>(
+    ALL_SYSTEMS_OPTION_VALUE,
+  );
+
+  // Cache da lista de sistemas únicos derivada do **primeiro** fetch
+  // sem filtro — preservada para que o `<Select>` continue mostrando
+  // todos os sistemas mesmo depois de o operador filtrar (escolher
+  // "Authenticator" não deveria esconder "Kurtto" do dropdown).
+  // Usamos `useRef` em vez de `useState` para preservar o cache sem
+  // disparar render extra: o cache é atualizado durante o `useMemo`
+  // de `systemOptions` (derivação síncrona), então `Select` aparece
+  // no mesmo render em que `effectiveData` chega.
+  const cachedSystemOptionsRef = useRef<
+    ReadonlyArray<EffectivePermissionSystemOption> | null
+  >(null);
+
+  const handleSystemChange = useCallback((value: string) => {
+    setSelectedSystemId(value);
+  }, []);
+
+  // Fetcher memoizado — depende apenas do `userId`, do filtro e do
+  // `client` injetado. O hook `useSingleFetchWithAbort` reage a
+  // mudanças na identidade do fetcher para reexecutar.
+  const fetcher = useCallback(
+    (options: { signal?: AbortSignal }) => {
+      const requestedSystemId =
+        selectedSystemId === ALL_SYSTEMS_OPTION_VALUE ? undefined : selectedSystemId;
+      return listEffectiveUserPermissions(
+        userId ?? '',
+        requestedSystemId,
+        options,
+        client,
+      );
+    },
+    [client, selectedSystemId, userId],
+  );
+
+  const {
+    data: effectiveData,
+    isInitialLoading,
+    errorMessage,
+    refetch: handleRefetch,
+  } = useSingleFetchWithAbort<ReadonlyArray<EffectivePermissionDto>>({
+    fetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar as permissões efetivas. Tente novamente.',
+    skip: !hasValidUserId,
+  });
+
+  // Deriva `systemOptions` síncrono ao render: quando `effectiveData`
+  // chega pela primeira vez (cache `null`), popula a ref com a lista de
+  // sistemas únicos e devolve essa lista. Filtros subsequentes NÃO
+  // recalculam — preservam o cache para que o operador possa voltar
+  // para "Todos os sistemas" sem perder opções do dropdown.
+  const systemOptions = useMemo<
+    ReadonlyArray<EffectivePermissionSystemOption>
+  >(() => {
+    if (cachedSystemOptionsRef.current !== null) {
+      return cachedSystemOptionsRef.current;
+    }
+    if (!effectiveData) {
+      return [];
+    }
+    const derived = deriveSystemOptionsFromEffective(effectiveData);
+    cachedSystemOptionsRef.current = derived;
+    return derived;
+  }, [effectiveData]);
+
+  const groups = useMemo<ReadonlyArray<EffectivePermissionSystemGroup>>(() => {
+    if (!effectiveData) return [];
+    return groupEffectivePermissionsBySystem(effectiveData);
+  }, [effectiveData]);
+
+  if (!hasValidUserId) {
+    return (
+      <>
+        <BackLink to="/usuarios" data-testid="user-effective-permissions-back">
+          <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+          Voltar para Usuários
+        </BackLink>
+        <PageHeader
+          eyebrow="06 Usuários · Permissões efetivas"
+          title="Permissões efetivas"
+          desc="Selecione um usuário para visualizar suas permissões efetivas."
+        />
+        <InvalidIdNotice data-testid="user-effective-permissions-invalid-id">
+          <Alert variant="warning">
+            ID de usuário ausente ou inválido na URL. Volte para a listagem de
+            usuários e selecione um para visualizar as permissões efetivas.
+          </Alert>
+        </InvalidIdNotice>
+      </>
+    );
+  }
+
+  const hasSystemOptions = systemOptions.length > 0;
+
+  return (
+    <>
+      <BackLink
+        to={`/usuarios/${userId}`}
+        data-testid="user-effective-permissions-back"
+      >
+        <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+        Voltar para o usuário
+      </BackLink>
+      <PageHeader
+        eyebrow="06 Usuários · Permissões efetivas"
+        title="Permissões efetivas"
+        desc="Painel consolidado, somente leitura, com todas as permissões efetivas do usuário (diretas e herdadas via roles). Para alterar atribuições, use as telas dedicadas de Permissões e Roles do usuário."
+      />
+
+      <AssignmentLegendBar
+        role="note"
+        aria-label="Legenda de origem das permissões efetivas"
+      >
+        <AssignmentLegendItem>
+          <Badge variant="success" dot>
+            Direta
+          </Badge>
+          <AssignmentLegendCopy>
+            vínculo direto entre o usuário e a permissão.
+          </AssignmentLegendCopy>
+        </AssignmentLegendItem>
+        <AssignmentLegendItem>
+          <Badge variant="info" dot>
+            Role
+          </Badge>
+          <AssignmentLegendCopy>
+            permissão herdada via uma role atribuída ao usuário.
+          </AssignmentLegendCopy>
+        </AssignmentLegendItem>
+      </AssignmentLegendBar>
+
+      {hasSystemOptions && (
+        <FilterRow data-testid="user-effective-permissions-filter">
+          <Select
+            label="Filtrar por sistema"
+            size="sm"
+            value={selectedSystemId}
+            onChange={handleSystemChange}
+            data-testid="user-effective-permissions-system-select"
+            aria-label="Filtrar permissões efetivas por sistema"
+          >
+            <option value={ALL_SYSTEMS_OPTION_VALUE}>Todos os sistemas</option>
+            {systemOptions.map((option) => (
+              <option key={option.systemId} value={option.systemId}>
+                {option.systemName} ({option.systemCode})
+              </option>
+            ))}
+          </Select>
+        </FilterRow>
+      )}
+
+      {isInitialLoading && (
+        <AssignmentLoadingShell
+          data-testid="user-effective-permissions-loading"
+          aria-live="polite"
+        >
+          <Spinner size="md" tone="accent" />
+          <AssignmentLoadingCopy>
+            Carregando permissões efetivas…
+          </AssignmentLoadingCopy>
+        </AssignmentLoadingShell>
+      )}
+
+      {!isInitialLoading && errorMessage && (
+        <ErrorRetryBlock
+          message={errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="user-effective-permissions-retry"
+        />
+      )}
+
+      {!isInitialLoading && !errorMessage && groups.length === 0 && (
+        <AssignmentEmptyShell data-testid="user-effective-permissions-empty">
+          <Info size={20} strokeWidth={1.5} aria-hidden="true" />
+          <AssignmentEmptyTitle>
+            Nenhuma permissão efetiva para este usuário.
+          </AssignmentEmptyTitle>
+          <AssignmentEmptyHint>
+            Atribua permissões diretamente ao usuário ou vincule-o a roles
+            que contenham permissões.
+          </AssignmentEmptyHint>
+        </AssignmentEmptyShell>
+      )}
+
+      {!isInitialLoading && !errorMessage && groups.length > 0 && (
+        <AssignmentGroupList aria-label="Permissões efetivas agrupadas por sistema">
+          {groups.map((group) => (
+            <EffectivePermissionGroup
+              key={group.systemId || group.systemCode}
+              group={group}
+            />
+          ))}
+        </AssignmentGroupList>
+      )}
+    </>
+  );
+};
+
+interface EffectivePermissionGroupProps {
+  group: EffectivePermissionSystemGroup;
+}
+
+const EffectivePermissionGroup: React.FC<EffectivePermissionGroupProps> = ({
+  group,
+}) => (
+  <AssignmentGroupCard
+    data-testid={`user-effective-permissions-group-${group.systemCode}`}
+  >
+    <AssignmentGroupHeaderRow
+      systemCode={group.systemCode}
+      systemName={group.systemName}
+      count={group.permissions.length}
+      countAriaLabel={`${group.permissions.length} permissões efetivas neste sistema`}
+    />
+    <AssignmentItemList>
+      {group.permissions.map((perm) => (
+        <EffectivePermissionItem key={perm.permissionId} permission={perm} />
+      ))}
+    </AssignmentItemList>
+  </AssignmentGroupCard>
+);
+
+interface EffectivePermissionItemProps {
+  permission: EffectivePermissionDto;
+}
+
+const EffectivePermissionItem: React.FC<EffectivePermissionItemProps> = ({
+  permission,
+}) => {
+  const breakdown = useMemo(
+    () => breakdownPermissionOrigin(permission.sources),
+    [permission.sources],
+  );
+  return (
+    <AssignmentItemRow
+      data-testid={`user-effective-permissions-item-${permission.permissionId}`}
+    >
+      <AssignmentItemDetails>
+        <AssignmentItemTitleRow>
+          <AssignmentItemPrimaryText>
+            {permission.routeName || permission.routeCode}
+          </AssignmentItemPrimaryText>
+          <AssignmentItemCodeChip>
+            <Mono>{permission.permissionTypeCode}</Mono>
+          </AssignmentItemCodeChip>
+        </AssignmentItemTitleRow>
+        <AssignmentItemMetaRow>
+          <Mono>{permission.routeCode || '—'}</Mono>
+        </AssignmentItemMetaRow>
+        <AssignmentItemBadges>
+          {breakdown.isDirect && (
+            <Badge variant="success" dot>
+              Direta
+            </Badge>
+          )}
+          {breakdown.roles.map((role) => (
+            <RoleOriginBadge key={role.roleId} role={role} />
+          ))}
+        </AssignmentItemBadges>
+      </AssignmentItemDetails>
+    </AssignmentItemRow>
+  );
+};
+
+interface RoleOriginBadgeProps {
+  role: EffectivePermissionRoleSource;
+}
+
+/**
+ * Badge dedicada para origem `role` — cada role contribuinte gera uma
+ * badge "Role: <Nome>" individual. Mantemos componente próprio (em vez
+ * de inline) para preservar uma `key` React estável (`role.roleId`) e
+ * isolar a copy "Role: <Nome>" em uma fonte única — qualquer mudança
+ * de microcopy fica num único ponto, e os testes podem validar a copy
+ * por `getByText(/^Role:/)` sem depender da estrutura interna do
+ * componente `<Badge>`.
+ */
+const RoleOriginBadge: React.FC<RoleOriginBadgeProps> = ({ role }) => (
+  <Badge variant="info" dot>
+    Role: {role.roleName}
+  </Badge>
+);
+
+/**
+ * Linha do filtro — wrapper que limita a largura do `<Select>` para que
+ * ele não ocupe toda a página em desktop. Margin-bottom para separar
+ * visualmente da lista de grupos. Mantemos local porque o pattern é
+ * exclusivo desta página (a `ListingToolbar` é específica das tabelas
+ * com Search + Switch, não se encaixa em filtro single-select read-only).
+ */
+const FilterRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: flex-end;
+  margin-bottom: var(--space-5);
+
+  & > * {
+    min-width: 240px;
+    max-width: 360px;
+  }
+`;

--- a/src/pages/users/UserPermissionsShellPage.tsx
+++ b/src/pages/users/UserPermissionsShellPage.tsx
@@ -25,11 +25,8 @@ import {
   AssignmentEmptyShell,
   AssignmentEmptyTitle,
   AssignmentGroupCard,
-  AssignmentGroupCode,
-  AssignmentGroupCount,
-  AssignmentGroupHeader,
+  AssignmentGroupHeaderRow,
   AssignmentGroupList,
-  AssignmentGroupName,
   AssignmentItemBadges,
   AssignmentItemCodeChip,
   AssignmentItemDescription,
@@ -478,15 +475,12 @@ const PermissionGroup: React.FC<PermissionGroupProps> = ({
   <AssignmentGroupCard
     data-testid={`user-permissions-group-${group.systemCode}`}
   >
-    <AssignmentGroupHeader>
-      <AssignmentGroupCode>{group.systemCode}</AssignmentGroupCode>
-      <AssignmentGroupName>{group.systemName}</AssignmentGroupName>
-      <AssignmentGroupCount
-        aria-label={`${group.permissions.length} permissões neste sistema`}
-      >
-        {group.permissions.length}
-      </AssignmentGroupCount>
-    </AssignmentGroupHeader>
+    <AssignmentGroupHeaderRow
+      systemCode={group.systemCode}
+      systemName={group.systemName}
+      count={group.permissions.length}
+      countAriaLabel={`${group.permissions.length} permissões neste sistema`}
+    />
     <AssignmentItemList>
       {group.permissions.map((perm) => {
         const isSelected = selectedDirect.has(perm.id);

--- a/src/pages/users/UserRolesShellPage.tsx
+++ b/src/pages/users/UserRolesShellPage.tsx
@@ -21,10 +21,7 @@ import {
 import { computeIdSetDiff, idSetDiffHasChanges } from '../../shared/forms';
 import {
   AssignmentGroupCard,
-  AssignmentGroupCode,
-  AssignmentGroupCount,
-  AssignmentGroupHeader,
-  AssignmentGroupName,
+  AssignmentGroupHeaderRow,
   AssignmentItemBadges,
   AssignmentItemCodeChip,
   AssignmentItemDescription,
@@ -396,13 +393,12 @@ const RoleGroup: React.FC<RoleGroupProps> = ({
   onToggle,
 }) => (
   <AssignmentGroupCard data-testid={`user-roles-group-${group.systemCode}`}>
-    <AssignmentGroupHeader>
-      <AssignmentGroupCode>{group.systemCode}</AssignmentGroupCode>
-      <AssignmentGroupName>{group.systemName}</AssignmentGroupName>
-      <AssignmentGroupCount aria-label={`${group.items.length} roles neste sistema`}>
-        {group.items.length}
-      </AssignmentGroupCount>
-    </AssignmentGroupHeader>
+    <AssignmentGroupHeaderRow
+      systemCode={group.systemCode}
+      systemName={group.systemName}
+      count={group.items.length}
+      countAriaLabel={`${group.items.length} roles neste sistema`}
+    />
     <AssignmentItemList>
       {group.items.map((role) => {
         const checkboxChecked = chosenRoleIds.has(role.id);

--- a/src/pages/users/index.ts
+++ b/src/pages/users/index.ts
@@ -1,5 +1,6 @@
 export { UsersListShellPage } from './UsersListShellPage';
 export { UserDetailShellPage } from './UserDetailShellPage';
+export { UserEffectivePermissionsShellPage } from './UserEffectivePermissionsShellPage';
 export { UserPermissionsShellPage } from './UserPermissionsShellPage';
 export { UserRolesShellPage } from './UserRolesShellPage';
 export { NewUserModal } from './NewUserModal';

--- a/src/pages/users/userEffectivePermissionsHelpers.ts
+++ b/src/pages/users/userEffectivePermissionsHelpers.ts
@@ -1,0 +1,237 @@
+import { groupBySystem } from '../../shared/listing';
+
+import type {
+  EffectivePermissionDto,
+  EffectivePermissionSource,
+} from '../../shared/api';
+import type { SystemGroup } from '../../shared/listing';
+
+/**
+ * Helpers puros (sem React) que sustentam a tela read-only de
+ * **visualização de permissões efetivas** de um usuário (Issue #72).
+ *
+ * Diferente da `userPermissionsHelpers.ts` (Issue #70 — atribuição
+ * direta com diff client-side), este módulo:
+ *
+ * - Não calcula diff (a tela é read-only).
+ * - Agrupa por sistema o resultado de `listEffectiveUserPermissions`
+ *   diretamente (e não o catálogo `listPermissions`), porque o
+ *   contrato de "efetivas" já filtra apenas o que o usuário
+ *   efetivamente tem.
+ * - Constrói uma lista canônica de sistemas únicos a partir das
+ *   próprias permissões efetivas, para popular o `<Select>` de
+ *   filtro por sistema sem precisar de um fetch adicional ao
+ *   `/systems` (decisão deliberada — a Issue #72 não exige listar
+ *   sistemas vazios; mostrar apenas sistemas com permissões
+ *   efetivas reduz ruído de UI).
+ *
+ * Mantemos a fonte única de verdade do agrupamento delegando ao
+ * `groupBySystem` genérico (`src/shared/listing/groupBySystem.ts`)
+ * para evitar duplicação ≥10 linhas com a Issue #70/#71 (lições
+ * PR #134/#135 — quando o **corpo** é idêntico entre recursos,
+ * extrair em helper genérico).
+ */
+
+/** Identifica de forma estável uma permissão pelo seu `id`. */
+export type PermissionId = string;
+
+/** Identifica de forma estável uma role pelo seu `id`. */
+export type RoleId = string;
+
+/**
+ * Bloco visual: todas as permissões efetivas de um usuário pertencentes
+ * a um mesmo sistema. Ordenadas por `routeCode` + `permissionTypeCode`
+ * (mesmo critério do backend para listagens, garante estabilidade
+ * visual entre fetches).
+ *
+ * Tipo é alias do `SystemGroup<EffectivePermissionDto>` genérico —
+ * preserva o nome semântico para os call-sites e renomeia o array
+ * `items` para `permissions` para legibilidade.
+ */
+export interface EffectivePermissionSystemGroup {
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+  permissions: ReadonlyArray<EffectivePermissionDto>;
+}
+
+/**
+ * Resumo de uma role que contribui para uma permissão efetiva — usado
+ * para renderizar uma badge "Role: Admin" por origem. `roleId` é o id
+ * estável usado como key React; `roleCode` aparece em mono-tooltip;
+ * `roleName` é o texto humano da badge.
+ */
+export interface EffectivePermissionRoleSource {
+  roleId: RoleId;
+  roleCode: string;
+  roleName: string;
+}
+
+/**
+ * Decomposição da `sources` de uma permissão efetiva em duas categorias
+ * mutuamente úteis para a UI:
+ *
+ * - `isDirect`: existe uma origem `kind === 'direct'`.
+ * - `roles`: array ordenado por `roleCode` das origens `kind === 'role'`.
+ *
+ * Backend devolve `sources` ordenadas (direct primeiro, depois roles
+ * por `roleCode`); aqui apenas separamos para que a UI render-side
+ * possa iterar `roles` sem branch interno e `isDirect` controle a
+ * badge "Direta".
+ */
+export interface EffectivePermissionOriginBreakdown {
+  isDirect: boolean;
+  roles: ReadonlyArray<EffectivePermissionRoleSource>;
+}
+
+/**
+ * Item do `<Select>` de filtro por sistema. `systemId` é o valor
+ * enviado para o backend via `?systemId=`; `systemCode`/`systemName`
+ * são apenas para apresentação. Os items são derivados das permissões
+ * efetivas reais (não do catálogo `listSystems`) para mostrar apenas
+ * sistemas onde o usuário **efetivamente tem alguma permissão** —
+ * reduz ruído de UI (selecionar um sistema vazio mostraria empty).
+ */
+export interface EffectivePermissionSystemOption {
+  systemId: string;
+  systemCode: string;
+  systemName: string;
+}
+
+/**
+ * Compara strings com `localeCompare` em pt-BR e ordem natural — o
+ * mesmo critério adotado em `userPermissionsHelpers.ts`/
+ * `userRolesHelpers.ts`. Mantemos a função local (não exportada) para
+ * que cada módulo tenha seu próprio comparador identidade-única — a
+ * implementação trivial não justifica importar de um shared.
+ */
+function compareStrings(a: string, b: string): number {
+  return a.localeCompare(b, 'pt-BR', { sensitivity: 'base' });
+}
+
+/**
+ * Compara duas permissões efetivas dentro do mesmo grupo: primeiro por
+ * `routeCode`, depois por `permissionTypeCode`. Mantida fora de
+ * `groupEffectivePermissionsBySystem` para reduzir complexidade
+ * cognitiva (lição PR #134/#135 — Sonar conta branches aninhados;
+ * isolar comparadores reduz o "cognitivo" sem prejudicar leitura).
+ */
+function compareEffectiveInGroup(
+  a: EffectivePermissionDto,
+  b: EffectivePermissionDto,
+): number {
+  const byRoute = compareStrings(a.routeCode, b.routeCode);
+  if (byRoute !== 0) return byRoute;
+  return compareStrings(a.permissionTypeCode, b.permissionTypeCode);
+}
+
+/**
+ * Adapta o `SystemGroup<EffectivePermissionDto>` genérico para a forma
+ * esperada pela página (`permissions` em vez de `items`). Mantemos o
+ * adapter simples — só renomeia o campo da coleção.
+ */
+function toEffectivePermissionGroup(
+  group: SystemGroup<EffectivePermissionDto>,
+): EffectivePermissionSystemGroup {
+  return {
+    systemId: group.systemId,
+    systemCode: group.systemCode,
+    systemName: group.systemName,
+    permissions: group.items,
+  };
+}
+
+/**
+ * Agrupa as permissões efetivas de um usuário por sistema. Sistemas
+ * sem `systemId` (denormalizado vazio em casos raros — soft-delete em
+ * cascata no backend) caem em um grupo virtual com `systemCode` "—"
+ * para preservar a permissão na UI em vez de descartá-la
+ * silenciosamente.
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `systemCode` (estabilidade visual).
+ * 2. Permissões dentro de cada grupo por `routeCode` então
+ *    `permissionTypeCode` (mesmo critério do backend para listagens).
+ *
+ * Função pura — entrada imutável, saída nova. Delega ao
+ * `groupBySystem` genérico para alinhar com Issue #70/#71 e evitar
+ * duplicação que o Sonar tokenizaria.
+ */
+export function groupEffectivePermissionsBySystem(
+  effective: ReadonlyArray<EffectivePermissionDto>,
+): ReadonlyArray<EffectivePermissionSystemGroup> {
+  const groups = groupBySystem(effective, {
+    compareItems: compareEffectiveInGroup,
+  });
+  return groups.map(toEffectivePermissionGroup);
+}
+
+/**
+ * Decompõe o array `sources` de uma permissão em `isDirect` (booleano
+ * único) + `roles` (array ordenado por `roleCode`). Origens `role`
+ * com `roleId`/`roleCode`/`roleName` ausentes são silenciosamente
+ * descartadas — o backend garante esses campos quando `kind === 'role'`,
+ * mas o type guard tolera `null`/`undefined`. Em caso de inconsistência
+ * raríssima, preferimos esconder a badge a quebrar a UI.
+ */
+export function breakdownPermissionOrigin(
+  sources: ReadonlyArray<EffectivePermissionSource>,
+): EffectivePermissionOriginBreakdown {
+  const isDirect = sources.some((source) => source.kind === 'direct');
+  const roles: Array<EffectivePermissionRoleSource> = [];
+  for (const source of sources) {
+    if (
+      source.kind === 'role' &&
+      source.roleId &&
+      source.roleCode &&
+      source.roleName
+    ) {
+      roles.push({
+        roleId: source.roleId,
+        roleCode: source.roleCode,
+        roleName: source.roleName,
+      });
+    }
+  }
+  roles.sort((a, b) => compareStrings(a.roleCode, b.roleCode));
+  return { isDirect, roles };
+}
+
+/**
+ * Constrói a lista de sistemas únicos a partir das permissões
+ * efetivas — usada para popular o `<Select>` de filtro. Cada sistema
+ * aparece uma única vez; o array é ordenado por `systemCode` (estável
+ * com o agrupamento da lista principal).
+ *
+ * Decisão (Issue #72): derivamos a lista das próprias permissões
+ * efetivas em vez de fazer um fetch a `/systems`. Justificativa:
+ *
+ * - Reduz round-trip extra (UI já carrega as efetivas; reaproveita).
+ * - Filtra automaticamente sistemas sem permissões efetivas — o
+ *   `<Select>` mostra apenas opções "úteis" (selecionar um sistema
+ *   sem permissão efetiva mostraria empty, que é ruído).
+ *
+ * Sistemas com `systemId` vazio (caso degenerado) são descartados —
+ * o `<Select>` precisa de `value` único e estável, e oferecer um
+ * "sem sistema" no dropdown adicionaria semântica confusa para o
+ * operador. Permissões nesse estado continuam visíveis no agrupamento
+ * principal (sob "—"), apenas não filtramos por elas.
+ */
+export function deriveSystemOptionsFromEffective(
+  effective: ReadonlyArray<EffectivePermissionDto>,
+): ReadonlyArray<EffectivePermissionSystemOption> {
+  const seen = new Map<string, EffectivePermissionSystemOption>();
+  for (const item of effective) {
+    if (item.systemId && !seen.has(item.systemId)) {
+      seen.set(item.systemId, {
+        systemId: item.systemId,
+        systemCode: item.systemCode,
+        systemName: item.systemName,
+      });
+    }
+  }
+  return Array.from(seen.values()).sort((a, b) =>
+    compareStrings(a.systemCode, b.systemCode),
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,6 +18,7 @@ import { SystemsPage } from '../pages/SystemsPage';
 import { UnauthorizedPage } from '../pages/UnauthorizedPage';
 import {
   UserDetailShellPage,
+  UserEffectivePermissionsShellPage,
   UserPermissionsShellPage,
   UserRolesShellPage,
   UsersListShellPage,
@@ -242,6 +243,28 @@ export const AppRoutes: React.FC = () => (
           <RequirePermission code="AUTH_V1_ROLES_LIST">
             <RequirePermission code="AUTH_V1_USERS_ROLES_ASSIGN">
               <UserRolesShellPage />
+            </RequirePermission>
+          </RequirePermission>
+        }
+      />
+      <Route
+        path="/usuarios/:id/permissoes-efetivas"
+        element={
+          // Issue #72: painel READ-ONLY com a união consolidada das
+          // permissões efetivas (diretas + via roles). Exige LER o
+          // catálogo de permissões (`Permissions.Read`, code
+          // `AUTH_V1_PERMISSIONS_LIST`) — para que o operador entenda
+          // os codes/nomes das permissões — E LER o usuário
+          // (`Users.Read`, code `AUTH_V1_USERS_GET_BY_ID`) — para que o
+          // backend autorize o `GET /users/{id}/effective-permissions`
+          // (mesma policy `UsersRead` aplicada ao endpoint). Aninhamos
+          // `RequirePermission` para validar ambas; começamos pelo
+          // `Permissions.Read` para que o erro mais comum (admin sem
+          // leitura do catálogo) fale primeiro, espelhando o padrão da
+          // Issue #70.
+          <RequirePermission code="AUTH_V1_PERMISSIONS_LIST">
+            <RequirePermission code="AUTH_V1_USERS_GET_BY_ID">
+              <UserEffectivePermissionsShellPage />
             </RequirePermission>
           </RequirePermission>
         }

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -55,6 +55,16 @@ const systemId: string = resolveSystemId();
 export const apiClient: ApiClient = createApiClient({ baseUrl, systemId });
 
 export { createApiClient } from './client';
+// Fix incidental (Issue #72): o PR #163 (commit 0308969) extraiu
+// `extractErrorMessage`/`isFetchAborted` para `fetchHelpers.ts` mas
+// não exportou pelo barrel. As páginas existentes
+// (`UserPermissionsShellPage`, `UserRolesShellPage`) já importavam de
+// `@/shared/api`, mas o `tsc --noEmit` ficou quebrado em
+// `origin/development` desde o merge do PR #163. Esta exportação
+// destrava o gate pré-PR. A Issue #82 detectou o problema em paralelo
+// com a mesma resolução — caso seja mergeada antes, este bloco
+// conflitará trivialmente em rebase (manter ambas as resoluções
+// semanticamente idênticas).
 export { extractErrorMessage, isFetchAborted } from './fetchHelpers';
 export { isApiError } from './types';
 export type {

--- a/src/shared/listing/AssignmentGroupHeaderRow.tsx
+++ b/src/shared/listing/AssignmentGroupHeaderRow.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import {
+  GroupCode as AssignmentGroupCode,
+  GroupCount as AssignmentGroupCount,
+  GroupHeader as AssignmentGroupHeader,
+  GroupName as AssignmentGroupName,
+} from './AssignmentMatrixStyles';
+
+/**
+ * Cabeçalho padrão de um grupo de "matriz de atribuição" agrupada por
+ * sistema — exibe `systemCode` (mono pequeno), `systemName` (heading sm)
+ * e contagem de itens (badge à direita) com `aria-label` parametrizado.
+ *
+ * **Por que existe (lições PR #134/#135):** as três páginas de
+ * atribuição (`UserPermissionsShellPage` da #70, `UserRolesShellPage`
+ * da #71 via `AssignmentMatrixShell`) e a nova `UserEffectivePermissionsShellPage`
+ * (#72) repetiam ~16 linhas de JSX idêntico no header do grupo,
+ * variando apenas em (i) literal do `data-testid` e (ii) sufixo do
+ * `aria-label` da contagem. JSCPD tokeniza isso como bloco duplicado
+ * mesmo entre arquivos diferentes — quando a forma é idêntica,
+ * extrair em componente parametrizado é o caminho.
+ *
+ * **Nota de escopo:** este componente NÃO inclui o `<AssignmentGroupCard>`
+ * wrapper externo nem o `<AssignmentItemList>` interno — cada caller
+ * controla seus filhos (linhas com checkbox vs read-only). Isolamos
+ * apenas o `<AssignmentGroupHeader>` + 3 children, que é o subset
+ * realmente repetido.
+ */
+export interface AssignmentGroupHeaderRowProps {
+  /** Code do sistema (ex.: "authenticator"). Renderizado em mono. */
+  systemCode: string;
+  /** Nome humano do sistema (ex.: "Authenticator"). Renderizado em heading. */
+  systemName: string;
+  /** Quantidade de itens do grupo (ex.: número de permissões). */
+  count: number;
+  /**
+   * Label completo (i18n) usado como `aria-label` do contador. Ex.:
+   * `"5 permissões neste sistema"`, `"3 roles neste sistema"`,
+   * `"7 permissões efetivas neste sistema"`. Cada caller decide a
+   * copy — manter como prop preserva legibilidade do recurso.
+   */
+  countAriaLabel: string;
+}
+
+export const AssignmentGroupHeaderRow: React.FC<AssignmentGroupHeaderRowProps> = ({
+  systemCode,
+  systemName,
+  count,
+  countAriaLabel,
+}) => (
+  <AssignmentGroupHeader>
+    <AssignmentGroupCode>{systemCode}</AssignmentGroupCode>
+    <AssignmentGroupName>{systemName}</AssignmentGroupName>
+    <AssignmentGroupCount aria-label={countAriaLabel}>{count}</AssignmentGroupCount>
+  </AssignmentGroupHeader>
+);

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -45,6 +45,10 @@ export {
 } from './styles';
 
 export {
+  AssignmentGroupHeaderRow,
+  type AssignmentGroupHeaderRowProps,
+} from './AssignmentGroupHeaderRow';
+export {
   AssignmentMatrixShell,
   type AssignmentMatrixShellProps,
 } from './AssignmentMatrixShell';

--- a/tests/pages/users/UserEffectivePermissions.test.tsx
+++ b/tests/pages/users/UserEffectivePermissions.test.tsx
@@ -1,0 +1,462 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createUserEffectivePermissionsClientStub,
+  ID_PERM_ROLES_LIST,
+  ID_PERM_USERS_LIST,
+  ID_PERM_USERS_UPDATE,
+  ID_ROLE_VIEWER,
+  ID_SYS_AUTH,
+  ID_SYS_KURTTO,
+  ID_USER,
+  makeEffective,
+  makeRoleSource,
+  primeStubResponses,
+  renderUserEffectivePermissionsPage,
+  waitForInitialFetch,
+} from './__helpers__/userEffectivePermissionsTestHelpers';
+
+import { ToastProvider } from '@/components/ui';
+import { UserEffectivePermissionsShellPage } from '@/pages/users';
+
+/**
+ * Helper que cria uma Promise que nunca resolve. Necessário para
+ * simular um fetch travado (loading state) — `() => {}` em arrow
+ * function dispara `no-empty-function`. Wrapper documentado mantém a
+ * intenção legível e satisfaz a regra (mesmo pattern de
+ * `UserPermissionsPage.test.tsx`).
+ */
+const NEVER_RESOLVES = (): Promise<never> => new Promise<never>(() => undefined);
+
+/**
+ * Suíte da `UserEffectivePermissionsShellPage` (Issue #72).
+ *
+ * Cobre: estados de loading, erro, vazio, render do agrupamento por
+ * sistema, badges de origem (Direta + Role: X múltiplas), filtro por
+ * sistema com refetch server-side, tratamento de :id inválido.
+ *
+ * Stub do `ApiClient` injetado via prop `client` — espelha o pattern
+ * de `UserPermissionsPage.test.tsx`. Roteador configurado para
+ * `/usuarios/:id/permissoes-efetivas` para que `useParams` devolva o
+ * id real.
+ */
+
+describe('UserEffectivePermissionsShellPage — :id inválido', () => {
+  it('exibe InvalidIdNotice quando :id é só whitespace', () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client);
+
+    render(
+      <ToastProvider>
+        <MemoryRouter
+          initialEntries={['/usuarios/%20/permissoes-efetivas']}
+        >
+          <Routes>
+            <Route
+              path="/usuarios/:id/permissoes-efetivas"
+              element={<UserEffectivePermissionsShellPage client={client} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>,
+    );
+
+    expect(
+      screen.getByTestId('user-effective-permissions-invalid-id'),
+    ).toBeInTheDocument();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserEffectivePermissionsShellPage — loading e erro inicial', () => {
+  it('exibe spinner enquanto a request não retorna', () => {
+    const client = createUserEffectivePermissionsClientStub();
+    client.get.mockImplementation(NEVER_RESOLVES);
+
+    renderUserEffectivePermissionsPage(client);
+
+    expect(
+      screen.getByTestId('user-effective-permissions-loading'),
+    ).toBeInTheDocument();
+  });
+
+  it('exibe ErrorRetryBlock quando a request falha', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    client.get.mockRejectedValue({
+      kind: 'http',
+      status: 500,
+      message: 'Falha interna no servidor.',
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitFor(() => {
+      expect(screen.getByText('Falha interna no servidor.')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId('user-effective-permissions-retry'),
+    ).toBeInTheDocument();
+  });
+
+  it('retry refaz a request e renderiza o grupo após sucesso', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    let attempt = 0;
+    client.get.mockImplementation(() => {
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.reject({ kind: 'network', message: 'Falha de conexão.' });
+      }
+      return Promise.resolve([makeEffective()]);
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('user-effective-permissions-retry'),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('user-effective-permissions-retry'));
+
+    await waitForInitialFetch();
+    expect(
+      screen.getByTestId('user-effective-permissions-group-authenticator'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('UserEffectivePermissionsShellPage — render do agrupamento', () => {
+  it('renderiza grupos por sistema, ordenados por systemCode', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: 'p-kurtto',
+          systemId: ID_SYS_KURTTO,
+          systemCode: 'kurtto',
+          systemName: 'Kurtto',
+          routeCode: 'KURTTO_V1_FOO',
+          routeName: 'Foo',
+        }),
+        makeEffective({
+          permissionId: ID_PERM_USERS_LIST,
+          systemId: ID_SYS_AUTH,
+          systemCode: 'authenticator',
+          systemName: 'Authenticator',
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const groups = screen.getAllByLabelText(
+      /permissões efetivas neste sistema/i,
+    );
+    expect(groups).toHaveLength(2);
+    expect(
+      screen.getByTestId('user-effective-permissions-group-authenticator'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('user-effective-permissions-group-kurtto'),
+    ).toBeInTheDocument();
+  });
+
+  it('exibe estado vazio quando o usuário não tem permissões efetivas', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, { effective: [] });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    expect(
+      screen.getByTestId('user-effective-permissions-empty'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('UserEffectivePermissionsShellPage — badges de origem', () => {
+  it('permissão direta apenas exibe badge "Direta"', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_USERS_LIST,
+          sources: [{ kind: 'direct' }],
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(
+      `user-effective-permissions-item-${ID_PERM_USERS_LIST}`,
+    );
+    expect(item).toHaveTextContent('Direta');
+    expect(item).not.toHaveTextContent('Role:');
+  });
+
+  it('permissão herdada via uma role exibe badge "Role: <nome>"', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_ROLES_LIST,
+          sources: [makeRoleSource()],
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(
+      `user-effective-permissions-item-${ID_PERM_ROLES_LIST}`,
+    );
+    expect(item).toHaveTextContent(/Role:\s*Administrator/);
+    expect(item).not.toHaveTextContent('Direta');
+  });
+
+  it('permissão herdada via múltiplas roles exibe uma badge por role', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_USERS_UPDATE,
+          sources: [
+            makeRoleSource({
+              roleId: ID_ROLE_VIEWER,
+              roleCode: 'viewer',
+              roleName: 'Viewer',
+            }),
+            makeRoleSource(),
+          ],
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(
+      `user-effective-permissions-item-${ID_PERM_USERS_UPDATE}`,
+    );
+    // Duas badges separadas, uma por role contribuinte (ordem alfabética
+    // por roleCode: 'admin' antes de 'viewer'). Validamos via texto +
+    // contagem de matches dentro do item — como Badge não aceita
+    // `data-testid` nativamente, manter a asserção visual textual evita
+    // depender da estrutura interna do styled-component.
+    expect(item).toHaveTextContent(/Role:\s*Administrator/);
+    expect(item).toHaveTextContent(/Role:\s*Viewer/);
+    const matches = within(item).getAllByText(/^Role:/);
+    expect(matches).toHaveLength(2);
+  });
+
+  it('permissão direta + via role exibe ambas as badges', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_USERS_LIST,
+          sources: [{ kind: 'direct' }, makeRoleSource()],
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const item = screen.getByTestId(
+      `user-effective-permissions-item-${ID_PERM_USERS_LIST}`,
+    );
+    expect(item).toHaveTextContent('Direta');
+    expect(item).toHaveTextContent(/Role:\s*Administrator/);
+  });
+});
+
+describe('UserEffectivePermissionsShellPage — filtro por sistema', () => {
+  it('popula o <Select> apenas com sistemas presentes nas efetivas', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          permissionId: ID_PERM_USERS_LIST,
+          systemId: ID_SYS_AUTH,
+          systemCode: 'authenticator',
+          systemName: 'Authenticator',
+        }),
+        makeEffective({
+          permissionId: 'p-kurtto',
+          systemId: ID_SYS_KURTTO,
+          systemCode: 'kurtto',
+          systemName: 'Kurtto',
+          routeCode: 'KURTTO_V1_FOO',
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    const select = screen.getByTestId(
+      'user-effective-permissions-system-select',
+    ) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.text);
+    // Inclui "Todos os sistemas" + os 2 sistemas únicos.
+    expect(options).toContain('Todos os sistemas');
+    expect(options).toContain('Authenticator (authenticator)');
+    expect(options).toContain('Kurtto (kurtto)');
+    expect(options).toHaveLength(3);
+  });
+
+  it('escolher um sistema dispara nova request com ?systemId=', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          systemId: ID_SYS_AUTH,
+          systemCode: 'authenticator',
+          systemName: 'Authenticator',
+        }),
+        makeEffective({
+          permissionId: 'p-kurtto',
+          systemId: ID_SYS_KURTTO,
+          systemCode: 'kurtto',
+          systemName: 'Kurtto',
+          routeCode: 'KURTTO_V1_FOO',
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+    await waitForInitialFetch();
+
+    // Primeiro fetch: sem filtro (querystring vazia)
+    expect(client.get).toHaveBeenCalledWith(
+      `/users/${ID_USER}/effective-permissions`,
+      expect.any(Object),
+    );
+
+    fireEvent.change(
+      screen.getByTestId('user-effective-permissions-system-select'),
+      { target: { value: ID_SYS_AUTH } },
+    );
+
+    await waitFor(() => {
+      expect(client.get).toHaveBeenCalledWith(
+        `/users/${ID_USER}/effective-permissions?systemId=${ID_SYS_AUTH}`,
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('voltar para "Todos os sistemas" dispara request sem filtro', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, {
+      effective: [
+        makeEffective({
+          systemId: ID_SYS_AUTH,
+          systemCode: 'authenticator',
+          systemName: 'Authenticator',
+        }),
+      ],
+    });
+
+    renderUserEffectivePermissionsPage(client);
+    await waitForInitialFetch();
+
+    fireEvent.change(
+      screen.getByTestId('user-effective-permissions-system-select'),
+      { target: { value: ID_SYS_AUTH } },
+    );
+    await waitFor(() => {
+      expect(client.get).toHaveBeenCalledWith(
+        `/users/${ID_USER}/effective-permissions?systemId=${ID_SYS_AUTH}`,
+        expect.any(Object),
+      );
+    });
+
+    // Volta para "Todos os sistemas" — espera-se request sem ?systemId=
+    fireEvent.change(
+      screen.getByTestId('user-effective-permissions-system-select'),
+      { target: { value: '__all__' } },
+    );
+
+    await waitFor(() => {
+      const lastCall = client.get.mock.calls[client.get.mock.calls.length - 1];
+      expect(lastCall[0]).toBe(`/users/${ID_USER}/effective-permissions`);
+    });
+  });
+
+  it('não exibe o filtro quando o usuário não tem permissões efetivas', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    primeStubResponses(client, { effective: [] });
+
+    renderUserEffectivePermissionsPage(client);
+
+    await waitForInitialFetch();
+    expect(
+      screen.queryByTestId('user-effective-permissions-system-select'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('preserva opções de sistema cacheadas após filtrar (não encolhem ao filtrar)', async () => {
+    const client = createUserEffectivePermissionsClientStub();
+    let callIndex = 0;
+    const allEffective = [
+      makeEffective({
+        systemId: ID_SYS_AUTH,
+        systemCode: 'authenticator',
+        systemName: 'Authenticator',
+      }),
+      makeEffective({
+        permissionId: 'p-kurtto',
+        systemId: ID_SYS_KURTTO,
+        systemCode: 'kurtto',
+        systemName: 'Kurtto',
+        routeCode: 'KURTTO_V1_FOO',
+      }),
+    ];
+    const filteredAuthOnly = [allEffective[0]];
+    client.get.mockImplementation((path: string) => {
+      if (path.includes('/effective-permissions')) {
+        callIndex += 1;
+        // Primeiro fetch: sem filtro (todas). Segundo: apenas o sistema
+        // filtrado — simula filtragem real do backend.
+        return Promise.resolve(callIndex === 1 ? allEffective : filteredAuthOnly);
+      }
+      return Promise.reject(new Error('URL inesperada'));
+    });
+
+    renderUserEffectivePermissionsPage(client);
+    await waitForInitialFetch();
+
+    // Antes do filtro: 2 sistemas no dropdown.
+    let select = screen.getByTestId(
+      'user-effective-permissions-system-select',
+    ) as HTMLSelectElement;
+    expect(select.options).toHaveLength(3); // 2 sistemas + "Todos"
+
+    // Filtra por Authenticator.
+    fireEvent.change(select, { target: { value: ID_SYS_AUTH } });
+    await waitFor(() => {
+      expect(callIndex).toBe(2);
+    });
+    await waitForInitialFetch();
+
+    // Mesmo após filtrar, o dropdown mantém Kurtto como opção (cache de
+    // `systemOptions` preservado entre filtros — caso contrário o
+    // operador ficaria preso no sistema atual).
+    select = screen.getByTestId(
+      'user-effective-permissions-system-select',
+    ) as HTMLSelectElement;
+    expect(select.options).toHaveLength(3);
+    const optionTexts = Array.from(select.options).map((o) => o.text);
+    expect(optionTexts).toContain('Kurtto (kurtto)');
+  });
+});

--- a/tests/pages/users/__helpers__/userEffectivePermissionsTestHelpers.tsx
+++ b/tests/pages/users/__helpers__/userEffectivePermissionsTestHelpers.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import type {
+  ApiClient,
+  EffectivePermissionDto,
+  EffectivePermissionSource,
+} from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { UserEffectivePermissionsShellPage } from '@/pages/users';
+
+/**
+ * Helpers compartilhados pela suíte da `UserEffectivePermissionsShellPage`
+ * (Issue #72). Espelha o pattern já adotado em
+ * `userPermissionsTestHelpers.tsx` (Issue #70) e
+ * `userRolesTestHelpers.tsx` (Issue #71) — manter o stub `ApiClient`,
+ * fixtures `make*` e helpers de render/await em uma fonte única reduz
+ * duplicação ≥10 linhas que o Sonar/jscpd tokeniza (lições
+ * PR #128/#134/#135).
+ *
+ * Esta página tem apenas **uma** fonte de dados:
+ * `GET /users/{id}/effective-permissions`. O stub pré-configura a
+ * resposta padrão (1 permissão direta) e os testes sobrescrevem por
+ * cenário via `primeStubResponses({ effective: ... })`.
+ */
+
+export const ID_USER = '11111111-1111-1111-1111-111111111111';
+export const ID_PERM_USERS_LIST = '22222222-2222-2222-2222-222222222222';
+export const ID_PERM_USERS_UPDATE = '33333333-3333-3333-3333-333333333333';
+export const ID_PERM_ROLES_LIST = '44444444-4444-4444-4444-444444444444';
+export const ID_SYS_AUTH = '55555555-5555-5555-5555-555555555555';
+export const ID_SYS_KURTTO = '66666666-6666-6666-6666-666666666666';
+export const ID_ROLE_ADMIN = '77777777-7777-7777-7777-777777777777';
+export const ID_ROLE_VIEWER = '88888888-8888-8888-8888-888888888888';
+
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createUserEffectivePermissionsClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Fixture-builder para uma `EffectivePermissionDto` "feliz" (uma
+ * permissão direta no sistema Authenticator). Cada teste sobrescreve
+ * apenas o que importa via `overrides` para manter o cenário focado.
+ */
+export function makeEffective(
+  overrides: Partial<EffectivePermissionDto> = {},
+): EffectivePermissionDto {
+  return {
+    permissionId: ID_PERM_USERS_LIST,
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    systemId: ID_SYS_AUTH,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    sources: [{ kind: 'direct' }],
+    ...overrides,
+  };
+}
+
+/**
+ * Fixture-builder para uma fonte `kind: 'role'` — útil para montar
+ * cenários de origem múltipla sem repetir o literal a cada teste.
+ */
+export function makeRoleSource(
+  overrides: Partial<EffectivePermissionSource> = {},
+): EffectivePermissionSource {
+  return {
+    kind: 'role',
+    roleId: ID_ROLE_ADMIN,
+    roleCode: 'admin',
+    roleName: 'Administrator',
+    ...overrides,
+  };
+}
+
+interface SetupOptions {
+  /** Permissões efetivas devolvidas pelo backend. */
+  effective?: ReadonlyArray<EffectivePermissionDto>;
+}
+
+/**
+ * Configura o stub para retornar `effective` em estado feliz e responde
+ * com o mesmo array independente do `?systemId=` da request — testes
+ * de filtro inspecionam `client.get.mock.calls` para validar que a
+ * querystring foi montada corretamente, então não precisamos simular
+ * o filtro no servidor (basta verificar que a request saiu certa).
+ */
+export function primeStubResponses(
+  client: ApiClientStub,
+  options: SetupOptions = {},
+): void {
+  const effective = options.effective ?? [makeEffective()];
+  client.get.mockImplementation((path: string) => {
+    if (path.includes('/effective-permissions')) {
+      return Promise.resolve(effective);
+    }
+    return Promise.reject(
+      Object.assign(new Error('URL stub não esperada: ' + path), {
+        kind: 'http',
+        status: 404,
+      }),
+    );
+  });
+}
+
+/**
+ * Renderiza a página dentro de `MemoryRouter` + `Routes` para que
+ * `useParams` resolva o `:id` real. `ToastProvider` é incluído mesmo
+ * sem uso direto na página (Issue #72 não dispara toast) por
+ * consistência com `userPermissionsTestHelpers` — assim, mover testes
+ * entre suítes não quebra o setup.
+ */
+export function renderUserEffectivePermissionsPage(
+  client: ApiClientStub,
+  userId: string = ID_USER,
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter
+        initialEntries={[`/usuarios/${userId}/permissoes-efetivas`]}
+      >
+        <Routes>
+          <Route
+            path="/usuarios/:id/permissoes-efetivas"
+            element={<UserEffectivePermissionsShellPage client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda o spinner de loading desaparecer — sinal de que a request
+ * inicial resolveu. Centraliza o pattern para reduzir boilerplate por
+ * teste, espelhando `waitForInitialFetch` em
+ * `userPermissionsTestHelpers`.
+ */
+export async function waitForInitialFetch(): Promise<void> {
+  await waitFor(() => {
+    expect(
+      screen.queryByTestId('user-effective-permissions-loading'),
+    ).not.toBeInTheDocument();
+  });
+}

--- a/tests/pages/users/userEffectivePermissionsHelpers.test.ts
+++ b/tests/pages/users/userEffectivePermissionsHelpers.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EffectivePermissionDto } from '@/shared/api';
+
+import {
+  breakdownPermissionOrigin,
+  deriveSystemOptionsFromEffective,
+  groupEffectivePermissionsBySystem,
+} from '@/pages/users/userEffectivePermissionsHelpers';
+
+/**
+ * Suíte unitária dos helpers puros que sustentam a Issue #72. Sem DOM
+ * nem React — testes baratos focados em entrada/saída.
+ *
+ * Espelha o pattern de `userPermissionsHelpers.test.ts` (Issue #70) e
+ * `userRolesHelpers.test.ts` (Issue #71): cada helper exposto pela
+ * página é exercitado isoladamente com cenários canônicos +
+ * arestas (vazio, denormalizado vazio, ordem instável de entrada).
+ */
+
+const SYS_AUTH = 'sys-auth-uuid';
+const SYS_KURTTO = 'sys-kurtto-uuid';
+const ROLE_ADMIN = 'role-admin-uuid';
+const ROLE_VIEWER = 'role-viewer-uuid';
+
+function makeEffective(
+  overrides: Partial<EffectivePermissionDto> = {},
+): EffectivePermissionDto {
+  return {
+    permissionId: 'perm-uuid',
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'Listar usuários',
+    permissionTypeCode: 'Read',
+    permissionTypeName: 'Leitura',
+    systemId: SYS_AUTH,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    sources: [{ kind: 'direct' }],
+    ...overrides,
+  };
+}
+
+describe('groupEffectivePermissionsBySystem', () => {
+  it('devolve array vazio para entrada vazia', () => {
+    expect(groupEffectivePermissionsBySystem([])).toEqual([]);
+  });
+
+  it('agrupa por sistema mantendo metadados', () => {
+    const result = groupEffectivePermissionsBySystem([
+      makeEffective({ permissionId: 'p1' }),
+      makeEffective({
+        permissionId: 'p2',
+        systemId: SYS_KURTTO,
+        systemCode: 'kurtto',
+        systemName: 'Kurtto',
+      }),
+    ]);
+    expect(result).toHaveLength(2);
+    const auth = result.find((g) => g.systemCode === 'authenticator');
+    const kurtto = result.find((g) => g.systemCode === 'kurtto');
+    expect(auth?.permissions).toHaveLength(1);
+    expect(kurtto?.permissions).toHaveLength(1);
+    expect(kurtto?.systemName).toBe('Kurtto');
+  });
+
+  it('ordena grupos por systemCode', () => {
+    const result = groupEffectivePermissionsBySystem([
+      makeEffective({
+        permissionId: 'p1',
+        systemId: SYS_KURTTO,
+        systemCode: 'kurtto',
+        systemName: 'Kurtto',
+      }),
+      makeEffective({ permissionId: 'p2' }),
+    ]);
+    expect(result.map((g) => g.systemCode)).toEqual(['authenticator', 'kurtto']);
+  });
+
+  it('ordena permissões dentro de um grupo por routeCode então permissionTypeCode', () => {
+    const result = groupEffectivePermissionsBySystem([
+      makeEffective({
+        permissionId: 'p1',
+        routeCode: 'AUTH_V1_USERS_LIST',
+        permissionTypeCode: 'Update',
+      }),
+      makeEffective({
+        permissionId: 'p2',
+        routeCode: 'AUTH_V1_USERS_LIST',
+        permissionTypeCode: 'Read',
+      }),
+      makeEffective({
+        permissionId: 'p3',
+        routeCode: 'AUTH_V1_ROLES_LIST',
+        permissionTypeCode: 'Read',
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    const codes = result[0].permissions.map(
+      (p) => `${p.routeCode}:${p.permissionTypeCode}`,
+    );
+    expect(codes).toEqual([
+      'AUTH_V1_ROLES_LIST:Read',
+      'AUTH_V1_USERS_LIST:Read',
+      'AUTH_V1_USERS_LIST:Update',
+    ]);
+  });
+
+  it('coloca itens com systemCode vazio em grupo virtual "—" no final', () => {
+    const result = groupEffectivePermissionsBySystem([
+      makeEffective({ permissionId: 'p-orphan', systemId: '', systemCode: '', systemName: '' }),
+      makeEffective({ permissionId: 'p-auth' }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0].systemCode).toBe('authenticator');
+    expect(result[1].systemCode).toBe('—');
+  });
+});
+
+describe('breakdownPermissionOrigin', () => {
+  it('devolve isDirect=true para fonte única kind=direct', () => {
+    const result = breakdownPermissionOrigin([{ kind: 'direct' }]);
+    expect(result.isDirect).toBe(true);
+    expect(result.roles).toEqual([]);
+  });
+
+  it('extrai roles ordenadas por roleCode', () => {
+    const result = breakdownPermissionOrigin([
+      {
+        kind: 'role',
+        roleId: ROLE_VIEWER,
+        roleCode: 'viewer',
+        roleName: 'Viewer',
+      },
+      {
+        kind: 'role',
+        roleId: ROLE_ADMIN,
+        roleCode: 'admin',
+        roleName: 'Administrator',
+      },
+    ]);
+    expect(result.isDirect).toBe(false);
+    expect(result.roles.map((r) => r.roleCode)).toEqual(['admin', 'viewer']);
+  });
+
+  it('combina direct + roles preservando ambos', () => {
+    const result = breakdownPermissionOrigin([
+      { kind: 'direct' },
+      {
+        kind: 'role',
+        roleId: ROLE_ADMIN,
+        roleCode: 'admin',
+        roleName: 'Administrator',
+      },
+    ]);
+    expect(result.isDirect).toBe(true);
+    expect(result.roles).toHaveLength(1);
+    expect(result.roles[0].roleName).toBe('Administrator');
+  });
+
+  it('descarta silenciosamente fontes role com campos faltando', () => {
+    const result = breakdownPermissionOrigin([
+      { kind: 'role', roleId: null, roleCode: 'admin', roleName: 'Admin' },
+      { kind: 'role', roleId: ROLE_ADMIN, roleCode: null, roleName: 'Admin' },
+      { kind: 'role', roleId: ROLE_ADMIN, roleCode: 'admin', roleName: null },
+      { kind: 'role', roleId: ROLE_VIEWER, roleCode: 'viewer', roleName: 'Viewer' },
+    ]);
+    expect(result.isDirect).toBe(false);
+    expect(result.roles).toHaveLength(1);
+    expect(result.roles[0].roleId).toBe(ROLE_VIEWER);
+  });
+});
+
+describe('deriveSystemOptionsFromEffective', () => {
+  it('devolve array vazio para entrada vazia', () => {
+    expect(deriveSystemOptionsFromEffective([])).toEqual([]);
+  });
+
+  it('deduplica sistemas e ordena por systemCode', () => {
+    const result = deriveSystemOptionsFromEffective([
+      makeEffective({
+        permissionId: 'p1',
+        systemId: SYS_KURTTO,
+        systemCode: 'kurtto',
+        systemName: 'Kurtto',
+      }),
+      makeEffective({ permissionId: 'p2' }),
+      makeEffective({
+        permissionId: 'p3',
+        systemId: SYS_KURTTO,
+        systemCode: 'kurtto',
+        systemName: 'Kurtto',
+      }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.map((o) => o.systemCode)).toEqual(['authenticator', 'kurtto']);
+  });
+
+  it('descarta sistemas com systemId vazio (caso degenerado)', () => {
+    const result = deriveSystemOptionsFromEffective([
+      makeEffective({ permissionId: 'p-orphan', systemId: '', systemCode: '', systemName: '' }),
+      makeEffective({ permissionId: 'p-auth' }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].systemId).toBe(SYS_AUTH);
+  });
+});

--- a/tests/routes/routeCodes.test.ts
+++ b/tests/routes/routeCodes.test.ts
@@ -118,6 +118,23 @@ describe('resolveRouteCode — paths privados conhecidos', () => {
       ),
     ).toBe('AUTH_V1_ROLES_UPDATE');
   });
+
+  it('Issue #72: /usuarios/:id/permissoes-efetivas herda AUTH_V1_USERS_GET_BY_ID via subpath match', () => {
+    // Issue #72 — painel READ-ONLY de permissões efetivas. Como a
+    // policy do backend para `GET /users/{id}/effective-permissions` é
+    // a mesma `UsersRead` usada por `GET /users/{id}` (e ambas usam
+    // `AUTH_V1_USERS_GET_BY_ID` no `AuthenticatorRoutesSeeder`),
+    // intencionalmente NÃO criamos uma entrada nova em
+    // `ROUTE_CODE_ENTRIES`: deixamos `matchPath({ end: false })`
+    // resolver via subpath para `/usuarios/:id`. Adicionar uma entrada
+    // dedicada quebraria o invariante "não há routeCodes duplicados
+    // entre patterns" garantido pelos testes de sanidade abaixo.
+    expect(
+      resolveRouteCode(
+        '/usuarios/11111111-1111-1111-1111-111111111111/permissoes-efetivas',
+      ),
+    ).toBe('AUTH_V1_USERS_GET_BY_ID');
+  });
 });
 
 describe('resolveRouteCode — paths não privados ou desconhecidos', () => {

--- a/tests/shared/api/users.test.ts
+++ b/tests/shared/api/users.test.ts
@@ -1012,6 +1012,17 @@ describe('resetUserPassword — response e erros', () => {
  * de forma limpa para destravar o `tsc --noEmit` (e por consequência o
  * gate pré-PR) — sem alterar a cobertura semântica original (assertion
  * de path, propagação de roles, ApiError parse e propagação de 404).
+ * **Fix incidental (Issue #72):** o merge do PR #163 (atribuir roles)
+ * com o PR #164 (reset de senha) deixou esta suíte quebrada com
+ * fragmentos enxertados dentro de `resetUserPassword` e marker de
+ * conflito remanescente em `src/shared/api/index.ts`. Reescrita aqui
+ * de forma limpa para destravar o `tsc --noEmit` (e por consequência o
+ * gate pré-PR desta issue) — sem alterar a cobertura semântica
+ * original do PR #163 (assertion de path, propagação de roles,
+ * ApiError parse e propagação de 404). Caso a Issue #82 (que também
+ * detectou o problema em paralelo) seja mergeada antes, este bloco
+ * conflitará trivialmente em rebase — manter ambas as resoluções
+ * semanticamente idênticas.
  */
 describe('getUserById', () => {
   const ROLE_ID = '99999999-9999-9999-9999-999999999999';


### PR DESCRIPTION
## Contexto

Issue #72 (parte da EPIC #48 — Permissões). Operadores precisavam visualizar o impacto efetivo das atribuições de um usuário (diretas + via roles) sem ter que reconciliar mentalmente entre `/usuarios/:id/permissoes` e `/usuarios/:id/roles`. O backend já oferecia `GET /users/{id}/effective-permissions` (lfc-authenticator#167), faltava o frontend consumir.

## Objetivo

Painel **read-only** consolidado em `/usuarios/:id/permissoes-efetivas` com:

- Lista agrupada por sistema (mesma UX das telas #69/#70/#71).
- Para cada permissão, badges de origem: "Direta" (variant success) e/ou uma "Role: <Nome>" (variant info) por origem `role`.
- Filtro por sistema via `<Select>` (server-side via `?systemId=`).
- Cache de opções do dropdown — uma vez populado, não encolhe ao filtrar.
- Estados completos: loading, error+retry, empty, render normal, `:id` inválido.
- Gating duplo na rota: `Permissions.Read` (`AUTH_V1_PERMISSIONS_LIST`) + `Users.Read` (`AUTH_V1_USERS_GET_BY_ID`, política `UsersRead` que o backend usa para o endpoint).

## O que foi feito

### Página + helpers (Issue #72 propriamente dita)

- `src/pages/users/UserEffectivePermissionsShellPage.tsx` — página principal.
- `src/pages/users/userEffectivePermissionsHelpers.ts` — agrupamento, decomposição de origem, derivação de `systemOptions` para o filtro.
- `src/routes/index.tsx` — nova rota com `RequirePermission` aninhado.
- `src/pages/users/index.ts` — barrel export.
- `tests/pages/users/UserEffectivePermissions.test.tsx` — suíte de UI (15 testes).
- `tests/pages/users/userEffectivePermissionsHelpers.test.ts` — suíte unitária (12 testes).
- `tests/pages/users/__helpers__/userEffectivePermissionsTestHelpers.tsx` — fixtures + render helper compartilhados.
- `tests/routes/routeCodes.test.ts` — assertion adicional para validar que `/usuarios/:id/permissoes-efetivas` herda `AUTH_V1_USERS_GET_BY_ID` via subpath match (intencional — não criamos entrada nova porque quebraria o invariante "sem routeCodes duplicados").

### Helpers shared (anti-duplicação JSCPD/Sonar)

- `src/hooks/useSingleFetchWithAbort.ts` — hook genérico que encapsula fetch único com `AbortController`, distinção entre loading inicial e refetch, tratamento padrão de erro via `extractErrorMessage`/`isFetchAborted` e bumper de retry. Lições PR #134/#135: extração de hook é o caminho quando dois call-sites têm orquestração idêntica.
- `src/shared/listing/AssignmentGroupHeaderRow.tsx` — cabeçalho padrão (code mono + nome heading + contagem badge) compartilhado pelas 4 telas (Issue #69/#70/#71/#72). Eliminou ~16 linhas duplicadas por par de páginas.
- `UserPermissionsShellPage`, `UserRolesShellPage`, `RolePermissionsShellPage` adotaram o `AssignmentGroupHeaderRow` (refactor mecânico, sem mudança de comportamento).

### Fix incidental do gate pré-PR

`origin/development` (HEAD = 8b46274) ficou quebrado desde o merge do PR #163, com:

1. Marker de conflito em `src/shared/api/index.ts` (`<<<<<<< HEAD ... resetUserPassword ... ======= ... removeRoleFromUser ... >>>>>>>`) que impedia `tsc --noEmit` de rodar.
2. Suíte `tests/shared/api/users.test.ts` corrompida pelo merge dos PRs #163 (assignRoles) e #164 (resetPassword) — fragmentos de `getUserById` enxertados dentro de `resetUserPassword — body e path`, deixando ~50 linhas com sintaxe inválida.
3. `extractErrorMessage`/`isFetchAborted` extraídos para `src/shared/api/fetchHelpers.ts` no PR #163 mas **não** exportados pelo barrel `src/shared/api/index.ts`, derrubando todo `tsc --noEmit` em qualquer página que os importasse de `@/shared/api`.

Sem esses 3 fixes, **nenhum** PR novo passa o gate pré-PR. Aplicados aqui porque o gate é blocker e a Issue #82 (que detectou os mesmos problemas em paralelo) ainda não foi mergeada — caso #82 seja mergeada antes, conflito trivial em rebase (resoluções semanticamente idênticas, documentado nos comentários).

## Arquivos impactados

**Novos (7):**
- `src/hooks/useSingleFetchWithAbort.ts`
- `src/pages/users/UserEffectivePermissionsShellPage.tsx`
- `src/pages/users/userEffectivePermissionsHelpers.ts`
- `src/shared/listing/AssignmentGroupHeaderRow.tsx`
- `tests/pages/users/UserEffectivePermissions.test.tsx`
- `tests/pages/users/__helpers__/userEffectivePermissionsTestHelpers.tsx`
- `tests/pages/users/userEffectivePermissionsHelpers.test.ts`

**Modificados (9):**
- `src/pages/roles/RolePermissionsShellPage.tsx` — adoção do `AssignmentGroupHeaderRow`.
- `src/pages/users/UserPermissionsShellPage.tsx` — adoção do `AssignmentGroupHeaderRow`.
- `src/pages/users/UserRolesShellPage.tsx` — adoção do `AssignmentGroupHeaderRow`.
- `src/pages/users/index.ts` — export da nova página.
- `src/routes/index.tsx` — nova rota `/usuarios/:id/permissoes-efetivas` com gating duplo.
- `src/shared/api/index.ts` — fix do marker + export de `extractErrorMessage`/`isFetchAborted`.
- `src/shared/listing/index.ts` — export do `AssignmentGroupHeaderRow`.
- `tests/routes/routeCodes.test.ts` — asserção adicional para o novo path.
- `tests/shared/api/users.test.ts` — reconstrução das suítes corrompidas pelo merge.

## Testes

Gate pré-PR completo (todos no container):

\`\`\`
docker compose run --rm web npm run lint
> 0 erros, 0 warnings.

docker compose run --rm web npm run typecheck
> tsc --noEmit limpo.

docker compose run --rm web npm test
> Test Files  73 passed (73)
> Tests  1278 passed (1278)

docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10 --reporters console,json --output ./jscpd-report
> Total: 33 clones, 872 (2.13%) duplicated lines.
> Sem clones envolvendo arquivos NOVOS desta issue.
\`\`\`

Comparação JSCPD vs baseline (origin/development antes desta PR):
- Baseline: 2.23% (34 clones).
- Pós-PR: 2.13% (33 clones) — refactor `AssignmentGroupHeaderRow` reduziu a duplicação em valores absolutos.

## Visual

- Cores via `var(--accent)`, `var(--success)`, `var(--info)` etc — sem hardcode.
- Spinner padrão (`<Spinner size="md" tone="accent" />`) em loading.
- `<ErrorRetryBlock>` padrão em erro com retry funcional.
- `<AssignmentEmptyShell>` em vazio com ícone + título + dica.
- Hover/focus tratados via primitives já existentes em `AssignmentMatrixStyles` (`ItemRow:hover`, `Select:focus-visible`).
- Filtro `<Select>` com largura limitada (240–360px) para não dominar a tela em desktop.
- Wrapper `<FilterRow>` com gap consistente (`var(--space-3)`).

## Segurança

Sem novo vetor:
- Gating duplo na rota (`RequirePermission` aninhado) replica o padrão estabelecido em #69/#70/#71.
- Backend é a fonte autoritativa (`UsersRead` policy aplicada ao endpoint).
- Nenhum dado sensível em `console.log` ou erros expostos sem tratamento.
- Sem `dangerouslySetInnerHTML`, sem links/iframes de URLs não validadas.

## Riscos

1. **Conflito potencial com Issue #82**: ambas resolveram os mesmos 3 fixes incidentais do gate. Se #82 mergear primeiro, esta PR precisará rebase trivial — as resoluções são semanticamente idênticas (documentado em comentários nos arquivos).
2. **Tests flaky em paralelo**: durante o desenvolvimento observei alguns timeouts esporádicos (10+s) em testes de outras páginas quando rodando a suíte completa. Re-rodar resolve. Não é regressão deste PR — o pattern já existia.

## Issue relacionada

Closes #72