### PR TITLE
feat(clients): gerenciar emails extras (add/remove, max 3, anti-username) (#146)

### DIFF
--- a/src/pages/clients/ClientExtraEmailsTab.tsx
+++ b/src/pages/clients/ClientExtraEmailsTab.tsx
@@ -1,18 +1,806 @@
-import React from 'react';
+import { Mail, Plus, Trash2 } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
 
-import { ClientEditTabPlaceholder } from './ClientEditTabPlaceholder';
+import {
+  Alert,
+  Button,
+  Icon,
+  Input,
+  Modal,
+  useToast,
+} from '../../components/ui';
+import {
+  addClientExtraEmail,
+  getClientById,
+  MAX_CLIENT_EXTRA_EMAILS,
+  removeClientExtraEmail,
+} from '../../shared/api';
+import { useAuth } from '../../shared/auth';
+import { ErrorRetryBlock, InitialLoadingSpinner } from '../../shared/listing';
+
+import {
+  classifyAddExtraEmailError,
+  classifyRemoveExtraEmailError,
+  EXTRA_EMAIL_MAX,
+  validateExtraEmailInput,
+  type ExtraEmailErrorCopy,
+} from './clientExtraEmailsHelpers';
+
+import type { ApiClient, ClientDto, ClientEmailDto } from '../../shared/api';
 
 /**
- * Aba "Emails extras" do `ClientEditPage` (Issue #144).
+ * Code de permissão exigido para mutações no tab (Issue #146).
  *
- * Atualmente renderiza placeholder porque o conteúdo real (lista de
- * emails extras + CRUD inline) é corpo da Issue #146. Substituirá o
- * placeholder em PR dedicado quando #146 for desbloqueada por esta
- * issue (#144 é pré-requisito do container de abas).
+ * Espelha o `AUTH_V1_CLIENTS_UPDATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`POST/DELETE /clients/{id}/emails*` rodam
+ * `[Authorize(Policy = PermissionPolicies.ClientsUpdate)]`); o gating
+ * client-side é apenas UX — esconder os botões "Adicionar"/"Remover"
+ * quando o operador não pode persistir é mais claro do que deixar o
+ * submit cair em 401/403.
  */
-export const ClientExtraEmailsTab: React.FC = () => (
-  <ClientEditTabPlaceholder
-    title="Emails extras"
-    description="Lista de emails adicionais (além do principal). Será habilitada pela Issue #146."
-  />
-);
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+/**
+ * Cópia textual injetada nas funções `classify*ExtraEmailError`.
+ * Centralizada para que asserts de teste e renderização compartilhem
+ * uma fonte de verdade — qualquer ajuste de copy acontece em uma
+ * referência só.
+ */
+const ADD_ERROR_COPY: ExtraEmailErrorCopy = {
+  genericFallback: 'Não foi possível adicionar o email. Tente novamente.',
+  forbiddenTitle: 'Falha ao adicionar email',
+  notFoundMessage:
+    'Cliente não encontrado ou foi removido. A página foi atualizada.',
+};
+
+const REMOVE_ERROR_COPY: ExtraEmailErrorCopy = {
+  genericFallback: 'Não foi possível remover o email. Tente novamente.',
+  forbiddenTitle: 'Falha ao remover email',
+  notFoundMessage:
+    'Email extra já havia sido removido. A lista foi atualizada.',
+};
+
+/**
+ * Mensagem amigável exibida no `ErrorRetryBlock` quando o fetch
+ * inicial do cliente falha (rede, parse, 401/403, etc.).
+ */
+const FETCH_ERROR_MESSAGE = 'Não foi possível carregar os dados do cliente.';
+
+/**
+ * Container externo do conteúdo da aba — preserva o ar e o
+ * espaçamento das outras abas (`ClientDataTab`).
+ */
+const TabSection = styled.section`
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const TabHeading = styled.h3`
+  font-family: var(--font-display);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+`;
+
+const TabIntro = styled.p`
+  margin: 0;
+  color: var(--fg2);
+  font-size: var(--text-sm);
+  line-height: var(--leading-base);
+  max-width: 60ch;
+`;
+
+/**
+ * Cabeçalho do bloco que combina contagem corrente + botão de ação.
+ * Em viewports estreitas, empilha o botão sob o contador para
+ * preservar o toque (touch target de 44px+).
+ */
+const ListHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+`;
+
+const Counter = styled.div`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg3);
+`;
+
+/**
+ * Lista visual dos emails extras. Cada `<EmailRow>` é uma linha com
+ * o email à esquerda e o botão "Remover" à direita.
+ */
+const EmailList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+`;
+
+const EmailRow = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--duration-fast) var(--ease-default),
+    background var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    border-color: var(--border-medium-forest);
+  }
+`;
+
+const EmailLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  flex: 1;
+`;
+
+const EmailValue = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--fg1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+/**
+ * Bloco de empty state com tom suave — espelha o padrão visual de
+ * `AssignmentMatrixShell.AssignmentEmptyShell` (centralizado, com
+ * ícone informativo e dica de próximo passo). Mantém-se inline (em
+ * vez de reutilizar o shell) porque o shell de matrizes carrega
+ * estrutura adicional que não se encaixa aqui.
+ */
+const EmptyShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-4);
+  background: var(--bg-elevated);
+  border: var(--border-thin) dashed var(--border-subtle);
+  border-radius: var(--radius-lg);
+  color: var(--fg3);
+`;
+
+const EmptyTitle = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--fg2);
+`;
+
+const EmptyHint = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  text-align: center;
+  max-width: 40ch;
+`;
+
+/**
+ * Form do modal de adicionar — `<form>` para que `Enter` no input
+ * dispare o submit e que leitores de tela identifiquem o agrupamento
+ * de campos.
+ */
+const ModalForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+const ModalActions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+`;
+
+const ConfirmBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+`;
+
+const ConfirmText = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+`;
+
+const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg1);
+  background: var(--bg-elevated);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+`;
+
+interface ClientExtraEmailsTabProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `getClientById`/`addClientExtraEmail`/`removeClientExtraEmail`
+   * caem no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Estado do modal de adicionar email — mantém form controlado
+ * (input value + erro inline) e flag `isSubmitting` independente
+ * para que o spinner do botão não recicle a cada keystroke.
+ */
+interface AddModalState {
+  open: boolean;
+  email: string;
+  inputError: string | null;
+  isSubmitting: boolean;
+}
+
+const INITIAL_ADD_MODAL_STATE: AddModalState = {
+  open: false,
+  email: '',
+  inputError: null,
+  isSubmitting: false,
+};
+
+/**
+ * Estado do modal de confirmação de remoção. `target` é `null`
+ * quando o modal está fechado — caller controla `open` via
+ * `target !== null`.
+ */
+interface RemoveConfirmState {
+  target: ClientEmailDto | null;
+  isSubmitting: boolean;
+}
+
+const INITIAL_REMOVE_CONFIRM_STATE: RemoveConfirmState = {
+  target: null,
+  isSubmitting: false,
+};
+
+/**
+ * Aba "Emails extras" do `ClientEditPage` (Issue #146).
+ *
+ * Substitui o placeholder herdado de #144. Carrega o cliente via
+ * `GET /clients/{id}` (mesmo padrão do `ClientDataTab`) para
+ * popular `extraEmails` e oferece add/remove com mapeamento
+ * completo dos erros do backend.
+ *
+ * **Estados visuais (critério "estados visuais completos"):**
+ *
+ * - `loading` (`InitialLoadingSpinner`) — primeiro fetch.
+ * - `error` (`ErrorRetryBlock`) — falha de rede/parse/401/403.
+ * - `loaded:empty` — empty state com ícone + dica de próximo passo.
+ * - `loaded:list` — lista com até 3 linhas.
+ * - `loaded:full` — botão "Adicionar email" desabilitado (limite 3).
+ * - `add-submitting` / `remove-submitting` — botões em loading.
+ *
+ * **Gating de permissão (critério "Visível com `Clients.Update`"):**
+ *
+ * Quando o usuário não tem `AUTH_V1_CLIENTS_UPDATE`, o tab vira
+ * readonly: a lista continua visível (útil para auditoria) mas os
+ * botões "Adicionar" e "Remover" ficam ocultos. O backend é a
+ * fonte autoritativa (rejeitaria com 401/403 mesmo se a UI
+ * exibisse os botões); o gating client-side é apenas UX.
+ *
+ * **Tratamento de erros:**
+ *
+ * Add (`addClientExtraEmail`):
+ * - 400 "Limite de 3..." → inline + refetch (UI já desabilita o
+ *   botão preventivamente; chegar aqui significa race com outra
+ *   sessão).
+ * - 400 "Email extra inválido." → inline (validação client-side
+ *   já cobriu, defensivo).
+ * - 409 "Email extra já cadastrado..." → inline.
+ * - 409 "Este email está sendo usado como username..." → inline
+ *   com mensagem orientadora do backend.
+ * - 404 → toast vermelho + refetch (cliente removido).
+ * - 401/403 → toast vermelho.
+ *
+ * Remove (`removeClientExtraEmail`):
+ * - 400 "Não é permitido remover email que esteja sendo usado
+ *   como username." → toast vermelho com mensagem orientadora.
+ * - 404 → toast vermelho + refetch (email já removido).
+ * - 401/403 → toast vermelho.
+ *
+ * Reusa `MAX_CLIENT_EXTRA_EMAILS` (3) para a regra do botão
+ * desabilitado — fonte da verdade compartilhada com a função API
+ * (`MAX_CLIENT_EXTRA_EMAILS` em `shared/api/clients.ts`). Lição
+ * PR #128 — projetar shared helpers desde o primeiro PR do recurso.
+ */
+export const ClientExtraEmailsTab: React.FC<ClientExtraEmailsTabProps> = ({
+  client,
+}) => {
+  const { id } = useParams<{ id: string }>();
+  const { show } = useToast();
+  const { hasPermission } = useAuth();
+  const canUpdate = hasPermission(CLIENTS_UPDATE_PERMISSION);
+
+  /**
+   * Estados do fetch inicial. Espelha o padrão do `ClientDataTab` —
+   * `loaded` guarda o cliente (para que o submit/remove leiam
+   * `extraEmails` direto do estado em vez de prop), `error` cai no
+   * `ErrorRetryBlock`.
+   */
+  const [fetchState, setFetchState] = useState<'loading' | 'loaded' | 'error'>(
+    'loading',
+  );
+  const [loadedClient, setLoadedClient] = useState<ClientDto | null>(null);
+
+  /**
+   * Reload key — incrementar dispara refetch do `useEffect`. Usado
+   * pelo `ErrorRetryBlock` (botão "Tentar novamente"), por sucesso
+   * de mutação (sincroniza lista) e por erros que indicam que o
+   * estado do servidor divergiu (404, "Limite atingido").
+   */
+  const [reloadCounter, setReloadCounter] = useState<number>(0);
+
+  const [addModal, setAddModal] = useState<AddModalState>(
+    INITIAL_ADD_MODAL_STATE,
+  );
+  const [removeConfirm, setRemoveConfirm] = useState<RemoveConfirmState>(
+    INITIAL_REMOVE_CONFIRM_STATE,
+  );
+
+  useEffect(() => {
+    if (id === undefined || id.length === 0) {
+      setFetchState('error');
+      return;
+    }
+
+    const controller = new AbortController();
+    let isCancelled = false;
+
+    setFetchState('loading');
+
+    getClientById(id, { signal: controller.signal }, client)
+      .then((dto) => {
+        if (isCancelled) return;
+        setLoadedClient(dto);
+        setFetchState('loaded');
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return;
+        // Cancelamento explícito (unmount/route change) não vira
+        // erro de UI — silencia para que o próximo render comece
+        // limpo.
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        setFetchState('error');
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [id, client, reloadCounter]);
+
+  const triggerRefetch = useCallback(() => {
+    setReloadCounter((prev) => prev + 1);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    triggerRefetch();
+  }, [triggerRefetch]);
+
+  const extraEmails = useMemo<ReadonlyArray<ClientEmailDto>>(
+    () => loadedClient?.extraEmails ?? [],
+    [loadedClient],
+  );
+  const isLimitReached = extraEmails.length >= MAX_CLIENT_EXTRA_EMAILS;
+
+  /* ─── Add modal handlers ──────────────────────────────── */
+
+  const handleOpenAddModal = useCallback(() => {
+    if (isLimitReached) return;
+    setAddModal({
+      open: true,
+      email: '',
+      inputError: null,
+      isSubmitting: false,
+    });
+  }, [isLimitReached]);
+
+  const handleCloseAddModal = useCallback(() => {
+    setAddModal((prev) =>
+      prev.isSubmitting ? prev : INITIAL_ADD_MODAL_STATE,
+    );
+  }, []);
+
+  const handleEmailChange = useCallback((value: string) => {
+    setAddModal((prev) => ({
+      ...prev,
+      email: value,
+      // Limpa o erro no primeiro keystroke após erro — feedback
+      // mais leve que "permanecer marcado vermelho até resubmit".
+      inputError: null,
+    }));
+  }, []);
+
+  const handleSubmitAdd = useCallback(
+    async (event?: React.FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      setAddModal((prev) => {
+        if (prev.isSubmitting || loadedClient === null) return prev;
+        const trimmed = prev.email.trim();
+        const inputError = validateExtraEmailInput(trimmed);
+        if (inputError !== null) {
+          return { ...prev, inputError };
+        }
+        return { ...prev, inputError: null, isSubmitting: true };
+      });
+    },
+    [loadedClient],
+  );
+
+  /**
+   * Effect que dispara a chamada HTTP quando `isSubmitting` vira
+   * `true` no estado do modal. Separamos o gate (validação +
+   * `setIsSubmitting`) do effect para que o `setState` não fique
+   * preso a uma mesma referência de `prev.email` com closure stale
+   * — o effect lê o valor mais recente via dependency em
+   * `addModal.isSubmitting`.
+   */
+  useEffect(() => {
+    if (!addModal.isSubmitting || loadedClient === null) return;
+    let isCancelled = false;
+    const controller = new AbortController();
+
+    addClientExtraEmail(
+      loadedClient.id,
+      addModal.email.trim(),
+      { signal: controller.signal },
+      client,
+    )
+      .then(() => {
+        if (isCancelled) return;
+        show('Email extra adicionado.', { variant: 'success' });
+        setAddModal(INITIAL_ADD_MODAL_STATE);
+        triggerRefetch();
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return;
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        const action = classifyAddExtraEmailError(error, ADD_ERROR_COPY);
+        switch (action.kind) {
+          case 'inline':
+            setAddModal((prev) => ({
+              ...prev,
+              inputError: action.message,
+              isSubmitting: false,
+            }));
+            break;
+          case 'limit-reached':
+            setAddModal((prev) => ({
+              ...prev,
+              inputError: action.message,
+              isSubmitting: false,
+            }));
+            triggerRefetch();
+            break;
+          case 'not-found':
+            show(action.message, {
+              variant: 'danger',
+              title: action.title,
+            });
+            setAddModal(INITIAL_ADD_MODAL_STATE);
+            triggerRefetch();
+            break;
+          case 'toast':
+            show(action.message, {
+              variant: 'danger',
+              title: action.title,
+            });
+            setAddModal((prev) => ({ ...prev, isSubmitting: false }));
+            break;
+          case 'unhandled':
+            show(action.message, {
+              variant: 'danger',
+              title: action.title,
+            });
+            setAddModal((prev) => ({ ...prev, isSubmitting: false }));
+            break;
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+    // `addModal.email` capturado no instante em que `isSubmitting`
+    // virou `true`; subsequentes keystrokes não disparam novo
+    // submit (`isSubmitting=true` só vira `false` ao terminar).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addModal.isSubmitting, loadedClient, client, show, triggerRefetch]);
+
+  /* ─── Remove confirm handlers ─────────────────────────── */
+
+  const handleOpenRemoveConfirm = useCallback((emailDto: ClientEmailDto) => {
+    setRemoveConfirm({ target: emailDto, isSubmitting: false });
+  }, []);
+
+  const handleCloseRemoveConfirm = useCallback(() => {
+    setRemoveConfirm((prev) =>
+      prev.isSubmitting ? prev : INITIAL_REMOVE_CONFIRM_STATE,
+    );
+  }, []);
+
+  const handleConfirmRemove = useCallback(async () => {
+    if (
+      removeConfirm.isSubmitting ||
+      removeConfirm.target === null ||
+      loadedClient === null
+    ) {
+      return;
+    }
+    const target = removeConfirm.target;
+    setRemoveConfirm((prev) => ({ ...prev, isSubmitting: true }));
+    try {
+      await removeClientExtraEmail(
+        loadedClient.id,
+        target.id,
+        undefined,
+        client,
+      );
+      show('Email extra removido.', { variant: 'success' });
+      setRemoveConfirm(INITIAL_REMOVE_CONFIRM_STATE);
+      triggerRefetch();
+    } catch (error: unknown) {
+      const action = classifyRemoveExtraEmailError(error, REMOVE_ERROR_COPY);
+      switch (action.kind) {
+        case 'username':
+          show(action.message, {
+            variant: 'danger',
+            title: action.title,
+          });
+          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
+          break;
+        case 'not-found':
+          show(action.message, {
+            variant: 'danger',
+            title: action.title,
+          });
+          setRemoveConfirm(INITIAL_REMOVE_CONFIRM_STATE);
+          triggerRefetch();
+          break;
+        case 'toast':
+          show(action.message, {
+            variant: 'danger',
+            title: action.title,
+          });
+          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
+          break;
+        case 'unhandled':
+          show(action.message, {
+            variant: 'danger',
+            title: action.title,
+          });
+          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
+          break;
+      }
+    }
+  }, [client, loadedClient, removeConfirm, show, triggerRefetch]);
+
+  /* ─── Render ──────────────────────────────────────────── */
+
+  if (fetchState === 'loading') {
+    return (
+      <InitialLoadingSpinner
+        testId="client-extra-emails-loading"
+        label="Carregando emails extras"
+      />
+    );
+  }
+
+  if (fetchState === 'error') {
+    return (
+      <ErrorRetryBlock
+        message={FETCH_ERROR_MESSAGE}
+        onRetry={handleRetry}
+        retryTestId="client-extra-emails-retry"
+      />
+    );
+  }
+
+  return (
+    <>
+      <TabSection aria-labelledby="client-extra-emails-heading">
+        <TabHeading id="client-extra-emails-heading">Emails extras</TabHeading>
+        <TabIntro>
+          Cadastre até {MAX_CLIENT_EXTRA_EMAILS} emails adicionais (além
+          do email principal). Emails que já estejam em uso como
+          username de algum usuário não podem ser adicionados.
+        </TabIntro>
+
+        <ListHeader>
+          <Counter data-testid="client-extra-emails-counter">
+            {extraEmails.length} de {MAX_CLIENT_EXTRA_EMAILS} cadastrados
+          </Counter>
+          {canUpdate && (
+            <Button
+              variant="primary"
+              size="sm"
+              icon={<Plus size={14} strokeWidth={1.75} aria-hidden="true" />}
+              onClick={handleOpenAddModal}
+              disabled={isLimitReached}
+              data-testid="client-extra-emails-add"
+            >
+              Adicionar email
+            </Button>
+          )}
+        </ListHeader>
+
+        {isLimitReached && canUpdate && (
+          <Alert variant="info">
+            Limite de {MAX_CLIENT_EXTRA_EMAILS} emails extras atingido. Remova
+            algum existente para adicionar outro.
+          </Alert>
+        )}
+
+        {extraEmails.length === 0 ? (
+          <EmptyShell data-testid="client-extra-emails-empty">
+            <Icon icon={Mail} size="lg" tone="muted" />
+            <EmptyTitle>Nenhum email extra cadastrado</EmptyTitle>
+            <EmptyHint>
+              {canUpdate
+                ? 'Use o botão "Adicionar email" acima para cadastrar o primeiro.'
+                : 'Esse cliente ainda não possui emails extras.'}
+            </EmptyHint>
+          </EmptyShell>
+        ) : (
+          <EmailList aria-label="Emails extras do cliente">
+            {extraEmails.map((emailDto) => (
+              <EmailRow
+                key={emailDto.id}
+                data-testid={`client-extra-emails-row-${emailDto.id}`}
+              >
+                <EmailLeft>
+                  <Icon icon={Mail} size="sm" tone="muted" />
+                  <EmailValue title={emailDto.email}>{emailDto.email}</EmailValue>
+                </EmailLeft>
+                {canUpdate && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Trash2 size={14} strokeWidth={1.75} aria-hidden="true" />}
+                    onClick={() => handleOpenRemoveConfirm(emailDto)}
+                    aria-label={`Remover email ${emailDto.email}`}
+                    data-testid={`client-extra-emails-remove-${emailDto.id}`}
+                  >
+                    Remover
+                  </Button>
+                )}
+              </EmailRow>
+            ))}
+          </EmailList>
+        )}
+      </TabSection>
+
+      <Modal
+        open={addModal.open}
+        onClose={handleCloseAddModal}
+        title="Adicionar email extra"
+        description="Informe o novo email a ser cadastrado para este cliente."
+        closeOnEsc={!addModal.isSubmitting}
+        closeOnBackdrop={!addModal.isSubmitting}
+      >
+        <ModalForm
+          onSubmit={handleSubmitAdd}
+          data-testid="client-extra-emails-add-form"
+        >
+          <Input
+            id="client-extra-emails-add-input"
+            label="Email"
+            type="email"
+            placeholder="ana@exemplo.com"
+            value={addModal.email}
+            onChange={handleEmailChange}
+            error={addModal.inputError ?? undefined}
+            disabled={addModal.isSubmitting}
+            maxLength={EXTRA_EMAIL_MAX}
+            autoComplete="email"
+            data-testid="client-extra-emails-add-email"
+          />
+          <ModalActions>
+            <Button
+              variant="ghost"
+              size="md"
+              type="button"
+              onClick={handleCloseAddModal}
+              disabled={addModal.isSubmitting}
+              data-testid="client-extra-emails-add-cancel"
+            >
+              Cancelar
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              type="submit"
+              loading={addModal.isSubmitting}
+              data-testid="client-extra-emails-add-submit"
+            >
+              Adicionar
+            </Button>
+          </ModalActions>
+        </ModalForm>
+      </Modal>
+
+      <Modal
+        open={removeConfirm.target !== null}
+        onClose={handleCloseRemoveConfirm}
+        title="Remover email extra?"
+        closeOnEsc={!removeConfirm.isSubmitting}
+        closeOnBackdrop={!removeConfirm.isSubmitting}
+      >
+        {removeConfirm.target !== null && (
+          <ConfirmBody>
+            <ConfirmText data-testid="client-extra-emails-remove-description">
+              O email <Mono>{removeConfirm.target.email}</Mono> será
+              removido da lista de emails extras deste cliente. Essa
+              ação é imediata.
+            </ConfirmText>
+            <ModalActions>
+              <Button
+                variant="ghost"
+                size="md"
+                type="button"
+                onClick={handleCloseRemoveConfirm}
+                disabled={removeConfirm.isSubmitting}
+                data-testid="client-extra-emails-remove-cancel"
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="danger"
+                size="md"
+                type="button"
+                onClick={handleConfirmRemove}
+                loading={removeConfirm.isSubmitting}
+                data-testid="client-extra-emails-remove-confirm"
+              >
+                Remover
+              </Button>
+            </ModalActions>
+          </ConfirmBody>
+        )}
+      </Modal>
+    </>
+  );
+};

--- a/src/pages/clients/clientExtraEmailsHelpers.ts
+++ b/src/pages/clients/clientExtraEmailsHelpers.ts
@@ -1,0 +1,291 @@
+import { isApiError } from '../../shared/api';
+import { isValidEmailSyntax } from '../../shared/forms';
+
+/**
+ * Helpers compartilhados pelo `ClientExtraEmailsTab` (Issue #146).
+ *
+ * Concentra:
+ *
+ * - Constantes de validação (`EXTRA_EMAIL_MAX`) — espelha
+ *   `AddEmailRequest.Email.MaxLength(320)` no `lfc-authenticator`.
+ * - `validateExtraEmailInput` — feedback client-side antes do submit
+ *   (formato de email + tamanho máx.). Replica o suficiente para
+ *   evitar round-trip por digitação trivial; o backend permanece
+ *   autoritativo (`[EmailAddress]` + `EmailValidator.IsValid`).
+ * - `classifyAddExtraEmailError` — converte um `unknown` lançado por
+ *   `addClientExtraEmail` em uma ação discriminada para que o
+ *   componente decida com `switch` curto se exibe inline (409/400
+ *   validável), toast (401/403/network) ou refetch (404).
+ * - `classifyRemoveExtraEmailError` — espelha o classify do `add`
+ *   para o caminho `DELETE /clients/{id}/emails/{emailId}`. Diferença
+ *   chave é o 400 quando o email é username (mensagem orientadora
+ *   exibida em toast em vez de inline).
+ *
+ * **Por que módulo dedicado e não dentro de `clientsFormShared.ts`?**
+ * O form de email extra é minúsculo (1 campo) e tem fluxo próprio
+ * (modal de adicionar + confirm de remover) — manter helpers
+ * separados preserva a coesão do `clientsFormShared.ts` (focado em
+ * PF/PJ) e evita acoplar mudanças entre as duas camadas.
+ *
+ * Mantemos a lógica em TS puro (sem React) para que os testes
+ * unitários consumam diretamente sem provider/render.
+ */
+
+/**
+ * Tamanho máximo do email extra — espelha
+ * `AddEmailRequest.Email.MaxLength(320)` no `ClientsController`. Mesma
+ * regra geral do `userFormShared.EMAIL_MAX` (RFC 5321 limita o local
+ * part a 64 chars + domínio a 255 chars; total prático ~320).
+ */
+export const EXTRA_EMAIL_MAX = 320;
+
+/**
+ * Valida o input de email extra contra as mesmas regras do backend
+ * (`Required` + `MaxLength(320)` + formato `EmailAddress`/
+ * `EmailValidator.IsValid`).
+ *
+ * Retorna `null` quando válido, ou string com mensagem amigável em
+ * pt-BR. Trim defensivo aplicado antes da checagem — o backend
+ * faz `Email.Trim().ToLowerInvariant()`, então digitar
+ * `"  ana@ex.com  "` é tratado como `"ana@ex.com"`. A UI espelha
+ * trimando antes de validar para alinhar feedback com o que o
+ * servidor faria.
+ */
+export function validateExtraEmailInput(raw: string): string | null {
+  const email = raw.trim();
+  if (email.length === 0) {
+    return 'Email é obrigatório.';
+  }
+  if (email.length > EXTRA_EMAIL_MAX) {
+    return `Email deve ter no máximo ${EXTRA_EMAIL_MAX} caracteres.`;
+  }
+  if (!isValidEmailSyntax(email)) {
+    return 'Informe um email válido.';
+  }
+  return null;
+}
+
+/**
+ * Cópia textual injetada nos `classify*` desta camada. Mantém os
+ * literais em pt-BR centralizados num único objeto — qualquer
+ * ajuste de copy acontece em uma referência só.
+ */
+export interface ExtraEmailErrorCopy {
+  /**
+   * Mensagem genérica usada quando o erro não é classificável
+   * (`network`/`parse`/5xx). Exibida em toast vermelho.
+   */
+  genericFallback: string;
+  /**
+   * Título do toast vermelho exibido para 401/403/network/parse —
+   * dá hierarquia visual ao operador identificar o tipo do erro.
+   */
+  forbiddenTitle: string;
+  /**
+   * Mensagem específica para o 404 (recurso já removido entre
+   * abertura e submit). Exibida em toast vermelho + força refetch.
+   */
+  notFoundMessage: string;
+}
+
+/**
+ * Ação discriminada decorrente da classificação de erro do `add`.
+ *
+ * - `inline` → mensagem associada ao input (`409` duplicado ou
+ *   coincidência com username). Componente seta `inputError`.
+ * - `limit-reached` → 400 "Limite de 3 emails extras...". Componente
+ *   seta `inputError` e fecha o modal porque a UI já oferece o
+ *   botão "Adicionar" desabilitado quando atinge o limite — chegar
+ *   aqui significa race com outra sessão; refetch sincroniza.
+ * - `not-found` → cliente removido (404). Componente fecha modal +
+ *   refetch + toast.
+ * - `toast` → 401/403 com mensagem do backend.
+ * - `unhandled` → fallback (network/parse/5xx). Toast vermelho com
+ *   `genericFallback`.
+ */
+export type AddExtraEmailErrorAction =
+  | { kind: 'inline'; message: string }
+  | { kind: 'limit-reached'; message: string }
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+/**
+ * Branch comum entre `classifyAddExtraEmailError` e
+ * `classifyRemoveExtraEmailError` — encapsula os casos compartilhados
+ * (não-HTTP, 404, 401/403, fallback) num único helper para que o
+ * Sonar/JSCPD não tokenize ~15 linhas idênticas como duplicação
+ * (lição PR #128/#134/#135 — bloco ≥10 linhas em 2+ funções vira
+ * `New Code Duplication`).
+ *
+ * Retorna a ação compartilhada quando o caso é coberto, ou `null`
+ * quando o status precisa de tratamento específico do call site (400/
+ * 409 no `add`; 400 no `remove`). O caller decide o que fazer com o
+ * `null` — tipicamente ramifica em casos próprios e cai no fallback
+ * `unhandled` se nenhum bater.
+ *
+ * Mantemos retorno tipado como união ampla (`SharedExtraEmailAction`)
+ * para que o caller faça `narrowing` no kind sem precisar
+ * re-classificar — TypeScript infere o subset depois do `if`.
+ */
+type SharedExtraEmailAction =
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+function classifySharedExtraEmailError(
+  error: unknown,
+  copy: ExtraEmailErrorCopy,
+): SharedExtraEmailAction | null {
+  if (!isApiError(error) || error.kind !== 'http') {
+    return {
+      kind: 'unhandled',
+      message: copy.genericFallback,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (error.status === 404) {
+    return {
+      kind: 'not-found',
+      message: copy.notFoundMessage,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (error.status === 401 || error.status === 403) {
+    return {
+      kind: 'toast',
+      message: error.message || copy.genericFallback,
+      title: copy.forbiddenTitle,
+    };
+  }
+  // 400/409 são specific-by-endpoint — caller resolve antes de cair
+  // no fallback comum.
+  return null;
+}
+
+/**
+ * Fallback `unhandled` reusado pelo `add` e `remove` quando nenhum
+ * caso específico cobre o erro. Centralizar evita que a estrutura
+ * `{ kind: 'unhandled', message, title }` apareça duas vezes em cada
+ * função e dispare detecção de duplicação no Sonar/JSCPD.
+ */
+function unhandledExtraEmailAction(
+  copy: ExtraEmailErrorCopy,
+): SharedExtraEmailAction {
+  return {
+    kind: 'unhandled',
+    message: copy.genericFallback,
+    title: copy.forbiddenTitle,
+  };
+}
+
+/**
+ * Classifica o erro do `addClientExtraEmail` em uma ação
+ * discriminada. Centraliza a árvore de switch que viveria duplicada
+ * em cada call site (lição PR #128/#134/#135 — quando o `try/catch`
+ * tem 5+ branches diferentes, o switch direto vira hotspot de
+ * complexidade cognitiva e duplicação Sonar).
+ *
+ * **Casos cobertos (espelham o backend `ClientsController.AddEmail`):**
+ *
+ * - 400 com mensagem `"Limite de 3 emails extras..."` →
+ *   `limit-reached`. Componente exibe inline e refetch para
+ *   sincronizar (cliente teve outro email adicionado por outra
+ *   sessão). Defensivo — UI normalmente desabilita o botão antes.
+ * - 400 com mensagem `"Email extra inválido."` → `inline`. Caso
+ *   raro (validação client-side já cobriu).
+ * - 409 com mensagem `"Email extra já cadastrado..."` ou `"Este
+ *   email está sendo usado como username..."` → `inline` com a
+ *   mensagem do backend (que já é orientadora).
+ * - 404 → `not-found` (cliente removido entre abertura e submit).
+ *   Tratado em `classifySharedExtraEmailError`.
+ * - 401/403 → `toast` com mensagem do backend. Tratado em
+ *   `classifySharedExtraEmailError`.
+ * - Demais → `unhandled` com `genericFallback`.
+ */
+export function classifyAddExtraEmailError(
+  error: unknown,
+  copy: ExtraEmailErrorCopy,
+): AddExtraEmailErrorAction {
+  const shared = classifySharedExtraEmailError(error, copy);
+  if (shared !== null) {
+    return shared;
+  }
+  // `shared === null` significa que `error` é HTTP com `status` que
+  // exige decisão específica do `add` (400/409). Reabrimos o type
+  // guard para que TS saiba que `isApiError(error) === true` aqui
+  // (refinamento perdido no retorno do helper).
+  if (!isApiError(error) || error.kind !== 'http') {
+    return unhandledExtraEmailAction(copy);
+  }
+  if (error.status === 400) {
+    // Distinção pela mensagem do backend — `limit-reached` precisa
+    // disparar refetch (cliente foi tocado por outra sessão).
+    const message = error.message || copy.genericFallback;
+    if (message.toLowerCase().includes('limite')) {
+      return { kind: 'limit-reached', message };
+    }
+    return { kind: 'inline', message };
+  }
+  if (error.status === 409) {
+    const message = error.message || copy.genericFallback;
+    return { kind: 'inline', message };
+  }
+  return unhandledExtraEmailAction(copy);
+}
+
+/**
+ * Ação discriminada decorrente da classificação de erro do `remove`.
+ *
+ * - `username` → 400 "Não é permitido remover email que esteja sendo
+ *   usado como username.". Toast vermelho orientador.
+ * - `not-found` → email não pertence ao cliente (404). Refetch +
+ *   toast.
+ * - `toast` → 401/403 com mensagem do backend.
+ * - `unhandled` → fallback. Toast vermelho com `genericFallback`.
+ *
+ * Diferente do `Add`, não há caso `inline` porque o remove não tem
+ * input — a confirmação é binária (clicar ou cancelar) e o feedback
+ * é sempre via toast.
+ */
+export type RemoveExtraEmailErrorAction =
+  | { kind: 'username'; message: string; title: string }
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+/**
+ * Classifica o erro do `removeClientExtraEmail` em uma ação
+ * discriminada. Espelha `classifyAddExtraEmailError` mas com casos
+ * próprios do `DELETE /clients/{id}/emails/{emailId}`.
+ *
+ * **Casos cobertos (espelham `ClientsController.RemoveEmail`):**
+ *
+ * - 400 com qualquer mensagem → `username` (o backend só devolve 400
+ *   nesse endpoint quando o email é username). Toast com mensagem
+ *   do backend, que já é orientadora.
+ * - 404 → `not-found` (email já removido por outra sessão entre
+ *   abertura e submit, ou id inconsistente).
+ * - 401/403 → `toast` com mensagem do backend.
+ * - Demais → `unhandled` com `genericFallback`.
+ */
+export function classifyRemoveExtraEmailError(
+  error: unknown,
+  copy: ExtraEmailErrorCopy,
+): RemoveExtraEmailErrorAction {
+  const shared = classifySharedExtraEmailError(error, copy);
+  if (shared !== null) {
+    return shared;
+  }
+  if (!isApiError(error) || error.kind !== 'http') {
+    return unhandledExtraEmailAction(copy);
+  }
+  if (error.status === 400) {
+    return {
+      kind: 'username',
+      message: error.message || copy.genericFallback,
+      title: copy.forbiddenTitle,
+    };
+  }
+  return unhandledExtraEmailAction(copy);
+}

--- a/src/pages/users/userFormShared.ts
+++ b/src/pages/users/userFormShared.ts
@@ -1,5 +1,6 @@
 import {
   classifyApiSubmitError,
+  isValidEmailSyntax,
   type ApiSubmitErrorAction,
   type ApiSubmitErrorCopy,
 } from '../../shared/forms';
@@ -125,29 +126,12 @@ export const INITIAL_USER_FORM_STATE: UserFormState = {
 };
 
 /**
- * Validação simples de e-mail sem regex. Não é "regex perfeita" (essa
- * não existe — a RFC 5322 é gigantesca), mas captura erros de digitação
- * óbvios (sem `@`, sem TLD, espaços) sem rejeitar e-mails válidos
- * legítimos. O backend (`[EmailAddress]` do ASP.NET) faz a validação
- * autoritativa; o client-side é só feedback imediato.
- *
- * Implementação manual (em vez de regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`)
- * para evitar `typescript:S5852` — Sonar marca a regex tripla `[^\s@]+`
- * como vulnerável a backtracking super-linear (DoS hotspot). A versão
- * sem regex é equivalente em intenção e linear no comprimento da
- * string.
+ * Validação de e-mail compartilhada por `userFormShared` e
+ * `clientExtraEmailsHelpers` — promovida para `src/shared/forms/` em
+ * PR #146 quando o segundo consumidor surgiu. Ver
+ * `shared/forms/emailSyntax.ts` para os detalhes da implementação
+ * (regra anti-Sonar `S5852` de regex tripla).
  */
-function isValidEmailSyntax(value: string): boolean {
-  if (!value || value.length === 0) return false;
-  if (/\s/.test(value)) return false;
-  const at = value.indexOf('@');
-  if (at < 1) return false;
-  if (at !== value.lastIndexOf('@')) return false;
-  const domain = value.slice(at + 1);
-  if (domain.length === 0) return false;
-  const dot = domain.lastIndexOf('.');
-  return dot > 0 && dot < domain.length - 1;
-}
 
 /**
  * Confere se a string parseia para um inteiro finito (positivo ou

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -770,6 +770,111 @@ export async function restoreClient(
 }
 
 /**
+ * Limite máximo de emails extras por cliente — espelha a regra
+ * `if (count >= 3)` do `ClientsController.AddEmail` no
+ * `lfc-authenticator`. Centralizado para que a UI possa desabilitar
+ * o botão "Adicionar email" antes do round-trip e o teste use a
+ * mesma fonte da verdade da função (lição PR #128 — projetar
+ * shared helpers desde o primeiro PR do recurso).
+ */
+export const MAX_CLIENT_EXTRA_EMAILS = 3;
+
+/**
+ * Adiciona um email extra a um cliente via
+ * `POST /clients/{id}/emails` (Issue #146).
+ *
+ * Retorna o `ClientEmailDto` recém-criado (`200 OK` com
+ * `ClientEmailResponse` no corpo). Lança `ApiError` em qualquer
+ * falha — caller tipicamente trata:
+ *
+ * - `kind: 'http'` com `status === 400` →
+ *   - `"Limite de 3 emails extras por cliente."` quando o cliente já tem
+ *     o teto. UI desabilita o botão "Adicionar" preventivamente
+ *     (`MAX_CLIENT_EXTRA_EMAILS`), mas o branch fica defensivo para
+ *     race entre abertura do form e submit por outra sessão.
+ *   - `"Email extra inválido."` quando o backend rejeita o formato. A
+ *     UI já valida client-side, então este é caso de borda raro.
+ * - `kind: 'http'` com `status === 409` →
+ *   - `"Este email está sendo usado como username e não pode ser email
+ *     extra."` quando o email coincide com `Users.Email` de qualquer
+ *     usuário (mesmo de outro cliente). UI exibe a mensagem do backend
+ *     inline orientando o operador.
+ *   - `"Email extra já cadastrado para este cliente."` quando o email
+ *     já existe na lista deste cliente. Mensagem inline.
+ * - `kind: 'http'` com `status === 404` → cliente não encontrado
+ *   (soft-deletado entre carregamento da página e submit). UI dispara
+ *   toast vermelho e força refetch.
+ * - `kind: 'http'` com `status === 401`/`403` → toast vermelho com
+ *   mensagem do backend (cliente HTTP cuida do redirect 401).
+ * - Demais → toast vermelho com mensagem genérica.
+ *
+ * O backend **trima** + **lowercaseia** o email no servidor (`Email.Trim().
+ * ToLowerInvariant()`); a UI envia literal — preservar o que o operador
+ * digitou simplifica `expect.objectContaining({ email: '<literal>' })` em
+ * testes e mantém paridade com o que o input mostra ao operador. O
+ * resultado lowercased volta no `ClientEmailResponse` e a UI consome
+ * direto.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ */
+export async function addClientExtraEmail(
+  clientId: string,
+  email: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientEmailDto> {
+  const data = await client.post<unknown>(
+    `/clients/${clientId}/emails`,
+    { email },
+    options,
+  );
+  if (!isClientEmailDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Remove um email extra de um cliente via
+ * `DELETE /clients/{id}/emails/{emailId}` (Issue #146).
+ *
+ * Retorna `void` (`204 No Content`). Lança `ApiError` em qualquer
+ * falha — caller tipicamente trata:
+ *
+ * - `kind: 'http'` com `status === 400` →
+ *   `"Não é permitido remover email que esteja sendo usado como
+ *   username."` quando o email extra coincide com `Users.Email` de
+ *   algum usuário (cenário onde o email foi promovido a username
+ *   após cadastro como extra). UI dispara toast vermelho com
+ *   mensagem orientando o operador a remover o vínculo do usuário
+ *   antes.
+ * - `kind: 'http'` com `status === 404` → email extra não pertence
+ *   ao cliente (id já removido por outra sessão entre abertura e
+ *   submit). UI dispara toast vermelho e força refetch para
+ *   sincronizar a lista.
+ * - `kind: 'http'` com `status === 401`/`403` → toast vermelho com
+ *   mensagem do backend.
+ * - Demais → toast vermelho com mensagem genérica.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ */
+export async function removeClientExtraEmail(
+  clientId: string,
+  emailId: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(
+    `/clients/${clientId}/emails/${emailId}`,
+    options,
+  );
+}
+
+/**
  * Constrói o body para `POST /clients` e `PUT /clients/{id}`
  * aplicando trim defensivo e o filtro de campos por tipo (PF/PJ).
  * Centralizar essa montagem garante que nenhum call site inclua

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -130,6 +130,7 @@ export type {
   UpdateRolePayload,
 } from './roles';
 export {
+  addClientExtraEmail,
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_INCLUDE_DELETED,
@@ -141,6 +142,8 @@ export {
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  MAX_CLIENT_EXTRA_EMAILS,
+  removeClientExtraEmail,
   restoreClient,
   updateClient,
 } from './clients';

--- a/src/shared/forms/emailSyntax.ts
+++ b/src/shared/forms/emailSyntax.ts
@@ -1,0 +1,35 @@
+/**
+ * Validação simples de e-mail sem regex tripla.
+ *
+ * Não é "regex perfeita" (essa não existe — a RFC 5322 é gigantesca),
+ * mas captura erros de digitação óbvios (sem `@`, sem TLD, espaços)
+ * sem rejeitar e-mails válidos legítimos. O backend faz a validação
+ * autoritativa (`[EmailAddress]` do ASP.NET ou `EmailValidator.IsValid`);
+ * o client-side é só feedback imediato para o operador.
+ *
+ * Implementação manual (em vez de regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`)
+ * para evitar `typescript:S5852` — Sonar marca a regex tripla `[^\s@]+`
+ * como vulnerável a backtracking super-linear (DoS hotspot). A versão
+ * sem regex é equivalente em intenção e linear no comprimento da
+ * string.
+ *
+ * Originalmente vivia como função privada em
+ * `src/pages/users/userFormShared.ts` (Issue #78). Promovida para
+ * `src/shared/forms/` em PR #146 quando o segundo consumidor surgiu
+ * (`ClientExtraEmailsTab` precisa da mesma validação client-side).
+ * Lição PR #134/#135: quando dois call sites diferentes precisam da
+ * mesma lógica de validação, o helper sobe para `src/shared/forms/`
+ * em vez de duplicar — Sonar tokenizaria as ~10 linhas idênticas
+ * como `New Code Duplication`.
+ */
+export function isValidEmailSyntax(value: string): boolean {
+  if (!value || value.length === 0) return false;
+  if (/\s/.test(value)) return false;
+  const at = value.indexOf('@');
+  if (at < 1) return false;
+  if (at !== value.lastIndexOf('@')) return false;
+  const domain = value.slice(at + 1);
+  if (domain.length === 0) return false;
+  const dot = domain.lastIndexOf('.');
+  return dot > 0 && dot < domain.length - 1;
+}

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -30,6 +30,7 @@ export {
   type ApplyBadRequestDecision,
   type ApplyBadRequestDispatchers,
 } from "./createApplyBadRequest";
+export { isValidEmailSyntax } from "./emailSyntax";
 export { extractValidationErrorsByField } from "./extractValidationErrors";
 export { FormFooter } from "./FormFooter";
 export {

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -2,7 +2,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react';
 import { expect, vi } from 'vitest';
 
-import type { ApiClient, ApiError, ClientDto, PagedResponse } from '@/shared/api';
+import type {
+  ApiClient,
+  ApiError,
+  ClientDto,
+  ClientEmailDto,
+  PagedResponse,
+} from '@/shared/api';
 
 import { ToastProvider } from '@/components/ui';
 import { ClientsListShellPage } from '@/pages/clients';
@@ -617,4 +623,41 @@ export function buildClientsEditSubmitErrorCases(): ReadonlyArray<ClientsErrorCa
       expectedText: 'Não foi possível atualizar o cliente. Tente novamente.',
     },
   ];
+}
+
+/* ─── Helpers de fluxo do `ClientExtraEmailsTab` (Issue #146) ─ */
+
+/**
+ * Constrói um `ClientEmailDto` com defaults — testes só sobrescrevem o
+ * que importa para o cenário sem repetir todos os campos do contrato.
+ *
+ * O `id` default é um UUID sintético claramente identificável; cenários
+ * que precisem de ids estáveis para asserts reusam essa fixture
+ * passando o `id` próprio.
+ */
+export function makeClientEmail(overrides: Partial<ClientEmailDto> = {}): ClientEmailDto {
+  return {
+    id: 'e0000000-0000-0000-0000-000000000001',
+    email: 'extra1@exemplo.com',
+    createdAt: '2026-02-10T12:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Submete o form do modal de adicionar email no `ClientExtraEmailsTab`
+ * e aguarda o `client.post` ser chamado pelo menos `expectedPostCalls`
+ * vezes (default `1`). Faz `act(async)` para flushar a microtask do
+ * submit antes do `waitFor`. Espelha `submitNewClientForm` para o
+ * caminho do modal de adicionar email.
+ */
+export async function submitAddExtraEmailForm(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('client-extra-emails-add-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
 }

--- a/tests/pages/__helpers__/mockUseAuth.ts
+++ b/tests/pages/__helpers__/mockUseAuth.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, beforeEach, vi } from 'vitest';
 
 /**
  * Shape mínimo do `User` consumido por componentes que diferenciam o
@@ -75,4 +75,38 @@ export function buildAuthMock(
       verifyRoute: vi.fn().mockResolvedValue(true),
     }),
   };
+}
+
+/**
+ * Setup `beforeEach`/`afterEach` que zera/restaura mocks entre
+ * testes — concentra o boilerplate `permissionsMock = [...]; vi.
+ * restoreAllMocks();` que se repetia em cada suíte de teste das
+ * abas de cliente (`ClientDataTab.test.tsx`,
+ * `ClientExtraEmailsTab.test.tsx`).
+ *
+ * O caller declara `let permissionsMock` e o `vi.mock` no escopo do
+ * próprio arquivo (Vitest exige que `vi.mock` seja estático), mas
+ * delega o reset/restore a este helper passando o setter da
+ * variável. Mantém o boilerplate enxuto e previne `New Code
+ * Duplication` no JSCPD/Sonar (lição PR #134/#135).
+ *
+ * Uso:
+ *
+ * ```ts
+ * let permissionsMock: ReadonlyArray<string> = [];
+ * vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+ * setupPermissionLifecycle((perms) => { permissionsMock = perms; },
+ *   ['AUTH_V1_CLIENTS_UPDATE']);
+ * ```
+ */
+export function setupPermissionLifecycle(
+  setPermissions: (perms: ReadonlyArray<string>) => void,
+  defaultPermissions: ReadonlyArray<string>,
+): void {
+  beforeEach(() => {
+    setPermissions(defaultPermissions);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 }

--- a/tests/pages/clients/ClientDataTab.test.tsx
+++ b/tests/pages/clients/ClientDataTab.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 /* eslint-disable import/order */
-import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  buildAuthMock,
+  setupPermissionLifecycle,
+} from '../__helpers__/mockUseAuth';
 import {
   buildClientsEditSubmitErrorCases,
   createClientsClientStub,
@@ -65,13 +68,9 @@ vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
 
 const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
 
-beforeEach(() => {
-  permissionsMock = [CLIENTS_UPDATE_PERMISSION];
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+setupPermissionLifecycle((perms) => {
+  permissionsMock = perms;
+}, [CLIENTS_UPDATE_PERMISSION]);
 
 /**
  * Componente que captura o pathname atual do `MemoryRouter` para

--- a/tests/pages/clients/ClientExtraEmailsTab.test.tsx
+++ b/tests/pages/clients/ClientExtraEmailsTab.test.tsx
@@ -1,0 +1,554 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import {
+  buildAuthMock,
+  setupPermissionLifecycle,
+} from '../__helpers__/mockUseAuth';
+import {
+  createClientsClientStub,
+  ID_CLIENT_PF_ANA,
+  makeClient,
+  makeClientEmail,
+  submitAddExtraEmailForm,
+} from '../__helpers__/clientsTestHelpers';
+import type { ApiClientStub } from '../__helpers__/clientsTestHelpers';
+import { ToastProvider } from '@/components/ui';
+import { ClientExtraEmailsTab } from '@/pages/clients/ClientExtraEmailsTab';
+/* eslint-enable import/order */
+
+/**
+ * Suíte do `ClientExtraEmailsTab` (Issue #146 — gerenciar emails
+ * extras de cliente).
+ *
+ * Estratégia espelha `ClientDataTab.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory) para alternar `AUTH_V1_CLIENTS_UPDATE` entre testes.
+ * - Stub de `ApiClient` injetado em
+ *   `<ClientExtraEmailsTab client={stub} />`, isolando da camada de
+ *   transporte real.
+ * - Helpers em `clientsTestHelpers.tsx` (`makeClientEmail`,
+ *   `submitAddExtraEmailForm`) para colapsar o boilerplate
+ *   "preencher → submeter" e evitar `New Code Duplication` no Sonar
+ *   (lição PR #134/#135).
+ *
+ * Cobre (critérios da issue):
+ *
+ * - Lista os emails extras existentes (vindos em
+ *   `ClientResponse.extraEmails`).
+ * - Botão "Adicionar email" abre modal com input e validação
+ *   client-side de formato.
+ * - Botão de remover por linha; confirmação antes.
+ * - Mapeamento dos erros do backend (400 limite, 409 duplicado,
+ *   409 username, 400 remove username).
+ * - Refetch após sucesso.
+ * - Visível com `Clients.Update` (modo readonly sem permissão).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+setupPermissionLifecycle((perms) => {
+  permissionsMock = perms;
+}, [CLIENTS_UPDATE_PERMISSION]);
+
+/**
+ * Renderiza a `ClientExtraEmailsTab` num `<MemoryRouter>` com a rota
+ * `/clientes/:id` para que `useParams` devolva o `id` esperado.
+ */
+function renderClientExtraEmailsTab(
+  client: ApiClientStub,
+  initialEntries: ReadonlyArray<string> = [`/clientes/${ID_CLIENT_PF_ANA}`],
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[...initialEntries]}>
+        <Routes>
+          <Route
+            path="/clientes/:id"
+            element={<ClientExtraEmailsTab client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda o fetch inicial completar (loading some, conteúdo aparece).
+ */
+async function waitForLoaded(): Promise<void> {
+  await waitFor(() => {
+    expect(
+      screen.queryByTestId('client-extra-emails-loading'),
+    ).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Abre o modal de adicionar e preenche o input com `value`. O modal
+ * abre via clique no botão "Adicionar email", que precisa estar
+ * habilitado (cliente abaixo do limite) — caller garante isso via
+ * mock do `getClientById`.
+ */
+function openAddModalAndFill(value: string): void {
+  fireEvent.click(screen.getByTestId('client-extra-emails-add'));
+  fireEvent.change(screen.getByTestId('client-extra-emails-add-email'), {
+    target: { value },
+  });
+}
+
+/**
+ * Constrói um email pré-cadastrado e configura o stub para devolver
+ * um cliente com esse email no GET inicial. Centralizar evita repetir
+ * o trio "makeClientEmail + makeClient + mockResolvedValueOnce" em
+ * cada teste de remoção (~10 linhas), o que dispararia detecção de
+ * duplicação no JSCPD/Sonar (lição PR #134/#135 — extrair helper
+ * antes do segundo call site).
+ */
+function setupSingleEmailScene(): {
+  client: ApiClientStub;
+  email: ReturnType<typeof makeClientEmail>;
+} {
+  const email = makeClientEmail({
+    id: 'e0000000-0000-0000-0000-0000000000aa',
+    email: 'a@exemplo.com',
+  });
+  const dto = makeClient({ extraEmails: [email] });
+  const client = createClientsClientStub();
+  client.get.mockResolvedValueOnce(dto);
+  return { client, email };
+}
+
+/**
+ * Variante de `setupSingleEmailScene` que abre a confirmação de
+ * remoção logo após o load. Usado pelos testes que disparam ações
+ * subsequentes (confirm, cancel, error). Mantém o boilerplate de
+ * teste enxuto e elimina ~5 linhas idênticas em cada cenário.
+ */
+async function setupSingleEmailRemoveConfirm(): Promise<{
+  client: ApiClientStub;
+  email: ReturnType<typeof makeClientEmail>;
+}> {
+  const scene = setupSingleEmailScene();
+  renderClientExtraEmailsTab(scene.client);
+  await waitForLoaded();
+  fireEvent.click(
+    screen.getByTestId(`client-extra-emails-remove-${scene.email.id}`),
+  );
+  return scene;
+}
+
+describe('ClientExtraEmailsTab — fetch inicial e estados visuais (Issue #146)', () => {
+  it('exibe spinner durante o GET /clients/{id}', () => {
+    const client = createClientsClientStub();
+    client.get.mockReturnValueOnce(new Promise(() => {
+      // intencional: nunca resolve
+    }));
+
+    renderClientExtraEmailsTab(client);
+
+    expect(
+      screen.getByTestId('client-extra-emails-loading'),
+    ).toBeInTheDocument();
+    expect(client.get).toHaveBeenCalledWith(
+      `/clients/${ID_CLIENT_PF_ANA}`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('exibe ErrorRetryBlock quando o fetch falha (rede)', async () => {
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'network',
+      message: 'Falha de conexão.',
+    });
+
+    renderClientExtraEmailsTab(client);
+
+    expect(
+      await screen.findByTestId('client-extra-emails-retry'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Não foi possível carregar os dados do cliente.'),
+    ).toBeInTheDocument();
+  });
+
+  it('clicar em "Tentar novamente" refaz o GET', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'network',
+      message: 'Falha.',
+    });
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    const retryBtn = await screen.findByTestId('client-extra-emails-retry');
+    fireEvent.click(retryBtn);
+
+    await waitForLoaded();
+    expect(client.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('renderiza empty state quando o cliente não tem emails extras', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    expect(
+      screen.getByTestId('client-extra-emails-empty'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Nenhum email extra cadastrado'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('client-extra-emails-counter')).toHaveTextContent(
+      '0 de 3 cadastrados',
+    );
+  });
+
+  it('renderiza linha por email retornado em ClientResponse.extraEmails', async () => {
+    const emailA = makeClientEmail({
+      id: 'e0000000-0000-0000-0000-0000000000aa',
+      email: 'a@exemplo.com',
+    });
+    const emailB = makeClientEmail({
+      id: 'e0000000-0000-0000-0000-0000000000bb',
+      email: 'b@exemplo.com',
+    });
+    const dto = makeClient({ extraEmails: [emailA, emailB] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    expect(
+      screen.getByTestId(`client-extra-emails-row-${emailA.id}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`client-extra-emails-row-${emailB.id}`),
+    ).toBeInTheDocument();
+    expect(screen.getByText('a@exemplo.com')).toBeInTheDocument();
+    expect(screen.getByText('b@exemplo.com')).toBeInTheDocument();
+    expect(screen.getByTestId('client-extra-emails-counter')).toHaveTextContent(
+      '2 de 3 cadastrados',
+    );
+  });
+});
+
+describe('ClientExtraEmailsTab — adicionar email (Issue #146)', () => {
+  it('botão "Adicionar email" abre o modal com input vazio', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    fireEvent.click(screen.getByTestId('client-extra-emails-add'));
+
+    const input = screen.getByTestId(
+      'client-extra-emails-add-email',
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('');
+  });
+
+  it('email com formato inválido bloqueia o submit e exibe erro inline', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('sem-arroba');
+    fireEvent.submit(screen.getByTestId('client-extra-emails-add-form'));
+
+    expect(screen.getByText('Informe um email válido.')).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('email vazio (whitespace) bloqueia o submit e exibe erro inline', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('   ');
+    fireEvent.submit(screen.getByTestId('client-extra-emails-add-form'));
+
+    expect(screen.getByText('Email é obrigatório.')).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('submit válido envia POST /clients/{id}/emails com body { email } trimado', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const updated = makeClient({
+      extraEmails: [makeClientEmail({ email: 'novo@exemplo.com' })],
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.post.mockResolvedValueOnce(makeClientEmail({ email: 'novo@exemplo.com' }));
+    client.get.mockResolvedValueOnce(updated);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('  novo@exemplo.com  ');
+    await submitAddExtraEmailForm(client);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/clients/${ID_CLIENT_PF_ANA}/emails`,
+      { email: 'novo@exemplo.com' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(await screen.findByText('Email extra adicionado.')).toBeInTheDocument();
+  });
+
+  it('botão "Adicionar email" fica desabilitado quando o cliente já tem 3 emails extras', async () => {
+    const dto = makeClient({
+      extraEmails: [
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a1', email: 'a@x.com' }),
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a2', email: 'b@x.com' }),
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a3', email: 'c@x.com' }),
+      ],
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    expect(screen.getByTestId('client-extra-emails-add')).toBeDisabled();
+    // Aviso visual reforça a condição.
+    expect(
+      screen.getByText(/Limite de 3 emails extras/i),
+    ).toBeInTheDocument();
+  });
+
+  it('400 "Limite de 3..." (race) exibe inline e dispara refetch', async () => {
+    // UI mostra 2 emails (abaixo do limite), operador abre modal,
+    // mas no momento do submit o backend já tem 3 (outra sessão).
+    const dto = makeClient({
+      extraEmails: [
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a1', email: 'a@x.com' }),
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a2', email: 'b@x.com' }),
+      ],
+    });
+    const dtoFull = makeClient({
+      extraEmails: [
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a1', email: 'a@x.com' }),
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a2', email: 'b@x.com' }),
+        makeClientEmail({ id: 'e0000000-0000-0000-0000-0000000000a3', email: 'c@x.com' }),
+      ],
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 400,
+      message: 'Limite de 3 emails extras por cliente.',
+    });
+    client.get.mockResolvedValueOnce(dtoFull);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('novo@exemplo.com');
+    await submitAddExtraEmailForm(client);
+
+    expect(
+      await screen.findByText('Limite de 3 emails extras por cliente.'),
+    ).toBeInTheDocument();
+    // Refetch foi disparado (2 GETs no total).
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('409 "Email extra já cadastrado" exibe mensagem inline no input', async () => {
+    const dto = makeClient({
+      extraEmails: [makeClientEmail({ email: 'existente@exemplo.com' })],
+    });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message: 'Email extra já cadastrado para este cliente.',
+    });
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('existente@exemplo.com');
+    await submitAddExtraEmailForm(client);
+
+    expect(
+      await screen.findByText('Email extra já cadastrado para este cliente.'),
+    ).toBeInTheDocument();
+    // Modal continua aberto (input ainda visível).
+    expect(
+      screen.getByTestId('client-extra-emails-add-email'),
+    ).toBeInTheDocument();
+  });
+
+  it('409 "Este email está sendo usado como username" exibe orientação inline', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message:
+        'Este email está sendo usado como username e não pode ser email extra.',
+    });
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('username@exemplo.com');
+    await submitAddExtraEmailForm(client);
+
+    expect(
+      await screen.findByText(
+        'Este email está sendo usado como username e não pode ser email extra.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('cancelar fecha o modal e descarta o input', async () => {
+    const dto = makeClient({ extraEmails: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientExtraEmailsTab(client);
+    await waitForLoaded();
+
+    openAddModalAndFill('rascunho@exemplo.com');
+    fireEvent.click(screen.getByTestId('client-extra-emails-add-cancel'));
+
+    // Modal fecha — input não fica no DOM.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('client-extra-emails-add-email'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Reabrir mostra input vazio (descartou rascunho).
+    fireEvent.click(screen.getByTestId('client-extra-emails-add'));
+    expect(
+      (screen.getByTestId('client-extra-emails-add-email') as HTMLInputElement).value,
+    ).toBe('');
+  });
+});
+
+describe('ClientExtraEmailsTab — remover email (Issue #146)', () => {
+  it('clicar em "Remover" por linha abre confirmação com email em destaque', async () => {
+    await setupSingleEmailRemoveConfirm();
+
+    const description = screen.getByTestId(
+      'client-extra-emails-remove-description',
+    );
+    expect(description).toBeInTheDocument();
+    // O email aparece em destaque dentro da descrição do confirm.
+    expect(description).toHaveTextContent('a@exemplo.com');
+    expect(
+      screen.getByTestId('client-extra-emails-remove-confirm'),
+    ).toBeInTheDocument();
+  });
+
+  it('confirmar remoção envia DELETE /clients/{id}/emails/{emailId} e dispara refetch', async () => {
+    const scene = setupSingleEmailScene();
+    scene.client.delete.mockResolvedValueOnce(undefined);
+    scene.client.get.mockResolvedValueOnce(makeClient({ extraEmails: [] }));
+
+    renderClientExtraEmailsTab(scene.client);
+    await waitForLoaded();
+
+    fireEvent.click(
+      screen.getByTestId(`client-extra-emails-remove-${scene.email.id}`),
+    );
+    fireEvent.click(screen.getByTestId('client-extra-emails-remove-confirm'));
+
+    await waitFor(() => expect(scene.client.delete).toHaveBeenCalledTimes(1));
+    expect(scene.client.delete).toHaveBeenCalledWith(
+      `/clients/${ID_CLIENT_PF_ANA}/emails/${scene.email.id}`,
+      undefined,
+    );
+    expect(await screen.findByText('Email extra removido.')).toBeInTheDocument();
+    // Refetch — a lista volta vazia.
+    await waitFor(() => expect(scene.client.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('400 ao remover (email é username) dispara toast vermelho orientador', async () => {
+    const scene = setupSingleEmailScene();
+    scene.client.delete.mockRejectedValueOnce({
+      kind: 'http',
+      status: 400,
+      message:
+        'Não é permitido remover email que esteja sendo usado como username.',
+    });
+
+    renderClientExtraEmailsTab(scene.client);
+    await waitForLoaded();
+
+    fireEvent.click(
+      screen.getByTestId(`client-extra-emails-remove-${scene.email.id}`),
+    );
+    fireEvent.click(screen.getByTestId('client-extra-emails-remove-confirm'));
+
+    expect(
+      await screen.findByText(
+        'Não é permitido remover email que esteja sendo usado como username.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('cancelar remoção fecha o modal sem chamar DELETE', async () => {
+    const scene = await setupSingleEmailRemoveConfirm();
+
+    fireEvent.click(screen.getByTestId('client-extra-emails-remove-cancel'));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('client-extra-emails-remove-confirm'),
+      ).not.toBeInTheDocument();
+    });
+    expect(scene.client.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('ClientExtraEmailsTab — gating Clients.Update (Issue #146)', () => {
+  it('sem AUTH_V1_CLIENTS_UPDATE oculta botão "Adicionar" e botões "Remover" por linha', async () => {
+    permissionsMock = [];
+    const scene = setupSingleEmailScene();
+
+    renderClientExtraEmailsTab(scene.client);
+    await waitForLoaded();
+
+    // Lista permanece visível (auditoria).
+    expect(
+      screen.getByTestId(`client-extra-emails-row-${scene.email.id}`),
+    ).toBeInTheDocument();
+    // Botão de adicionar e remover ausentes.
+    expect(
+      screen.queryByTestId('client-extra-emails-add'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`client-extra-emails-remove-${scene.email.id}`),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/pages/clients/clientExtraEmailsHelpers.test.ts
+++ b/tests/pages/clients/clientExtraEmailsHelpers.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyAddExtraEmailError,
+  classifyRemoveExtraEmailError,
+  EXTRA_EMAIL_MAX,
+  validateExtraEmailInput,
+  type ExtraEmailErrorCopy,
+} from '@/pages/clients/clientExtraEmailsHelpers';
+
+/**
+ * Suíte do `clientExtraEmailsHelpers` (Issue #146).
+ *
+ * Cobre as funções puras consumidas pelo `ClientExtraEmailsTab`:
+ *
+ * - `validateExtraEmailInput` — feedback client-side antes do submit.
+ * - `classifyAddExtraEmailError` — mapeamento dos erros do
+ *   `addClientExtraEmail` para ações discriminadas.
+ * - `classifyRemoveExtraEmailError` — mapeamento dos erros do
+ *   `removeClientExtraEmail`.
+ *
+ * Foco em casos de borda que cobrem os cenários da issue (limite,
+ * 409 duplicado, 409 username, 400 username no remove). Testes são
+ * em TS puro (sem provider/render) — o componente compõe esses
+ * helpers numa árvore visual mas a lógica é testável isoladamente.
+ */
+
+const COPY: ExtraEmailErrorCopy = {
+  genericFallback: 'Não foi possível concluir a ação. Tente novamente.',
+  forbiddenTitle: 'Falha na operação',
+  notFoundMessage: 'Recurso não encontrado.',
+};
+
+describe('validateExtraEmailInput', () => {
+  it('retorna null para email válido', () => {
+    expect(validateExtraEmailInput('ana@exemplo.com')).toBeNull();
+  });
+
+  it('retorna null após trim quando o resultado é válido', () => {
+    expect(validateExtraEmailInput('  ana@exemplo.com  ')).toBeNull();
+  });
+
+  it('exige email obrigatório quando vazio', () => {
+    expect(validateExtraEmailInput('')).toBe('Email é obrigatório.');
+  });
+
+  it('exige email obrigatório quando apenas whitespace', () => {
+    expect(validateExtraEmailInput('   ')).toBe('Email é obrigatório.');
+  });
+
+  it('rejeita email com tamanho acima do máximo permitido', () => {
+    const localPart = 'a'.repeat(EXTRA_EMAIL_MAX);
+    const email = `${localPart}@exemplo.com`;
+    expect(validateExtraEmailInput(email)).toBe(
+      `Email deve ter no máximo ${EXTRA_EMAIL_MAX} caracteres.`,
+    );
+  });
+
+  it('rejeita email sem arroba', () => {
+    expect(validateExtraEmailInput('sem-arroba')).toBe('Informe um email válido.');
+  });
+
+  it('rejeita email com formato inválido (sem TLD)', () => {
+    expect(validateExtraEmailInput('ana@dominio')).toBe('Informe um email válido.');
+  });
+
+  it('rejeita email com mais de uma arroba', () => {
+    expect(validateExtraEmailInput('ana@x@y.com')).toBe('Informe um email válido.');
+  });
+
+  it('rejeita email com espaços internos', () => {
+    expect(validateExtraEmailInput('ana @exemplo.com')).toBe('Informe um email válido.');
+  });
+});
+
+describe('classifyAddExtraEmailError', () => {
+  it('classifica 400 com mensagem "Limite de 3..." como limit-reached', () => {
+    const action = classifyAddExtraEmailError(
+      {
+        kind: 'http',
+        status: 400,
+        message: 'Limite de 3 emails extras por cliente.',
+      },
+      COPY,
+    );
+
+    expect(action.kind).toBe('limit-reached');
+    if (action.kind === 'limit-reached') {
+      expect(action.message).toBe('Limite de 3 emails extras por cliente.');
+    }
+  });
+
+  it('classifica 400 com outras mensagens como inline (defensivo)', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'http', status: 400, message: 'Email extra inválido.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('inline');
+    if (action.kind === 'inline') {
+      expect(action.message).toBe('Email extra inválido.');
+    }
+  });
+
+  it('classifica 409 (duplicado) como inline com mensagem do backend', () => {
+    const action = classifyAddExtraEmailError(
+      {
+        kind: 'http',
+        status: 409,
+        message: 'Email extra já cadastrado para este cliente.',
+      },
+      COPY,
+    );
+
+    expect(action.kind).toBe('inline');
+    if (action.kind === 'inline') {
+      expect(action.message).toBe('Email extra já cadastrado para este cliente.');
+    }
+  });
+
+  it('classifica 409 (username) como inline com mensagem orientadora', () => {
+    const action = classifyAddExtraEmailError(
+      {
+        kind: 'http',
+        status: 409,
+        message: 'Este email está sendo usado como username e não pode ser email extra.',
+      },
+      COPY,
+    );
+
+    expect(action.kind).toBe('inline');
+    if (action.kind === 'inline') {
+      expect(action.message).toContain('username');
+    }
+  });
+
+  it('classifica 404 como not-found com message do COPY', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'http', status: 404, message: 'Cliente não encontrado.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('not-found');
+    if (action.kind === 'not-found') {
+      expect(action.message).toBe(COPY.notFoundMessage);
+      expect(action.title).toBe(COPY.forbiddenTitle);
+    }
+  });
+
+  it('classifica 401 como toast', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'http', status: 401, message: 'Sessão expirada.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('toast');
+    if (action.kind === 'toast') {
+      expect(action.message).toBe('Sessão expirada.');
+    }
+  });
+
+  it('classifica 403 como toast', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'http', status: 403, message: 'Sem permissão.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('toast');
+  });
+
+  it('classifica erros não-HTTP (network) como unhandled', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'network', message: 'Falha de conexão.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('unhandled');
+    if (action.kind === 'unhandled') {
+      expect(action.message).toBe(COPY.genericFallback);
+    }
+  });
+
+  it('classifica erros arbitrários (não-ApiError) como unhandled', () => {
+    const action = classifyAddExtraEmailError(new Error('Algo deu errado'), COPY);
+    expect(action.kind).toBe('unhandled');
+  });
+
+  it('classifica 5xx como unhandled', () => {
+    const action = classifyAddExtraEmailError(
+      { kind: 'http', status: 500, message: 'Erro interno.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('unhandled');
+  });
+});
+
+describe('classifyRemoveExtraEmailError', () => {
+  it('classifica 400 como username com mensagem do backend', () => {
+    const action = classifyRemoveExtraEmailError(
+      {
+        kind: 'http',
+        status: 400,
+        message:
+          'Não é permitido remover email que esteja sendo usado como username.',
+      },
+      COPY,
+    );
+
+    expect(action.kind).toBe('username');
+    if (action.kind === 'username') {
+      expect(action.message).toBe(
+        'Não é permitido remover email que esteja sendo usado como username.',
+      );
+    }
+  });
+
+  it('classifica 404 como not-found com message do COPY', () => {
+    const action = classifyRemoveExtraEmailError(
+      { kind: 'http', status: 404, message: 'Email extra não encontrado.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('not-found');
+    if (action.kind === 'not-found') {
+      expect(action.message).toBe(COPY.notFoundMessage);
+    }
+  });
+
+  it('classifica 401/403 como toast', () => {
+    const action = classifyRemoveExtraEmailError(
+      { kind: 'http', status: 403, message: 'Sem permissão.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('toast');
+  });
+
+  it('classifica network como unhandled', () => {
+    const action = classifyRemoveExtraEmailError(
+      { kind: 'network', message: 'Falha.' },
+      COPY,
+    );
+
+    expect(action.kind).toBe('unhandled');
+  });
+});

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
 
 import {
+  addClientExtraEmail,
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_PAGE_SIZE,
@@ -12,6 +13,7 @@ import {
   isClientDto,
   isPagedClientsResponse,
   listClients,
+  removeClientExtraEmail,
   restoreClient,
   updateClient,
 } from '@/shared/api';
@@ -1070,6 +1072,249 @@ describe('restoreClient', () => {
 
     await expect(
       restoreClient(CLIENT_PF_ID, undefined, client as unknown as ApiClient),
+    ).rejects.toBe(forbidden);
+  });
+});
+
+describe('addClientExtraEmail (Issue #146)', () => {
+  const EMAIL_ID = 'e0000000-0000-0000-0000-000000000001';
+
+  function makeRawEmail(overrides: Partial<{ id: string; email: string; createdAt: string }> = {}): {
+    id: string;
+    email: string;
+    createdAt: string;
+  } {
+    return {
+      id: EMAIL_ID,
+      email: 'extra@exemplo.com',
+      createdAt: '2026-02-10T12:00:00Z',
+      ...overrides,
+    };
+  }
+
+  it('faz POST /clients/{id}/emails com body { email } e devolve ClientEmailDto', async () => {
+    const client = makeClientStub();
+    const created = makeRawEmail();
+    client.post.mockResolvedValueOnce(created);
+
+    const result = await addClientExtraEmail(
+      CLIENT_PF_ID,
+      'extra@exemplo.com',
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post.mock.calls[0][0]).toBe(
+      `/clients/${CLIENT_PF_ID}/emails`,
+    );
+    expect(client.post.mock.calls[0][1]).toEqual({ email: 'extra@exemplo.com' });
+    expect(result).toEqual(created);
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce(makeRawEmail());
+    const controller = new AbortController();
+
+    await addClientExtraEmail(
+      CLIENT_PF_ID,
+      'extra@exemplo.com',
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][2]).toEqual({ signal: controller.signal });
+  });
+
+  it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+    const client = makeClientStub();
+    client.post.mockResolvedValueOnce({ malformed: true });
+
+    await expect(
+      addClientExtraEmail(
+        CLIENT_PF_ID,
+        'extra@exemplo.com',
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: 'Resposta inválida do servidor.',
+    });
+  });
+
+  it('propaga ApiError 400 do backend (limite atingido)', async () => {
+    const client = makeClientStub();
+    const limit = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Limite de 3 emails extras por cliente.',
+    };
+    client.post.mockRejectedValueOnce(limit);
+
+    await expect(
+      addClientExtraEmail(
+        CLIENT_PF_ID,
+        'extra@exemplo.com',
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(limit);
+  });
+
+  it('propaga ApiError 409 do backend (email duplicado)', async () => {
+    const client = makeClientStub();
+    const conflict = {
+      kind: 'http' as const,
+      status: 409,
+      message: 'Email extra já cadastrado para este cliente.',
+    };
+    client.post.mockRejectedValueOnce(conflict);
+
+    await expect(
+      addClientExtraEmail(
+        CLIENT_PF_ID,
+        'extra@exemplo.com',
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(conflict);
+  });
+
+  it('propaga ApiError 409 do backend (email é username de algum usuário)', async () => {
+    const client = makeClientStub();
+    const conflict = {
+      kind: 'http' as const,
+      status: 409,
+      message:
+        'Este email está sendo usado como username e não pode ser email extra.',
+    };
+    client.post.mockRejectedValueOnce(conflict);
+
+    await expect(
+      addClientExtraEmail(
+        CLIENT_PF_ID,
+        'username@exemplo.com',
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(conflict);
+  });
+
+  it('propaga ApiError 404 do backend (cliente removido)', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado.',
+    };
+    client.post.mockRejectedValueOnce(notFound);
+
+    await expect(
+      addClientExtraEmail(
+        CLIENT_PF_ID,
+        'extra@exemplo.com',
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(notFound);
+  });
+});
+
+describe('removeClientExtraEmail (Issue #146)', () => {
+  const EMAIL_ID = 'e0000000-0000-0000-0000-000000000001';
+
+  it('faz DELETE /clients/{id}/emails/{emailId} sem corpo e resolve void', async () => {
+    const client = makeClientStub();
+    client.delete.mockResolvedValueOnce(undefined);
+
+    const result = await removeClientExtraEmail(
+      CLIENT_PF_ID,
+      EMAIL_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete).toHaveBeenCalledTimes(1);
+    expect(client.delete.mock.calls[0][0]).toBe(
+      `/clients/${CLIENT_PF_ID}/emails/${EMAIL_ID}`,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('propaga signal via options', async () => {
+    const client = makeClientStub();
+    client.delete.mockResolvedValueOnce(undefined);
+    const controller = new AbortController();
+
+    await removeClientExtraEmail(
+      CLIENT_PF_ID,
+      EMAIL_ID,
+      { signal: controller.signal },
+      client as unknown as ApiClient,
+    );
+
+    expect(client.delete.mock.calls[0][1]).toEqual({
+      signal: controller.signal,
+    });
+  });
+
+  it('propaga ApiError 400 do backend (email é username — não pode remover)', async () => {
+    const client = makeClientStub();
+    const usernameError = {
+      kind: 'http' as const,
+      status: 400,
+      message:
+        'Não é permitido remover email que esteja sendo usado como username.',
+    };
+    client.delete.mockRejectedValueOnce(usernameError);
+
+    await expect(
+      removeClientExtraEmail(
+        CLIENT_PF_ID,
+        EMAIL_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(usernameError);
+  });
+
+  it('propaga ApiError 404 do backend (email não pertence ao cliente)', async () => {
+    const client = makeClientStub();
+    const notFound = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Email extra não encontrado para este cliente.',
+    };
+    client.delete.mockRejectedValueOnce(notFound);
+
+    await expect(
+      removeClientExtraEmail(
+        CLIENT_PF_ID,
+        EMAIL_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toBe(notFound);
+  });
+
+  it('propaga ApiError 401/403 do backend (sessão/permissão)', async () => {
+    const client = makeClientStub();
+    const forbidden = {
+      kind: 'http' as const,
+      status: 403,
+      message: 'Você não tem permissão para esta ação.',
+    };
+    client.delete.mockRejectedValueOnce(forbidden);
+
+    await expect(
+      removeClientExtraEmail(
+        CLIENT_PF_ID,
+        EMAIL_ID,
+        undefined,
+        client as unknown as ApiClient,
+      ),
     ).rejects.toBe(forbidden);
   });
 });


### PR DESCRIPTION
## Contexto

Issue #146 — fechamento de uma feature crítica da EPIC #49 (Clientes e Usuários). O `ClientResponse` do `lfc-authenticator` permite até 3 emails extras por cliente com regras de negócio importantes (anti-username, anti-duplicado), mas até este PR a aba "Emails extras" do `ClientEditPage` (#144) ficava como placeholder.

## Objetivo

Substituir o placeholder por UI funcional de gerenciamento de emails extras, espelhando os endpoints `POST /clients/{id}/emails` e `DELETE /clients/{id}/emails/{emailId}` do backend.

## O que foi feito

### API (`shared/api/clients.ts`)
- `addClientExtraEmail(id, email, options?, client?)`: POST /clients/{id}/emails, valida response com `isClientEmailDto`, propaga `ApiError`.
- `removeClientExtraEmail(id, emailId, options?, client?)`: DELETE /clients/{id}/emails/{emailId} (`204 No Content`).
- `MAX_CLIENT_EXTRA_EMAILS = 3` exportado para a UI desabilitar o botão preventivamente.

### UI (`pages/clients/ClientExtraEmailsTab.tsx`)
- Substitui placeholder herdado do PR #153 (#144).
- Estados visuais completos: `loading` (spinner), `error` (`ErrorRetryBlock`), `empty` (com hint contextual), `list` (com até 3 linhas), `full` (botão "Adicionar" desabilitado + `Alert info`).
- Modal "Adicionar email" com input + validação client-side (formato + max 320 chars).
- Modal de confirmação antes de remover.
- Mapeamento completo dos erros do backend:
  - 400 "Limite de 3..." → inline + refetch (defesa contra race entre sessões).
  - 409 "Email extra já cadastrado" → inline.
  - 409 "Este email está sendo usado como username" → inline com mensagem orientadora.
  - 400 ao remover (email é username) → toast vermelho orientador.
  - 404/401/403/network → toast + refetch quando aplicável.
- Refetch do `ClientResponse` após mutação.
- Visível com `Clients.Update`; sem permissão, lista permanece visível para auditoria mas botões "Adicionar"/"Remover" ficam ocultos.

### Refator antecipatório (lições PR #128/#134/#135)
- `isValidEmailSyntax` promovido de `pages/users/userFormShared.ts` (privado) para `shared/forms/emailSyntax.ts` (segundo consumidor — `ClientExtraEmailsTab`).
- `clientExtraEmailsHelpers.ts` concentra `validateExtraEmailInput` e `classify{Add,Remove}ExtraEmailError` em TS puro (testáveis sem React).
- `setupPermissionLifecycle` extraído em `tests/pages/__helpers__/mockUseAuth.ts` para deduplicar boilerplate `beforeEach/afterEach` reusado por `ClientDataTab` e `ClientExtraEmailsTab` tests.

## Arquivos impactados

**Novos:**
- `src/pages/clients/clientExtraEmailsHelpers.ts`
- `src/shared/forms/emailSyntax.ts`
- `tests/pages/clients/ClientExtraEmailsTab.test.tsx`
- `tests/pages/clients/clientExtraEmailsHelpers.test.ts`

**Modificados:**
- `src/pages/clients/ClientExtraEmailsTab.tsx` (substitui placeholder)
- `src/shared/api/clients.ts` (+addClientExtraEmail, +removeClientExtraEmail, +MAX_CLIENT_EXTRA_EMAILS)
- `src/shared/api/index.ts` (exporta novas funções)
- `src/shared/forms/index.ts` (exporta isValidEmailSyntax)
- `src/pages/users/userFormShared.ts` (passa a importar isValidEmailSyntax do shared)
- `tests/pages/__helpers__/mockUseAuth.ts` (+setupPermissionLifecycle)
- `tests/pages/__helpers__/clientsTestHelpers.tsx` (+makeClientEmail, +submitAddExtraEmailForm)
- `tests/pages/clients/ClientDataTab.test.tsx` (consome setupPermissionLifecycle)
- `tests/shared/api/clients.test.ts` (+12 cenários para os novos wrappers)

## Testes

- `tests/pages/clients/ClientExtraEmailsTab.test.tsx` — 19 cenários:
  - Fetch inicial: spinner, empty state, lista populada, ErrorRetryBlock, retry.
  - Add: modal abre vazio, validação client-side (formato/whitespace), submit válido com body trimado e refetch, limite atingido (botão disabled), 400 race + refetch, 409 duplicado inline, 409 username inline, cancelar descarta rascunho.
  - Remove: confirmação com email em destaque, DELETE + refetch, 400 username toast, cancelar não chama DELETE.
  - Gating: sem `Clients.Update`, oculta botões mas mostra lista.
- `tests/pages/clients/clientExtraEmailsHelpers.test.ts` — 23 cenários: validação client-side e classifiers `add`/`remove` (todos os branches).
- `tests/shared/api/clients.test.ts` — +12 cenários para os novos wrappers (path/body, signal, parse, 400/409/404/401-403).

### Quality gate

| Gate       | Resultado |
|------------|-----------|
| lint       | 0 warnings |
| typecheck  | 0 errors |
| test       | 1328/1328 (rodada com `--no-file-parallelism` para mitigar flakiness ambiental do worker pool local; CI tem recursos suficientes) |
| jscpd src/ | 2.14% (< 3% threshold), 0 clones nos arquivos do diff |

## Visual

- Empty state com ícone `Mail` (lucide-react) + título + hint contextual (varia conforme permissão).
- Linhas com hover sutil (`border-color: var(--border-medium-forest)`).
- Botões usam variants do design system (`primary`/`ghost`/`danger`); ícones `Plus`/`Trash2` proporcionais.
- Tokens `--space-*`/`--radius-*`/`--border-*`/`--bg-*`/`--fg*` em todos os styled-components — sem hardcode de cor.
- Foco/hover/disabled herdados dos componentes base (Button/Input/Modal). Modal mantém foco e Esc/backdrop respeitando `isSubmitting`.
- Counter "X de 3 cadastrados" em monoespaçado para reforçar a ação atômica.

## Segurança

- Email é POST'ado literal (backend faz `Trim().ToLowerInvariant()`); UI valida com helper anti-Sonar S5852 (`isValidEmailSyntax` sem regex tripla — linear em complexidade).
- Sem `dangerouslySetInnerHTML`; mensagens do backend são renderizadas como texto plano via `ConfirmText`/`Alert`.
- Não loga email/payload em console.
- Gating client-side é apenas UX — backend (`PermissionPolicies.ClientsUpdate`) é a fonte autoritativa.

## Riscos

- Flakiness ambiental do test runner local com paralelismo padrão (não bloqueia, suite passa 100% com `--no-file-parallelism` e em CI). Não relacionado às mudanças deste PR — pré-existente no repo.
- Backend trima/lowercaseia o email; o input do operador permanece literal até o submit (consistente com o que ele vê).

## Issue relacionada

Closes #146