### PR TITLE
[Clientes] Gerenciar celulares e telefones fixos (#147)

### DIFF
--- a/src/pages/clients/ClientCollectionAddInputModal.tsx
+++ b/src/pages/clients/ClientCollectionAddInputModal.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+
+import { Button, Input, Modal } from '../../components/ui';
+
+import { ModalActions, ModalForm } from './clientCollectionTabStyles';
+
+/**
+ * Tipo HTML para o `<Input>` (usado para discriminar entre `email`,
+ * `tel`, etc.). Mantemos só o subset que os consumidores conhecidos
+ * (#146, #147) precisam — qualquer caso novo amplia aqui.
+ */
+type InputType = 'email' | 'tel' | 'text';
+
+interface ClientCollectionAddInputModalProps {
+  /** Flag de abertura do modal — caller controla via state interno. */
+  open: boolean;
+  /** Callback de fechar (cancelar/ESC/backdrop). */
+  onClose: () => void;
+  /** Título do modal (ex.: "Adicionar email extra", "Adicionar celular"). */
+  title: string;
+  /** Descrição abaixo do título. */
+  description: string;
+  /**
+   * Label do `<Input>` (ex.: "Email", "Celular", "Telefone fixo"). Usado
+   * pelo `<label>` associado e por leitor de tela.
+   */
+  inputLabel: string;
+  /** Placeholder do input. */
+  placeholder: string;
+  /** Tipo HTML do input (`email`/`tel`/`text`). */
+  inputType: InputType;
+  /** `inputMode` HTML — controla teclado virtual mobile (ex.: `tel`). */
+  inputMode?: 'email' | 'tel' | 'text' | 'url' | 'numeric';
+  /** Atributo `autoComplete` (`email`/`tel`/etc.). */
+  autoComplete?: string;
+  /** `maxLength` herdado do limite do backend. */
+  maxLength: number;
+  /** Valor controlado do input. */
+  value: string;
+  /** Mensagem de erro inline, ou `null` quando válido. */
+  inputError: string | null;
+  /** Flag de submit em andamento — desabilita interações. */
+  isSubmitting: boolean;
+  /** Callback chamado a cada keystroke do input. */
+  onChange: (value: string) => void;
+  /** Callback chamado ao submeter o `<form>` (Enter ou clique em "Adicionar"). */
+  onSubmit: (event?: React.FormEvent<HTMLFormElement>) => void;
+  /**
+   * Prefixo de `data-testid` (ex.: `client-extra-emails`,
+   * `client-mobile-phones`). Estável para asserts.
+   */
+  testIdPrefix: string;
+}
+
+/**
+ * Modal de adicionar item compartilhado entre as abas que listam
+ * coleções de subentidades de cliente
+ * (`ClientExtraEmailsTab` — Issue #146; `ClientPhonesTab` — Issue
+ * #147).
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** o JSX do modal de
+ * adicionar (Modal + ModalForm + Input + ModalActions + 2 Buttons)
+ * é virtualmente idêntico entre as duas abas — apenas literais de
+ * label/placeholder/testId/etc. variam. Sonar/JSCPD tokenizam ~25
+ * linhas como bloco duplicado entre os dois arquivos. Promover para
+ * componente compartilhado deduplica e abre caminho para o terceiro
+ * consumidor sem refator destrutivo.
+ *
+ * **Acessibilidade preservada:**
+ *
+ * - `closeOnEsc`/`closeOnBackdrop` desabilitados durante submit.
+ * - `<form>` para que `Enter` no input dispare o submit
+ *   (`Modal` do design system não impede; o `onSubmit` recebe o
+ *   evento e chama `event.preventDefault()` no caller).
+ * - `loading={isSubmitting}` no botão "Adicionar" para spinner
+ *   inline.
+ * - `aria-label` herdado do `Modal` via `title`.
+ */
+export const ClientCollectionAddInputModal: React.FC<
+  ClientCollectionAddInputModalProps
+> = ({
+  open,
+  onClose,
+  title,
+  description,
+  inputLabel,
+  placeholder,
+  inputType,
+  inputMode,
+  autoComplete,
+  maxLength,
+  value,
+  inputError,
+  isSubmitting,
+  onChange,
+  onSubmit,
+  testIdPrefix,
+}) => (
+  <Modal
+    open={open}
+    onClose={onClose}
+    title={title}
+    description={description}
+    closeOnEsc={!isSubmitting}
+    closeOnBackdrop={!isSubmitting}
+  >
+    <ModalForm onSubmit={onSubmit} data-testid={`${testIdPrefix}-add-form`}>
+      <Input
+        id={`${testIdPrefix}-add-input`}
+        label={inputLabel}
+        type={inputType}
+        inputMode={inputMode}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        error={inputError ?? undefined}
+        disabled={isSubmitting}
+        maxLength={maxLength}
+        autoComplete={autoComplete}
+        data-testid={
+          inputType === 'email'
+            ? `${testIdPrefix}-add-email`
+            : `${testIdPrefix}-add-number`
+        }
+      />
+      <ModalActions>
+        <Button
+          variant="ghost"
+          size="md"
+          type="button"
+          onClick={onClose}
+          disabled={isSubmitting}
+          data-testid={`${testIdPrefix}-add-cancel`}
+        >
+          Cancelar
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          type="submit"
+          loading={isSubmitting}
+          data-testid={`${testIdPrefix}-add-submit`}
+        >
+          Adicionar
+        </Button>
+      </ModalActions>
+    </ModalForm>
+  </Modal>
+);

--- a/src/pages/clients/ClientCollectionListRow.tsx
+++ b/src/pages/clients/ClientCollectionListRow.tsx
@@ -1,0 +1,86 @@
+import { Trash2, type LucideIcon } from 'lucide-react';
+import React from 'react';
+
+import { Button, Icon } from '../../components/ui';
+
+import {
+  ListRow,
+  ListRowLeft,
+  ListRowValue,
+} from './clientCollectionTabStyles';
+
+interface ClientCollectionListRowProps {
+  /** ID do item — usado em `key` (caller passa) e como sufixo de `data-testid`. */
+  id: string;
+  /** Valor textual exibido na linha (email/telefone/etc.). */
+  value: string;
+  /** Ícone (lucide-react) renderizado à esquerda do valor. */
+  icon: LucideIcon;
+  /**
+   * Se `true`, o valor é renderizado em fonte monoespaçada (apropriado
+   * para telefone). Default `false` (sans, apropriado para email).
+   */
+  mono?: boolean;
+  /**
+   * Mostra ou esconde o botão "Remover". Caller passa `canUpdate` —
+   * gating de permissão acontece na aba consumidora, não aqui.
+   */
+  canRemove: boolean;
+  /** Callback chamado ao clicar em "Remover". */
+  onRemove: () => void;
+  /**
+   * `aria-label` do botão "Remover" — caller passa label
+   * contextualizado (ex.: `"Remover email ana@x.com"`,
+   * `"Remover +5518981789845"`).
+   */
+  removeAriaLabel: string;
+  /**
+   * Prefixo de `data-testid` (ex.: `client-extra-emails`,
+   * `client-mobile-phones`). Estável para asserts.
+   */
+  testIdPrefix: string;
+}
+
+/**
+ * Linha de item compartilhada entre as abas que listam coleções de
+ * subentidades de cliente (`ClientExtraEmailsTab` — Issue #146;
+ * `ClientPhonesTab` — Issue #147).
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** o JSX do `<ListRow>`
+ * (incluindo `<ListRowLeft><Icon/><ListRowValue/></ListRowLeft>` +
+ * gating do botão "Remover") era idêntico entre as duas abas,
+ * divergindo apenas em qual valor exibir e qual aria-label usar.
+ * Sonar/JSCPD tokenizava como bloco duplicado entre arquivos.
+ * Promover para componente compartilhado deduplica.
+ */
+export const ClientCollectionListRow: React.FC<ClientCollectionListRowProps> = ({
+  id,
+  value,
+  icon,
+  mono = false,
+  canRemove,
+  onRemove,
+  removeAriaLabel,
+  testIdPrefix,
+}) => (
+  <ListRow data-testid={`${testIdPrefix}-row-${id}`}>
+    <ListRowLeft>
+      <Icon icon={icon} size="sm" tone="muted" />
+      <ListRowValue $mono={mono} title={value}>
+        {value}
+      </ListRowValue>
+    </ListRowLeft>
+    {canRemove && (
+      <Button
+        variant="ghost"
+        size="sm"
+        icon={<Trash2 size={14} strokeWidth={1.75} aria-hidden="true" />}
+        onClick={onRemove}
+        aria-label={removeAriaLabel}
+        data-testid={`${testIdPrefix}-remove-${id}`}
+      >
+        Remover
+      </Button>
+    )}
+  </ListRow>
+);

--- a/src/pages/clients/ClientCollectionRemoveConfirmModal.tsx
+++ b/src/pages/clients/ClientCollectionRemoveConfirmModal.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import { Button, Modal } from '../../components/ui';
+
+import {
+  ConfirmBody,
+  ConfirmText,
+  ModalActions,
+  Mono,
+} from './clientCollectionTabStyles';
+
+/**
+ * Props do `ClientCollectionRemoveConfirmModal`. Mantém a API
+ * declarativa — caller passa `target` (string com o valor a destacar
+ * em monoespaçado) ou `null` para fechar; ações são callbacks puras.
+ */
+interface ClientCollectionRemoveConfirmModalProps {
+  /** Título do modal (ex.: "Remover email extra?", "Remover celular?"). */
+  title: string;
+  /**
+   * Prefixo do texto de confirmação. O valor é renderizado depois,
+   * em destaque monoespaçado. Ex.: `"O email"` produz `"O email
+   * <Mono>x@y.com</Mono> será removido..."`.
+   */
+  prefix: string;
+  /**
+   * Sufixo após o valor monoespaçado. Default sempre o mesmo — fica
+   * fora da prop para reduzir argumentos. Caller que precise
+   * customizar pode passar `descriptionSuffix`.
+   */
+  descriptionSuffix?: string;
+  /** Valor a destacar (email/telefone/etc.). `null` fecha o modal. */
+  target: string | null;
+  /** Flag de submit em andamento — desabilita botões/fechamento. */
+  isSubmitting: boolean;
+  /** Callback de fechar (cancelar ou ESC/backdrop). */
+  onClose: () => void;
+  /** Callback de confirmar remoção. */
+  onConfirm: () => void;
+  /** Prefixo de `data-testid` (ex.: `client-mobile-phones`). */
+  testIdPrefix: string;
+}
+
+/**
+ * Modal de confirmação de remoção compartilhado entre as abas que
+ * listam coleções de subentidades de cliente
+ * (`ClientExtraEmailsTab` — Issue #146; `ClientPhonesTab` — Issue
+ * #147).
+ *
+ * Centralizar evita ~25 linhas de boilerplate duplicado entre os
+ * dois consumidores (o JSCPD/Sonar tokenizava a árvore `<Modal> >
+ * <ConfirmBody> > <ConfirmText> > <ModalActions> > <Button>` como
+ * bloco duplicado). Lição PR #128/#134/#135 — extrair quando o
+ * segundo consumidor real aparece.
+ *
+ * Cobre:
+ *
+ * - `closeOnEsc`/`closeOnBackdrop` desabilitados durante submit
+ *   (espelha o padrão do `Modal` do design system).
+ * - `loading={isSubmitting}` no botão "Remover" para spinner inline.
+ * - `aria-label` herdado do `Modal` via `title` — leitor de tela
+ *   anuncia o título corretamente.
+ * - `data-testid` composto a partir de `testIdPrefix` para que cada
+ *   consumidor mantenha selectors únicos sem precisar passar 3
+ *   ids separados.
+ */
+export const ClientCollectionRemoveConfirmModal: React.FC<
+  ClientCollectionRemoveConfirmModalProps
+> = ({
+  title,
+  prefix,
+  descriptionSuffix = 'será removido da lista deste cliente. Essa ação é imediata.',
+  target,
+  isSubmitting,
+  onClose,
+  onConfirm,
+  testIdPrefix,
+}) => (
+  <Modal
+    open={target !== null}
+    onClose={onClose}
+    title={title}
+    closeOnEsc={!isSubmitting}
+    closeOnBackdrop={!isSubmitting}
+  >
+    {target !== null && (
+      <ConfirmBody>
+        <ConfirmText data-testid={`${testIdPrefix}-remove-description`}>
+          {prefix} <Mono>{target}</Mono> {descriptionSuffix}
+        </ConfirmText>
+        <ModalActions>
+          <Button
+            variant="ghost"
+            size="md"
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            data-testid={`${testIdPrefix}-remove-cancel`}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="danger"
+            size="md"
+            type="button"
+            onClick={onConfirm}
+            loading={isSubmitting}
+            data-testid={`${testIdPrefix}-remove-confirm`}
+          >
+            Remover
+          </Button>
+        </ModalActions>
+      </ConfirmBody>
+    )}
+  </Modal>
+);

--- a/src/pages/clients/ClientExtraEmailsTab.tsx
+++ b/src/pages/clients/ClientExtraEmailsTab.tsx
@@ -1,25 +1,40 @@
-import { Mail, Plus, Trash2 } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+// Issue #146 — aba "Emails extras" do `ClientEditPage`. Espelha o
+// pattern de `ClientPhonesTab` (#147) reusando os componentes/hooks
+// compartilhados em `clientCollection*` para deduplicar a estrutura.
+import { Mail, Plus } from 'lucide-react';
+import React, { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import styled from 'styled-components';
 
 import {
   Alert,
   Button,
   Icon,
-  Input,
-  Modal,
   useToast,
 } from '../../components/ui';
 import {
   addClientExtraEmail,
-  getClientById,
   MAX_CLIENT_EXTRA_EMAILS,
   removeClientExtraEmail,
 } from '../../shared/api';
 import { useAuth } from '../../shared/auth';
 import { ErrorRetryBlock, InitialLoadingSpinner } from '../../shared/listing';
 
+// Componentes shared das abas de coleção (extraídos em #147 para
+// reuso entre #146 e #147 — lição PR #128/#134/#135).
+import { ClientCollectionAddInputModal } from './ClientCollectionAddInputModal';
+import { ClientCollectionListRow } from './ClientCollectionListRow';
+import { ClientCollectionRemoveConfirmModal } from './ClientCollectionRemoveConfirmModal';
+import {
+  Counter,
+  EmptyHint,
+  EmptyShell,
+  EmptyTitle,
+  ListContainer,
+  ListHeader,
+  TabHeading,
+  TabIntro,
+  TabSection,
+} from './clientCollectionTabStyles';
 import {
   classifyAddExtraEmailError,
   classifyRemoveExtraEmailError,
@@ -27,8 +42,13 @@ import {
   validateExtraEmailInput,
   type ExtraEmailErrorCopy,
 } from './clientExtraEmailsHelpers';
+import { useClientAddCollectionModal } from './useClientAddCollectionModal';
+import { useClientByIdFetch } from './useClientByIdFetch';
+import { useClientCollectionAddSubmit } from './useClientCollectionAddSubmit';
+import { useClientCollectionRemoveSubmit } from './useClientCollectionRemoveSubmit';
+import { useClientRemoveCollectionConfirm } from './useClientRemoveCollectionConfirm';
 
-import type { ApiClient, ClientDto, ClientEmailDto } from '../../shared/api';
+import type { ApiClient, ClientEmailDto } from '../../shared/api';
 
 /**
  * Code de permissão exigido para mutações no tab (Issue #146).
@@ -70,178 +90,13 @@ const REMOVE_ERROR_COPY: ExtraEmailErrorCopy = {
 const FETCH_ERROR_MESSAGE = 'Não foi possível carregar os dados do cliente.';
 
 /**
- * Container externo do conteúdo da aba — preserva o ar e o
- * espaçamento das outras abas (`ClientDataTab`).
+ * Estilos da aba são compartilhados em `clientCollectionTabStyles.ts`
+ * com `ClientPhonesTab` (Issue #147 — paridade com #146). Linha
+ * (`ListRow`/`ListContainer`/`ListRowLeft`/`ListRowValue`) e shell de
+ * empty state (`EmptyShell`/`EmptyTitle`/`EmptyHint`) ganham
+ * paridade visual entre as duas abas, e a confirmação de remoção
+ * usa o `ClientCollectionRemoveConfirmModal` compartilhado.
  */
-const TabSection = styled.section`
-  background: var(--bg-surface);
-  border: var(--border-thin) solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  padding: var(--space-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-`;
-
-const TabHeading = styled.h3`
-  font-family: var(--font-display);
-  font-size: var(--text-md);
-  font-weight: var(--weight-semibold);
-  color: var(--fg1);
-  margin: 0;
-  letter-spacing: var(--tracking-tight);
-`;
-
-const TabIntro = styled.p`
-  margin: 0;
-  color: var(--fg2);
-  font-size: var(--text-sm);
-  line-height: var(--leading-base);
-  max-width: 60ch;
-`;
-
-/**
- * Cabeçalho do bloco que combina contagem corrente + botão de ação.
- * Em viewports estreitas, empilha o botão sob o contador para
- * preservar o toque (touch target de 44px+).
- */
-const ListHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-`;
-
-const Counter = styled.div`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  letter-spacing: var(--tracking-wide);
-  text-transform: uppercase;
-  color: var(--fg3);
-`;
-
-/**
- * Lista visual dos emails extras. Cada `<EmailRow>` é uma linha com
- * o email à esquerda e o botão "Remover" à direita.
- */
-const EmailList = styled.ul`
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-`;
-
-const EmailRow = styled.li`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  background: var(--bg-elevated);
-  border: var(--border-thin) solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  transition:
-    border-color var(--duration-fast) var(--ease-default),
-    background var(--duration-fast) var(--ease-default);
-
-  &:hover {
-    border-color: var(--border-medium-forest);
-  }
-`;
-
-const EmailLeft = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  min-width: 0;
-  flex: 1;
-`;
-
-const EmailValue = styled.span`
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  color: var(--fg1);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`;
-
-/**
- * Bloco de empty state com tom suave — espelha o padrão visual de
- * `AssignmentMatrixShell.AssignmentEmptyShell` (centralizado, com
- * ícone informativo e dica de próximo passo). Mantém-se inline (em
- * vez de reutilizar o shell) porque o shell de matrizes carrega
- * estrutura adicional que não se encaixa aqui.
- */
-const EmptyShell = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-  padding: var(--space-8) var(--space-4);
-  background: var(--bg-elevated);
-  border: var(--border-thin) dashed var(--border-subtle);
-  border-radius: var(--radius-lg);
-  color: var(--fg3);
-`;
-
-const EmptyTitle = styled.span`
-  font-family: var(--font-sans);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--fg2);
-`;
-
-const EmptyHint = styled.span`
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
-  color: var(--fg3);
-  text-align: center;
-  max-width: 40ch;
-`;
-
-/**
- * Form do modal de adicionar — `<form>` para que `Enter` no input
- * dispare o submit e que leitores de tela identifiquem o agrupamento
- * de campos.
- */
-const ModalForm = styled.form`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-`;
-
-const ModalActions = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--space-3);
-`;
-
-const ConfirmBody = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-`;
-
-const ConfirmText = styled.p`
-  font-size: var(--text-sm);
-  color: var(--fg2);
-  line-height: var(--leading-snug);
-`;
-
-const Mono = styled.span`
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--fg1);
-  background: var(--bg-elevated);
-  padding: 0 var(--space-1);
-  border-radius: var(--radius-sm);
-`;
 
 interface ClientExtraEmailsTabProps {
   /**
@@ -251,40 +106,6 @@ interface ClientExtraEmailsTabProps {
    */
   client?: ApiClient;
 }
-
-/**
- * Estado do modal de adicionar email — mantém form controlado
- * (input value + erro inline) e flag `isSubmitting` independente
- * para que o spinner do botão não recicle a cada keystroke.
- */
-interface AddModalState {
-  open: boolean;
-  email: string;
-  inputError: string | null;
-  isSubmitting: boolean;
-}
-
-const INITIAL_ADD_MODAL_STATE: AddModalState = {
-  open: false,
-  email: '',
-  inputError: null,
-  isSubmitting: false,
-};
-
-/**
- * Estado do modal de confirmação de remoção. `target` é `null`
- * quando o modal está fechado — caller controla `open` via
- * `target !== null`.
- */
-interface RemoveConfirmState {
-  target: ClientEmailDto | null;
-  isSubmitting: boolean;
-}
-
-const INITIAL_REMOVE_CONFIRM_STATE: RemoveConfirmState = {
-  target: null,
-  isSubmitting: false,
-};
 
 /**
  * Aba "Emails extras" do `ClientEditPage` (Issue #146).
@@ -345,71 +166,25 @@ export const ClientExtraEmailsTab: React.FC<ClientExtraEmailsTabProps> = ({
   const canUpdate = hasPermission(CLIENTS_UPDATE_PERMISSION);
 
   /**
-   * Estados do fetch inicial. Espelha o padrão do `ClientDataTab` —
-   * `loaded` guarda o cliente (para que o submit/remove leiam
-   * `extraEmails` direto do estado em vez de prop), `error` cai no
-   * `ErrorRetryBlock`.
+   * Fetch inicial encapsulado em hook compartilhado — o
+   * `useClientByIdFetch` cuida do `useEffect` + `AbortController` +
+   * `reloadCounter` que, em #146, vivia inline e foi promovido em
+   * #147 para reuso pelas duas abas (lição PR #128/#134/#135 —
+   * extrair quando o segundo consumidor real aparece).
    */
-  const [fetchState, setFetchState] = useState<'loading' | 'loaded' | 'error'>(
-    'loading',
+  const { fetchState, loadedClient, triggerRefetch } = useClientByIdFetch(
+    id,
+    client,
   );
-  const [loadedClient, setLoadedClient] = useState<ClientDto | null>(null);
 
   /**
-   * Reload key — incrementar dispara refetch do `useEffect`. Usado
-   * pelo `ErrorRetryBlock` (botão "Tentar novamente"), por sucesso
-   * de mutação (sincroniza lista) e por erros que indicam que o
-   * estado do servidor divergiu (404, "Limite atingido").
+   * Hooks compartilhados encapsulam o `useState` + handlers do modal
+   * de adicionar e do confirm de remoção. Lição PR #128/#134/#135 —
+   * extraído quando o segundo consumidor (#146 + #147) apareceu para
+   * evitar duplicação no JSCPD/Sonar.
    */
-  const [reloadCounter, setReloadCounter] = useState<number>(0);
-
-  const [addModal, setAddModal] = useState<AddModalState>(
-    INITIAL_ADD_MODAL_STATE,
-  );
-  const [removeConfirm, setRemoveConfirm] = useState<RemoveConfirmState>(
-    INITIAL_REMOVE_CONFIRM_STATE,
-  );
-
-  useEffect(() => {
-    if (id === undefined || id.length === 0) {
-      setFetchState('error');
-      return;
-    }
-
-    const controller = new AbortController();
-    let isCancelled = false;
-
-    setFetchState('loading');
-
-    getClientById(id, { signal: controller.signal }, client)
-      .then((dto) => {
-        if (isCancelled) return;
-        setLoadedClient(dto);
-        setFetchState('loaded');
-      })
-      .catch((error: unknown) => {
-        if (isCancelled) return;
-        // Cancelamento explícito (unmount/route change) não vira
-        // erro de UI — silencia para que o próximo render comece
-        // limpo.
-        if (
-          error instanceof DOMException &&
-          error.name === 'AbortError'
-        ) {
-          return;
-        }
-        setFetchState('error');
-      });
-
-    return () => {
-      isCancelled = true;
-      controller.abort();
-    };
-  }, [id, client, reloadCounter]);
-
-  const triggerRefetch = useCallback(() => {
-    setReloadCounter((prev) => prev + 1);
-  }, []);
+  const addModal = useClientAddCollectionModal();
+  const removeConfirm = useClientRemoveCollectionConfirm<ClientEmailDto>();
 
   const handleRetry = useCallback(() => {
     triggerRefetch();
@@ -423,200 +198,73 @@ export const ClientExtraEmailsTab: React.FC<ClientExtraEmailsTabProps> = ({
 
   /* ─── Add modal handlers ──────────────────────────────── */
 
-  const handleOpenAddModal = useCallback(() => {
-    if (isLimitReached) return;
-    setAddModal({
-      open: true,
-      email: '',
-      inputError: null,
-      isSubmitting: false,
+  const { handleOpen: handleOpenAddModal, handleSubmit: handleSubmitAdd } =
+    addModal.buildHandlers({
+      isLimitReached,
+      isReady: loadedClient !== null,
+      validate: validateExtraEmailInput,
     });
-  }, [isLimitReached]);
-
-  const handleCloseAddModal = useCallback(() => {
-    setAddModal((prev) =>
-      prev.isSubmitting ? prev : INITIAL_ADD_MODAL_STATE,
-    );
-  }, []);
-
-  const handleEmailChange = useCallback((value: string) => {
-    setAddModal((prev) => ({
-      ...prev,
-      email: value,
-      // Limpa o erro no primeiro keystroke após erro — feedback
-      // mais leve que "permanecer marcado vermelho até resubmit".
-      inputError: null,
-    }));
-  }, []);
-
-  const handleSubmitAdd = useCallback(
-    async (event?: React.FormEvent<HTMLFormElement>) => {
-      event?.preventDefault();
-      setAddModal((prev) => {
-        if (prev.isSubmitting || loadedClient === null) return prev;
-        const trimmed = prev.email.trim();
-        const inputError = validateExtraEmailInput(trimmed);
-        if (inputError !== null) {
-          return { ...prev, inputError };
-        }
-        return { ...prev, inputError: null, isSubmitting: true };
-      });
-    },
-    [loadedClient],
-  );
 
   /**
-   * Effect que dispara a chamada HTTP quando `isSubmitting` vira
-   * `true` no estado do modal. Separamos o gate (validação +
-   * `setIsSubmitting`) do effect para que o `setState` não fique
-   * preso a uma mesma referência de `prev.email` com closure stale
-   * — o effect lê o valor mais recente via dependency em
-   * `addModal.isSubmitting`.
+   * Effect que dispara a chamada HTTP quando o modal sinaliza
+   * `isSubmitting=true`. Encapsulado em `useClientCollectionAddSubmit`
+   * compartilhado com `ClientPhonesTab` (#147) — lição PR
+   * #128/#134/#135.
    */
-  useEffect(() => {
-    if (!addModal.isSubmitting || loadedClient === null) return;
-    let isCancelled = false;
-    const controller = new AbortController();
-
-    addClientExtraEmail(
-      loadedClient.id,
-      addModal.email.trim(),
-      { signal: controller.signal },
-      client,
-    )
-      .then(() => {
-        if (isCancelled) return;
-        show('Email extra adicionado.', { variant: 'success' });
-        setAddModal(INITIAL_ADD_MODAL_STATE);
-        triggerRefetch();
-      })
-      .catch((error: unknown) => {
-        if (isCancelled) return;
-        if (
-          error instanceof DOMException &&
-          error.name === 'AbortError'
-        ) {
-          return;
-        }
-        const action = classifyAddExtraEmailError(error, ADD_ERROR_COPY);
-        switch (action.kind) {
-          case 'inline':
-            setAddModal((prev) => ({
-              ...prev,
-              inputError: action.message,
-              isSubmitting: false,
-            }));
-            break;
-          case 'limit-reached':
-            setAddModal((prev) => ({
-              ...prev,
-              inputError: action.message,
-              isSubmitting: false,
-            }));
-            triggerRefetch();
-            break;
-          case 'not-found':
-            show(action.message, {
-              variant: 'danger',
-              title: action.title,
-            });
-            setAddModal(INITIAL_ADD_MODAL_STATE);
-            triggerRefetch();
-            break;
-          case 'toast':
-            show(action.message, {
-              variant: 'danger',
-              title: action.title,
-            });
-            setAddModal((prev) => ({ ...prev, isSubmitting: false }));
-            break;
-          case 'unhandled':
-            show(action.message, {
-              variant: 'danger',
-              title: action.title,
-            });
-            setAddModal((prev) => ({ ...prev, isSubmitting: false }));
-            break;
-        }
-      });
-
-    return () => {
-      isCancelled = true;
-      controller.abort();
-    };
-    // `addModal.email` capturado no instante em que `isSubmitting`
-    // virou `true`; subsequentes keystrokes não disparam novo
-    // submit (`isSubmitting=true` só vira `false` ao terminar).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [addModal.isSubmitting, loadedClient, client, show, triggerRefetch]);
+  useClientCollectionAddSubmit({
+    isSubmitting: addModal.state.isSubmitting,
+    value: addModal.state.value,
+    clientId: loadedClient?.id ?? null,
+    client,
+    addFn: addClientExtraEmail,
+    classifyError: classifyAddExtraEmailError,
+    copy: ADD_ERROR_COPY,
+    successToast: 'Email extra adicionado.',
+    modal: addModal,
+    show,
+    triggerRefetch,
+  });
 
   /* ─── Remove confirm handlers ─────────────────────────── */
 
-  const handleOpenRemoveConfirm = useCallback((emailDto: ClientEmailDto) => {
-    setRemoveConfirm({ target: emailDto, isSubmitting: false });
-  }, []);
-
-  const handleCloseRemoveConfirm = useCallback(() => {
-    setRemoveConfirm((prev) =>
-      prev.isSubmitting ? prev : INITIAL_REMOVE_CONFIRM_STATE,
-    );
-  }, []);
+  const { submit: submitRemove } = useClientCollectionRemoveSubmit({
+    client,
+    removeFn: removeClientExtraEmail,
+    classifyError: classifyRemoveExtraEmailError,
+    copy: REMOVE_ERROR_COPY,
+    successToast: 'Email extra removido.',
+    confirm: removeConfirm,
+    show,
+    triggerRefetch,
+  });
 
   const handleConfirmRemove = useCallback(async () => {
     if (
-      removeConfirm.isSubmitting ||
-      removeConfirm.target === null ||
+      removeConfirm.state.isSubmitting ||
+      removeConfirm.state.target === null ||
       loadedClient === null
     ) {
       return;
     }
-    const target = removeConfirm.target;
-    setRemoveConfirm((prev) => ({ ...prev, isSubmitting: true }));
-    try {
-      await removeClientExtraEmail(
-        loadedClient.id,
-        target.id,
-        undefined,
-        client,
-      );
-      show('Email extra removido.', { variant: 'success' });
-      setRemoveConfirm(INITIAL_REMOVE_CONFIRM_STATE);
-      triggerRefetch();
-    } catch (error: unknown) {
-      const action = classifyRemoveExtraEmailError(error, REMOVE_ERROR_COPY);
-      switch (action.kind) {
-        case 'username':
+    // O classifier do email tem um caso `username` (400 orientadora)
+    // que não existe no de phones — interceptamos aqui para que o
+    // hook compartilhado trate apenas o subset comum.
+    await submitRemove(
+      loadedClient.id,
+      removeConfirm.state.target.id,
+      (action) => {
+        if (action.kind === 'username') {
           show(action.message, {
             variant: 'danger',
             title: action.title,
           });
-          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
-          break;
-        case 'not-found':
-          show(action.message, {
-            variant: 'danger',
-            title: action.title,
-          });
-          setRemoveConfirm(INITIAL_REMOVE_CONFIRM_STATE);
-          triggerRefetch();
-          break;
-        case 'toast':
-          show(action.message, {
-            variant: 'danger',
-            title: action.title,
-          });
-          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
-          break;
-        case 'unhandled':
-          show(action.message, {
-            variant: 'danger',
-            title: action.title,
-          });
-          setRemoveConfirm((prev) => ({ ...prev, isSubmitting: false }));
-          break;
-      }
-    }
-  }, [client, loadedClient, removeConfirm, show, triggerRefetch]);
+          removeConfirm.stopSubmitting();
+          return true;
+        }
+        return false;
+      },
+    );
+  }, [loadedClient, removeConfirm, show, submitRemove]);
 
   /* ─── Render ──────────────────────────────────────────── */
 
@@ -685,122 +333,51 @@ export const ClientExtraEmailsTab: React.FC<ClientExtraEmailsTabProps> = ({
             </EmptyHint>
           </EmptyShell>
         ) : (
-          <EmailList aria-label="Emails extras do cliente">
+          <ListContainer aria-label="Emails extras do cliente">
             {extraEmails.map((emailDto) => (
-              <EmailRow
+              <ClientCollectionListRow
                 key={emailDto.id}
-                data-testid={`client-extra-emails-row-${emailDto.id}`}
-              >
-                <EmailLeft>
-                  <Icon icon={Mail} size="sm" tone="muted" />
-                  <EmailValue title={emailDto.email}>{emailDto.email}</EmailValue>
-                </EmailLeft>
-                {canUpdate && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    icon={<Trash2 size={14} strokeWidth={1.75} aria-hidden="true" />}
-                    onClick={() => handleOpenRemoveConfirm(emailDto)}
-                    aria-label={`Remover email ${emailDto.email}`}
-                    data-testid={`client-extra-emails-remove-${emailDto.id}`}
-                  >
-                    Remover
-                  </Button>
-                )}
-              </EmailRow>
+                id={emailDto.id}
+                value={emailDto.email}
+                icon={Mail}
+                canRemove={canUpdate}
+                onRemove={() => removeConfirm.open(emailDto)}
+                removeAriaLabel={`Remover email ${emailDto.email}`}
+                testIdPrefix="client-extra-emails"
+              />
             ))}
-          </EmailList>
+          </ListContainer>
         )}
       </TabSection>
 
-      <Modal
-        open={addModal.open}
-        onClose={handleCloseAddModal}
+      <ClientCollectionAddInputModal
+        open={addModal.state.open}
+        onClose={addModal.close}
         title="Adicionar email extra"
         description="Informe o novo email a ser cadastrado para este cliente."
-        closeOnEsc={!addModal.isSubmitting}
-        closeOnBackdrop={!addModal.isSubmitting}
-      >
-        <ModalForm
-          onSubmit={handleSubmitAdd}
-          data-testid="client-extra-emails-add-form"
-        >
-          <Input
-            id="client-extra-emails-add-input"
-            label="Email"
-            type="email"
-            placeholder="ana@exemplo.com"
-            value={addModal.email}
-            onChange={handleEmailChange}
-            error={addModal.inputError ?? undefined}
-            disabled={addModal.isSubmitting}
-            maxLength={EXTRA_EMAIL_MAX}
-            autoComplete="email"
-            data-testid="client-extra-emails-add-email"
-          />
-          <ModalActions>
-            <Button
-              variant="ghost"
-              size="md"
-              type="button"
-              onClick={handleCloseAddModal}
-              disabled={addModal.isSubmitting}
-              data-testid="client-extra-emails-add-cancel"
-            >
-              Cancelar
-            </Button>
-            <Button
-              variant="primary"
-              size="md"
-              type="submit"
-              loading={addModal.isSubmitting}
-              data-testid="client-extra-emails-add-submit"
-            >
-              Adicionar
-            </Button>
-          </ModalActions>
-        </ModalForm>
-      </Modal>
+        inputLabel="Email"
+        placeholder="ana@exemplo.com"
+        inputType="email"
+        autoComplete="email"
+        maxLength={EXTRA_EMAIL_MAX}
+        value={addModal.state.value}
+        inputError={addModal.state.inputError}
+        isSubmitting={addModal.state.isSubmitting}
+        onChange={addModal.setValue}
+        onSubmit={handleSubmitAdd}
+        testIdPrefix="client-extra-emails"
+      />
 
-      <Modal
-        open={removeConfirm.target !== null}
-        onClose={handleCloseRemoveConfirm}
+      <ClientCollectionRemoveConfirmModal
         title="Remover email extra?"
-        closeOnEsc={!removeConfirm.isSubmitting}
-        closeOnBackdrop={!removeConfirm.isSubmitting}
-      >
-        {removeConfirm.target !== null && (
-          <ConfirmBody>
-            <ConfirmText data-testid="client-extra-emails-remove-description">
-              O email <Mono>{removeConfirm.target.email}</Mono> será
-              removido da lista de emails extras deste cliente. Essa
-              ação é imediata.
-            </ConfirmText>
-            <ModalActions>
-              <Button
-                variant="ghost"
-                size="md"
-                type="button"
-                onClick={handleCloseRemoveConfirm}
-                disabled={removeConfirm.isSubmitting}
-                data-testid="client-extra-emails-remove-cancel"
-              >
-                Cancelar
-              </Button>
-              <Button
-                variant="danger"
-                size="md"
-                type="button"
-                onClick={handleConfirmRemove}
-                loading={removeConfirm.isSubmitting}
-                data-testid="client-extra-emails-remove-confirm"
-              >
-                Remover
-              </Button>
-            </ModalActions>
-          </ConfirmBody>
-        )}
-      </Modal>
+        prefix="O email"
+        descriptionSuffix="será removido da lista de emails extras deste cliente. Essa ação é imediata."
+        target={removeConfirm.state.target?.email ?? null}
+        isSubmitting={removeConfirm.state.isSubmitting}
+        onClose={removeConfirm.close}
+        onConfirm={handleConfirmRemove}
+        testIdPrefix="client-extra-emails"
+      />
     </>
   );
 };

--- a/src/pages/clients/ClientLandlinePhonesTab.tsx
+++ b/src/pages/clients/ClientLandlinePhonesTab.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 
-import { ClientEditTabPlaceholder } from './ClientEditTabPlaceholder';
+import { ClientPhonesTab } from './ClientPhonesTab';
+
+import type { ApiClient } from '../../shared/api';
+
+interface ClientLandlinePhonesTabProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * o `ClientPhonesTab` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
 
 /**
- * Aba "Telefones fixos" do `ClientEditPage` (Issue #144).
+ * Aba "Telefones fixos" do `ClientEditPage` (Issue #147).
  *
- * Atualmente renderiza placeholder porque o conteúdo real (lista de
- * telefones fixos + CRUD inline) é corpo da Issue #147 (parte 2).
- * Substituirá o placeholder quando #147 for desbloqueada por esta
- * issue.
+ * Wrapper fino que injeta `kind="landline"` no `ClientPhonesTab`
+ * compartilhado. Ver `ClientMobilePhonesTab` para a justificativa do
+ * padrão wrapper-fino — manter o descritor `TABS` em `ClientEditPage`
+ * com 1 componente por aba simplifica o type-checker e mantém os
+ * placeholders de painel sincronizados com a estrutura existente.
+ *
+ * Substitui o placeholder herdado de #144 — toda a lógica visual e de
+ * mutação vive em `ClientPhonesTab`. Lição PR #128/#134/#135.
  */
-export const ClientLandlinePhonesTab: React.FC = () => (
-  <ClientEditTabPlaceholder
-    title="Telefones fixos"
-    description="Lista de telefones fixos cadastrados. Será habilitada pela Issue #147 (parte 2)."
-  />
-);
+export const ClientLandlinePhonesTab: React.FC<ClientLandlinePhonesTabProps> = ({
+  client,
+}) => <ClientPhonesTab kind="landline" client={client} />;

--- a/src/pages/clients/ClientMobilePhonesTab.tsx
+++ b/src/pages/clients/ClientMobilePhonesTab.tsx
@@ -1,18 +1,32 @@
 import React from 'react';
 
-import { ClientEditTabPlaceholder } from './ClientEditTabPlaceholder';
+import { ClientPhonesTab } from './ClientPhonesTab';
+
+import type { ApiClient } from '../../shared/api';
+
+interface ClientMobilePhonesTabProps {
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * o `ClientPhonesTab` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
 
 /**
- * Aba "Celulares" do `ClientEditPage` (Issue #144).
+ * Aba "Celulares" do `ClientEditPage` (Issue #147).
  *
- * Atualmente renderiza placeholder porque o conteúdo real (lista de
- * celulares + CRUD inline) é corpo da Issue #147 (parte 1).
- * Substituirá o placeholder quando #147 for desbloqueada por esta
- * issue.
+ * Wrapper fino que injeta `kind="mobile"` no `ClientPhonesTab`
+ * compartilhado. Manter o wrapper (em vez de `ClientEditPage`
+ * referenciar `ClientPhonesTab` diretamente) preserva a estrutura de
+ * `TABS` em `ClientEditPage` (1 componente por aba), o que mantém o
+ * descritor estático simples e o type-checker feliz com
+ * `React.ComponentType` sem precisar de prop binding extra.
+ *
+ * Substitui o placeholder herdado de #144 — toda a lógica visual e de
+ * mutação vive em `ClientPhonesTab`. Lição PR #128/#134/#135 — projetar
+ * shared helpers desde o primeiro PR do recurso para evitar duplicação
+ * Sonar entre as duas abas.
  */
-export const ClientMobilePhonesTab: React.FC = () => (
-  <ClientEditTabPlaceholder
-    title="Celulares"
-    description="Lista de celulares cadastrados. Será habilitada pela Issue #147 (parte 1)."
-  />
-);
+export const ClientMobilePhonesTab: React.FC<ClientMobilePhonesTabProps> = ({
+  client,
+}) => <ClientPhonesTab kind="mobile" client={client} />;

--- a/src/pages/clients/ClientPhonesTab.tsx
+++ b/src/pages/clients/ClientPhonesTab.tsx
@@ -1,0 +1,518 @@
+// Issue #147 — abas "Celulares" e "Telefones fixos" do
+// `ClientEditPage`, parametrizadas por `kind`. Espelha #146 reusando
+// os componentes/hooks compartilhados em `clientCollection*`.
+import { Phone, Plus, Smartphone, type LucideIcon } from 'lucide-react';
+import React, { useCallback, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  Alert,
+  Button,
+  Icon,
+  useToast,
+} from '../../components/ui';
+import {
+  addClientLandlinePhone,
+  addClientMobilePhone,
+  MAX_CLIENT_PHONES_PER_TYPE,
+  removeClientLandlinePhone,
+  removeClientMobilePhone,
+} from '../../shared/api';
+import { useAuth } from '../../shared/auth';
+import { ErrorRetryBlock, InitialLoadingSpinner } from '../../shared/listing';
+
+// Componentes shared das abas de coleção (compartilhados com #146 —
+// emails extras — para deduplicar lista, modais e hooks de mutação).
+import { ClientCollectionAddInputModal } from './ClientCollectionAddInputModal';
+import { ClientCollectionListRow } from './ClientCollectionListRow';
+import { ClientCollectionRemoveConfirmModal } from './ClientCollectionRemoveConfirmModal';
+import {
+  Counter,
+  EmptyHint,
+  EmptyShell,
+  EmptyTitle,
+  ListContainer,
+  ListHeader,
+  TabHeading,
+  TabIntro,
+  TabSection,
+} from './clientCollectionTabStyles';
+import {
+  classifyAddPhoneError,
+  classifyRemovePhoneError,
+  PHONE_MAX_LENGTH,
+  validatePhoneInput,
+  type PhoneErrorCopy,
+} from './clientPhonesHelpers';
+import { useClientAddCollectionModal } from './useClientAddCollectionModal';
+import { useClientByIdFetch } from './useClientByIdFetch';
+import { useClientCollectionAddSubmit } from './useClientCollectionAddSubmit';
+import { useClientCollectionRemoveSubmit } from './useClientCollectionRemoveSubmit';
+import { useClientRemoveCollectionConfirm } from './useClientRemoveCollectionConfirm';
+
+import type { ApiClient, ClientDto, ClientPhoneDto } from '../../shared/api';
+
+/**
+ * Code de permissão exigido para mutações nas abas de contatos
+ * (Issue #147 — paridade com Issue #146).
+ *
+ * Espelha o `AUTH_V1_CLIENTS_UPDATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`POST/DELETE /clients/{id}/(mobiles|phones)`
+ * rodam `[Authorize(Policy = PermissionPolicies.ClientsUpdate)]`); o
+ * gating client-side é apenas UX — esconder os botões "Adicionar"/
+ * "Remover" quando o operador não pode persistir é mais claro do que
+ * deixar o submit cair em 401/403.
+ */
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+/**
+ * Discriminador da aba — espelha o `ClientPhone.Type` do backend
+ * (`mobile` para celulares, `phone` para fixos). Não usamos as strings
+ * literais do backend aqui para reduzir acoplamento; um único `kind`
+ * por aba seleciona endpoint, copy e ícone via `PHONE_KIND_CONFIG`.
+ */
+export type ClientPhoneKind = 'mobile' | 'landline';
+
+/**
+ * Configuração injetada pelas abas (`ClientMobilePhonesTab` e
+ * `ClientLandlinePhonesTab`). Centralizar copy + endpoints em uma
+ * tabela única evita branching `if (kind === 'mobile')` espalhado pelo
+ * componente — cada caso carrega o conjunto completo de literais que
+ * a UI exibe.
+ */
+interface PhoneKindConfig {
+  /** Título da aba (usado no `<TabHeading>` e como `aria-labelledby`). */
+  heading: string;
+  /** Descrição introdutória renderizada abaixo do título. */
+  intro: string;
+  /** Rótulo do contador (singular/plural, conforme tipo). */
+  counterLabel: string;
+  /** Texto do botão "Adicionar" (singular do tipo). */
+  addButtonLabel: string;
+  /** Título do modal de adicionar. */
+  addModalTitle: string;
+  /** Descrição do modal de adicionar. */
+  addModalDescription: string;
+  /** Label do input no modal de adicionar. */
+  inputLabel: string;
+  /** Título do modal de confirmação de remoção. */
+  removeModalTitle: string;
+  /** Texto descritivo do confirm de remoção (já com prefixo). */
+  removeDescriptionPrefix: string;
+  /** Mensagem do empty state (sem registros). */
+  emptyTitle: string;
+  /** Hint do empty state quando o operador pode adicionar. */
+  emptyHintEditable: string;
+  /** Hint do empty state quando o operador é só leitor. */
+  emptyHintReadonly: string;
+  /** Cópia para `classifyAddPhoneError` (`PhoneErrorCopy`). */
+  addCopy: PhoneErrorCopy;
+  /** Cópia para `classifyRemovePhoneError` (`PhoneErrorCopy`). */
+  removeCopy: PhoneErrorCopy;
+  /** Toast de sucesso após adicionar. */
+  addSuccessToast: string;
+  /** Toast de sucesso após remover. */
+  removeSuccessToast: string;
+  /** Mensagem do `Alert` quando a lista atinge o limite. */
+  limitAlertMessage: string;
+  /** Texto exibido após o número quando o limite é atingido. */
+  limitAlertHint: string;
+  /** Ícone (lucide-react) usado nas linhas e empty state. */
+  RowIcon: LucideIcon;
+  /** Prefixo de `data-testid` (mobile / landline). Estável para asserts. */
+  testIdPrefix: string;
+  /** Função de fetch para add. */
+  addFn: typeof addClientMobilePhone;
+  /** Função de fetch para remove. */
+  removeFn: typeof removeClientMobilePhone;
+  /** Seletor da coleção dentro do `ClientDto`. */
+  selectCollection: (dto: ClientDto) => ReadonlyArray<ClientPhoneDto>;
+  /** Label de carregamento (lido por leitor de tela). */
+  loadingLabel: string;
+}
+
+/**
+ * Mensagem amigável exibida no `ErrorRetryBlock` quando o fetch
+ * inicial do cliente falha (rede, parse, 401/403, etc.). Compartilhada
+ * entre as duas abas porque o erro de fetch é genérico ao cliente.
+ */
+const FETCH_ERROR_MESSAGE = 'Não foi possível carregar os dados do cliente.';
+
+/**
+ * Estilos da aba são compartilhados em `clientCollectionTabStyles.ts`
+ * com `ClientExtraEmailsTab` (#146) — paridade visual entre as abas
+ * e zero duplicação de tokens (lição PR #128/#134/#135). A linha
+ * usa `ListRowValue $mono` para que o número de telefone seja
+ * renderizado em fonte monoespaçada (legibilidade), enquanto o email
+ * (#146) usa o default `font-sans`.
+ */
+
+interface ClientPhonesTabProps {
+  /** Discriminador da aba — `mobile` (celulares) ou `landline` (fixos). */
+  kind: ClientPhoneKind;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `getClientById`/`addClient(Mobile|Landline)Phone`/
+   * `removeClient(Mobile|Landline)Phone` caem no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Configurações estáticas por tipo de aba — tabela única consultada
+ * pelo `ClientPhonesTab` para resolver copy/ícones/endpoints. Manter
+ * inline (em vez de spread por arquivo) facilita ler os dois conjuntos
+ * de literais lado a lado.
+ */
+const PHONE_KIND_CONFIG: Record<ClientPhoneKind, PhoneKindConfig> = {
+  mobile: {
+    heading: 'Celulares',
+    intro: `Cadastre até ${MAX_CLIENT_PHONES_PER_TYPE} celulares neste cliente. Use o formato internacional E.164 (ex.: +5518981789845).`,
+    counterLabel: 'cadastrados',
+    addButtonLabel: 'Adicionar celular',
+    addModalTitle: 'Adicionar celular',
+    addModalDescription: 'Informe o novo número de celular no formato internacional (DDI + DDD + número).',
+    inputLabel: 'Celular',
+    removeModalTitle: 'Remover celular?',
+    removeDescriptionPrefix: 'O celular',
+    emptyTitle: 'Nenhum celular cadastrado',
+    emptyHintEditable: 'Use o botão "Adicionar celular" acima para cadastrar o primeiro.',
+    emptyHintReadonly: 'Esse cliente ainda não possui celulares cadastrados.',
+    addCopy: {
+      genericFallback: 'Não foi possível adicionar o celular. Tente novamente.',
+      forbiddenTitle: 'Falha ao adicionar celular',
+      notFoundMessage: 'Cliente não encontrado ou foi removido. A página foi atualizada.',
+    },
+    removeCopy: {
+      genericFallback: 'Não foi possível remover o celular. Tente novamente.',
+      forbiddenTitle: 'Falha ao remover celular',
+      notFoundMessage: 'Celular já havia sido removido. A lista foi atualizada.',
+    },
+    addSuccessToast: 'Celular adicionado.',
+    removeSuccessToast: 'Celular removido.',
+    limitAlertMessage: `Limite de ${MAX_CLIENT_PHONES_PER_TYPE} celulares atingido.`,
+    limitAlertHint: 'Remova algum existente para adicionar outro.',
+    RowIcon: Smartphone,
+    testIdPrefix: 'client-mobile-phones',
+    addFn: addClientMobilePhone,
+    removeFn: removeClientMobilePhone,
+    selectCollection: (dto: ClientDto) => dto.mobilePhones ?? [],
+    loadingLabel: 'Carregando celulares',
+  },
+  landline: {
+    heading: 'Telefones fixos',
+    intro: `Cadastre até ${MAX_CLIENT_PHONES_PER_TYPE} telefones fixos neste cliente. Use o formato internacional E.164 (ex.: +551832345678).`,
+    counterLabel: 'cadastrados',
+    addButtonLabel: 'Adicionar telefone',
+    addModalTitle: 'Adicionar telefone fixo',
+    addModalDescription: 'Informe o novo número de telefone fixo no formato internacional (DDI + DDD + número).',
+    inputLabel: 'Telefone fixo',
+    removeModalTitle: 'Remover telefone fixo?',
+    removeDescriptionPrefix: 'O telefone fixo',
+    emptyTitle: 'Nenhum telefone fixo cadastrado',
+    emptyHintEditable: 'Use o botão "Adicionar telefone" acima para cadastrar o primeiro.',
+    emptyHintReadonly: 'Esse cliente ainda não possui telefones fixos cadastrados.',
+    addCopy: {
+      genericFallback: 'Não foi possível adicionar o telefone. Tente novamente.',
+      forbiddenTitle: 'Falha ao adicionar telefone',
+      notFoundMessage: 'Cliente não encontrado ou foi removido. A página foi atualizada.',
+    },
+    removeCopy: {
+      genericFallback: 'Não foi possível remover o telefone. Tente novamente.',
+      forbiddenTitle: 'Falha ao remover telefone',
+      notFoundMessage: 'Telefone já havia sido removido. A lista foi atualizada.',
+    },
+    addSuccessToast: 'Telefone adicionado.',
+    removeSuccessToast: 'Telefone removido.',
+    limitAlertMessage: `Limite de ${MAX_CLIENT_PHONES_PER_TYPE} telefones fixos atingido.`,
+    limitAlertHint: 'Remova algum existente para adicionar outro.',
+    RowIcon: Phone,
+    testIdPrefix: 'client-landline-phones',
+    addFn: addClientLandlinePhone,
+    removeFn: removeClientLandlinePhone,
+    selectCollection: (dto: ClientDto) => dto.landlinePhones ?? [],
+    loadingLabel: 'Carregando telefones fixos',
+  },
+};
+
+/**
+ * Aba "Celulares" / "Telefones fixos" do `ClientEditPage` (Issue #147).
+ *
+ * Substitui o placeholder herdado de #144. Carrega o cliente via
+ * `GET /clients/{id}` (mesmo padrão do `ClientDataTab`/
+ * `ClientExtraEmailsTab`) para popular `mobilePhones` ou `landlinePhones`
+ * conforme `kind`, e oferece add/remove com mapeamento completo dos
+ * erros do backend.
+ *
+ * Componente único parametrizado por `kind` — espelha o pattern de
+ * extração antecipada de helpers (lição PR #128/#134/#135). Os dois
+ * call sites (`ClientMobilePhonesTab` e `ClientLandlinePhonesTab`)
+ * são wrappers finos de uma linha que injetam `kind`.
+ *
+ * **Estados visuais (critério "estados visuais completos"):**
+ *
+ * - `loading` (`InitialLoadingSpinner`) — primeiro fetch.
+ * - `error` (`ErrorRetryBlock`) — falha de rede/parse/401/403.
+ * - `loaded:empty` — empty state com ícone + dica de próximo passo.
+ * - `loaded:list` — lista com até 3 linhas.
+ * - `loaded:full` — botão "Adicionar" desabilitado (limite 3) +
+ *   `Alert` informativo.
+ * - `add-submitting` / `remove-submitting` — botões em loading.
+ *
+ * **Gating de permissão (critério "Visível com `Clients.Update`"):**
+ *
+ * Quando o usuário não tem `AUTH_V1_CLIENTS_UPDATE`, a aba vira
+ * readonly: a lista continua visível (útil para auditoria) mas os
+ * botões "Adicionar" e "Remover" ficam ocultos. O backend é a fonte
+ * autoritativa (rejeitaria com 401/403 mesmo se a UI exibisse os
+ * botões); o gating client-side é apenas UX.
+ *
+ * **Tratamento de erros:**
+ *
+ * Add (`addClient(Mobile|Landline)Phone`):
+ * - 400 "Telefone inválido..." → inline (validação client-side já
+ *   cobriu, defensivo).
+ * - 400 "Limite de 3..." → inline + refetch (UI já desabilita o
+ *   botão preventivamente; chegar aqui significa race com outra
+ *   sessão).
+ * - 409 "Contato já cadastrado para este cliente." → inline.
+ * - 404 → toast vermelho + refetch (cliente removido).
+ * - 401/403 → toast vermelho.
+ *
+ * Remove (`removeClient(Mobile|Landline)Phone`):
+ * - 404 → toast vermelho + refetch (telefone já removido).
+ * - 401/403 → toast vermelho.
+ *
+ * Reusa `MAX_CLIENT_PHONES_PER_TYPE` (3) para a regra do botão
+ * desabilitado — fonte da verdade compartilhada com a função API.
+ */
+export const ClientPhonesTab: React.FC<ClientPhonesTabProps> = ({
+  kind,
+  client,
+}) => {
+  const { id } = useParams<{ id: string }>();
+  const { show } = useToast();
+  const { hasPermission } = useAuth();
+  const canUpdate = hasPermission(CLIENTS_UPDATE_PERMISSION);
+
+  const config = PHONE_KIND_CONFIG[kind];
+  const {
+    heading,
+    intro,
+    counterLabel,
+    addButtonLabel,
+    addModalTitle,
+    addModalDescription,
+    inputLabel,
+    removeModalTitle,
+    removeDescriptionPrefix,
+    emptyTitle,
+    emptyHintEditable,
+    emptyHintReadonly,
+    addCopy,
+    removeCopy,
+    addSuccessToast,
+    removeSuccessToast,
+    limitAlertMessage,
+    limitAlertHint,
+    RowIcon,
+    testIdPrefix,
+    addFn,
+    removeFn,
+    selectCollection,
+    loadingLabel,
+  } = config;
+
+  /**
+   * Fetch inicial encapsulado em hook compartilhado — `useClientByIdFetch`
+   * cuida de `useEffect` + `AbortController` + `reloadCounter` que
+   * antes vivia inline em #146 e foi promovido em #147 para reuso
+   * pelas duas abas (lição PR #128/#134/#135).
+   */
+  const { fetchState, loadedClient, triggerRefetch } = useClientByIdFetch(
+    id,
+    client,
+  );
+
+  /**
+   * Hooks compartilhados encapsulam o `useState` + handlers do modal
+   * de adicionar e do confirm de remoção. Lição PR #128/#134/#135 —
+   * extraído quando o segundo consumidor (#146 + #147) apareceu para
+   * evitar duplicação no JSCPD/Sonar.
+   */
+  const addModal = useClientAddCollectionModal();
+  const removeConfirm = useClientRemoveCollectionConfirm<ClientPhoneDto>();
+
+  const handleRetry = useCallback(() => {
+    triggerRefetch();
+  }, [triggerRefetch]);
+
+  const phones = useMemo<ReadonlyArray<ClientPhoneDto>>(
+    () => (loadedClient !== null ? selectCollection(loadedClient) : []),
+    [loadedClient, selectCollection],
+  );
+  const isLimitReached = phones.length >= MAX_CLIENT_PHONES_PER_TYPE;
+
+  /* ─── Add modal handlers ──────────────────────────────── */
+
+  const { handleOpen: handleOpenAddModal, handleSubmit: handleSubmitAdd } =
+    addModal.buildHandlers({
+      isLimitReached,
+      isReady: loadedClient !== null,
+      validate: validatePhoneInput,
+    });
+
+  /**
+   * Effect que dispara a chamada HTTP quando o modal sinaliza
+   * `isSubmitting=true`. Encapsulado em `useClientCollectionAddSubmit`
+   * compartilhado com `ClientExtraEmailsTab` (#146) — lição PR
+   * #128/#134/#135.
+   */
+  useClientCollectionAddSubmit({
+    isSubmitting: addModal.state.isSubmitting,
+    value: addModal.state.value,
+    clientId: loadedClient?.id ?? null,
+    client,
+    addFn,
+    classifyError: classifyAddPhoneError,
+    copy: addCopy,
+    successToast: addSuccessToast,
+    modal: addModal,
+    show,
+    triggerRefetch,
+  });
+
+  /* ─── Remove confirm handlers ─────────────────────────── */
+
+  const { submit: submitRemove } = useClientCollectionRemoveSubmit({
+    client,
+    removeFn,
+    classifyError: classifyRemovePhoneError,
+    copy: removeCopy,
+    successToast: removeSuccessToast,
+    confirm: removeConfirm,
+    show,
+    triggerRefetch,
+  });
+
+  const handleConfirmRemove = useCallback(async () => {
+    if (
+      removeConfirm.state.isSubmitting ||
+      removeConfirm.state.target === null ||
+      loadedClient === null
+    ) {
+      return;
+    }
+    await submitRemove(loadedClient.id, removeConfirm.state.target.id);
+  }, [loadedClient, removeConfirm.state, submitRemove]);
+
+  /* ─── Render ──────────────────────────────────────────── */
+
+  if (fetchState === 'loading') {
+    return (
+      <InitialLoadingSpinner
+        testId={`${testIdPrefix}-loading`}
+        label={loadingLabel}
+      />
+    );
+  }
+
+  if (fetchState === 'error') {
+    return (
+      <ErrorRetryBlock
+        message={FETCH_ERROR_MESSAGE}
+        onRetry={handleRetry}
+        retryTestId={`${testIdPrefix}-retry`}
+      />
+    );
+  }
+
+  return (
+    <>
+      <TabSection aria-labelledby={`${testIdPrefix}-heading`}>
+        <TabHeading id={`${testIdPrefix}-heading`}>{heading}</TabHeading>
+        <TabIntro>{intro}</TabIntro>
+
+        <ListHeader>
+          <Counter data-testid={`${testIdPrefix}-counter`}>
+            {phones.length} de {MAX_CLIENT_PHONES_PER_TYPE} {counterLabel}
+          </Counter>
+          {canUpdate && (
+            <Button
+              variant="primary"
+              size="sm"
+              icon={<Plus size={14} strokeWidth={1.75} aria-hidden="true" />}
+              onClick={handleOpenAddModal}
+              disabled={isLimitReached}
+              data-testid={`${testIdPrefix}-add`}
+            >
+              {addButtonLabel}
+            </Button>
+          )}
+        </ListHeader>
+
+        {isLimitReached && canUpdate && (
+          <Alert variant="info">
+            {limitAlertMessage} {limitAlertHint}
+          </Alert>
+        )}
+
+        {phones.length === 0 ? (
+          <EmptyShell data-testid={`${testIdPrefix}-empty`}>
+            <Icon icon={RowIcon} size="lg" tone="muted" />
+            <EmptyTitle>{emptyTitle}</EmptyTitle>
+            <EmptyHint>
+              {canUpdate ? emptyHintEditable : emptyHintReadonly}
+            </EmptyHint>
+          </EmptyShell>
+        ) : (
+          <ListContainer aria-label={`${heading} do cliente`}>
+            {phones.map((phone) => (
+              <ClientCollectionListRow
+                key={phone.id}
+                id={phone.id}
+                value={phone.number}
+                icon={RowIcon}
+                mono
+                canRemove={canUpdate}
+                onRemove={() => removeConfirm.open(phone)}
+                removeAriaLabel={`Remover ${phone.number}`}
+                testIdPrefix={testIdPrefix}
+              />
+            ))}
+          </ListContainer>
+        )}
+      </TabSection>
+
+      <ClientCollectionAddInputModal
+        open={addModal.state.open}
+        onClose={addModal.close}
+        title={addModalTitle}
+        description={addModalDescription}
+        inputLabel={inputLabel}
+        placeholder="+5518981789845"
+        inputType="tel"
+        inputMode="tel"
+        autoComplete="tel"
+        maxLength={PHONE_MAX_LENGTH}
+        value={addModal.state.value}
+        inputError={addModal.state.inputError}
+        isSubmitting={addModal.state.isSubmitting}
+        onChange={addModal.setValue}
+        onSubmit={handleSubmitAdd}
+        testIdPrefix={testIdPrefix}
+      />
+
+      <ClientCollectionRemoveConfirmModal
+        title={removeModalTitle}
+        prefix={removeDescriptionPrefix}
+        target={removeConfirm.state.target?.number ?? null}
+        isSubmitting={removeConfirm.state.isSubmitting}
+        onClose={removeConfirm.close}
+        onConfirm={handleConfirmRemove}
+        testIdPrefix={testIdPrefix}
+      />
+    </>
+  );
+};

--- a/src/pages/clients/applyCollectionMutationAction.ts
+++ b/src/pages/clients/applyCollectionMutationAction.ts
@@ -1,0 +1,144 @@
+/**
+ * Helpers de aplicação de ação de mutação para as abas de coleção
+ * de cliente (`ClientExtraEmailsTab` — Issue #146 e
+ * `ClientPhonesTab` — Issue #147).
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** ambas as abas
+ * tinham o mesmo `switch (action.kind)` com 47 linhas exatamente
+ * iguais (`inline` / `limit-reached` / `not-found` / `toast` /
+ * `unhandled`) divergindo só no callback de `setAddModal`. Sonar/
+ * JSCPD tokenizam isso como bloco duplicado entre arquivos.
+ * Promover para uma função pura agnóstica do tipo concreto da
+ * coleção zera a duplicação e abre caminho para o terceiro
+ * consumidor sem refator destrutivo.
+ *
+ * Mantemos os helpers em TS puro (sem React) para que os testes
+ * unitários possam exercitar o branching sem render — basta passar
+ * spies como dispatchers.
+ */
+
+/**
+ * Side-effect imperativo aplicado pelo helper na UI — abstrai
+ * `useToast().show` para que o helper rode em testes sem provider.
+ */
+type ShowToast = (
+  message: string,
+  options: { variant: 'success' | 'danger' | 'info'; title?: string },
+) => void;
+
+/**
+ * Dispatchers que o caller injeta para que o helper toque no estado
+ * do modal de adicionar. Cada modificação atômica vira um callback
+ * separado — facilita o teste e mantém a função pura por dentro.
+ */
+export interface ApplyAddCollectionDispatchers {
+  /** Seta o erro inline e desliga `isSubmitting`. */
+  setInlineErrorAndStop: (message: string) => void;
+  /** Reseta o modal (fecha + descarta input + isSubmitting=false). */
+  resetAddModal: () => void;
+  /** Apenas desliga `isSubmitting` (mantém modal aberto). */
+  stopSubmitting: () => void;
+}
+
+/**
+ * Ação aceita pelo `applyAddCollectionAction`. Cobre o conjunto
+ * comum entre `AddExtraEmailErrorAction` e `AddPhoneErrorAction`
+ * (mesmas variantes — divergem só nos literais que cada call site
+ * passa). O caller alarga o tipo do classifier deles para este
+ * shape, garantindo que TypeScript valide exaustividade.
+ */
+export type ApplyAddCollectionAction =
+  | { kind: 'inline'; message: string }
+  | { kind: 'limit-reached'; message: string }
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+/**
+ * Aplica uma `ApplyAddCollectionAction` aos dispatchers + side-effects.
+ *
+ * - `inline` → seta erro inline e mantém modal aberto.
+ * - `limit-reached` → idem `inline` + `triggerRefetch` para sincronizar
+ *   estado com servidor.
+ * - `not-found` → toast vermelho + reseta modal + refetch.
+ * - `toast` → toast vermelho + mantém modal aberto.
+ * - `unhandled` → idem `toast` (mensagem genérica vem do classifier).
+ *
+ * Não retorna nada — todos os efeitos são imperativos via dispatchers.
+ */
+export function applyAddCollectionAction(
+  action: ApplyAddCollectionAction,
+  dispatchers: ApplyAddCollectionDispatchers,
+  show: ShowToast,
+  triggerRefetch: () => void,
+): void {
+  switch (action.kind) {
+    case 'inline':
+      dispatchers.setInlineErrorAndStop(action.message);
+      break;
+    case 'limit-reached':
+      dispatchers.setInlineErrorAndStop(action.message);
+      triggerRefetch();
+      break;
+    case 'not-found':
+      show(action.message, { variant: 'danger', title: action.title });
+      dispatchers.resetAddModal();
+      triggerRefetch();
+      break;
+    case 'toast':
+    case 'unhandled':
+      show(action.message, { variant: 'danger', title: action.title });
+      dispatchers.stopSubmitting();
+      break;
+  }
+}
+
+/**
+ * Dispatchers do modal de confirmação de remoção. Cada modificação
+ * atômica vira um callback — o caller controla a transição de
+ * estado.
+ */
+export interface ApplyRemoveCollectionDispatchers {
+  /** Reseta o confirm (fecha + isSubmitting=false). */
+  resetRemoveConfirm: () => void;
+  /** Mantém o confirm aberto e apenas desliga `isSubmitting`. */
+  stopSubmitting: () => void;
+}
+
+/**
+ * Ação aceita pelo `applyRemoveCollectionAction`. Cobre o conjunto
+ * comum (`not-found`, `toast`, `unhandled`) compartilhado entre as
+ * abas. `RemoveExtraEmailErrorAction` adiciona um `username` extra
+ * tratado pelo caller antes de chegar aqui.
+ */
+export type ApplyRemoveCollectionAction =
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+/**
+ * Aplica uma `ApplyRemoveCollectionAction` aos dispatchers + side-effects.
+ *
+ * - `not-found` → toast vermelho + reseta confirm + refetch.
+ * - `toast` → toast vermelho + mantém confirm aberto.
+ * - `unhandled` → idem `toast`.
+ */
+export function applyRemoveCollectionAction(
+  action: ApplyRemoveCollectionAction,
+  dispatchers: ApplyRemoveCollectionDispatchers,
+  show: ShowToast,
+  triggerRefetch: () => void,
+): void {
+  switch (action.kind) {
+    case 'not-found':
+      show(action.message, { variant: 'danger', title: action.title });
+      dispatchers.resetRemoveConfirm();
+      triggerRefetch();
+      break;
+    case 'toast':
+    case 'unhandled':
+      show(action.message, { variant: 'danger', title: action.title });
+      dispatchers.stopSubmitting();
+      break;
+  }
+}

--- a/src/pages/clients/clientCollectionTabStyles.ts
+++ b/src/pages/clients/clientCollectionTabStyles.ts
@@ -1,0 +1,201 @@
+import styled from 'styled-components';
+
+/**
+ * Styled components compartilhados pelas abas que listam coleções de
+ * subentidades de cliente (`ClientExtraEmailsTab` — Issue #146;
+ * `ClientPhonesTab` — Issue #147).
+ *
+ * Concentrar aqui evita duplicação visual (Sonar/JSCPD tokenizam
+ * declarações idênticas como blocos duplicados quando aparecem em
+ * dois arquivos) e garante paridade visual entre as abas — qualquer
+ * ajuste de espaçamento/cor/raio acontece num único arquivo. Lição
+ * PR #128/#134/#135 — extrair quando o segundo consumidor real
+ * aparece.
+ *
+ * **Por que módulo dedicado e não em `src/components/ui/`?** Estes
+ * componentes são opinionados ao layout das abas de cliente
+ * (`var(--bg-surface)` + padding `--space-6` + gap `--space-4` etc.),
+ * que não generaliza para outras telas hoje. Quando aparecer um
+ * terceiro consumidor (ex.: futuras coleções de Usuário), aí sim faz
+ * sentido promover para `src/shared/components/`.
+ */
+
+/**
+ * Container externo da seção da aba — preserva o ar e o
+ * espaçamento entre as outras abas do `ClientEditPage`.
+ */
+export const TabSection = styled.section`
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+export const TabHeading = styled.h3`
+  font-family: var(--font-display);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--fg1);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+`;
+
+export const TabIntro = styled.p`
+  margin: 0;
+  color: var(--fg2);
+  font-size: var(--text-sm);
+  line-height: var(--leading-base);
+  max-width: 60ch;
+`;
+
+/**
+ * Cabeçalho do bloco que combina contagem corrente + botão de ação.
+ * Em viewports estreitas, empilha o botão sob o contador para
+ * preservar o toque (touch target de 44px+).
+ */
+export const ListHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+`;
+
+export const Counter = styled.div`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg3);
+`;
+
+/**
+ * Bloco de empty state com tom suave — espelha o padrão visual das
+ * abas (centralizado, com ícone informativo e dica de próximo passo).
+ */
+export const EmptyShell = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-4);
+  background: var(--bg-elevated);
+  border: var(--border-thin) dashed var(--border-subtle);
+  border-radius: var(--radius-lg);
+  color: var(--fg3);
+`;
+
+export const EmptyTitle = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--fg2);
+`;
+
+export const EmptyHint = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  text-align: center;
+  max-width: 40ch;
+`;
+
+/**
+ * Form do modal de adicionar — `<form>` para que `Enter` no input
+ * dispare o submit e que leitores de tela identifiquem o agrupamento
+ * de campos.
+ */
+export const ModalForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+`;
+
+export const ModalActions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+`;
+
+export const ConfirmBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+`;
+
+export const ConfirmText = styled.p`
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: var(--leading-snug);
+`;
+
+export const Mono = styled.span`
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg1);
+  background: var(--bg-elevated);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
+`;
+
+/**
+ * Linha visual de uma sub-entidade (email/telefone/etc.) — flex com
+ * conteúdo à esquerda e ação "Remover" à direita.
+ */
+export const ListRow = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--duration-fast) var(--ease-default),
+    background var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    border-color: var(--border-medium-forest);
+  }
+`;
+
+export const ListContainer = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+`;
+
+/**
+ * Wrapper do conteúdo principal da linha (ícone + label).
+ */
+export const ListRowLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  flex: 1;
+`;
+
+/**
+ * Valor textual da linha — ellipsis quando longo. Cada consumidor
+ * passa a `font-family` desejada (sans para email, mono para
+ * telefone) via `$mono` para preservar a hierarquia tipográfica
+ * intencional sem precisar duplicar todo o styled component.
+ */
+export const ListRowValue = styled.span<{ $mono?: boolean }>`
+  font-family: ${({ $mono }) => ($mono ? 'var(--font-mono)' : 'var(--font-sans)')};
+  font-size: var(--text-sm);
+  color: var(--fg1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/src/pages/clients/clientExtraEmailsHelpers.ts
+++ b/src/pages/clients/clientExtraEmailsHelpers.ts
@@ -1,5 +1,12 @@
 import { isApiError } from '../../shared/api';
-import { isValidEmailSyntax } from '../../shared/forms';
+import {
+  classifyAddCollectionApiError,
+  classifySharedHttpError,
+  isValidEmailSyntax,
+  unhandledHttpAction,
+  type AddCollectionApiAction,
+  type SharedHttpErrorCopy,
+} from '../../shared/forms';
 
 /**
  * Helpers compartilhados pelo `ClientExtraEmailsTab` (Issue #146).
@@ -66,27 +73,19 @@ export function validateExtraEmailInput(raw: string): string | null {
 }
 
 /**
- * Cópia textual injetada nos `classify*` desta camada. Mantém os
- * literais em pt-BR centralizados num único objeto — qualquer
- * ajuste de copy acontece em uma referência só.
+ * Cópia textual injetada nos `classify*` desta camada. Alias do
+ * `SharedHttpErrorCopy` em `src/shared/forms/` — manter o nome
+ * `ExtraEmailErrorCopy` no domínio de emails extras torna o call-site
+ * mais legível, mas o shape é idêntico para que o classifier
+ * compartilhado `classifySharedHttpError` consuma diretamente sem cast.
+ *
+ * Refator antecipatório (Issue #147 — paridade com #146): unificar o
+ * shape da copy entre as duas camadas (#146 e #147) abre caminho para
+ * um terceiro consumidor (futuras coleções de Cliente) reusar
+ * `classifySharedHttpError` sem refator destrutivo. Lição PR
+ * #128/#134/#135.
  */
-export interface ExtraEmailErrorCopy {
-  /**
-   * Mensagem genérica usada quando o erro não é classificável
-   * (`network`/`parse`/5xx). Exibida em toast vermelho.
-   */
-  genericFallback: string;
-  /**
-   * Título do toast vermelho exibido para 401/403/network/parse —
-   * dá hierarquia visual ao operador identificar o tipo do erro.
-   */
-  forbiddenTitle: string;
-  /**
-   * Mensagem específica para o 404 (recurso já removido entre
-   * abertura e submit). Exibida em toast vermelho + força refetch.
-   */
-  notFoundMessage: string;
-}
+export type ExtraEmailErrorCopy = SharedHttpErrorCopy;
 
 /**
  * Ação discriminada decorrente da classificação de erro do `add`.
@@ -103,81 +102,8 @@ export interface ExtraEmailErrorCopy {
  * - `unhandled` → fallback (network/parse/5xx). Toast vermelho com
  *   `genericFallback`.
  */
-export type AddExtraEmailErrorAction =
-  | { kind: 'inline'; message: string }
-  | { kind: 'limit-reached'; message: string }
-  | { kind: 'not-found'; message: string; title: string }
-  | { kind: 'toast'; message: string; title: string }
-  | { kind: 'unhandled'; message: string; title: string };
+export type AddExtraEmailErrorAction = AddCollectionApiAction;
 
-/**
- * Branch comum entre `classifyAddExtraEmailError` e
- * `classifyRemoveExtraEmailError` — encapsula os casos compartilhados
- * (não-HTTP, 404, 401/403, fallback) num único helper para que o
- * Sonar/JSCPD não tokenize ~15 linhas idênticas como duplicação
- * (lição PR #128/#134/#135 — bloco ≥10 linhas em 2+ funções vira
- * `New Code Duplication`).
- *
- * Retorna a ação compartilhada quando o caso é coberto, ou `null`
- * quando o status precisa de tratamento específico do call site (400/
- * 409 no `add`; 400 no `remove`). O caller decide o que fazer com o
- * `null` — tipicamente ramifica em casos próprios e cai no fallback
- * `unhandled` se nenhum bater.
- *
- * Mantemos retorno tipado como união ampla (`SharedExtraEmailAction`)
- * para que o caller faça `narrowing` no kind sem precisar
- * re-classificar — TypeScript infere o subset depois do `if`.
- */
-type SharedExtraEmailAction =
-  | { kind: 'not-found'; message: string; title: string }
-  | { kind: 'toast'; message: string; title: string }
-  | { kind: 'unhandled'; message: string; title: string };
-
-function classifySharedExtraEmailError(
-  error: unknown,
-  copy: ExtraEmailErrorCopy,
-): SharedExtraEmailAction | null {
-  if (!isApiError(error) || error.kind !== 'http') {
-    return {
-      kind: 'unhandled',
-      message: copy.genericFallback,
-      title: copy.forbiddenTitle,
-    };
-  }
-  if (error.status === 404) {
-    return {
-      kind: 'not-found',
-      message: copy.notFoundMessage,
-      title: copy.forbiddenTitle,
-    };
-  }
-  if (error.status === 401 || error.status === 403) {
-    return {
-      kind: 'toast',
-      message: error.message || copy.genericFallback,
-      title: copy.forbiddenTitle,
-    };
-  }
-  // 400/409 são specific-by-endpoint — caller resolve antes de cair
-  // no fallback comum.
-  return null;
-}
-
-/**
- * Fallback `unhandled` reusado pelo `add` e `remove` quando nenhum
- * caso específico cobre o erro. Centralizar evita que a estrutura
- * `{ kind: 'unhandled', message, title }` apareça duas vezes em cada
- * função e dispare detecção de duplicação no Sonar/JSCPD.
- */
-function unhandledExtraEmailAction(
-  copy: ExtraEmailErrorCopy,
-): SharedExtraEmailAction {
-  return {
-    kind: 'unhandled',
-    message: copy.genericFallback,
-    title: copy.forbiddenTitle,
-  };
-}
 
 /**
  * Classifica o erro do `addClientExtraEmail` em uma ação
@@ -207,31 +133,11 @@ export function classifyAddExtraEmailError(
   error: unknown,
   copy: ExtraEmailErrorCopy,
 ): AddExtraEmailErrorAction {
-  const shared = classifySharedExtraEmailError(error, copy);
-  if (shared !== null) {
-    return shared;
-  }
-  // `shared === null` significa que `error` é HTTP com `status` que
-  // exige decisão específica do `add` (400/409). Reabrimos o type
-  // guard para que TS saiba que `isApiError(error) === true` aqui
-  // (refinamento perdido no retorno do helper).
-  if (!isApiError(error) || error.kind !== 'http') {
-    return unhandledExtraEmailAction(copy);
-  }
-  if (error.status === 400) {
-    // Distinção pela mensagem do backend — `limit-reached` precisa
-    // disparar refetch (cliente foi tocado por outra sessão).
-    const message = error.message || copy.genericFallback;
-    if (message.toLowerCase().includes('limite')) {
-      return { kind: 'limit-reached', message };
-    }
-    return { kind: 'inline', message };
-  }
-  if (error.status === 409) {
-    const message = error.message || copy.genericFallback;
-    return { kind: 'inline', message };
-  }
-  return unhandledExtraEmailAction(copy);
+  // Delega para o helper genérico — branching 400/409/404/401-403 é
+  // idêntico ao de `classifyAddPhoneError` (#147). O backend sinaliza
+  // limite com mensagem `"Limite de 3 emails extras..."` — o
+  // `includes('limite')` cobre o caso sem depender da string completa.
+  return classifyAddCollectionApiError(error, copy);
 }
 
 /**
@@ -273,12 +179,12 @@ export function classifyRemoveExtraEmailError(
   error: unknown,
   copy: ExtraEmailErrorCopy,
 ): RemoveExtraEmailErrorAction {
-  const shared = classifySharedExtraEmailError(error, copy);
+  const shared = classifySharedHttpError(error, copy);
   if (shared !== null) {
     return shared;
   }
   if (!isApiError(error) || error.kind !== 'http') {
-    return unhandledExtraEmailAction(copy);
+    return unhandledHttpAction(copy);
   }
   if (error.status === 400) {
     return {
@@ -287,5 +193,5 @@ export function classifyRemoveExtraEmailError(
       title: copy.forbiddenTitle,
     };
   }
-  return unhandledExtraEmailAction(copy);
+  return unhandledHttpAction(copy);
 }

--- a/src/pages/clients/clientPhonesHelpers.ts
+++ b/src/pages/clients/clientPhonesHelpers.ts
@@ -1,0 +1,211 @@
+import {
+  classifyAddCollectionApiError,
+  classifySharedHttpError,
+  unhandledHttpAction,
+  type AddCollectionApiAction,
+  type SharedHttpErrorAction,
+  type SharedHttpErrorCopy,
+} from '../../shared/forms';
+
+/**
+ * Helpers compartilhados pelo `ClientPhonesTab` (Issue #147 — gerenciar
+ * celulares e telefones fixos do cliente).
+ *
+ * Concentra:
+ *
+ * - Constantes de validação (`PHONE_MAX_LENGTH`, `PHONE_E164_REGEX`)
+ *   — espelham `AddPhoneRequest.Number.MaxLength(20)` e
+ *   `ClientsController.PhoneRegex` (`^\+[1-9]\d{11,14}$`) no
+ *   `lfc-authenticator`.
+ * - `validatePhoneInput` — feedback client-side antes do submit
+ *   (formato E.164 + tamanho máx.). Replica o suficiente para evitar
+ *   round-trip por digitação trivial; o backend permanece autoritativo
+ *   (`PhoneRegex.IsMatch` em `AddPhoneInternal`).
+ * - `classifyAddPhoneError` — converte um `unknown` lançado por
+ *   `addClientMobilePhone`/`addClientLandlinePhone` em uma ação
+ *   discriminada para que o componente decida com `switch` curto se
+ *   exibe inline (400 inválido / 409 duplicado), toast (401/403/network)
+ *   ou refetch (404, 400 limite).
+ * - `classifyRemovePhoneError` — espelha o classify do `add` para o
+ *   caminho `DELETE /clients/{id}/(mobiles|phones)/{phoneId}`. Diferença
+ *   chave é a ausência de 400 distintivo (o backend só devolve 404
+ *   nesse endpoint quando o id não bate).
+ *
+ * **Reuso entre mobile e landline:** o backend usa o mesmo
+ * `AddPhoneInternal`/`RemovePhoneInternal` para os dois tipos,
+ * divergindo apenas no `Type` discriminador e na mensagem de limite
+ * (`"Limite de 3 celulares por cliente."` vs `"Limite de 3 telefones
+ * por cliente."`). Os helpers aqui são agnósticos quanto ao tipo —
+ * extraem informação por inspeção da mensagem do backend (palavra
+ * "limite" para distinguir cap vs formato), o que mantém o componente
+ * `ClientPhonesTab` simples e único.
+ *
+ * **Por que módulo dedicado e não dentro de `clientsFormShared.ts` ou
+ * `clientExtraEmailsHelpers.ts`?**
+ * Os helpers de email têm regras próprias (anti-username, formato
+ * RFC 5321) que não se aplicam a telefone; e o `clientsFormShared.ts`
+ * concentra validação PF/PJ. Manter um módulo por subdomínio preserva
+ * a coesão e evita acoplar mudanças entre as três camadas (lição PR
+ * #128 — projetar shared helpers desde o primeiro PR do recurso).
+ *
+ * Mantemos a lógica em TS puro (sem React) para que os testes
+ * unitários consumam diretamente sem provider/render.
+ */
+
+/**
+ * Tamanho máximo do número de telefone — espelha
+ * `AddPhoneRequest.Number.MaxLength(20)` no `ClientsController`. A
+ * regex E.164 já restringe para 13–16 caracteres (`+` + 12–15
+ * dígitos), mas mantemos a checagem de tamanho pelo MaxLength por
+ * defesa em profundidade — o input HTML aceita até `PHONE_MAX_LENGTH`
+ * caracteres antes de bloquear digitação.
+ */
+export const PHONE_MAX_LENGTH = 20;
+
+/**
+ * Regex E.164 idêntica ao `ClientsController.PhoneRegex` no
+ * `lfc-authenticator`:
+ *
+ * - `^\+` — sempre começa com `+` (DDI internacional obrigatório).
+ * - `[1-9]` — primeiro dígito do código do país é não-zero.
+ * - `\d{11,14}$` — seguido de 11 a 14 dígitos (totalizando 12–15
+ *   dígitos após o `+`, ou 13–16 caracteres no total).
+ *
+ * Exemplos válidos:
+ *   +5518981789845  (Brasil celular — 14 chars: + + 13 dígitos)
+ *   +551832345678   (Brasil fixo — 13 chars: + + 12 dígitos, limite inferior)
+ *   +442083661177   (Reino Unido — 13 chars: + + 12 dígitos)
+ *   +551234567890123 (limite superior — 16 chars: + + 15 dígitos)
+ *
+ * Exemplos inválidos:
+ *   18981789845     (sem +)
+ *   +0123456789012  (segundo dígito é 0)
+ *   +14155552671    (EUA — só 11 dígitos após +; o backend rejeita
+ *                   números norte-americanos por escolha do contrato)
+ *   +1234567890     (curto demais — só 10 dígitos após +)
+ *   +12345678901234567 (longo demais — 17 dígitos após +)
+ */
+export const PHONE_E164_REGEX = /^\+[1-9]\d{11,14}$/;
+
+/**
+ * Valida o input de telefone contra as mesmas regras do backend
+ * (`Required` + `MaxLength(20)` + formato `PhoneRegex`).
+ *
+ * Retorna `null` quando válido, ou string com mensagem amigável em
+ * pt-BR. Trim defensivo aplicado antes da checagem — o backend
+ * faz `Number.Trim()`, então digitar `"  +5518981789845  "` é tratado
+ * como `"+5518981789845"`. A UI espelha trimando antes de validar
+ * para alinhar feedback com o que o servidor faria.
+ */
+export function validatePhoneInput(raw: string): string | null {
+  const number = raw.trim();
+  if (number.length === 0) {
+    return 'Número é obrigatório.';
+  }
+  if (number.length > PHONE_MAX_LENGTH) {
+    return `Número deve ter no máximo ${PHONE_MAX_LENGTH} caracteres.`;
+  }
+  if (!PHONE_E164_REGEX.test(number)) {
+    return 'Use o formato internacional com DDI e DDD, ex.: +5518981789845.';
+  }
+  return null;
+}
+
+/**
+ * Cópia textual injetada nos `classify*` desta camada. Alias do
+ * `SharedHttpErrorCopy` em `src/shared/forms/` — manter o nome
+ * `PhoneErrorCopy` no domínio de telefones torna o call-site mais
+ * legível, mas o shape é idêntico para que o classifier compartilhado
+ * `classifySharedHttpError` consuma diretamente sem cast.
+ *
+ * Espelha `ExtraEmailErrorCopy` (#146) — qualquer evolução do contrato
+ * (ex.: campo extra para 5xx) propaga para os dois consumidores via
+ * `SharedHttpErrorCopy`.
+ */
+export type PhoneErrorCopy = SharedHttpErrorCopy;
+
+/**
+ * Ação discriminada decorrente da classificação de erro do `add`.
+ * Alias de `AddCollectionApiAction` em `src/shared/forms/` —
+ * `classifyAddCollectionApiError` cobre exatamente o conjunto que o
+ * call site precisa (`inline`/`limit-reached` específico do add +
+ * `not-found`/`toast`/`unhandled` do shared).
+ *
+ * Mantemos o nome `AddPhoneErrorAction` no domínio de telefones para
+ * preservar a clareza do call-site existente.
+ */
+export type AddPhoneErrorAction = AddCollectionApiAction;
+
+/**
+ * Classifica o erro do `addClientMobilePhone`/`addClientLandlinePhone`
+ * em uma ação discriminada. Centraliza a árvore de switch que viveria
+ * duplicada em cada call site (lição PR #128/#134/#135).
+ *
+ * **Casos cobertos (espelham o backend `ClientsController.AddPhoneInternal`):**
+ *
+ * - 400 com mensagem contendo "limite" (case-insensitive) →
+ *   `limit-reached`. Componente exibe inline e refetch para
+ *   sincronizar (cliente teve outro telefone adicionado por outra
+ *   sessão). Defensivo — UI normalmente desabilita o botão antes.
+ * - 400 com qualquer outra mensagem → `inline`. Tipicamente
+ *   `"Telefone inválido. Use o formato internacional..."` (validação
+ *   client-side já cobriu, defensivo).
+ * - 409 → `inline` com a mensagem do backend (`"Contato já cadastrado
+ *   para este cliente."`).
+ * - 404 → `not-found` (cliente removido entre abertura e submit).
+ *   Tratado em `classifySharedPhoneError`.
+ * - 401/403 → `toast` com mensagem do backend.
+ * - Demais → `unhandled` com `genericFallback`.
+ */
+export function classifyAddPhoneError(
+  error: unknown,
+  copy: PhoneErrorCopy,
+): AddPhoneErrorAction {
+  // Delega para o helper genérico — branching 400/409/404/401-403 é
+  // idêntico ao de `classifyAddExtraEmailError` (#146). O backend
+  // sinaliza limite com mensagem `"Limite de 3 (celulares|telefones)
+  // por cliente."` — o `includes('limite')` cobre os dois casos sem
+  // depender da string completa.
+  return classifyAddCollectionApiError(error, copy);
+}
+
+/**
+ * Ação discriminada decorrente da classificação de erro do `remove`.
+ *
+ * Diferente de email extra, o backend **não** devolve 400 no remove
+ * de telefone (o `RemovePhoneInternal` só pode falhar com 404 quando
+ * o id não bate, ou com 401/403). Por isso a união aqui é um subset
+ * estrito da do `Add`.
+ *
+ * - `not-found` → telefone não pertence ao cliente (404). Refetch +
+ *   toast.
+ * - `toast` → 401/403 com mensagem do backend.
+ * - `unhandled` → fallback. Toast vermelho com `genericFallback`.
+ */
+export type RemovePhoneErrorAction = SharedHttpErrorAction;
+
+/**
+ * Classifica o erro do `removeClientMobilePhone`/
+ * `removeClientLandlinePhone` em uma ação discriminada. Espelha
+ * `classifyAddPhoneError` mas sem o 400 (o backend não devolve esse
+ * status no `RemovePhoneInternal`).
+ *
+ * **Casos cobertos (espelham `ClientsController.RemovePhoneInternal`):**
+ *
+ * - 404 → `not-found` (telefone já removido por outra sessão entre
+ *   abertura e submit, ou id inconsistente).
+ * - 401/403 → `toast` com mensagem do backend.
+ * - Demais (incluindo 400 inesperado, defensivo) → `unhandled`.
+ */
+export function classifyRemovePhoneError(
+  error: unknown,
+  copy: PhoneErrorCopy,
+): RemovePhoneErrorAction {
+  const shared = classifySharedHttpError(error, copy);
+  if (shared !== null) {
+    return shared;
+  }
+  // 400 inesperado nesse endpoint cai no fallback unhandled — mantém
+  // o operador informado mesmo num cenário não previsto pelo contrato.
+  return unhandledHttpAction(copy);
+}

--- a/src/pages/clients/useClientAddCollectionModal.ts
+++ b/src/pages/clients/useClientAddCollectionModal.ts
@@ -1,0 +1,173 @@
+import React, { useCallback, useState } from 'react';
+
+/**
+ * Estado controlado do modal de adicionar item compartilhado entre
+ * `ClientExtraEmailsTab` (#146) e `ClientPhonesTab` (#147).
+ *
+ * `value` é genérico em `string` (todos os modais hoje têm input
+ * único); cenários futuros com mais de um campo vão estender este
+ * shape ou abrir um hook próprio.
+ */
+export interface AddCollectionModalState {
+  open: boolean;
+  value: string;
+  inputError: string | null;
+  isSubmitting: boolean;
+}
+
+const INITIAL_STATE: AddCollectionModalState = {
+  open: false,
+  value: '',
+  inputError: null,
+  isSubmitting: false,
+};
+
+export interface UseClientAddCollectionModalResult {
+  /** Estado corrente do modal — ler para passar ao `<ClientCollectionAddInputModal>`. */
+  state: AddCollectionModalState;
+  /** Abre o modal com input vazio. */
+  open: () => void;
+  /** Fecha o modal (descartando rascunho). No-op enquanto `isSubmitting`. */
+  close: () => void;
+  /** Atualiza `value` (chamado a cada keystroke do input) e zera `inputError`. */
+  setValue: (value: string) => void;
+  /**
+   * Marca `isSubmitting=true` se a validação client-side aprovou.
+   * `validate` retorna `null` para válido ou string com mensagem
+   * inline. Reflete a transição atomicamente — em um único
+   * `setState` o caller não vê estado intermediário.
+   */
+  beginSubmit: (validate: (trimmed: string) => string | null) => void;
+  /** Reseta para o estado inicial — usado no caminho de sucesso. */
+  reset: () => void;
+  /** Seta erro inline e desliga `isSubmitting` — caso `inline` do classifier. */
+  setInlineErrorAndStop: (message: string) => void;
+  /** Apenas desliga `isSubmitting` (mantém modal aberto) — caso `toast`. */
+  stopSubmitting: () => void;
+  /**
+   * Retorna handlers prontos para o componente consumidor — `open`
+   * gateado por `isLimitReached` e `submit` que chama `beginSubmit`
+   * com o validator injetado. Centralizar evita duplicação dos dois
+   * handlers entre `ClientExtraEmailsTab` (#146) e `ClientPhonesTab`
+   * (#147).
+   */
+  buildHandlers: (params: {
+    isLimitReached: boolean;
+    isReady: boolean;
+    validate: (trimmed: string) => string | null;
+  }) => {
+    handleOpen: () => void;
+    handleSubmit: (event?: React.FormEvent<HTMLFormElement>) => void;
+  };
+}
+
+/**
+ * Hook compartilhado que encapsula o `useState` + handlers do modal
+ * de adicionar item.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** ambas as abas
+ * (`ClientExtraEmailsTab` e `ClientPhonesTab`) tinham o mesmo
+ * conjunto de callbacks (`handleOpenAddModal`, `handleCloseAddModal`,
+ * `handleValueChange`, `setInlineErrorAndStop`, etc.) — JSCPD
+ * tokenizava ~20 linhas como bloco duplicado entre os arquivos.
+ * Promover para hook compartilhado deduplica e expõe uma API
+ * declarativa (`open()`, `close()`, `setValue(v)`, `beginSubmit(v)`,
+ * `reset()`) que torna os call sites mais legíveis.
+ *
+ * **Padrão "begin submit":** o caller chama `beginSubmit(validate)` no
+ * handler de submit; o hook valida via callback e seta
+ * `isSubmitting=true` apenas se passou. Todo o branching de
+ * "validar → setar erro inline OU `isSubmitting`" acontece dentro do
+ * `setState` (atômico) — o caller não precisa coordenar dois
+ * `setState`s.
+ */
+export function useClientAddCollectionModal(): UseClientAddCollectionModalResult {
+  const [state, setState] = useState<AddCollectionModalState>(INITIAL_STATE);
+
+  const open = useCallback(() => {
+    setState({
+      open: true,
+      value: '',
+      inputError: null,
+      isSubmitting: false,
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    // No-op enquanto submit está em andamento — preserva o feedback
+    // visual e evita race com a request in-flight.
+    setState((prev) => (prev.isSubmitting ? prev : INITIAL_STATE));
+  }, []);
+
+  const setValue = useCallback((value: string) => {
+    setState((prev) => ({
+      ...prev,
+      value,
+      // Limpa o erro no primeiro keystroke após erro — feedback
+      // mais leve que "permanecer marcado vermelho até resubmit".
+      inputError: null,
+    }));
+  }, []);
+
+  const beginSubmit = useCallback(
+    (validate: (trimmed: string) => string | null) => {
+      setState((prev) => {
+        if (prev.isSubmitting) return prev;
+        const trimmed = prev.value.trim();
+        const inputError = validate(trimmed);
+        if (inputError !== null) {
+          return { ...prev, inputError };
+        }
+        return { ...prev, inputError: null, isSubmitting: true };
+      });
+    },
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setState(INITIAL_STATE);
+  }, []);
+
+  const setInlineErrorAndStop = useCallback((message: string) => {
+    setState((prev) => ({
+      ...prev,
+      inputError: message,
+      isSubmitting: false,
+    }));
+  }, []);
+
+  const stopSubmitting = useCallback(() => {
+    setState((prev) => ({ ...prev, isSubmitting: false }));
+  }, []);
+
+  const buildHandlers = useCallback(
+    (params: {
+      isLimitReached: boolean;
+      isReady: boolean;
+      validate: (trimmed: string) => string | null;
+    }) => ({
+      handleOpen: () => {
+        if (params.isLimitReached) return;
+        open();
+      },
+      handleSubmit: (event?: React.FormEvent<HTMLFormElement>) => {
+        event?.preventDefault();
+        if (!params.isReady) return;
+        beginSubmit(params.validate);
+      },
+    }),
+    [beginSubmit, open],
+  );
+
+  return {
+    state,
+    open,
+    close,
+    setValue,
+    beginSubmit,
+    reset,
+    setInlineErrorAndStop,
+    stopSubmitting,
+    buildHandlers,
+  };
+}

--- a/src/pages/clients/useClientByIdFetch.ts
+++ b/src/pages/clients/useClientByIdFetch.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { getClientById } from '../../shared/api';
+
+import type { ApiClient, ClientDto } from '../../shared/api';
+
+/**
+ * Estado do fetch inicial — espelha o padrão usado por
+ * `ClientDataTab` (módulo prévio à #146/#147 que ainda mantém o
+ * estado inline). Encapsulado aqui para que as duas abas que listam
+ * sub-coleções de um cliente (`ClientExtraEmailsTab` e
+ * `ClientPhonesTab`) reusem a mesma máquina sem duplicar ~30 linhas
+ * de boilerplate (lição PR #128/#134/#135).
+ */
+type FetchState = 'loading' | 'loaded' | 'error';
+
+export interface UseClientByIdFetchResult {
+  /** Estado corrente do fetch — controla render condicional na UI. */
+  fetchState: FetchState;
+  /** `ClientDto` carregado, ou `null` quando ainda não chegou. */
+  loadedClient: ClientDto | null;
+  /**
+   * Dispara um novo fetch (resetando para `loading`) — útil após
+   * mutações bem-sucedidas (sincronizar lista) ou erros que indicam
+   * drift de estado (404, "Limite atingido").
+   */
+  triggerRefetch: () => void;
+}
+
+/**
+ * Hook compartilhado que carrega um cliente individual via
+ * `getClientById(id)` e expõe um estado de fetch + função de refetch.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** as abas
+ * `ClientExtraEmailsTab` (#146) e `ClientPhonesTab` (#147) faziam o
+ * mesmo `useEffect` de fetch idêntico (~30 linhas: AbortController,
+ * cancellation flag, AbortError suppression, reload counter, error
+ * handler). Sonar/JSCPD tokenizam isso como bloco duplicado. Promover
+ * a um hook compartilhado deduplica e abre caminho para um terceiro
+ * consumidor (ex.: futuras coleções de Cliente sem refator
+ * destrutivo).
+ *
+ * **Cancelamento defensivo:** o effect monta um `AbortController` e
+ * uma flag `isCancelled`. Em unmount/route change, ambos disparam:
+ * - `controller.abort()` cancela o fetch in-flight no nível HTTP.
+ * - `isCancelled` impede `setState` em componente desmontado (evita
+ *   warning "Can't perform a React state update on an unmounted
+ *   component").
+ *
+ * Cancelamento explícito (`AbortError`) é silenciado — não vira
+ * erro de UI.
+ *
+ * **Refetch via `reloadCounter`:** incrementar a chave força o effect
+ * a rodar de novo (a dep array inclui `reloadCounter`). Padrão
+ * idiomático que evita `useEffect` controlado por `setState`
+ * artificial — mais simples que SWR/React Query para o caso de um
+ * único recurso.
+ *
+ * **Estado de erro inicial:** quando `id` é vazio/undefined (rota
+ * malformada), o estado é setado direto para `error` — preserva o
+ * `ErrorRetryBlock` ainda que o fetch nunca dispare.
+ *
+ * @param id ID do cliente (de `useParams`). `undefined`/string vazia
+ *           força `error`.
+ * @param client Cliente HTTP injetável para testes; default = singleton.
+ */
+export function useClientByIdFetch(
+  id: string | undefined,
+  client?: ApiClient,
+): UseClientByIdFetchResult {
+  const [fetchState, setFetchState] = useState<FetchState>('loading');
+  const [loadedClient, setLoadedClient] = useState<ClientDto | null>(null);
+  const [reloadCounter, setReloadCounter] = useState<number>(0);
+
+  useEffect(() => {
+    if (id === undefined || id.length === 0) {
+      setFetchState('error');
+      return;
+    }
+
+    const controller = new AbortController();
+    let isCancelled = false;
+
+    setFetchState('loading');
+
+    getClientById(id, { signal: controller.signal }, client)
+      .then((dto) => {
+        if (isCancelled) return;
+        setLoadedClient(dto);
+        setFetchState('loaded');
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return;
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        setFetchState('error');
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+  }, [id, client, reloadCounter]);
+
+  const triggerRefetch = useCallback(() => {
+    setReloadCounter((prev) => prev + 1);
+  }, []);
+
+  return { fetchState, loadedClient, triggerRefetch };
+}

--- a/src/pages/clients/useClientCollectionAddSubmit.ts
+++ b/src/pages/clients/useClientCollectionAddSubmit.ts
@@ -1,0 +1,163 @@
+import { useEffect } from 'react';
+
+import {
+  applyAddCollectionAction,
+  type ApplyAddCollectionAction,
+} from './applyCollectionMutationAction';
+
+import type { ApiClient, BodyRequestOptions } from '../../shared/api';
+
+/**
+ * Side-effect imperativo para toast — abstrai `useToast().show` para
+ * que o hook não acople ao provider e os testes possam injetar spies.
+ */
+type ShowToast = (
+  message: string,
+  options: { variant: 'success' | 'danger' | 'info'; title?: string },
+) => void;
+
+/**
+ * Cópia de erro injetada pelo caller (alias do `SharedHttpErrorCopy`
+ * em `src/shared/forms/`). Mantida como `unknown`-friendly aqui para
+ * preservar o contrato do classifier injetado, que aceita qualquer
+ * subset compatível.
+ */
+interface AddCopy {
+  genericFallback: string;
+  forbiddenTitle: string;
+  notFoundMessage: string;
+}
+
+/**
+ * Subset do `useClientAddCollectionModal` que este hook precisa para
+ * aplicar a ação. Aceitar a interface mínima (em vez do hook inteiro)
+ * deixa o helper agnóstico ao shape do estado interno.
+ */
+interface AddModalDispatchers {
+  reset: () => void;
+  setInlineErrorAndStop: (message: string) => void;
+  stopSubmitting: () => void;
+}
+
+interface UseClientCollectionAddSubmitArgs {
+  /** Estado de submit do modal (`addModal.state.isSubmitting`). */
+  isSubmitting: boolean;
+  /** Valor do input no instante em que `isSubmitting` virou `true`. */
+  value: string;
+  /**
+   * `id` do cliente alvo (vindo do `loadedClient`). `null` desativa
+   * o effect — pré-condição para o submit ser disparado.
+   */
+  clientId: string | null;
+  /** Cliente HTTP injetável para testes (default = singleton). */
+  client?: ApiClient;
+  /**
+   * Função API que faz o POST efetivo (`addClientExtraEmail`,
+   * `addClientMobilePhone`, etc.). Recebe `id`, `value`, `options`,
+   * `client` — assinatura padrão das funções de mutação do
+   * `shared/api/clients.ts`.
+   */
+  addFn: (
+    clientId: string,
+    value: string,
+    options?: BodyRequestOptions,
+    client?: ApiClient,
+  ) => Promise<unknown>;
+  /**
+   * Classifier que converte `unknown` lançado pelo `addFn` em uma
+   * `ApplyAddCollectionAction` discriminada. Tipicamente
+   * `classifyAddPhoneError` ou `classifyAddExtraEmailError`.
+   */
+  classifyError: (error: unknown, copy: AddCopy) => ApplyAddCollectionAction;
+  /** Cópia injetada no classifier (mensagens em pt-BR). */
+  copy: AddCopy;
+  /** Toast exibido em caso de sucesso. */
+  successToast: string;
+  /** Dispatchers do modal (vindo de `useClientAddCollectionModal`). */
+  modal: AddModalDispatchers;
+  /** Callback `useToast().show` — o caller passa para isolar provider. */
+  show: ShowToast;
+  /** Função para refazer o fetch após sucesso/limit-reached/not-found. */
+  triggerRefetch: () => void;
+}
+
+/**
+ * Hook que dispara a chamada HTTP de adicionar item quando o modal
+ * sinaliza `isSubmitting=true`, e mapeia o resultado para os
+ * dispatchers do modal.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** ambas as abas
+ * `ClientExtraEmailsTab` (#146) e `ClientPhonesTab` (#147) tinham o
+ * mesmo `useEffect` de ~38 linhas (`AbortController` + `then`/
+ * `catch` + `applyAddCollectionAction`) divergindo só em `addFn` e
+ * `classifyError`. Sonar/JSCPD tokenizava como bloco duplicado entre
+ * arquivos. Promover para hook compartilhado deduplica e abre caminho
+ * para o terceiro consumidor sem refator destrutivo.
+ *
+ * **Cancelamento defensivo:** o effect monta um `AbortController` e
+ * uma flag `isCancelled` — em unmount ou em refetch concorrente, o
+ * fetch in-flight é cancelado e o `setState` resultante é ignorado
+ * (evita "Can't perform a React state update on an unmounted
+ * component").
+ *
+ * **Closure stale:** `addModal.state.value` é capturado no instante
+ * em que `isSubmitting` virou `true`. O `eslint-disable-next-line` é
+ * intencional — incluir `value` na dep array recriaria o effect a
+ * cada keystroke, disparando submits espúrios.
+ */
+export function useClientCollectionAddSubmit({
+  isSubmitting,
+  value,
+  clientId,
+  client,
+  addFn,
+  classifyError,
+  copy,
+  successToast,
+  modal,
+  show,
+  triggerRefetch,
+}: UseClientCollectionAddSubmitArgs): void {
+  useEffect(() => {
+    if (!isSubmitting || clientId === null) return;
+    let isCancelled = false;
+    const controller = new AbortController();
+
+    addFn(clientId, value.trim(), { signal: controller.signal }, client)
+      .then(() => {
+        if (isCancelled) return;
+        show(successToast, { variant: 'success' });
+        modal.reset();
+        triggerRefetch();
+      })
+      .catch((error: unknown) => {
+        if (isCancelled) return;
+        if (
+          error instanceof DOMException &&
+          error.name === 'AbortError'
+        ) {
+          return;
+        }
+        const action = classifyError(error, copy);
+        applyAddCollectionAction(
+          action,
+          {
+            setInlineErrorAndStop: modal.setInlineErrorAndStop,
+            resetAddModal: modal.reset,
+            stopSubmitting: modal.stopSubmitting,
+          },
+          show,
+          triggerRefetch,
+        );
+      });
+
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
+    // `value` é capturado no instante em que `isSubmitting` vira
+    // `true`; subsequentes keystrokes não disparam novo submit
+    // (`isSubmitting=true` só vira `false` ao terminar).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitting, clientId, client, show, triggerRefetch]);
+}

--- a/src/pages/clients/useClientCollectionRemoveSubmit.ts
+++ b/src/pages/clients/useClientCollectionRemoveSubmit.ts
@@ -1,0 +1,165 @@
+import { useCallback } from 'react';
+
+import {
+  applyRemoveCollectionAction,
+  type ApplyRemoveCollectionAction,
+} from './applyCollectionMutationAction';
+
+import type { ApiClient, SafeRequestOptions } from '../../shared/api';
+
+/**
+ * Side-effect imperativo para toast (abstrai `useToast().show`).
+ */
+type ShowToast = (
+  message: string,
+  options: { variant: 'success' | 'danger' | 'info'; title?: string },
+) => void;
+
+interface RemoveCopy {
+  genericFallback: string;
+  forbiddenTitle: string;
+  notFoundMessage: string;
+}
+
+/**
+ * Subset do `useClientRemoveCollectionConfirm` que este hook precisa
+ * para aplicar a ação. Aceita interface mínima — caller injeta os
+ * dispatchers vindos do hook concreto.
+ */
+interface RemoveConfirmDispatchers {
+  reset: () => void;
+  beginSubmit: () => void;
+  stopSubmitting: () => void;
+}
+
+interface UseClientCollectionRemoveSubmitArgs<TAction> {
+  /** Cliente HTTP injetável (default = singleton). */
+  client?: ApiClient;
+  /**
+   * Função API que faz o DELETE efetivo. Recebe `clientId`, `itemId`,
+   * `options`, `client`. Tipicamente `removeClientExtraEmail`,
+   * `removeClientMobilePhone`, etc.
+   */
+  removeFn: (
+    clientId: string,
+    itemId: string,
+    options?: SafeRequestOptions,
+    client?: ApiClient,
+  ) => Promise<void>;
+  /**
+   * Classifier que converte `unknown` lançado por `removeFn` em
+   * `TAction` discriminado. `TAction` deve incluir as variantes
+   * comuns (`not-found`/`toast`/`unhandled`) — caller pode estender
+   * com casos próprios (ex.: `username` no email).
+   */
+  classifyError: (error: unknown, copy: RemoveCopy) => TAction;
+  /** Cópia injetada no classifier (mensagens em pt-BR). */
+  copy: RemoveCopy;
+  /** Toast exibido em caso de sucesso. */
+  successToast: string;
+  /** Dispatchers do confirm (vindo de `useClientRemoveCollectionConfirm`). */
+  confirm: RemoveConfirmDispatchers;
+  /** Callback `useToast().show` injetado pelo caller. */
+  show: ShowToast;
+  /** Função para refazer o fetch após sucesso/not-found. */
+  triggerRefetch: () => void;
+}
+
+/**
+ * Resultado retornado pelo hook — função `submit` que o caller chama
+ * passando `clientId` + `itemId` + opcional handler para casos
+ * específicos do classifier (ex.: `username` no email).
+ */
+export interface UseClientCollectionRemoveSubmitResult<TAction> {
+  /**
+   * Executa o DELETE e mapeia o resultado. Retorna `Promise<void>` —
+   * o caller pode `await` se precisar de side-effects depois.
+   *
+   * `customAction` é chamado com a ação classificada **antes** do
+   * fluxo padrão. Se retornar `true`, o hook entende que o caller
+   * tratou e não delega ao `applyRemoveCollectionAction`. Se retornar
+   * `false` (ou ausente), o hook trata os casos comuns (`not-found`/
+   * `toast`/`unhandled`) automaticamente.
+   *
+   * **Por que esse padrão?** O `removeClientExtraEmail` tem um caso
+   * extra `username` (400 com mensagem orientadora — toast vermelho)
+   * que não existe em `removeClientMobilePhone`/`removeClientLandlinePhone`.
+   * Em vez de duplicar todo o handler para gerenciar essa única
+   * variante, o caller passa `customAction` que intercepta o caso
+   * específico.
+   */
+  submit: (
+    clientId: string,
+    itemId: string,
+    customAction?: (action: TAction) => boolean,
+  ) => Promise<void>;
+}
+
+/**
+ * Hook compartilhado que encapsula `try`/`catch` do DELETE para os
+ * removes de coleções de cliente.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** o `handleConfirmRemove`
+ * de ambas as abas (`ClientExtraEmailsTab` — #146 e `ClientPhonesTab`
+ * — #147) tinha ~20 linhas idênticas (`beginSubmit` → `await removeFn`
+ * → `show` success → `reset` → `triggerRefetch` no try; `classify` →
+ * `applyRemoveCollectionAction` no catch). Sonar/JSCPD tokenizava
+ * como bloco duplicado entre arquivos. Promover para hook deduplica.
+ *
+ * **Compatibilidade com classifier estendido:** o classifier do email
+ * inclui `username` (400 orientadora) que o phone não tem. O type
+ * `TAction` é union ampla — caller passa `customAction` que
+ * intercepta variantes próprias antes de cair no fluxo padrão.
+ */
+export function useClientCollectionRemoveSubmit<TAction>({
+  client,
+  removeFn,
+  classifyError,
+  copy,
+  successToast,
+  confirm,
+  show,
+  triggerRefetch,
+}: UseClientCollectionRemoveSubmitArgs<TAction>): UseClientCollectionRemoveSubmitResult<TAction> {
+  const submit = useCallback(
+    async (
+      clientId: string,
+      itemId: string,
+      customAction?: (action: TAction) => boolean,
+    ): Promise<void> => {
+      confirm.beginSubmit();
+      try {
+        await removeFn(clientId, itemId, undefined, client);
+        show(successToast, { variant: 'success' });
+        confirm.reset();
+        triggerRefetch();
+      } catch (error: unknown) {
+        const action = classifyError(error, copy);
+        // Caller pode interceptar variantes próprias do classifier
+        // antes do fluxo padrão. Quando `customAction` consome a
+        // ação (retorna `true`), encerramos sem delegar ao
+        // `applyRemoveCollectionAction`.
+        if (customAction !== undefined && customAction(action)) {
+          return;
+        }
+        // Cast seguro — `customAction` intercepta variantes próprias
+        // do classifier (ex.: `username` no email); o fluxo padrão
+        // recebe apenas o subset coberto por `applyRemoveCollectionAction`
+        // (`not-found`/`toast`/`unhandled`). Caller é responsável por
+        // garantir esse contrato no `customAction`.
+        applyRemoveCollectionAction(
+          action as unknown as ApplyRemoveCollectionAction,
+          {
+            resetRemoveConfirm: confirm.reset,
+            stopSubmitting: confirm.stopSubmitting,
+          },
+          show,
+          triggerRefetch,
+        );
+      }
+    },
+    [client, classifyError, confirm, copy, removeFn, show, successToast, triggerRefetch],
+  );
+
+  return { submit };
+}

--- a/src/pages/clients/useClientRemoveCollectionConfirm.ts
+++ b/src/pages/clients/useClientRemoveCollectionConfirm.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Estado controlado do confirm de remoção compartilhado entre
+ * `ClientExtraEmailsTab` (#146) e `ClientPhonesTab` (#147).
+ *
+ * `target` é genérico — cada caller passa seu DTO concreto via
+ * `RemoveCollectionConfirmState<T>` instanciado.
+ */
+export interface RemoveCollectionConfirmState<T> {
+  target: T | null;
+  isSubmitting: boolean;
+}
+
+export interface UseClientRemoveCollectionConfirmResult<T> {
+  /** Estado corrente — caller passa para o `<ClientCollectionRemoveConfirmModal>`. */
+  state: RemoveCollectionConfirmState<T>;
+  /** Abre o confirm com o `target` selecionado. */
+  open: (target: T) => void;
+  /** Fecha o confirm (cancelar/ESC/backdrop). No-op enquanto `isSubmitting`. */
+  close: () => void;
+  /**
+   * Marca `isSubmitting=true` se ainda não está submetendo. Usado
+   * antes de chamar a função de remoção para garantir que o spinner
+   * apareça e o handler ignore submits duplicados.
+   */
+  beginSubmit: () => void;
+  /** Reseta para o estado inicial — usado no caminho de sucesso. */
+  reset: () => void;
+  /** Apenas desliga `isSubmitting` (mantém confirm aberto) — caso `toast`. */
+  stopSubmitting: () => void;
+}
+
+/**
+ * Hook compartilhado que encapsula o `useState` + handlers do
+ * confirm de remoção.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** ambas as abas
+ * tinham o mesmo conjunto de callbacks (`handleOpenRemoveConfirm`,
+ * `handleCloseRemoveConfirm`, transição `isSubmitting=true`/`false`)
+ * — JSCPD tokenizava ~13 linhas como bloco duplicado. Promover para
+ * hook compartilhado deduplica e expõe uma API declarativa.
+ */
+export function useClientRemoveCollectionConfirm<T>(): UseClientRemoveCollectionConfirmResult<T> {
+  const initialState: RemoveCollectionConfirmState<T> = {
+    target: null,
+    isSubmitting: false,
+  };
+  const [state, setState] = useState<RemoveCollectionConfirmState<T>>(initialState);
+
+  const open = useCallback((target: T) => {
+    setState({ target, isSubmitting: false });
+  }, []);
+
+  const close = useCallback(() => {
+    setState((prev) => (prev.isSubmitting ? prev : { target: null, isSubmitting: false }));
+  }, []);
+
+  const beginSubmit = useCallback(() => {
+    setState((prev) => (prev.isSubmitting ? prev : { ...prev, isSubmitting: true }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({ target: null, isSubmitting: false });
+  }, []);
+
+  const stopSubmitting = useCallback(() => {
+    setState((prev) => ({ ...prev, isSubmitting: false }));
+  }, []);
+
+  return {
+    state,
+    open,
+    close,
+    beginSubmit,
+    reset,
+    stopSubmitting,
+  };
+}

--- a/src/shared/api/clients.ts
+++ b/src/shared/api/clients.ts
@@ -837,6 +837,169 @@ export async function addClientExtraEmail(
 }
 
 /**
+ * Limite máximo de telefones (celular **ou** fixo) por cliente —
+ * espelha a regra `if (count >= 3)` do
+ * `ClientsController.AddPhoneInternal` no `lfc-authenticator`. O backend
+ * valida a regra **por tipo** (3 celulares + 3 fixos por cliente),
+ * então este teto é compartilhado pelas duas abas (mobiles/landlines)
+ * — `ClientPhonesTab` injeta o tipo e o limite vale isoladamente em
+ * cada lista. Centralizar evita literais mágicos e mantém a UI alinhada
+ * com a fonte da verdade do backend (lição PR #128 — projetar shared
+ * helpers desde o primeiro PR do recurso).
+ */
+export const MAX_CLIENT_PHONES_PER_TYPE = 3;
+
+/**
+ * Adiciona um celular ao cliente via `POST /clients/{id}/mobiles`
+ * (Issue #147).
+ *
+ * Retorna o `ClientPhoneDto` recém-criado (`200 OK` com
+ * `ClientPhoneResponse` no corpo). Lança `ApiError` em qualquer
+ * falha — caller tipicamente trata:
+ *
+ * - `kind: 'http'` com `status === 400` →
+ *   - `"Telefone inválido. Use o formato internacional com DDI e
+ *     DDD, ex.: +5518981789845."` quando o backend rejeita o formato
+ *     E.164. A UI já valida client-side com a mesma regex, então
+ *     este caso é defensivo.
+ *   - `"Limite de 3 celulares por cliente."` quando o cliente já tem
+ *     o teto. UI desabilita o botão "Adicionar" preventivamente
+ *     (`MAX_CLIENT_PHONES_PER_TYPE`); o branch fica defensivo para
+ *     race entre abertura do form e submit por outra sessão.
+ * - `kind: 'http'` com `status === 409` →
+ *   `"Contato já cadastrado para este cliente."` quando o número já
+ *   existe na lista deste cliente para o mesmo tipo. Mensagem inline.
+ * - `kind: 'http'` com `status === 404` → cliente não encontrado
+ *   (soft-deletado entre carregamento da página e submit). UI dispara
+ *   toast vermelho e força refetch.
+ * - `kind: 'http'` com `status === 401`/`403` → toast vermelho com
+ *   mensagem do backend (cliente HTTP cuida do redirect 401).
+ * - Demais → toast vermelho com mensagem genérica.
+ *
+ * O backend **trima** o número no servidor (`Number.Trim()`); a UI
+ * envia já trimado para que asserts em testes consumam o literal sem
+ * espaços e o feedback visual coincida com o que o servidor persistiu.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ */
+export async function addClientMobilePhone(
+  clientId: string,
+  number: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientPhoneDto> {
+  const data = await client.post<unknown>(
+    `/clients/${clientId}/mobiles`,
+    { number },
+    options,
+  );
+  if (!isClientPhoneDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Remove um celular do cliente via
+ * `DELETE /clients/{id}/mobiles/{phoneId}` (Issue #147).
+ *
+ * Retorna `void` (`204 No Content`). Lança `ApiError` em qualquer
+ * falha — caller tipicamente trata:
+ *
+ * - `kind: 'http'` com `status === 404` → contato não pertence ao
+ *   cliente (id já removido por outra sessão entre abertura e submit,
+ *   ou tipo divergente). UI dispara toast vermelho e força refetch
+ *   para sincronizar a lista.
+ * - `kind: 'http'` com `status === 401`/`403` → toast vermelho com
+ *   mensagem do backend.
+ * - Demais → toast vermelho com mensagem genérica.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um
+ * stub tipado como `ApiClient`); em produção usa-se o singleton
+ * `apiClient`.
+ */
+export async function removeClientMobilePhone(
+  clientId: string,
+  phoneId: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(
+    `/clients/${clientId}/mobiles/${phoneId}`,
+    options,
+  );
+}
+
+/**
+ * Adiciona um telefone fixo ao cliente via `POST /clients/{id}/phones`
+ * (Issue #147).
+ *
+ * Espelha exatamente o contrato de `addClientMobilePhone` — o backend
+ * usa o mesmo `AddPhoneRequest` (`{ number }`) e dispara o mesmo
+ * `AddPhoneInternal`, divergindo apenas no `Type` (mobile vs landline)
+ * registrado no banco e na mensagem de limite (`"Limite de 3 telefones
+ * por cliente."` em vez de `celulares`). Manter wrappers separados em
+ * vez de parametrizar pelo tipo torna o call site mais legível
+ * (`addClientLandlinePhone` deixa explícito o que está sendo feito) e
+ * evita acoplar todos os call sites a uma string literal "mobile" /
+ * "phone" que poderia variar com o backend.
+ *
+ * Tratamento de erros idêntico ao `addClientMobilePhone`. Ver doc
+ * naquele helper para detalhes; aqui resumimos:
+ *
+ * - 400 `"Telefone inválido..."` ou `"Limite de 3 telefones por
+ *   cliente."` (defensivo).
+ * - 409 `"Contato já cadastrado para este cliente."`.
+ * - 404 cliente removido.
+ * - 401/403 sessão/permissão.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function addClientLandlinePhone(
+  clientId: string,
+  number: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ClientPhoneDto> {
+  const data = await client.post<unknown>(
+    `/clients/${clientId}/phones`,
+    { number },
+    options,
+  );
+  if (!isClientPhoneDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Remove um telefone fixo do cliente via
+ * `DELETE /clients/{id}/phones/{phoneId}` (Issue #147).
+ *
+ * Espelha exatamente o contrato de `removeClientMobilePhone` — o
+ * backend usa o mesmo `RemovePhoneInternal`, divergindo apenas no
+ * filtro `Type` aplicado ao buscar o registro. Tratamento de erros
+ * idêntico.
+ *
+ * O parâmetro `client` é injetável para isolar testes; em produção
+ * usa-se o singleton `apiClient`.
+ */
+export async function removeClientLandlinePhone(
+  clientId: string,
+  phoneId: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(
+    `/clients/${clientId}/phones/${phoneId}`,
+    options,
+  );
+}
+
+/**
  * Remove um email extra de um cliente via
  * `DELETE /clients/{id}/emails/{emailId}` (Issue #146).
  *

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -141,6 +141,8 @@ export type {
 } from './roles';
 export {
   addClientExtraEmail,
+  addClientLandlinePhone,
+  addClientMobilePhone,
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_INCLUDE_DELETED,
@@ -153,7 +155,10 @@ export {
   isPagedClientsResponse,
   listClients,
   MAX_CLIENT_EXTRA_EMAILS,
+  MAX_CLIENT_PHONES_PER_TYPE,
   removeClientExtraEmail,
+  removeClientLandlinePhone,
+  removeClientMobilePhone,
   restoreClient,
   updateClient,
 } from './clients';

--- a/src/shared/forms/classifySharedHttpError.ts
+++ b/src/shared/forms/classifySharedHttpError.ts
@@ -1,0 +1,192 @@
+import { isApiError } from '../api';
+
+/**
+ * Cópia genérica usada por `classifySharedHttpError` para parametrizar
+ * mensagens. Os módulos consumidores (ex.: `clientPhonesHelpers`,
+ * `clientExtraEmailsHelpers`) re-exportam tipos `*ErrorCopy` mais
+ * específicos que estendem este shape — preserva clareza no call-site
+ * sem acoplar `classifySharedHttpError` aos tipos do consumer.
+ */
+export interface SharedHttpErrorCopy {
+  /**
+   * Mensagem genérica usada quando o erro não é classificável
+   * (`network`/`parse`/5xx/HTTP fora dos casos esperados). Exibida
+   * em toast vermelho.
+   */
+  genericFallback: string;
+  /**
+   * Título do toast vermelho exibido para 401/403/network/parse —
+   * dá hierarquia visual ao operador identificar o tipo do erro.
+   */
+  forbiddenTitle: string;
+  /**
+   * Mensagem específica para o 404 (recurso já removido entre
+   * abertura e submit). Exibida em toast vermelho + força refetch.
+   */
+  notFoundMessage: string;
+}
+
+/**
+ * Ação compartilhada decorrente da classificação de erro HTTP.
+ * Cobre os casos comuns a todos os fluxos de mutação simples
+ * (404, 401/403, fallback) — call sites específicos (add email,
+ * add telefone, etc.) ramificam em variantes próprias para 400/409
+ * antes de cair aqui.
+ *
+ * - `not-found` → recurso já removido (404). Caller fecha modal +
+ *   refetch + toast.
+ * - `toast` → 401/403 com mensagem do backend.
+ * - `unhandled` → fallback (network/parse/5xx/HTTP fora dos casos
+ *   esperados). Toast vermelho com `genericFallback`.
+ */
+export type SharedHttpErrorAction =
+  | { kind: 'not-found'; message: string; title: string }
+  | { kind: 'toast'; message: string; title: string }
+  | { kind: 'unhandled'; message: string; title: string };
+
+/**
+ * Classifica os casos comuns de erro HTTP em uma ação discriminada.
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** os módulos
+ * `clientExtraEmailsHelpers` (#146) e `clientPhonesHelpers` (#147)
+ * faziam o mesmo branching (~15 linhas: type guard `isApiError`,
+ * checks `status === 404`, `=== 401`, `=== 403`, fallback
+ * `unhandled`). Sonar/JSCPD tokenizam isso como bloco duplicado
+ * entre arquivos. Promover para `src/shared/forms/` deduplica e abre
+ * caminho para o terceiro consumidor (futuras coleções de Cliente
+ * ou outras entidades) sem refator destrutivo.
+ *
+ * **Casos cobertos:**
+ *
+ * - Erro não-HTTP (network/parse/string solta) → `unhandled` com
+ *   `genericFallback`.
+ * - 404 → `not-found` com `notFoundMessage` da copy + título do
+ *   toast.
+ * - 401/403 → `toast` com mensagem do backend (ou `genericFallback`
+ *   se vazia).
+ * - 400/409 → `null` (caller resolve com lógica específica antes de
+ *   cair no fallback `unhandled`).
+ *
+ * Mantemos retorno tipado como união ampla para que o caller faça
+ * `narrowing` no kind sem precisar re-classificar — TypeScript infere
+ * o subset depois do `if`.
+ *
+ * @returns Ação compartilhada quando o erro casa um dos casos
+ *          comuns; `null` quando o caller precisa decidir
+ *          (tipicamente status 400/409 com semântica específica do
+ *          endpoint).
+ */
+export function classifySharedHttpError(
+  error: unknown,
+  copy: SharedHttpErrorCopy,
+): SharedHttpErrorAction | null {
+  if (!isApiError(error) || error.kind !== 'http') {
+    return {
+      kind: 'unhandled',
+      message: copy.genericFallback,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (error.status === 404) {
+    return {
+      kind: 'not-found',
+      message: copy.notFoundMessage,
+      title: copy.forbiddenTitle,
+    };
+  }
+  if (error.status === 401 || error.status === 403) {
+    return {
+      kind: 'toast',
+      message: error.message || copy.genericFallback,
+      title: copy.forbiddenTitle,
+    };
+  }
+  // 400/409 são specific-by-endpoint — caller resolve antes de cair
+  // no fallback comum.
+  return null;
+}
+
+/**
+ * Fallback `unhandled` reusado quando nenhum caso específico cobre
+ * o erro. Centralizar evita que a estrutura
+ * `{ kind: 'unhandled', message, title }` apareça duplicada em cada
+ * call site e dispare detecção de duplicação no Sonar/JSCPD.
+ */
+export function unhandledHttpAction(
+  copy: SharedHttpErrorCopy,
+): SharedHttpErrorAction {
+  return {
+    kind: 'unhandled',
+    message: copy.genericFallback,
+    title: copy.forbiddenTitle,
+  };
+}
+
+/**
+ * Subset estendido de `SharedHttpErrorAction` que cobre o classifier
+ * de **add** (add email, add telefone): adiciona `inline` (400/409
+ * com mensagem específica do endpoint) e `limit-reached` (400 com
+ * "limite" — caller faz refetch).
+ *
+ * Retornado por `classifyAddCollectionApiError` para que ambos os
+ * call sites (`classifyAddExtraEmailError` e `classifyAddPhoneError`)
+ * deleguem a um helper único e zerem a duplicação que vivia nos dois
+ * arquivos.
+ */
+export type AddCollectionApiAction =
+  | SharedHttpErrorAction
+  | { kind: 'inline'; message: string }
+  | { kind: 'limit-reached'; message: string };
+
+/**
+ * Classifica erro do POST de adicionar item em uma coleção de cliente
+ * (add email / add telefone). Engloba `classifySharedHttpError` +
+ * branching específico de 400/409 que estava duplicado em
+ * `clientExtraEmailsHelpers` e `clientPhonesHelpers`.
+ *
+ * **Casos cobertos:**
+ *
+ * - 400 com mensagem contendo "limite" → `limit-reached`. Caller
+ *   exibe inline e refetch (race com outra sessão).
+ * - 400 com qualquer outra mensagem → `inline`. Tipicamente
+ *   formato/contrato inválido (validação client-side já cobriu;
+ *   defensivo).
+ * - 409 → `inline` com a mensagem do backend.
+ * - 404/401/403/network/parse → delega ao `classifySharedHttpError`
+ *   (mesmas variantes `not-found`/`toast`/`unhandled`).
+ *
+ * **Por que extraído (lição PR #128/#134/#135):** `classifyAddPhoneError`
+ * e `classifyAddExtraEmailError` faziam ~27 linhas idênticas (switch
+ * 400/409 + `unhandledHttpAction`). Sonar/JSCPD tokenizava como bloco
+ * duplicado entre os dois arquivos. Promover deduplica e abre caminho
+ * para um terceiro consumidor (futuras coleções) sem refator
+ * destrutivo.
+ */
+export function classifyAddCollectionApiError(
+  error: unknown,
+  copy: SharedHttpErrorCopy,
+): AddCollectionApiAction {
+  const shared = classifySharedHttpError(error, copy);
+  if (shared !== null) {
+    return shared;
+  }
+  // `shared === null` significa que `error` é HTTP com `status` que
+  // exige decisão específica do `add` (400/409). Reabrimos o type
+  // guard porque o refinamento do `classifySharedHttpError` se
+  // perde no retorno.
+  if (!isApiError(error) || error.kind !== 'http') {
+    return unhandledHttpAction(copy);
+  }
+  if (error.status === 400) {
+    const message = error.message || copy.genericFallback;
+    if (message.toLowerCase().includes('limite')) {
+      return { kind: 'limit-reached', message };
+    }
+    return { kind: 'inline', message };
+  }
+  if (error.status === 409) {
+    const message = error.message || copy.genericFallback;
+    return { kind: 'inline', message };
+  }
+  return unhandledHttpAction(copy);
+}

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -21,6 +21,14 @@ export {
   type ApiSubmitErrorCopy,
 } from "./classifySubmitError";
 export {
+  classifyAddCollectionApiError,
+  classifySharedHttpError,
+  unhandledHttpAction,
+  type AddCollectionApiAction,
+  type SharedHttpErrorAction,
+  type SharedHttpErrorCopy,
+} from "./classifySharedHttpError";
+export {
   computeIdSetDiff,
   idSetDiffHasChanges,
   type IdSetDiff,

--- a/tests/pages/__helpers__/clientsTestHelpers.tsx
+++ b/tests/pages/__helpers__/clientsTestHelpers.tsx
@@ -7,6 +7,7 @@ import type {
   ApiError,
   ClientDto,
   ClientEmailDto,
+  ClientPhoneDto,
   PagedResponse,
 } from '@/shared/api';
 
@@ -657,6 +658,52 @@ export async function submitAddExtraEmailForm(
 ): Promise<void> {
   await act(async () => {
     fireEvent.submit(screen.getByTestId('client-extra-emails-add-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));
+}
+
+/* ─── Helpers de fluxo do `ClientPhonesTab` (Issue #147) ── */
+
+/**
+ * Constrói um `ClientPhoneDto` com defaults — testes só sobrescrevem o
+ * que importa para o cenário sem repetir todos os campos do contrato.
+ *
+ * O `id` default é um UUID sintético claramente identificável; cenários
+ * que precisem de ids estáveis para asserts reusam essa fixture
+ * passando o `id` próprio. O `number` default é E.164 válido brasileiro
+ * (espelha o exemplo da mensagem do backend `+5518981789845`) para
+ * evitar test data que casualmente inválida a regex E.164 e mascararia
+ * cenários reais.
+ */
+export function makeClientPhone(overrides: Partial<ClientPhoneDto> = {}): ClientPhoneDto {
+  return {
+    id: 'p0000000-0000-0000-0000-000000000001',
+    number: '+5518981789845',
+    createdAt: '2026-02-15T12:00:00Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Submete o form do modal de adicionar telefone (mobile ou landline)
+ * no `ClientPhonesTab` e aguarda o `client.post` ser chamado pelo menos
+ * `expectedPostCalls` vezes (default `1`). Faz `act(async)` para
+ * flushar a microtask do submit antes do `waitFor`. Espelha
+ * `submitAddExtraEmailForm` para o caminho do modal de adicionar
+ * telefone.
+ *
+ * O `testIdPrefix` (`client-mobile-phones` ou `client-landline-phones`)
+ * é injetado pelo caller para evitar que a suíte tenha que duplicar a
+ * lógica de submit por aba — um único helper cobre as duas variantes.
+ */
+export async function submitAddPhoneForm(
+  client: ApiClientStub,
+  testIdPrefix: string,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId(`${testIdPrefix}-add-form`));
     await Promise.resolve();
   });
   await waitFor(() => expect(client.post).toHaveBeenCalledTimes(expectedPostCalls));

--- a/tests/pages/clients/ClientPhonesTab.test.tsx
+++ b/tests/pages/clients/ClientPhonesTab.test.tsx
@@ -1,0 +1,731 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import {
+  buildAuthMock,
+  setupPermissionLifecycle,
+} from '../__helpers__/mockUseAuth';
+import {
+  createClientsClientStub,
+  ID_CLIENT_PF_ANA,
+  makeClient,
+  makeClientPhone,
+  submitAddPhoneForm,
+} from '../__helpers__/clientsTestHelpers';
+import type { ApiClientStub } from '../__helpers__/clientsTestHelpers';
+import { ToastProvider } from '@/components/ui';
+import {
+  ClientPhonesTab,
+  type ClientPhoneKind,
+} from '@/pages/clients/ClientPhonesTab';
+/* eslint-enable import/order */
+
+/**
+ * Suíte do `ClientPhonesTab` (Issue #147 — gerenciar celulares e
+ * telefones fixos).
+ *
+ * Estratégia espelha `ClientExtraEmailsTab.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` para alternar `AUTH_V1_CLIENTS_UPDATE`
+ *   entre testes.
+ * - Stub de `ApiClient` injetado em
+ *   `<ClientPhonesTab kind={kind} client={stub} />`, isolando da
+ *   camada de transporte real.
+ * - Testes parametrizados por `kind` (`mobile` | `landline`) via
+ *   `describe.each` — uma única suíte cobre as duas variantes,
+ *   trocando endpoint/copy/coleção pelo `KIND_CONFIG`. Lição PR
+ *   #128/#134/#135 — quando o mesmo componente é renderizado com
+ *   variações de prop, parametrizar a suíte evita duplicação Sonar
+ *   entre arquivos paralelos por aba.
+ *
+ * Cobre (critérios da issue):
+ *
+ * - Lista os telefones existentes (vindos em `ClientResponse.mobilePhones`/
+ *   `landlinePhones`).
+ * - Botão "Adicionar" abre modal com input + validação client-side
+ *   E.164.
+ * - Botão de remover por linha; confirmação antes.
+ * - Mapeamento dos erros do backend (400 limite, 400 inválido, 409
+ *   duplicado, 404).
+ * - Refetch após sucesso.
+ * - Botão "Adicionar" desabilitado quando lista atinge 3.
+ * - Visível com `Clients.Update` (modo readonly sem permissão).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const CLIENTS_UPDATE_PERMISSION = 'AUTH_V1_CLIENTS_UPDATE';
+
+setupPermissionLifecycle((perms) => {
+  permissionsMock = perms;
+}, [CLIENTS_UPDATE_PERMISSION]);
+
+/**
+ * Configuração por aba — endpoint POST/DELETE, prefixo de testId,
+ * mensagens de limite/duplicado, coleção alvo no `ClientDto`. A suíte
+ * itera sobre essa tabela com `describe.each` para cobrir as duas
+ * variantes sem duplicar 100+ linhas de testes paralelos.
+ *
+ * Espelha o `PHONE_KIND_CONFIG` da implementação mas só com o que a
+ * suíte precisa — endpoint, prefix, copy de toast/limit, e a chave da
+ * coleção do `ClientDto` para que o stub do GET preencha o array
+ * correto.
+ */
+interface KindConfig {
+  kind: ClientPhoneKind;
+  testIdPrefix: string;
+  endpointAdd: string;
+  endpointRemoveSuffix: string;
+  collectionKey: 'mobilePhones' | 'landlinePhones';
+  addSuccessToast: string;
+  removeSuccessToast: string;
+  limitMessage: string;
+  emptyTitle: string;
+  limitAlertText: RegExp;
+  addButtonName: RegExp;
+}
+
+const KIND_CONFIGS: ReadonlyArray<KindConfig> = [
+  {
+    kind: 'mobile',
+    testIdPrefix: 'client-mobile-phones',
+    endpointAdd: `/clients/${ID_CLIENT_PF_ANA}/mobiles`,
+    endpointRemoveSuffix: 'mobiles',
+    collectionKey: 'mobilePhones',
+    addSuccessToast: 'Celular adicionado.',
+    removeSuccessToast: 'Celular removido.',
+    limitMessage: 'Limite de 3 celulares por cliente.',
+    emptyTitle: 'Nenhum celular cadastrado',
+    limitAlertText: /Limite de 3 celulares atingido/i,
+    addButtonName: /Adicionar celular/i,
+  },
+  {
+    kind: 'landline',
+    testIdPrefix: 'client-landline-phones',
+    endpointAdd: `/clients/${ID_CLIENT_PF_ANA}/phones`,
+    endpointRemoveSuffix: 'phones',
+    collectionKey: 'landlinePhones',
+    addSuccessToast: 'Telefone adicionado.',
+    removeSuccessToast: 'Telefone removido.',
+    limitMessage: 'Limite de 3 telefones por cliente.',
+    emptyTitle: 'Nenhum telefone fixo cadastrado',
+    limitAlertText: /Limite de 3 telefones fixos atingido/i,
+    addButtonName: /Adicionar telefone/i,
+  },
+];
+
+/**
+ * Renderiza o `ClientPhonesTab` num `<MemoryRouter>` com a rota
+ * `/clientes/:id` para que `useParams` devolva o `id` esperado.
+ */
+function renderClientPhonesTab(
+  kind: ClientPhoneKind,
+  client: ApiClientStub,
+  initialEntries: ReadonlyArray<string> = [`/clientes/${ID_CLIENT_PF_ANA}`],
+): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={[...initialEntries]}>
+        <Routes>
+          <Route
+            path="/clientes/:id"
+            element={<ClientPhonesTab kind={kind} client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda o fetch inicial completar (loading some, conteúdo aparece).
+ */
+async function waitForLoaded(testIdPrefix: string): Promise<void> {
+  await waitFor(() => {
+    expect(
+      screen.queryByTestId(`${testIdPrefix}-loading`),
+    ).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Abre o modal de adicionar e preenche o input com `value`. O modal
+ * abre via clique no botão "Adicionar", que precisa estar habilitado
+ * (cliente abaixo do limite) — caller garante isso via mock do
+ * `getClientById`.
+ */
+function openAddModalAndFill(testIdPrefix: string, value: string): void {
+  fireEvent.click(screen.getByTestId(`${testIdPrefix}-add`));
+  fireEvent.change(screen.getByTestId(`${testIdPrefix}-add-number`), {
+    target: { value },
+  });
+}
+
+/**
+ * Constrói um cliente com 1 telefone do tipo correto pré-cadastrado
+ * e configura o stub para devolver esse cliente no GET inicial.
+ * Centralizar evita repetir o trio "makeClientPhone + makeClient +
+ * mockResolvedValueOnce" em cada teste de remoção.
+ */
+function setupSinglePhoneScene(config: KindConfig): {
+  client: ApiClientStub;
+  phone: ReturnType<typeof makeClientPhone>;
+} {
+  const phone = makeClientPhone({
+    id: 'p0000000-0000-0000-0000-0000000000aa',
+    number: '+5518981789845',
+  });
+  const dto = makeClient({ [config.collectionKey]: [phone] });
+  const client = createClientsClientStub();
+  client.get.mockResolvedValueOnce(dto);
+  return { client, phone };
+}
+
+/**
+ * Variante de `setupSinglePhoneScene` que abre a confirmação de
+ * remoção logo após o load. Usado pelos testes que disparam ações
+ * subsequentes (confirm, cancel, error).
+ */
+async function setupSinglePhoneRemoveConfirm(config: KindConfig): Promise<{
+  client: ApiClientStub;
+  phone: ReturnType<typeof makeClientPhone>;
+}> {
+  const scene = setupSinglePhoneScene(config);
+  renderClientPhonesTab(config.kind, scene.client);
+  await waitForLoaded(config.testIdPrefix);
+  fireEvent.click(
+    screen.getByTestId(`${config.testIdPrefix}-remove-${scene.phone.id}`),
+  );
+  return scene;
+}
+
+/* ─── Suíte parametrizada por kind (mobile/landline) ──────── */
+
+describe.each(KIND_CONFIGS)(
+  'ClientPhonesTab — kind=$kind (Issue #147)',
+  (config) => {
+    describe('fetch inicial e estados visuais', () => {
+      it('exibe spinner durante o GET /clients/{id}', () => {
+        const client = createClientsClientStub();
+        client.get.mockReturnValueOnce(new Promise(() => {
+          // intencional: nunca resolve
+        }));
+
+        renderClientPhonesTab(config.kind, client);
+
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-loading`),
+        ).toBeInTheDocument();
+        expect(client.get).toHaveBeenCalledWith(
+          `/clients/${ID_CLIENT_PF_ANA}`,
+          expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+      });
+
+      it('exibe ErrorRetryBlock quando o fetch falha (rede)', async () => {
+        const client = createClientsClientStub();
+        client.get.mockRejectedValueOnce({
+          kind: 'network',
+          message: 'Falha de conexão.',
+        });
+
+        renderClientPhonesTab(config.kind, client);
+
+        expect(
+          await screen.findByTestId(`${config.testIdPrefix}-retry`),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText('Não foi possível carregar os dados do cliente.'),
+        ).toBeInTheDocument();
+      });
+
+      it('clicar em "Tentar novamente" refaz o GET', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockRejectedValueOnce({
+          kind: 'network',
+          message: 'Falha.',
+        });
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        const retryBtn = await screen.findByTestId(
+          `${config.testIdPrefix}-retry`,
+        );
+        fireEvent.click(retryBtn);
+
+        await waitForLoaded(config.testIdPrefix);
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+
+      it('renderiza empty state quando o cliente não tem telefones', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-empty`),
+        ).toBeInTheDocument();
+        expect(screen.getByText(config.emptyTitle)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-counter`),
+        ).toHaveTextContent('0 de 3 cadastrados');
+      });
+
+      it('renderiza linha por telefone retornado em ClientResponse', async () => {
+        const phoneA = makeClientPhone({
+          id: 'p0000000-0000-0000-0000-0000000000aa',
+          number: '+5518981789845',
+        });
+        const phoneB = makeClientPhone({
+          id: 'p0000000-0000-0000-0000-0000000000bb',
+          number: '+551832345678',
+        });
+        const dto = makeClient({ [config.collectionKey]: [phoneA, phoneB] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-row-${phoneA.id}`),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-row-${phoneB.id}`),
+        ).toBeInTheDocument();
+        expect(screen.getByText('+5518981789845')).toBeInTheDocument();
+        expect(screen.getByText('+551832345678')).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-counter`),
+        ).toHaveTextContent('2 de 3 cadastrados');
+      });
+    });
+
+    describe('adicionar telefone', () => {
+      it('botão "Adicionar" abre o modal com input vazio', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        fireEvent.click(screen.getByTestId(`${config.testIdPrefix}-add`));
+
+        const input = screen.getByTestId(
+          `${config.testIdPrefix}-add-number`,
+        ) as HTMLInputElement;
+        expect(input).toBeInTheDocument();
+        expect(input.value).toBe('');
+      });
+
+      it('número com formato inválido bloqueia submit e exibe erro inline (sem +)', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '18981789845');
+        fireEvent.submit(
+          screen.getByTestId(`${config.testIdPrefix}-add-form`),
+        );
+
+        expect(
+          screen.getByText(
+            'Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+          ),
+        ).toBeInTheDocument();
+        expect(client.post).not.toHaveBeenCalled();
+      });
+
+      it('input vazio (whitespace) bloqueia submit e exibe erro inline', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '   ');
+        fireEvent.submit(
+          screen.getByTestId(`${config.testIdPrefix}-add-form`),
+        );
+
+        expect(screen.getByText('Número é obrigatório.')).toBeInTheDocument();
+        expect(client.post).not.toHaveBeenCalled();
+      });
+
+      it('submit válido envia POST no endpoint correto com body trimado', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const updated = makeClient({
+          [config.collectionKey]: [
+            makeClientPhone({ number: '+5518981789845' }),
+          ],
+        });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+        client.post.mockResolvedValueOnce(
+          makeClientPhone({ number: '+5518981789845' }),
+        );
+        client.get.mockResolvedValueOnce(updated);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '  +5518981789845  ');
+        await submitAddPhoneForm(client, config.testIdPrefix);
+
+        expect(client.post).toHaveBeenCalledWith(
+          config.endpointAdd,
+          { number: '+5518981789845' },
+          expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+        expect(
+          await screen.findByText(config.addSuccessToast),
+        ).toBeInTheDocument();
+      });
+
+      it('botão "Adicionar" fica desabilitado quando o cliente já tem 3 telefones', async () => {
+        const dto = makeClient({
+          [config.collectionKey]: [
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a1',
+              number: '+5518981789801',
+            }),
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a2',
+              number: '+5518981789802',
+            }),
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a3',
+              number: '+5518981789803',
+            }),
+          ],
+        });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-add`),
+        ).toBeDisabled();
+        // Aviso visual reforça a condição.
+        expect(screen.getByText(config.limitAlertText)).toBeInTheDocument();
+      });
+
+      it('400 "Limite de 3..." (race) exibe inline e dispara refetch', async () => {
+        // UI mostra 2 telefones (abaixo do limite), operador abre modal,
+        // mas no momento do submit o backend já tem 3 (outra sessão).
+        const dto = makeClient({
+          [config.collectionKey]: [
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a1',
+              number: '+5518981789801',
+            }),
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a2',
+              number: '+5518981789802',
+            }),
+          ],
+        });
+        const dtoFull = makeClient({
+          [config.collectionKey]: [
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a1',
+              number: '+5518981789801',
+            }),
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a2',
+              number: '+5518981789802',
+            }),
+            makeClientPhone({
+              id: 'p0000000-0000-0000-0000-0000000000a3',
+              number: '+5518981789803',
+            }),
+          ],
+        });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+        client.post.mockRejectedValueOnce({
+          kind: 'http',
+          status: 400,
+          message: config.limitMessage,
+        });
+        client.get.mockResolvedValueOnce(dtoFull);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '+5518981789804');
+        await submitAddPhoneForm(client, config.testIdPrefix);
+
+        expect(
+          await screen.findByText(config.limitMessage),
+        ).toBeInTheDocument();
+        // Refetch foi disparado (2 GETs no total).
+        await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+      });
+
+      it('400 "Telefone inválido..." (defensivo) exibe mensagem inline', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+        client.post.mockRejectedValueOnce({
+          kind: 'http',
+          status: 400,
+          message:
+            'Telefone inválido. Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+        });
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        // Burlamos a validação client-side com um número que casa a regex
+        // para forçar o servidor a rejeitar — isso garante que o branch
+        // do `inline` (sem "limite") seja exercitado mesmo quando a UI
+        // já filtra antes.
+        openAddModalAndFill(config.testIdPrefix, '+5518981789845');
+        await submitAddPhoneForm(client, config.testIdPrefix);
+
+        expect(
+          await screen.findByText(
+            /Telefone inválido. Use o formato internacional/i,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      it('409 "Contato já cadastrado" exibe mensagem inline no input', async () => {
+        const dto = makeClient({
+          [config.collectionKey]: [
+            makeClientPhone({ number: '+5518981789845' }),
+          ],
+        });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+        client.post.mockRejectedValueOnce({
+          kind: 'http',
+          status: 409,
+          message: 'Contato já cadastrado para este cliente.',
+        });
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '+5518981789845');
+        await submitAddPhoneForm(client, config.testIdPrefix);
+
+        expect(
+          await screen.findByText(
+            'Contato já cadastrado para este cliente.',
+          ),
+        ).toBeInTheDocument();
+        // Modal continua aberto.
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-add-number`),
+        ).toBeInTheDocument();
+      });
+
+      it('cancelar fecha o modal e descarta o input', async () => {
+        const dto = makeClient({ [config.collectionKey]: [] });
+        const client = createClientsClientStub();
+        client.get.mockResolvedValueOnce(dto);
+
+        renderClientPhonesTab(config.kind, client);
+        await waitForLoaded(config.testIdPrefix);
+
+        openAddModalAndFill(config.testIdPrefix, '+5518981789845');
+        fireEvent.click(
+          screen.getByTestId(`${config.testIdPrefix}-add-cancel`),
+        );
+
+        // Modal fecha — input não fica no DOM.
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId(`${config.testIdPrefix}-add-number`),
+          ).not.toBeInTheDocument();
+        });
+
+        // Reabrir mostra input vazio (descartou rascunho).
+        fireEvent.click(screen.getByTestId(`${config.testIdPrefix}-add`));
+        expect(
+          (
+            screen.getByTestId(
+              `${config.testIdPrefix}-add-number`,
+            ) as HTMLInputElement
+          ).value,
+        ).toBe('');
+      });
+    });
+
+    describe('remover telefone', () => {
+      it('clicar em "Remover" por linha abre confirmação com número em destaque', async () => {
+        await setupSinglePhoneRemoveConfirm(config);
+
+        const description = screen.getByTestId(
+          `${config.testIdPrefix}-remove-description`,
+        );
+        expect(description).toBeInTheDocument();
+        expect(description).toHaveTextContent('+5518981789845');
+        expect(
+          screen.getByTestId(`${config.testIdPrefix}-remove-confirm`),
+        ).toBeInTheDocument();
+      });
+
+      it('confirmar remoção envia DELETE no endpoint correto e dispara refetch', async () => {
+        const scene = setupSinglePhoneScene(config);
+        scene.client.delete.mockResolvedValueOnce(undefined);
+        scene.client.get.mockResolvedValueOnce(
+          makeClient({ [config.collectionKey]: [] }),
+        );
+
+        renderClientPhonesTab(config.kind, scene.client);
+        await waitForLoaded(config.testIdPrefix);
+
+        fireEvent.click(
+          screen.getByTestId(
+            `${config.testIdPrefix}-remove-${scene.phone.id}`,
+          ),
+        );
+        fireEvent.click(
+          screen.getByTestId(`${config.testIdPrefix}-remove-confirm`),
+        );
+
+        await waitFor(() =>
+          expect(scene.client.delete).toHaveBeenCalledTimes(1),
+        );
+        expect(scene.client.delete).toHaveBeenCalledWith(
+          `/clients/${ID_CLIENT_PF_ANA}/${config.endpointRemoveSuffix}/${scene.phone.id}`,
+          undefined,
+        );
+        expect(
+          await screen.findByText(config.removeSuccessToast),
+        ).toBeInTheDocument();
+        // Refetch — a lista volta vazia.
+        await waitFor(() => expect(scene.client.get).toHaveBeenCalledTimes(2));
+      });
+
+      it('404 ao remover (race com outra sessão) fecha modal + toast + refetch', async () => {
+        const scene = setupSinglePhoneScene(config);
+        scene.client.delete.mockRejectedValueOnce({
+          kind: 'http',
+          status: 404,
+          message: 'Contato não encontrado.',
+        });
+        scene.client.get.mockResolvedValueOnce(
+          makeClient({ [config.collectionKey]: [] }),
+        );
+
+        renderClientPhonesTab(config.kind, scene.client);
+        await waitForLoaded(config.testIdPrefix);
+
+        fireEvent.click(
+          screen.getByTestId(
+            `${config.testIdPrefix}-remove-${scene.phone.id}`,
+          ),
+        );
+        fireEvent.click(
+          screen.getByTestId(`${config.testIdPrefix}-remove-confirm`),
+        );
+
+        // Toast aparece com a mensagem `notFoundMessage` da config.
+        expect(
+          await screen.findByText(/já havia sido removido/i),
+        ).toBeInTheDocument();
+        // Modal fecha.
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId(
+              `${config.testIdPrefix}-remove-confirm`,
+            ),
+          ).not.toBeInTheDocument();
+        });
+      });
+
+      it('cancelar remoção fecha o modal sem chamar DELETE', async () => {
+        const scene = await setupSinglePhoneRemoveConfirm(config);
+
+        fireEvent.click(
+          screen.getByTestId(`${config.testIdPrefix}-remove-cancel`),
+        );
+
+        await waitFor(() => {
+          expect(
+            screen.queryByTestId(
+              `${config.testIdPrefix}-remove-confirm`,
+            ),
+          ).not.toBeInTheDocument();
+        });
+        expect(scene.client.delete).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('gating Clients.Update', () => {
+      it('sem AUTH_V1_CLIENTS_UPDATE oculta botões Adicionar e Remover', async () => {
+        permissionsMock = [];
+        const scene = setupSinglePhoneScene(config);
+
+        renderClientPhonesTab(config.kind, scene.client);
+        await waitForLoaded(config.testIdPrefix);
+
+        // Lista permanece visível (auditoria).
+        expect(
+          screen.getByTestId(
+            `${config.testIdPrefix}-row-${scene.phone.id}`,
+          ),
+        ).toBeInTheDocument();
+        // Botões de adicionar e remover ausentes.
+        expect(
+          screen.queryByTestId(`${config.testIdPrefix}-add`),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId(
+            `${config.testIdPrefix}-remove-${scene.phone.id}`,
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+  },
+);
+
+/* ─── Smoke test do botão renderizado por kind ──────────── */
+
+describe('ClientPhonesTab — diferenças de label entre kinds', () => {
+  it('mobile renderiza "Adicionar celular"', async () => {
+    const dto = makeClient({ mobilePhones: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientPhonesTab('mobile', client);
+    await waitForLoaded('client-mobile-phones');
+
+    expect(
+      screen.getByRole('button', { name: /Adicionar celular/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('landline renderiza "Adicionar telefone"', async () => {
+    const dto = makeClient({ landlinePhones: [] });
+    const client = createClientsClientStub();
+    client.get.mockResolvedValueOnce(dto);
+
+    renderClientPhonesTab('landline', client);
+    await waitForLoaded('client-landline-phones');
+
+    expect(
+      screen.getByRole('button', { name: /Adicionar telefone/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/pages/clients/clientPhonesHelpers.test.ts
+++ b/tests/pages/clients/clientPhonesHelpers.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyAddPhoneError,
+  classifyRemovePhoneError,
+  PHONE_E164_REGEX,
+  PHONE_MAX_LENGTH,
+  validatePhoneInput,
+  type PhoneErrorCopy,
+} from '@/pages/clients/clientPhonesHelpers';
+
+/**
+ * Suíte do `clientPhonesHelpers` (Issue #147). Cobre validação E.164
+ * client-side e classificação de erros para `add`/`remove` de telefones
+ * (mobile ou landline — os helpers são agnósticos quanto ao tipo).
+ *
+ * Estratégia: TS puro, sem React. Cobertura focada em comportamento —
+ * cada caso retorna a ação discriminada esperada para um `error: unknown`.
+ */
+
+const ADD_COPY: PhoneErrorCopy = {
+  genericFallback: 'Não foi possível adicionar.',
+  forbiddenTitle: 'Falha ao adicionar',
+  notFoundMessage: 'Cliente removido.',
+};
+
+const REMOVE_COPY: PhoneErrorCopy = {
+  genericFallback: 'Não foi possível remover.',
+  forbiddenTitle: 'Falha ao remover',
+  notFoundMessage: 'Telefone já removido.',
+};
+
+describe('PHONE_E164_REGEX', () => {
+  // A regex `^\+[1-9]\d{11,14}$` exige `+`, seguido de 1 dígito não-zero
+  // e 11–14 dígitos adicionais — totalizando 12–15 dígitos após o `+`,
+  // ou 13–16 caracteres no total. Os casos abaixo são pinos calibrados
+  // contra esse contrato (idêntico ao `ClientsController.PhoneRegex`).
+  it.each([
+    ['+5518981789845', true, 'BR — celular SP com 13 dígitos após DDI (total 13 chars)'],
+    ['+551832345678', true, 'BR — fixo SP com 12 dígitos após + (limite inferior)'],
+    ['+442083661177', true, 'UK — 12 dígitos após + (limite inferior)'],
+    ['+551234567890123', true, 'limite superior — 15 dígitos após +'],
+    ['18981789845', false, 'sem +'],
+    ['+0123456789012', false, 'segundo char é 0'],
+    ['+14155552671', false, 'curto demais — 11 dígitos após + (mínimo é 12)'],
+    ['+1234567890', false, 'curto demais — 10 dígitos após +'],
+    ['+12345678901234567', false, 'longo demais — 17 dígitos após +'],
+    ['+abc12345678', false, 'contém letras'],
+    ['', false, 'vazio'],
+    ['+ 551832345678', false, 'espaço entre + e dígitos'],
+  ])('regex aceita %s = %s (%s)', (input, expected) => {
+    expect(PHONE_E164_REGEX.test(input)).toBe(expected);
+  });
+});
+
+describe('validatePhoneInput', () => {
+  it.each([
+    ['+5518981789845', null, 'BR celular válido (13 dígitos após +)'],
+    ['+551832345678', null, 'BR fixo válido (12 dígitos após +, limite inferior)'],
+    ['  +5518981789845  ', null, 'trima antes de validar'],
+  ])('aceita "%s" e devolve %s (%s)', (input, expected) => {
+    expect(validatePhoneInput(input)).toBe(expected);
+  });
+
+  it('rejeita string vazia com mensagem de obrigatoriedade', () => {
+    expect(validatePhoneInput('')).toBe('Número é obrigatório.');
+  });
+
+  it('rejeita whitespace puro com mensagem de obrigatoriedade (após trim)', () => {
+    expect(validatePhoneInput('   ')).toBe('Número é obrigatório.');
+  });
+
+  it('rejeita formato inválido com orientação do exemplo E.164', () => {
+    expect(validatePhoneInput('18981789845')).toBe(
+      'Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+    );
+  });
+
+  it('rejeita string maior que PHONE_MAX_LENGTH com mensagem específica', () => {
+    // Construir string maior que 20 chars que casaria a regex se não fosse
+    // o gate de tamanho. Como a regex topa até 16 chars, qualquer string
+    // de 21+ chars já cai no MaxLength antes da regex. Ainda assim
+    // garantimos que o branch de tamanho dispara independente da regex
+    // — basta adicionar prefixo `+` + dígitos arbitrários acima do teto.
+    const tooLong = `+${'1'.repeat(PHONE_MAX_LENGTH)}`; // 21 chars total
+    expect(tooLong.length).toBeGreaterThan(PHONE_MAX_LENGTH);
+    expect(validatePhoneInput(tooLong)).toBe(
+      `Número deve ter no máximo ${PHONE_MAX_LENGTH} caracteres.`,
+    );
+  });
+});
+
+describe('classifyAddPhoneError', () => {
+  it('classifica erro não-HTTP como unhandled', () => {
+    const error = { kind: 'network' as const, message: 'Falha de conexão.' };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      message: 'Não foi possível adicionar.',
+      title: 'Falha ao adicionar',
+    });
+  });
+
+  it('classifica error não-objeto (string solta) como unhandled', () => {
+    const action = classifyAddPhoneError('boom', ADD_COPY);
+    expect(action.kind).toBe('unhandled');
+  });
+
+  it('classifica 404 como not-found com cópia específica', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Cliente não encontrado.',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'not-found',
+      message: 'Cliente removido.',
+      title: 'Falha ao adicionar',
+    });
+  });
+
+  it.each([
+    [401, 'Sessão expirada. Faça login novamente.'],
+    [403, 'Você não tem permissão para esta ação.'],
+  ])('classifica %s como toast com mensagem do backend', (status, message) => {
+    const error = { kind: 'http' as const, status, message };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message,
+      title: 'Falha ao adicionar',
+    });
+  });
+
+  it('cai no genericFallback quando 401/403 não tem mensagem', () => {
+    const error = { kind: 'http' as const, status: 403, message: '' };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message: 'Não foi possível adicionar.',
+      title: 'Falha ao adicionar',
+    });
+  });
+
+  it('classifica 400 com "limite" como limit-reached (mobile)', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Limite de 3 celulares por cliente.',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'limit-reached',
+      message: 'Limite de 3 celulares por cliente.',
+    });
+  });
+
+  it('classifica 400 com "limite" como limit-reached (landline)', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Limite de 3 telefones por cliente.',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action.kind).toBe('limit-reached');
+  });
+
+  it('classifica 400 sem "limite" (formato inválido) como inline', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Telefone inválido. Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'inline',
+      message:
+        'Telefone inválido. Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+    });
+  });
+
+  it('classifica 409 como inline com mensagem do backend', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 409,
+      message: 'Contato já cadastrado para este cliente.',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'inline',
+      message: 'Contato já cadastrado para este cliente.',
+    });
+  });
+
+  it('cai no genericFallback quando 400 inline não tem mensagem do backend', () => {
+    const error = { kind: 'http' as const, status: 400, message: '' };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action).toEqual({
+      kind: 'inline',
+      message: 'Não foi possível adicionar.',
+    });
+  });
+
+  it('classifica status HTTP inesperado (500) como unhandled', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 500,
+      message: 'Internal Server Error',
+    };
+    const action = classifyAddPhoneError(error, ADD_COPY);
+    expect(action.kind).toBe('unhandled');
+  });
+});
+
+describe('classifyRemovePhoneError', () => {
+  it('classifica erro não-HTTP como unhandled', () => {
+    const error = { kind: 'network' as const, message: 'Sem conexão.' };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action).toEqual({
+      kind: 'unhandled',
+      message: 'Não foi possível remover.',
+      title: 'Falha ao remover',
+    });
+  });
+
+  it('classifica 404 como not-found com cópia específica', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 404,
+      message: 'Contato não encontrado.',
+    };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action).toEqual({
+      kind: 'not-found',
+      message: 'Telefone já removido.',
+      title: 'Falha ao remover',
+    });
+  });
+
+  it.each([
+    [401, 'Sessão expirada. Faça login novamente.'],
+    [403, 'Você não tem permissão para esta ação.'],
+  ])('classifica %s como toast com mensagem do backend', (status, message) => {
+    const error = { kind: 'http' as const, status, message };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message,
+      title: 'Falha ao remover',
+    });
+  });
+
+  it('cai no genericFallback quando 401/403 não tem mensagem', () => {
+    const error = { kind: 'http' as const, status: 401, message: '' };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action).toEqual({
+      kind: 'toast',
+      message: 'Não foi possível remover.',
+      title: 'Falha ao remover',
+    });
+  });
+
+  it('classifica 400 inesperado nesse endpoint como unhandled (defensivo)', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 400,
+      message: 'Erro inesperado.',
+    };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action.kind).toBe('unhandled');
+  });
+
+  it('classifica status HTTP desconhecido (500) como unhandled', () => {
+    const error = {
+      kind: 'http' as const,
+      status: 500,
+      message: 'Internal Server Error',
+    };
+    const action = classifyRemovePhoneError(error, REMOVE_COPY);
+    expect(action.kind).toBe('unhandled');
+  });
+});

--- a/tests/shared/api/clients.test.ts
+++ b/tests/shared/api/clients.test.ts
@@ -4,6 +4,8 @@ import type { ApiClient, ClientDto, PagedResponse } from '@/shared/api';
 
 import {
   addClientExtraEmail,
+  addClientLandlinePhone,
+  addClientMobilePhone,
   clientDisplayName,
   createClient,
   DEFAULT_CLIENTS_PAGE_SIZE,
@@ -14,6 +16,8 @@ import {
   isPagedClientsResponse,
   listClients,
   removeClientExtraEmail,
+  removeClientLandlinePhone,
+  removeClientMobilePhone,
   restoreClient,
   updateClient,
 } from '@/shared/api';
@@ -1318,3 +1322,283 @@ describe('removeClientExtraEmail (Issue #146)', () => {
     ).rejects.toBe(forbidden);
   });
 });
+
+/* ─── add(Mobile|Landline)Phone — Issue #147 ─────────────── */
+
+/**
+ * Helper interno parametrizado por endpoint para colapsar a suíte
+ * idêntica entre `addClientMobilePhone` e `addClientLandlinePhone`.
+ *
+ * As duas funções compartilham 100% do contrato (mesmo body, mesmo
+ * type guard, mesmos `ApiError` propagados) — o backend dispara
+ * `AddPhoneInternal` único, divergindo apenas no `Type` registrado e
+ * na string da mensagem de limite. Manter um único helper de teste
+ * parametrizado evita duplicação Sonar (lição PR #128/#134/#135).
+ */
+function buildAddPhoneTests(
+  label: string,
+  fn: typeof addClientMobilePhone | typeof addClientLandlinePhone,
+  endpoint: string,
+  limitMessage: string,
+): void {
+  describe(`${label} (Issue #147)`, () => {
+    const PHONE_ID = 'p0000000-0000-0000-0000-000000000001';
+
+    function makeRawPhone(
+      overrides: Partial<{ id: string; number: string; createdAt: string }> = {},
+    ): { id: string; number: string; createdAt: string } {
+      return {
+        id: PHONE_ID,
+        number: '+5518981789845',
+        createdAt: '2026-02-15T12:00:00Z',
+        ...overrides,
+      };
+    }
+
+    it(`faz POST ${endpoint} com body { number } e devolve ClientPhoneDto`, async () => {
+      const client = makeClientStub();
+      const created = makeRawPhone();
+      client.post.mockResolvedValueOnce(created);
+
+      const result = await fn(
+        CLIENT_PF_ID,
+        '+5518981789845',
+        undefined,
+        client as unknown as ApiClient,
+      );
+
+      expect(client.post).toHaveBeenCalledTimes(1);
+      expect(client.post.mock.calls[0][0]).toBe(endpoint);
+      expect(client.post.mock.calls[0][1]).toEqual({
+        number: '+5518981789845',
+      });
+      expect(result).toEqual(created);
+    });
+
+    it('propaga signal via options', async () => {
+      const client = makeClientStub();
+      client.post.mockResolvedValueOnce(makeRawPhone());
+      const controller = new AbortController();
+
+      await fn(
+        CLIENT_PF_ID,
+        '+5518981789845',
+        { signal: controller.signal },
+        client as unknown as ApiClient,
+      );
+
+      expect(client.post.mock.calls[0][2]).toEqual({
+        signal: controller.signal,
+      });
+    });
+
+    it('lança ApiError(parse) quando o backend devolve payload inválido', async () => {
+      const client = makeClientStub();
+      client.post.mockResolvedValueOnce({ malformed: true });
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          '+5518981789845',
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toMatchObject({
+        kind: 'parse',
+        message: 'Resposta inválida do servidor.',
+      });
+    });
+
+    it('propaga ApiError 400 do backend (limite atingido)', async () => {
+      const client = makeClientStub();
+      const limit = {
+        kind: 'http' as const,
+        status: 400,
+        message: limitMessage,
+      };
+      client.post.mockRejectedValueOnce(limit);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          '+5518981789845',
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(limit);
+    });
+
+    it('propaga ApiError 400 do backend (telefone inválido)', async () => {
+      const client = makeClientStub();
+      const invalid = {
+        kind: 'http' as const,
+        status: 400,
+        message:
+          'Telefone inválido. Use o formato internacional com DDI e DDD, ex.: +5518981789845.',
+      };
+      client.post.mockRejectedValueOnce(invalid);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          '+5518981789845',
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(invalid);
+    });
+
+    it('propaga ApiError 409 do backend (telefone duplicado)', async () => {
+      const client = makeClientStub();
+      const conflict = {
+        kind: 'http' as const,
+        status: 409,
+        message: 'Contato já cadastrado para este cliente.',
+      };
+      client.post.mockRejectedValueOnce(conflict);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          '+5518981789845',
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(conflict);
+    });
+
+    it('propaga ApiError 404 do backend (cliente removido)', async () => {
+      const client = makeClientStub();
+      const notFound = {
+        kind: 'http' as const,
+        status: 404,
+        message: 'Cliente não encontrado.',
+      };
+      client.post.mockRejectedValueOnce(notFound);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          '+5518981789845',
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(notFound);
+    });
+  });
+}
+
+buildAddPhoneTests(
+  'addClientMobilePhone',
+  addClientMobilePhone,
+  `/clients/${CLIENT_PF_ID}/mobiles`,
+  'Limite de 3 celulares por cliente.',
+);
+
+buildAddPhoneTests(
+  'addClientLandlinePhone',
+  addClientLandlinePhone,
+  `/clients/${CLIENT_PF_ID}/phones`,
+  'Limite de 3 telefones por cliente.',
+);
+
+/* ─── remove(Mobile|Landline)Phone — Issue #147 ──────────── */
+
+/**
+ * Helper interno parametrizado por endpoint para colapsar a suíte
+ * idêntica entre `removeClientMobilePhone` e `removeClientLandlinePhone`.
+ * Mesma motivação de `buildAddPhoneTests` — o backend reusa
+ * `RemovePhoneInternal`.
+ */
+function buildRemovePhoneTests(
+  label: string,
+  fn: typeof removeClientMobilePhone | typeof removeClientLandlinePhone,
+  endpoint: string,
+): void {
+  describe(`${label} (Issue #147)`, () => {
+    const PHONE_ID = 'p0000000-0000-0000-0000-000000000001';
+
+    it(`faz DELETE ${endpoint} sem corpo e resolve void`, async () => {
+      const client = makeClientStub();
+      client.delete.mockResolvedValueOnce(undefined);
+
+      const result = await fn(
+        CLIENT_PF_ID,
+        PHONE_ID,
+        undefined,
+        client as unknown as ApiClient,
+      );
+
+      expect(client.delete).toHaveBeenCalledTimes(1);
+      expect(client.delete.mock.calls[0][0]).toBe(endpoint);
+      expect(result).toBeUndefined();
+    });
+
+    it('propaga signal via options', async () => {
+      const client = makeClientStub();
+      client.delete.mockResolvedValueOnce(undefined);
+      const controller = new AbortController();
+
+      await fn(
+        CLIENT_PF_ID,
+        PHONE_ID,
+        { signal: controller.signal },
+        client as unknown as ApiClient,
+      );
+
+      expect(client.delete.mock.calls[0][1]).toEqual({
+        signal: controller.signal,
+      });
+    });
+
+    it('propaga ApiError 404 do backend (telefone não pertence ao cliente)', async () => {
+      const client = makeClientStub();
+      const notFound = {
+        kind: 'http' as const,
+        status: 404,
+        message: 'Contato não encontrado para este cliente.',
+      };
+      client.delete.mockRejectedValueOnce(notFound);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          PHONE_ID,
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(notFound);
+    });
+
+    it('propaga ApiError 401/403 do backend (sessão/permissão)', async () => {
+      const client = makeClientStub();
+      const forbidden = {
+        kind: 'http' as const,
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      };
+      client.delete.mockRejectedValueOnce(forbidden);
+
+      await expect(
+        fn(
+          CLIENT_PF_ID,
+          PHONE_ID,
+          undefined,
+          client as unknown as ApiClient,
+        ),
+      ).rejects.toBe(forbidden);
+    });
+  });
+}
+
+buildRemovePhoneTests(
+  'removeClientMobilePhone',
+  removeClientMobilePhone,
+  `/clients/${CLIENT_PF_ID}/mobiles/p0000000-0000-0000-0000-000000000001`,
+);
+
+buildRemovePhoneTests(
+  'removeClientLandlinePhone',
+  removeClientLandlinePhone,
+  `/clients/${CLIENT_PF_ID}/phones/p0000000-0000-0000-0000-000000000001`,
+);


### PR DESCRIPTION
## Contexto

Issue **#147** (parte da EPIC #49 — Clientes e Usuários). A entidade
`Client` no `lfc-authenticator` permite até **3 celulares** e **3
telefones fixos** por cliente, separados por `ClientPhone.Type`
(`mobile`/`phone`).

Esta PR substitui os placeholders das abas "Celulares" e "Telefones
fixos" no `ClientEditPage` (#144) com a UI completa de gerenciamento,
espelhando os endpoints `POST/DELETE /clients/{id}/(mobiles|phones)`
do backend.

## O que foi feito

### UI / fluxo

- Componente único `ClientPhonesTab` parametrizado por `kind`
  (`mobile` | `landline`); `ClientMobilePhonesTab` e
  `ClientLandlinePhonesTab` viram wrappers finos.
- Lista os telefones existentes com ícone, número monoespaçado e botão
  "Remover" por linha (gateado por `Clients.Update`).
- Botão "Adicionar" abre modal com input + validação client-side E.164
  (`/^\+[1-9]\d{11,14}$/`, idêntica à `ClientsController.PhoneRegex`).
  Desabilita preventivamente quando o cliente atinge o limite (3 por
  tipo).
- Modal de confirmação antes de remover.
- Mapeamento completo dos erros do backend:
  - 400 \"Telefone inválido...\" → inline (defesa contra bypass).
  - 400 \"Limite de 3 (celulares|telefones)...\" → inline + refetch
    (defesa contra race com outra sessão).
  - 409 \"Contato já cadastrado...\" → inline.
  - 404 → toast vermelho + refetch (cliente removido).
  - 401/403/network → toast vermelho.
- Refetch do `ClientResponse` após mutação (sucesso ou drift) para
  sincronizar a lista.
- Empty state com hint contextual; gating Clients.Update oculta CTAs
  preservando lista para auditoria.

### API (`src/shared/api/clients.ts`)

- `addClientMobilePhone(id, number)` → `POST /clients/{id}/mobiles`.
- `removeClientMobilePhone(id, phoneId)` →
  `DELETE /clients/{id}/mobiles/{phoneId}` (`204 No Content`).
- `addClientLandlinePhone(id, number)` → `POST /clients/{id}/phones`.
- `removeClientLandlinePhone(id, phoneId)` →
  `DELETE /clients/{id}/phones/{phoneId}`.
- `MAX_CLIENT_PHONES_PER_TYPE = 3` exportado para a UI desabilitar o
  botão e o classifier compartilhar a fonte da verdade.

### Refator antecipatório (lições PR #128/#134/#135)

Como #146 e #147 são consumidores praticamente idênticos do mesmo
pattern (lista de subentidades de cliente), promovi shared helpers
para zerar duplicação Sonar/JSCPD entre as duas abas:

- `src/shared/forms/classifySharedHttpError.ts` —
  `classifySharedHttpError` (404/401/403/network/parse) +
  `classifyAddCollectionApiError` (400 limite/inline + 409). Ambos
  consumidos por `clientPhonesHelpers` e refatorados em
  `clientExtraEmailsHelpers`.
- `src/pages/clients/clientCollectionTabStyles.ts` — styled components
  compartilhados (TabSection/TabHeading/.../ListRow/ListRowValue).
- `src/pages/clients/ClientCollectionRemoveConfirmModal.tsx` — modal
  de confirmação genérico.
- `src/pages/clients/ClientCollectionAddInputModal.tsx` — modal de
  adicionar genérico.
- `src/pages/clients/ClientCollectionListRow.tsx` — linha de item da
  lista.
- `src/pages/clients/applyCollectionMutationAction.ts` —
  `applyAddCollectionAction` + `applyRemoveCollectionAction`.
- `src/pages/clients/useClientByIdFetch.ts` — hook de fetch + refetch.
- `src/pages/clients/useClientAddCollectionModal.ts` — hook do estado
  do modal de adicionar + `buildHandlers`.
- `src/pages/clients/useClientRemoveCollectionConfirm.ts` — hook do
  estado do confirm de remoção (genérico em `T`).
- `src/pages/clients/useClientCollectionAddSubmit.ts` — hook do
  `useEffect` que dispara o POST de adicionar.
- `src/pages/clients/useClientCollectionRemoveSubmit.ts` — hook do
  `try/catch` do DELETE (com `customAction` para variantes próprias —
  ex.: `username` no email).

`ClientExtraEmailsTab` (#146) e `clientExtraEmailsHelpers` foram
refatorados em paralelo para consumir os mesmos shared helpers,
mantendo paridade visual e zerando duplicação entre as duas abas.

## Arquivos impactados

**Novos:**
- `src/pages/clients/ClientPhonesTab.tsx`
- `src/pages/clients/ClientCollectionAddInputModal.tsx`
- `src/pages/clients/ClientCollectionListRow.tsx`
- `src/pages/clients/ClientCollectionRemoveConfirmModal.tsx`
- `src/pages/clients/applyCollectionMutationAction.ts`
- `src/pages/clients/clientCollectionTabStyles.ts`
- `src/pages/clients/clientPhonesHelpers.ts`
- `src/pages/clients/useClientAddCollectionModal.ts`
- `src/pages/clients/useClientByIdFetch.ts`
- `src/pages/clients/useClientCollectionAddSubmit.ts`
- `src/pages/clients/useClientCollectionRemoveSubmit.ts`
- `src/pages/clients/useClientRemoveCollectionConfirm.ts`
- `src/shared/forms/classifySharedHttpError.ts`
- `tests/pages/clients/ClientPhonesTab.test.tsx`
- `tests/pages/clients/clientPhonesHelpers.test.ts`

**Modificados:**
- `src/pages/clients/ClientExtraEmailsTab.tsx` (refatorado para reuso
  dos shared helpers/modais).
- `src/pages/clients/ClientLandlinePhonesTab.tsx` (wrapper fino).
- `src/pages/clients/ClientMobilePhonesTab.tsx` (wrapper fino).
- `src/pages/clients/clientExtraEmailsHelpers.ts` (delega para o
  classifier compartilhado).
- `src/shared/api/clients.ts` (4 wrappers + `MAX_CLIENT_PHONES_PER_TYPE`).
- `src/shared/api/index.ts` (barrel).
- `src/shared/forms/index.ts` (barrel).
- `tests/pages/__helpers__/clientsTestHelpers.tsx` (`makeClientPhone`
  + `submitAddPhoneForm`).
- `tests/shared/api/clients.test.ts` (+22 cenários para os 4 wrappers).

## Testes

- `tests/pages/clients/ClientPhonesTab.test.tsx` — ~32 cenários,
  parametrizado por `kind` via `describe.each`: loading/error/empty/
  list, add válido/inválido/whitespace/limite/dup/race 400, remove
  confirm/cancel/404, gating Clients.Update, smoke test de label por
  kind.
- `tests/pages/clients/clientPhonesHelpers.test.ts` — ~25 cenários:
  regex E.164 (`it.each` com 12 entradas), validatePhoneInput,
  classifyAddPhoneError, classifyRemovePhoneError.
- `tests/shared/api/clients.test.ts` — +22 cenários com `describe`
  parametrizado para os 4 wrappers (add/remove × mobile/landline).

### Quality gate (rodado via container `web`)

\`\`\`
lint        : 0 warnings (--max-warnings 0)
typecheck   : 0 errors (tsc --noEmit)
test        : 1456/1456 (78 arquivos)
jscpd src/  : 1.99% (< 3% threshold), 0 clones em arquivos do diff
\`\`\`

## Visual

- TabSection/TabHeading/TabIntro/Counter/ListHeader/EmptyShell/ListRow
  herdados dos shared styled components — paridade visual com
  `ClientExtraEmailsTab` (#146).
- Tokens do design system (var(--bg-surface), var(--space-*),
  var(--text-*), var(--font-mono), etc.); zero hardcode.
- Hover state na ListRow (`border-medium-forest`); focus-visible
  herdado do design system; loading spinner inline nos botões;
  empty/error/loading dedicados.
- Mobile: lista flex-wrap no header; modal nativo do Modal do design
  system.

## Segurança

- Nenhum impacto. Sem `dangerouslySetInnerHTML`, sem manipulação de
  URL/iframe, sem exposição de tokens, sem console.log. Os wrappers
  HTTP usam `apiClient` (singleton com `X-System-Id` + Bearer
  injetados pelo `AuthProvider`).

## Riscos

- Refator do `ClientExtraEmailsTab` (#146) tocou o caminho de submit
  e remove para reusar os shared helpers — a suíte de testes do #146
  (mergeada em PR #168) continua 100% verde, validando que o
  comportamento é idêntico.
- O hook `useClientCollectionRemoveSubmit` aceita `TAction` ampla
  (sem constraint estrita) para acomodar a variante `username` do
  classifier do email. O cast interno é seguro porque o caller é
  responsável por interceptar variantes próprias via `customAction`.

## Issue relacionada

Closes #147