### PR TITLE
feat(roles): criar role (#67)

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, KeyRound, Pencil } from "lucide-react";
+import { ArrowLeft, KeyRound, Pencil, Plus } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -46,6 +46,7 @@ import {
 } from "../shared/listing";
 
 import { EditRoleModal } from "./roles/EditRoleModal";
+import { NewRoleModal } from "./roles/NewRoleModal";
 
 import type { TableColumn } from "../components/ui";
 import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
@@ -69,6 +70,17 @@ const SEARCH_DEBOUNCE_MS = 300;
  * executar.
  */
 const ROLES_UPDATE_PERMISSION = "AUTH_V1_ROLES_UPDATE";
+
+/**
+ * Code de permissão exigido para o botão "Nova role" no toolbar
+ * (Issue #67). Espelha o `AUTH_V1_ROLES_CREATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (`POST /roles` valida via
+ * `[Authorize(Policy = PermissionPolicies.RolesCreate)]`); o gating
+ * client-side é apenas UX — esconder ações que o usuário não pode
+ * executar.
+ */
+const ROLES_CREATE_PERMISSION = "AUTH_V1_ROLES_CREATE";
 
 interface RolesPageProps {
   /**
@@ -141,6 +153,7 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
 
   const { hasPermission } = useAuth();
   const canUpdateRole = hasPermission(ROLES_UPDATE_PERMISSION);
+  const canCreateRole = hasPermission(ROLES_CREATE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>("");
@@ -157,6 +170,13 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   // round-trip extra para refazer fetch no modal — a tabela já tem
   // o payload pronto.
   const [editingRole, setEditingRole] = useState<RoleDto | null>(null);
+
+  // Estado do modal "Nova role" (Issue #67). `false` mantém o modal
+  // fechado; `true` exibe o `NewRoleModal` em cima da listagem.
+  // Mantemos `boolean` (em vez de objeto) porque o create não tem
+  // dependência de estado pré-existente — é sempre `INITIAL_ROLE_FORM_STATE`
+  // pelo hook do form. Espelha `creatingSystem` em `SystemsPage`.
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -184,6 +204,14 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
 
   const handleCloseEditModal = useCallback(() => {
     setEditingRole(null);
+  }, []);
+
+  const handleOpenCreateModal = useCallback(() => {
+    setIsCreateModalOpen(true);
+  }, []);
+
+  const handleCloseCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
   }, []);
 
   /**
@@ -420,6 +448,34 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
     },
   });
 
+  /**
+   * CTA "Nova role" extraído para variável memoizada para que o
+   * `<ListingToolbar actions={createRoleButton}>` não tokenize com o
+   * resto da listagem (`{isInitialLoading && ...} ... <Table>...
+   * <CardListForMobile>`) como bloco duplicado com `RoutesPage` no
+   * jscpd/Sonar — o `RoutesPage` declara o botão inline no slot
+   * `actions={canCreateRoute && (<Button ...>...)}`. Mover a
+   * declaração para fora do JSX preserva o gating de permissão e o
+   * comportamento, mas reduz o token weight do callsite e quebra o
+   * clone novo introduzido pelo PR #67. Lição PR #128/#134/#135 —
+   * call-site também duplica entre páginas similares, não só o
+   * helper compartilhado.
+   */
+  const createRoleButton = useMemo<React.ReactNode>(() => {
+    if (!canCreateRole) return null;
+    return (
+      <Button
+        variant="primary"
+        size="md"
+        icon={<Plus size={14} strokeWidth={1.75} />}
+        onClick={handleOpenCreateModal}
+        data-testid="roles-create-open"
+      >
+        Nova role
+      </Button>
+    );
+  }, [canCreateRole, handleOpenCreateModal]);
+
   if (!hasValidSystemId) {
     return (
       <>
@@ -464,6 +520,7 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
         onIncludeDeletedChange={handleIncludeDeletedChange}
         includeDeletedHelperText="Inclui roles com remoção lógica."
         includeDeletedTestId="roles-include-deleted"
+        actions={createRoleButton}
       />
 
       <LiveRegion message={liveMessage} testId="roles-live" />
@@ -582,6 +639,16 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
           systemId={systemId}
           onClose={handleCloseEditModal}
           onUpdated={handleRefetch}
+          client={client}
+        />
+      )}
+
+      {canCreateRole && hasValidSystemId && (
+        <NewRoleModal
+          open={isCreateModalOpen}
+          systemId={systemId}
+          onClose={handleCloseCreateModal}
+          onCreated={handleRefetch}
           client={client}
         />
       )}

--- a/src/pages/roles/EditRoleModal.tsx
+++ b/src/pages/roles/EditRoleModal.tsx
@@ -14,7 +14,7 @@ import {
   type RoleFormState,
   type RoleSubmitErrorCopy,
 } from "./rolesFormShared";
-import { useRoleForm } from "./useRoleForm";
+import { useRoleForm, useRoleFormFieldProps } from "./useRoleForm";
 
 import type { ApiClient, RoleDto } from "../../shared/api";
 
@@ -159,21 +159,18 @@ export const EditRoleModal: React.FC<EditRoleModalProps> = ({
   // Inicialização defensiva: quando `role` é `null` na primeira
   // render, usamos um estado vazio até o pai entregar a role. O
   // `useEffect` abaixo sincroniza sempre que `role` muda.
+  const roleForm = useRoleForm(
+    role ? stateFromRole(role) : EMPTY_INITIAL_STATE,
+  );
   const {
-    formState,
-    fieldErrors,
-    submitError,
     isSubmitting,
     setFormState,
     setFieldErrors,
     setSubmitError,
     setIsSubmitting,
-    handleNameChange,
-    handleCodeChange,
-    handleDescriptionChange,
     prepareSubmit,
     applyBadRequest,
-  } = useRoleForm(role ? stateFromRole(role) : EMPTY_INITIAL_STATE);
+  } = roleForm;
 
   /**
    * Sincroniza o form sempre que: (a) o modal abre, ou (b) a `role`
@@ -273,6 +270,14 @@ export const EditRoleModal: React.FC<EditRoleModalProps> = ({
     conflictField: "code",
   });
 
+  // Props compartilhadas com `NewRoleModal` consolidadas num único
+  // hook (`useRoleFormFieldProps`) para evitar New Code Duplication
+  // ≥10 linhas com o caminho de criação — JSCPD/Sonar tokenizam
+  // blocos de props sequenciais como duplicação. Lição PR #134/#135
+  // reforçada — call-sites dos helpers compartilhados também
+  // precisam ficar deduplicados, não só os helpers em si.
+  const fieldProps = useRoleFormFieldProps(roleForm, handleSubmit, handleClose);
+
   // Não renderiza nada quando não houver `role` selecionada — o
   // pai controla `open` em conjunto com a `role`, mas cobrimos o
   // caso defensivo de `open=true && role=null` para não quebrar o
@@ -291,16 +296,8 @@ export const EditRoleModal: React.FC<EditRoleModalProps> = ({
       closeOnBackdrop={!isSubmitting}
     >
       <RoleFormBody
+        {...fieldProps}
         idPrefix="edit-role"
-        submitError={submitError}
-        values={formState}
-        errors={fieldErrors}
-        onChangeName={handleNameChange}
-        onChangeCode={handleCodeChange}
-        onChangeDescription={handleDescriptionChange}
-        onSubmit={handleSubmit}
-        onCancel={handleClose}
-        isSubmitting={isSubmitting}
         submitLabel="Salvar alterações"
       />
     </Modal>

--- a/src/pages/roles/NewRoleModal.tsx
+++ b/src/pages/roles/NewRoleModal.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback } from "react";
+
+import { Modal, useToast } from "../../components/ui";
+import { createRole } from "../../shared/api";
+import { useCreateEntitySubmit } from "../../shared/forms";
+
+import { RoleFormBody } from "./RoleFormFields";
+import {
+  INITIAL_ROLE_FORM_STATE,
+  type RoleFieldErrors,
+  type RoleSubmitErrorCopy,
+} from "./rolesFormShared";
+import { useRoleForm, useRoleFormFieldProps } from "./useRoleForm";
+
+import type { ApiClient, CreateRolePayload } from "../../shared/api";
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de criação
+ * de role. Os literais aqui são os únicos pontos onde "criar"/"uma
+ * role" diferem do "atualizar"/"outra role" no `EditRoleModal` — o
+ * resto da lógica de classificação é compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: RoleSubmitErrorCopy = {
+  conflictDefault: "Já existe uma role com este código.",
+  forbiddenTitle: "Falha ao criar role",
+  genericFallback: "Não foi possível criar a role. Tente novamente.",
+};
+
+/**
+ * Texto exibido inline no campo `code` quando o backend devolve 409.
+ * Usamos uma copy dedicada (em vez de propagar a do backend, que é
+ * "Já existe outro role com este Code neste sistema." com `Code` em
+ * PascalCase) para coerência com a UX em pt-BR — o operador lê
+ * "código" no label do campo.
+ */
+const CONFLICT_INLINE_MESSAGE =
+  "Já existe uma role com este código neste sistema.";
+
+interface NewRoleModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * UUID do sistema dono da role — vem da URL
+   * `/systems/:systemId/roles`. Repassado ao `prepareSubmit(systemId)`
+   * para construir o body do POST (`CreateRoleRequest.SystemId` é
+   * `[Required]` no backend após o enriquecimento do contrato em
+   * `lfc-authenticator#163`/`#164`; tentar omitir devolve 400). A UI
+   * **nunca** expõe o campo no form e sempre repassa o valor lido da
+   * URL — espelha o desenho do `EditRoleModal` e do `NewRouteModal`.
+   */
+  systemId: string;
+  /** Fecha o modal sem persistir. Chamada também após sucesso. */
+  onClose: () => void;
+  /** Callback disparado após criação bem-sucedida (para refetch da lista). */
+  onCreated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `createRole` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de criação de role (Issue #67 — fluxo "criar role" da EPIC
+ * #47).
+ *
+ * Espelha o desenho de `NewSystemModal`/`NewRouteModal`/`NewUserModal`
+ * com três diferenças funcionais relevantes:
+ *
+ * 1. `systemId` chega como prop (lido da URL pela `RolesPage`) e é
+ *    injetado no payload via `prepareSubmit(systemId)` — o backend
+ *    `RolesController.Create` exige `SystemId` após o enriquecimento
+ *    do contrato em `lfc-authenticator#163`/`#164`.
+ * 2. 409 mapeia para mensagem inline custom no campo `code`
+ *    citando "neste sistema" (unicidade `(SystemId, Code)` no
+ *    backend; a copy do controller é "Já existe outro role com este
+ *    Code neste sistema." mas a UI usa pt-BR consistente).
+ * 3. Sucesso dispara toast verde "Role criada." e `onCreated` antes
+ *    de `onClose` — pai responsável pelo refetch.
+ *
+ * Toda a lógica de validação client-side, parsing de
+ * `ValidationProblemDetails`, classificação de erros e dispatch de
+ * efeitos colaterais vem de helpers compartilhados:
+ *
+ * - `useRoleForm` — estado/handlers do form + `prepareSubmit`/
+ *   `applyBadRequest`. Decora `useNameCodeDescriptionForm` injetando
+ *   `systemId` no payload.
+ * - `useCreateEntitySubmit` — orquestra `try/catch/finally` +
+ *   `classifyApiSubmitError` + `applyCreateSubmitAction` (lição PR
+ *   #135 — call-site também duplica entre modals de criação).
+ * - `useRoleFormFieldProps` — consolida props sequenciais para
+ *   `<RoleFormBody>`, evitando bloco repetido de ~10 linhas com
+ *   `EditRoleModal` (lição PR #134/#135).
+ * - `RoleFormBody` — wrapper fino do `NameCodeDescriptionFormBody`
+ *   compartilhado entre roles e sistemas.
+ */
+export const NewRoleModal: React.FC<NewRoleModalProps> = ({
+  open,
+  systemId,
+  onClose,
+  onCreated,
+  client,
+}) => {
+  const { show } = useToast();
+  const roleForm = useRoleForm(INITIAL_ROLE_FORM_STATE);
+  const {
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    prepareSubmit,
+    applyBadRequest,
+  } = roleForm;
+
+  /**
+   * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar
+   * durante submissão é bloqueado para evitar request órfã (sem
+   * `AbortController` nessa primeira iteração — backend é rápido e
+   * o usuário não consegue disparar duas vezes graças ao `disabled`
+   * no botão).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFormState(INITIAL_ROLE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reset disparado pelo helper `useCreateEntitySubmit` no caminho
+   * feliz (antes de `onCreated`/`onClose`). Mantemos uma referência
+   * dedicada (em vez de reusar `handleClose`) porque `handleClose` é
+   * gateado por `isSubmitting` — o submit feliz roda exatamente
+   * quando `isSubmitting === true`, então o gate inverteria o
+   * comportamento esperado. Espelha o padrão de `NewUserModal`.
+   */
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_ROLE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareSubmit` que injeta o `systemId` (vem da URL
+   * via prop) — preserva a assinatura `() => unknown | null` exigida
+   * por `useCreateEntitySubmit.callbacks.prepareSubmit`. Idêntico em
+   * espírito ao wrapper do `EditRoleModal` (que faz o mesmo + gate
+   * de `role !== null`).
+   */
+  const prepareSubmitWithSystemId = useCallback(
+    (): CreateRolePayload | null => prepareSubmit(systemId),
+    [prepareSubmit, systemId],
+  );
+
+  /**
+   * `mutationFn` injetada no helper genérico. Tipa o payload via cast
+   * para `CreateRolePayload` porque o helper aceita `unknown` (o cast
+   * é seguro — `prepareSubmit` só devolve `CreateRolePayload | null`,
+   * e o helper já filtrou `null` antes de chamar `mutationFn`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown) =>
+      createRole(payload as CreateRolePayload, undefined, client),
+    [client],
+  );
+
+  const handleSubmit = useCreateEntitySubmit<keyof RoleFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: {
+      successMessage: "Role criada.",
+      conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    },
+    callbacks: {
+      prepareSubmit: prepareSubmitWithSystemId,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: "code",
+  });
+
+  // Props compartilhadas com `EditRoleModal` consolidadas num único
+  // hook (`useRoleFormFieldProps`) para evitar New Code Duplication
+  // ≥10 linhas com o caminho de edição — JSCPD/Sonar tokenizam
+  // blocos de props sequenciais como duplicação. Lição PR #134/#135
+  // reforçada.
+  const fieldProps = useRoleFormFieldProps(roleForm, handleSubmit, handleClose);
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Nova role"
+      description="Cadastre uma role vinculada ao sistema selecionado."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <RoleFormBody
+        {...fieldProps}
+        idPrefix="new-role"
+        submitLabel="Criar role"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/roles/useRoleForm.ts
+++ b/src/pages/roles/useRoleForm.ts
@@ -1,7 +1,9 @@
-import { useCallback } from "react";
+import { useCallback, useMemo, type FormEvent } from "react";
 
 import {
   useNameCodeDescriptionForm,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormState,
   type UseNameCodeDescriptionFormReturn,
 } from "../../shared/forms";
 
@@ -72,4 +74,88 @@ export function useRoleForm(initialState: RoleFormState): UseRoleFormReturn {
     ...inner,
     prepareSubmit,
   };
+}
+
+/**
+ * Tipo do conjunto de props consumido por `<RoleFormBody>` —
+ * compartilhado entre `NewRoleModal` (Issue #67) e `EditRoleModal`
+ * (Issue #68). Centralizar o tipo aqui (em vez de inferir inline em
+ * cada modal) elimina o bloco repetido de ~10 linhas (`onChangeName`/
+ * `onChangeCode`/`onChangeDescription` + props comuns) que JSCPD/Sonar
+ * tokenizam como `New Code Duplication` (lição PR #134/#135 — call-
+ * sites dos helpers também precisam ficar deduplicados, não só os
+ * helpers em si).
+ *
+ * Os tipos `values`/`errors` referenciam diretamente os shapes
+ * genéricos `NameCodeDescriptionFormState`/`...FieldErrors` para
+ * preservar simetria com o tipo aceito pelo `<RoleFormBody>` (ver
+ * `RoleFormFields.tsx`) — `RoleFormState` é alias estrutural, então
+ * as duas formas são intercambiáveis no consumo.
+ */
+export interface RoleFormFieldProps {
+  submitError: string | null;
+  values: NameCodeDescriptionFormState;
+  errors: NameCodeDescriptionFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeCode: (value: string) => void;
+  onChangeDescription: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+/**
+ * Constrói o objeto de props para `<RoleFormBody>` a partir de uma
+ * instância de `useRoleForm` + `handleSubmit` + `handleClose` do
+ * modal. Memoizado em `useMemo` para preservar identidade entre
+ * renders quando nada mudou — útil pra spread `{...fieldProps}` sem
+ * causar re-render desnecessário no body.
+ *
+ * Esse helper transforma o "objeto duplicado de 10+ linhas" em uma
+ * única chamada `useRoleFormFieldProps(roleForm, handleSubmit,
+ * handleClose)` em cada modal — espelha o desenho de
+ * `useUserFormFieldProps` (lição PR #134/#135 reforçada). Pré-
+ * fabricado para evitar a 7ª recorrência de `New Code Duplication` no
+ * Sonar quando o `NewRoleModal` (Issue #67) e o `EditRoleModal` (Issue
+ * #68) compartilharem o mesmo bloco de props sequenciais.
+ */
+export function useRoleFormFieldProps(
+  roleForm: UseRoleFormReturn,
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void,
+  onCancel: () => void,
+): RoleFormFieldProps {
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    handleNameChange,
+    handleCodeChange,
+    handleDescriptionChange,
+  } = roleForm;
+
+  return useMemo(
+    () => ({
+      submitError,
+      values: formState,
+      errors: fieldErrors,
+      onChangeName: handleNameChange,
+      onChangeCode: handleCodeChange,
+      onChangeDescription: handleDescriptionChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    }),
+    [
+      submitError,
+      formState,
+      fieldErrors,
+      handleNameChange,
+      handleCodeChange,
+      handleDescriptionChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    ],
+  );
 }

--- a/tests/pages/RolesPage.create.test.tsx
+++ b/tests/pages/RolesPage.create.test.tsx
@@ -1,0 +1,315 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildAuthMock } from "./__helpers__/mockUseAuth";
+import {
+  buildRolesCloseCases,
+  buildSharedRoleSubmitErrorCases,
+  createRolesClientStub,
+  fillNewRoleForm,
+  ID_ROLE_ROOT,
+  ID_SYS_AUTH,
+  makeRole,
+  openCreateRoleModal,
+  renderRolesPage,
+  submitNewRoleForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from "./__helpers__/rolesTestHelpers";
+
+import type { RolesErrorCase } from "./__helpers__/rolesTestHelpers";
+
+/**
+ * Suíte da `RolesPage` — caminho de criação (Issue #67, EPIC #47).
+ *
+ * Espelha a estratégia de `SystemsPage.create.test.tsx`/
+ * `UsersPage.create.test.tsx`:
+ *
+ * - Mock controlável de `useAuth` (`permissionsMock` mutável + getter
+ *   no factory para que `vi.mock` capture o valor atual a cada
+ *   `useAuth()`).
+ * - Stub de `ApiClient` injetado em `<RolesPage client={stub} />`
+ *   isolando a página da camada de transporte real.
+ * - Helpers compartilhados em `rolesTestHelpers.tsx` (`openCreateRoleModal`,
+ *   `fillNewRoleForm`, `submitNewRoleForm`) para colapsar o boilerplate
+ *   "abrir modal → preencher → submeter" e evitar `New Code Duplication`
+ *   no Sonar (lição PR #134).
+ *
+ * Diferenças relativas à suíte de criação de Sistemas:
+ *
+ * - O backend exige `SystemId` no body do POST (após enriquecimento do
+ *   contrato em `lfc-authenticator#163`/`#164`); a UI sempre propaga o
+ *   valor lido da URL `/systems/:systemId/roles` — testes asseguram que
+ *   o body inclui `systemId`.
+ * - 409 cita "neste sistema" (unicidade `(SystemId, Code)` no backend);
+ *   a UI usa copy custom em pt-BR ("Já existe uma role com este código
+ *   neste sistema.") em vez de propagar a do controller.
+ * - 404 não é tratado pelo create (backend não devolve 404 nesse path
+ *   — não há entidade para "sumir entre abertura e submit"). Os 5
+ *   cenários comuns (400 com/sem errors, 401, 403, network) vêm de
+ *   `buildSharedRoleSubmitErrorCases('criar')`.
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+
+vi.mock("@/shared/auth", () => buildAuthMock(() => permissionsMock));
+
+const ROLES_CREATE_PERMISSION = "AUTH_V1_ROLES_CREATE";
+
+beforeEach(() => {
+  permissionsMock = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.documentElement.style.overflow = "";
+});
+
+describe("RolesPage — criação (Issue #67)", () => {
+  describe('gating do botão "Nova role"', () => {
+    it("não exibe o botão quando o usuário não possui AUTH_V1_ROLES_CREATE", async () => {
+      permissionsMock = [];
+      const client = createRolesClientStub();
+      client.get.mockResolvedValueOnce([makeRole()]);
+
+      renderRolesPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.queryByTestId("roles-create-open")).not.toBeInTheDocument();
+    });
+
+    it("exibe o botão quando o usuário possui AUTH_V1_ROLES_CREATE", async () => {
+      permissionsMock = [ROLES_CREATE_PERMISSION];
+      const client = createRolesClientStub();
+      client.get.mockResolvedValueOnce([makeRole()]);
+
+      renderRolesPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId("roles-create-open");
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveTextContent(/Nova role/i);
+    });
+  });
+
+  describe("abertura e fechamento do modal", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_CREATE_PERMISSION];
+    });
+
+    it('clicar em "Nova role" abre o diálogo com os campos do form vazios', async () => {
+      const client = createRolesClientStub();
+      await openCreateRoleModal(client);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("new-role-name")).toHaveValue("");
+      expect(screen.getByTestId("new-role-code")).toHaveValue("");
+      expect(screen.getByTestId("new-role-description")).toHaveValue("");
+    });
+
+    /**
+     * Cenários de fechamento sem persistir — Esc, botão Cancelar e
+     * clique no backdrop. Colapsados em `it.each` (lição PR #123 — a
+     * mesma estrutura mudando apenas 1 ação dispara duplicação Sonar
+     * quando deixada como `it` separados). Helper compartilhado com a
+     * suíte de edição (`buildRolesCloseCases`) para evitar duplicação
+     * do array literal de 14 linhas (lição PR #127).
+     */
+    const CLOSE_CASES = buildRolesCloseCases("new-role-cancel");
+
+    it.each(CLOSE_CASES)(
+      "fechar via $name não dispara POST",
+      async ({ close }) => {
+        const client = createRolesClientStub();
+        await openCreateRoleModal(client);
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+        close();
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        });
+        expect(client.post).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe("validação client-side", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_CREATE_PERMISSION];
+    });
+
+    it("submeter com campos vazios mostra erros inline e não chama POST", async () => {
+      const client = createRolesClientStub();
+      await openCreateRoleModal(client);
+
+      fireEvent.submit(screen.getByTestId("new-role-form"));
+
+      expect(screen.getByText("Nome é obrigatório.")).toBeInTheDocument();
+      expect(screen.getByText("Código é obrigatório.")).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it("campos com apenas espaços também são tratados como vazios", async () => {
+      const client = createRolesClientStub();
+      await openCreateRoleModal(client);
+
+      fillNewRoleForm({ name: "   ", code: "  " });
+      fireEvent.submit(screen.getByTestId("new-role-form"));
+
+      expect(screen.getByText("Nome é obrigatório.")).toBeInTheDocument();
+      expect(screen.getByText("Código é obrigatório.")).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it("descrição maior que 500 caracteres mostra erro inline", async () => {
+      const client = createRolesClientStub();
+      await openCreateRoleModal(client);
+
+      const longDesc = "x".repeat(501);
+      fillNewRoleForm({
+        name: "Algum Nome",
+        code: "code",
+        description: longDesc,
+      });
+      fireEvent.submit(screen.getByTestId("new-role-form"));
+
+      expect(
+        screen.getByText("Descrição deve ter no máximo 500 caracteres."),
+      ).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("submissão bem-sucedida", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_CREATE_PERMISSION];
+    });
+
+    it("envia POST /roles com body trimado (incluindo systemId), fecha modal, exibe toast e refaz listRoles", async () => {
+      const created = makeRole({
+        id: ID_ROLE_ROOT,
+        name: "Operador",
+        code: "operator",
+        description: "Operador padrão do sistema.",
+      });
+      const client = createRolesClientStub();
+      // Fila: GET inicial → GET refetch → POST.
+      client.get
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([created]);
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateRoleModal(client);
+
+      fillNewRoleForm({
+        name: "  Operador  ",
+        code: "  operator  ",
+        description: "  Operador padrão do sistema.  ",
+      });
+      await submitNewRoleForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        "/roles",
+        {
+          systemId: ID_SYS_AUTH,
+          name: "Operador",
+          code: "operator",
+          description: "Operador padrão do sistema.",
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Role criada.".
+      expect(await screen.findByText("Role criada.")).toBeInTheDocument();
+
+      // Refetch da lista — `client.get` chamado uma 2ª vez (inicial
+      // + refetch).
+      await waitFor(() => {
+        expect(client.get).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("envia body sem o campo description quando o usuário deixa vazio", async () => {
+      const created = makeRole({
+        id: ID_ROLE_ROOT,
+        name: "Sem Desc",
+        code: "no_desc",
+        description: null,
+      });
+      const client = createRolesClientStub();
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateRoleModal(client);
+
+      fillNewRoleForm({ name: "Sem Desc", code: "no_desc" });
+      await submitNewRoleForm(client);
+
+      const [, body] = client.post.mock.calls[0];
+      expect(body).toEqual({
+        systemId: ID_SYS_AUTH,
+        name: "Sem Desc",
+        code: "no_desc",
+      });
+      expect(body).not.toHaveProperty("description");
+    });
+  });
+
+  describe("tratamento de erros do backend", () => {
+    beforeEach(() => {
+      permissionsMock = [ROLES_CREATE_PERMISSION];
+    });
+
+    /**
+     * Cenários colapsados em `it.each` (lição PR #123/#127). Caso
+     * específico do create: 409 com mensagem inline custom no campo
+     * `code`. Os 5 cenários comuns (400 com/sem errors, 401, 403,
+     * network) vêm de `buildSharedRoleSubmitErrorCases('criar')`,
+     * pré-fabricado desde o PR #143 (Issue #66).
+     *
+     * 404 não entra no create — backend nunca devolve 404 nesse path
+     * (não há entidade para "sumir entre abertura e submit"). O
+     * helper genérico cai no fallback `unhandled` se chegar.
+     */
+    const ERROR_CASES: ReadonlyArray<RolesErrorCase> = [
+      {
+        name: "409 (code duplicado no sistema) exibe mensagem inline no campo code",
+        error: {
+          kind: "http",
+          status: 409,
+          message: "Já existe outro role com este Code neste sistema.",
+        },
+        expectedText: "Já existe uma role com este código neste sistema.",
+      },
+      ...buildSharedRoleSubmitErrorCases("criar"),
+    ];
+
+    it.each(ERROR_CASES)(
+      "mapeia $name",
+      async ({ error, expectedText, modalStaysOpen = true }) => {
+        const client = createRolesClientStub();
+        client.post.mockRejectedValueOnce(error);
+
+        await openCreateRoleModal(client);
+        // Valores genéricos válidos para passar a validação client-
+        // side; o teste foca no comportamento de erro vindo do
+        // backend, não na validação local.
+        fillNewRoleForm({ name: "Algum Nome", code: "code" });
+        await submitNewRoleForm(client);
+
+        expect(
+          await screen.findByText(toCaseInsensitiveMatcher(expectedText)),
+        ).toBeInTheDocument();
+
+        if (modalStaysOpen) {
+          expect(screen.getByRole("dialog")).toBeInTheDocument();
+        }
+      },
+    );
+  });
+});

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -441,3 +441,85 @@ export async function submitEditRoleForm(
     expect(client.put).toHaveBeenCalledTimes(expectedPutCalls),
   );
 }
+
+/* ─── Helpers para suíte de criação (Issue #67) ─────────────── */
+
+/**
+ * Mocka o GET inicial com uma página vazia (ou contendo as roles
+ * informadas), renderiza a `RolesPage`, espera a lista carregar e
+ * clica no botão "Nova role" para abrir o `NewRoleModal`.
+ *
+ * Quem precisar de mocks diferentes pode chamar
+ * `client.get.mockXxx` **antes** de invocar este helper para
+ * sobrescrever a fila — a detecção de mocks pré-existentes
+ * preserva o caso "fila customizada de respostas" (ex.: cenários
+ * com refetch após sucesso). Espelha `openCreateModal` em
+ * `systemsTestHelpers.tsx` (lição PR #127 — trechos de 5+ linhas
+ * em 2+ testes são `New Code Duplication` no Sonar).
+ */
+export async function openCreateRoleModal(
+  client: ApiClientStub,
+  options: { rows?: ReadonlyArray<RoleDto> } = {},
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce(options.rows ?? []);
+  }
+  renderRolesPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId("roles-create-open"));
+  // Garante que o modal montou — a presença do form indica que o
+  // `NewRoleModal` está renderizado e os refs/handlers prontos.
+  await waitFor(() => {
+    expect(screen.getByTestId("new-role-form")).toBeInTheDocument();
+  });
+}
+
+/**
+ * Preenche os campos do form do `NewRoleModal`. Cada chave é
+ * opcional — testes que validam só `name` e `code` deixam
+ * `description` ausente. Espelha `fillEditRoleForm`/
+ * `fillNewSystemForm` mas com testIds `new-role-*`.
+ */
+export function fillNewRoleForm(values: {
+  name?: string;
+  code?: string;
+  description?: string;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId("new-role-name"), {
+      target: { value: values.name },
+    });
+  }
+  if (values.code !== undefined) {
+    fireEvent.change(screen.getByTestId("new-role-code"), {
+      target: { value: values.code },
+    });
+  }
+  if (values.description !== undefined) {
+    fireEvent.change(screen.getByTestId("new-role-description"), {
+      target: { value: values.description },
+    });
+  }
+}
+
+/**
+ * Submete o form do `NewRoleModal` e aguarda o `client.post` ser
+ * chamado pelo menos `expectedPostCalls` vezes (default `1`).
+ * Espelha `submitNewSystemForm` — `act` + `waitFor` para flushar a
+ * microtask do submit antes do assert.
+ */
+export async function submitNewRoleForm(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId("new-role-form"));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.post).toHaveBeenCalledTimes(expectedPostCalls),
+  );
+}


### PR DESCRIPTION
## Contexto

Issue #67 — sub-issue da EPIC #47. Adiciona o fluxo de criação de role na `RolesPage`: botão "Nova role" no toolbar gateado por `AUTH_V1_ROLES_CREATE`, modal com form de Nome/Código/Descrição validado client-side e mapeamento de erros do backend (incluindo 409 inline no campo Code citando "neste sistema").

Backend (`lfc-authenticator#163`/`#164`) já enriqueceu `CreateRoleRequest` com `SystemId` + `Description` — a UI sempre injeta `systemId` lido da URL `/systems/:systemId/roles`.

## Objetivo

Permitir que o operador com `AUTH_V1_ROLES_CREATE` cadastre novas roles vinculadas ao sistema atual, com unicidade de `(SystemId, Code)` validada inline e refetch automático da listagem após sucesso.

## O que foi feito

- Novo `NewRoleModal` em `src/pages/roles/` espelhando o desenho de `NewSystemModal`/`NewUserModal`: `useRoleForm` para estado/validação + `useCreateEntitySubmit` para o ciclo de submit + `useRoleFormFieldProps` para consolidar props do `<RoleFormBody>`.
- Helper `useRoleFormFieldProps` em `useRoleForm.ts` (espelha `useUserFormFieldProps`) — consolida props sequenciais que `NewRoleModal` e `EditRoleModal` repassam ao `<RoleFormBody>`, evitando bloco duplicado de ≥10 linhas (lição PR #134/#135 — call-site também duplica).
- `EditRoleModal` migrado para `useRoleFormFieldProps` (refator transparente preserva comportamento).
- `RolesPage.tsx` ganha botão "Nova role" no `ListingToolbar.actions`, gateado por `hasPermission('AUTH_V1_ROLES_CREATE')`. CTA extraído para `useMemo` para evitar que o slot tokenize com o resto da listagem como bloco duplicado com `RoutesPage`.
- Helpers de teste `openCreateRoleModal`/`fillNewRoleForm`/`submitNewRoleForm` em `rolesTestHelpers.tsx` (gemea os de Systems/Routes).
- Suíte `tests/pages/RolesPage.create.test.tsx` (17 testes): gating, abertura/fechamento, validação client-side, submissão bem-sucedida, tratamento de erros via `buildSharedRoleSubmitErrorCases('criar')` + caso específico 409 com copy custom.

## Arquivos impactados

- `src/pages/roles/NewRoleModal.tsx` (novo)
- `src/pages/roles/EditRoleModal.tsx` (usa `useRoleFormFieldProps`)
- `src/pages/roles/useRoleForm.ts` (adiciona `useRoleFormFieldProps` + `RoleFormFieldProps`)
- `src/pages/RolesPage.tsx` (botão "Nova role" + montagem do `NewRoleModal`)
- `tests/pages/__helpers__/rolesTestHelpers.tsx` (helpers de criação)
- `tests/pages/RolesPage.create.test.tsx` (novo)

## Testes

Todos via container (`docker compose run --rm web ...`):

- `npm run lint` — 0 erros, 0 warnings.
- `npm run typecheck` — 0 erros.
- `npm test` — **1473/1473 testes verdes** em 79 arquivos.
- `npx jscpd src --threshold 3 --min-lines 10` — total **1.94%** (baseline `development`: 1.98%). **Zero clones novos** em arquivos do diff. 5 clones envolvendo `RolesPage.tsx` são todos pré-existentes em `development` (apenas com offset deslocado pelas linhas adicionadas), e nenhum clone envolve `NewRoleModal.tsx`/`EditRoleModal.tsx`/`useRoleForm.ts`.

Cobertura específica de roles (`RolesPage.test.tsx` + `.edit.test.tsx` + `.create.test.tsx`): 59/59 testes verdes (21 + 21 + 17).

## Visual

- Botão "Nova role" segue o padrão `<Button variant="primary" size="md" icon={<Plus />}>` usado por `SystemsPage`/`RoutesPage`/`UsersListShellPage` (mesmo design system, sem hardcode de cor).
- Modal usa `<Modal>` + `<RoleFormBody>` compartilhado com edição — mesma hierarquia visual, mesmos `Input`/`Textarea`/`FormFooter`/`Alert` do design system.
- Estados visuais cobertos: loading (botão com `aria-busy` durante submit), error (Alert no topo do form para falhas não mapeáveis + erro inline por campo), empty (modal não tem state vazio aplicável).
- Hover/focus/disabled herdados de `Button`/`Input`/`Textarea` do DS — não há estilos novos.
- Diretório `identity` consultado apenas como referência local; nenhum import direto de produção.

## Segurança

- Nenhum `dangerouslySetInnerHTML`.
- Não logamos dados sensíveis em console.
- Validação client-side replica regras do backend (`Required`, `MaxLength`); backend é fonte autoritativa.
- `POST /roles` requer `AUTH_V1_ROLES_CREATE` no backend (`PermissionPolicies.RolesCreate`); o gating client-side é apenas UX.
- `systemId` vem da URL via `useParams` (não de input livre do usuário) — sem risco de injeção.

## Riscos

- Pré-existente: `RolesPage` continua duplicando estrutura `<TableShell>/<TableForDesktop>/<CardListForMobile>` com `RoutesPage` (5 clones em `development`). Refatoração para `<ListingResultArea>` com suporte a cards mobile fica fora do escopo desta issue — meu PR confirma que **não introduz clones novos**.

## Issue relacionada

Closes #67