### PR TITLE
feat(permissions): catálogo global em /permissoes (#174)

### DIFF
--- a/src/pages/permissions/PermissionsListShellPage.tsx
+++ b/src/pages/permissions/PermissionsListShellPage.tsx
@@ -1,18 +1,637 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { PlaceholderPage } from '../PlaceholderPage';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Button, Select, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
+import { usePaginationControls } from '../../hooks/usePaginationControls';
+import {
+  DEFAULT_PERMISSIONS_INCLUDE_DELETED,
+  DEFAULT_PERMISSIONS_PAGE,
+  DEFAULT_PERMISSIONS_PAGE_SIZE,
+  isApiError,
+  listPermissions,
+  listSystems,
+} from '../../shared/api';
+import {
+  CardCode,
+  CardDescription,
+  CardHeader,
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  CardName,
+  DescriptionCell,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ListingResultArea,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  Placeholder,
+  StatusBadge,
+  TableForDesktop,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import type { TableColumn } from '../../components/ui';
+import type {
+  ApiClient,
+  PermissionDto,
+  SafeRequestOptions,
+  SystemDto,
+} from '../../shared/api';
 
 /**
- * Página-shell da listagem global de permissões (`/permissoes`).
- *
- * Esqueleto introduzido pela Issue #145 — substitui a antiga
- * `PermissionsPage` (mockada com a matriz Resource.Action) e dá
- * lugar à vista global real, entregue por sub-issues subsequentes.
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms
+ * é o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que
+ * uma digitação fluida não dispare 1 request por caractere. Espelha o
+ * valor usado por `SystemsPage`/`RolesPage`/`ClientsListShellPage`.
  */
-export const PermissionsListShellPage: React.FC = () => (
-  <PlaceholderPage
-    eyebrow="04 Permissões"
-    title="Permissões"
-    desc="Catálogo global Resource.Action. A matriz completa será habilitada nas próximas iterações."
-  />
-);
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Valor sentinel usado pelos `<Select>` de filtro para representar
+ * "todos" (sem filtro). Mantido fora dos valores reais (UUIDs ou codes)
+ * para que a comparação no callback continue restrita ao domínio
+ * conhecido. O valor `'ALL'` é apenas uma string de UI; quando
+ * detectado, omitimos o respectivo param da request, mantendo a URL
+ * canônica. Espelha `TYPE_FILTER_ALL` em `ClientsListShellPage`.
+ */
+const FILTER_ALL = 'ALL' as const;
+
+/**
+ * Codes de tipo de permissão suportados pelo backend, espelhando o
+ * seeder `AuthenticatorPermissionsSeeder.RequiredPermissionTypeCodes`
+ * (ver `lfc-authenticator/AuthService/Data/AuthenticatorPermissionsSeeder.cs`).
+ *
+ * Hard-coded em vez de carregados dinamicamente (não há endpoint
+ * `GET /permission-types` exposto hoje) — o conjunto é estável e raro
+ * de mudar (tipos representam verbos CRUD canônicos). Quando o backend
+ * expuser endpoint dedicado, dá pra trocar essa constante por um
+ * `useFetch` sem alterar a API do componente.
+ */
+const PERMISSION_TYPE_CODES = ['create', 'read', 'update', 'delete', 'restore'] as const;
+
+type PermissionTypeCode = (typeof PERMISSION_TYPE_CODES)[number];
+
+/**
+ * Map estático code→label em pt-BR para o `<Select>` de tipo. Mantém
+ * a UI consistente com a copy usada nas listagens vizinhas (Sistemas,
+ * Rotas, Roles) sem expor o code técnico ("create") ao operador
+ * final.
+ */
+const PERMISSION_TYPE_LABELS: Record<PermissionTypeCode, string> = {
+  create: 'Criar',
+  read: 'Ler',
+  update: 'Atualizar',
+  delete: 'Excluir',
+  restore: 'Restaurar',
+};
+
+/**
+ * Tamanho de página alvo do `listSystems` para popular o `<Select>`
+ * de filtro. Backend rejeita `> 100`, então usamos o teto — em
+ * deployments com mais de 100 sistemas, o filtro só vai expor os 100
+ * primeiros (ordenação alfabética padrão do backend); cenário raro
+ * em catálogos administrativos. Quando crescer, dá pra trocar por
+ * busca incremental (combobox) — fora do escopo desta issue.
+ */
+const SYSTEMS_FILTER_PAGE_SIZE = 100;
+
+interface PermissionsListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido —
+   * a página usa o singleton `apiClient` por trás de `listPermissions`
+   * /`listSystems`. Em testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Renderiza a célula de descrição truncando textos longos via
+ * `text-overflow: ellipsis`. Quando o backend devolve `description: null`
+ * (campo opcional — o admin pode não ter preenchido na criação),
+ * exibimos "—" em itálico — espelha o tratamento das listagens
+ * vizinhas para manter consistência visual.
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile —
+ * centralizar evita duplicação visual (lição PR #127/#128).
+ */
+function renderDescription(row: PermissionDto): React.ReactNode {
+  if (row.description === null || row.description.trim().length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return (
+    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
+  );
+}
+
+/**
+ * Renderiza valor textual denormalizado vindo do backend que pode
+ * chegar como string vazia (`""`) quando o LEFT JOIN no
+ * `PermissionsController.ProjectPermissionResponses` é nulo (ver
+ * `lfc-authenticator/AuthService/Controllers/Permissions/PermissionsController.cs`).
+ * Em vez de quebrar a UI, mostramos "—" nesses casos — sinal visual
+ * claro de relacionamento órfão sem corromper o resto da linha.
+ *
+ * Helper local em vez de inline para evitar duplicação JSCPD entre as
+ * 4 colunas que precisam do mesmo tratamento (Sistema, RouteCode,
+ * RouteName, PermissionTypeName).
+ */
+function renderTextOrPlaceholder(value: string): React.ReactNode {
+  if (value.trim().length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return value;
+}
+
+export const PermissionsListShellPage: React.FC<PermissionsListShellPageProps> = ({
+  client,
+}) => {
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  // Filtro de sistema (UUID). 'ALL' é o sentinel — quando ativo,
+  // omitimos o param da request e o backend devolve todos os
+  // sistemas. O valor real é o `systemId` do `<option>` selecionado.
+  const [systemFilter, setSystemFilter] = useState<string>(FILTER_ALL);
+
+  // Filtro de tipo de permissão (code). 'ALL' é o sentinel; valores
+  // válidos vêm de `PERMISSION_TYPE_CODES`. Mantemos o code como
+  // estado (em vez do UUID) porque a UI hard-coda os 5 codes
+  // canônicos — o mapping para `permissionTypeId` (que é o que o
+  // backend aceita) acontece dinamicamente a partir do payload da
+  // listagem (ver `permissionTypeIdByCode`).
+  const [typeFilter, setTypeFilter] = useState<string>(FILTER_ALL);
+
+  // Cache de mapping `permissionTypeCode → permissionTypeId`
+  // construído incrementalmente a partir das responses da listagem.
+  // Backend não expõe `GET /permission-types` (não há endpoint
+  // dedicado), então a única forma de descobrir o `permissionTypeId`
+  // é olhando para os itens devolvidos pelo `GET /permissions`. A
+  // primeira request (sem filtro de tipo) tipicamente cobre os 5
+  // codes; o filtro só envia `permissionTypeId` quando o code já
+  // foi visto — caso contrário, omite e a UI continua mostrando
+  // todos enquanto aguarda a primeira descoberta.
+  //
+  // Trade-off documentado no PR: alternativa seria criar endpoint
+  // backend dedicado, mas isso aumenta o escopo desta issue. Map
+  // local é suficiente para o catálogo de 5 tipos canônicos; cenários
+  // de deployments com tipos customizados ficam como follow-up.
+  const [permissionTypeIdByCode, setPermissionTypeIdByCode] = useState<
+    ReadonlyMap<string, string>
+  >(() => new Map());
+
+  // Lista de sistemas para popular o `<Select>` de filtro. Carregada
+  // uma vez no mount via `listSystems({pageSize: 100})` — o catálogo
+  // tipicamente tem poucas dezenas. Falha silenciosa: se a request
+  // de sistemas falhar, o filtro vira "Todos" desabilitado mas a
+  // listagem principal continua funcionando.
+  const [systems, setSystems] = useState<ReadonlyArray<SystemDto>>([]);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_PERMISSIONS_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_PERMISSIONS_PAGE);
+
+  // Carrega o catálogo de sistemas no mount para popular o
+  // `<Select>` de filtro. Aborta em unmount via AbortController
+  // padrão. O cleanup está em `cancelled` flag (mesmo padrão do
+  // `usePaginatedFetch`).
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    listSystems(
+      { pageSize: SYSTEMS_FILTER_PAGE_SIZE },
+      { signal: controller.signal },
+      client,
+    )
+      .then((response) => {
+        if (cancelled) return;
+        setSystems(response.data);
+      })
+      .catch((error: unknown) => {
+        // Cancelamento explícito é fluxo normal. Outros erros são
+        // engolidos para que a falha do filtro não derrube a tela
+        // principal — operador ainda pode usar busca + tipo. Logging
+        // via console fica fora porque a CI tem `no-console`.
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (
+          isApiError(error) &&
+          error.kind === 'network' &&
+          error.message === 'Requisição cancelada.'
+        ) {
+          return;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client]);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, filtro por sistema X que
+   * tem 3 itens, mas continuo na página 5 vazia". Espelha a
+   * estratégia das listagens vizinhas.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_PERMISSIONS_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_PERMISSIONS_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_PERMISSIONS_PAGE);
+  }, []);
+
+  const handleSystemFilterChange = useCallback((value: string) => {
+    setSystemFilter(value.length > 0 ? value : FILTER_ALL);
+    setPage(DEFAULT_PERMISSIONS_PAGE);
+  }, []);
+
+  const handleTypeFilterChange = useCallback((value: string) => {
+    setTypeFilter(value.length > 0 ? value : FILTER_ALL);
+    setPage(DEFAULT_PERMISSIONS_PAGE);
+  }, []);
+
+  /**
+   * Resolve o `permissionTypeId` real (UUID) a partir do code
+   * selecionado no `<Select>`. Quando `'ALL'` ou code ainda não
+   * mapeado (primeira render), retorna `undefined` — o `fetcher`
+   * omite o param e o backend devolve todos os tipos.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const effectiveSystemId =
+    systemFilter === FILTER_ALL ? undefined : systemFilter;
+  const effectivePermissionTypeId =
+    typeFilter === FILTER_ALL
+      ? undefined
+      : permissionTypeIdByCode.get(typeFilter);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`. Captura os
+   * params derivados (busca debounced, page, filtros resolvidos) e
+   * devolve uma função que aceita `signal` no `options`. O hook
+   * reage à mudança de identidade do `fetcher` para reexecutar —
+   * `useCallback` com as deps corretas mantém o ciclo previsível.
+   *
+   * Importante: o resultado dispara o efeito secundário de popular
+   * `permissionTypeIdByCode` via `useEffect` (não dentro do then,
+   * para evitar setState durante render do hook). A primeira
+   * request sem filtro de tipo tipicamente devolve permissões de
+   * todos os tipos, populando o map completo.
+   */
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listPermissions(
+        {
+          systemId: effectiveSystemId,
+          permissionTypeId: effectivePermissionTypeId,
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_PERMISSIONS_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [
+      client,
+      effectivePermissionTypeId,
+      effectiveSystemId,
+      includeDeleted,
+      page,
+      trimmedSearchInput,
+    ],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<PermissionDto>({
+    fetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar a lista de permissões. Tente novamente.',
+  });
+
+  // Atualiza o map `code → id` a partir dos rows recebidos. O effect
+  // só dispara quando `rows` muda (push de cada response do
+  // `usePaginatedFetch`); merge incremental — preserva codes vistos
+  // em requests anteriores caso a request atual filtre por sistema
+  // específico que não cubra todos os tipos.
+  useEffect(() => {
+    if (rows.length === 0) return;
+    setPermissionTypeIdByCode((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const row of rows) {
+        const code = row.permissionTypeCode;
+        if (code.length > 0 && !next.has(code)) {
+          next.set(code, row.permissionTypeId);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [rows]);
+
+  const { totalPages, isFirstPage, isLastPage, handlePrevPage, handleNextPage } =
+    usePaginationControls({
+      total,
+      appliedPageSize,
+      defaultPageSize: DEFAULT_PERMISSIONS_PAGE_SIZE,
+      page,
+      setPage,
+    });
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio sem busca → "nenhuma permissão" + dica sobre o toggle
+   *   "Mostrar inativas" caso esteja desligado.
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhuma permissão encontrada para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="permissions-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhuma permissão cadastrada.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Permissões removidas podem ser visualizadas ativando &quot;Mostrar
+            inativas&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  const columns = useMemo<ReadonlyArray<TableColumn<PermissionDto>>>(
+    () => [
+      {
+        key: 'system',
+        label: 'Sistema',
+        render: (row) => renderTextOrPlaceholder(row.systemName),
+      },
+      {
+        key: 'routeCode',
+        label: 'Código da rota',
+        render: (row) => (
+          <Mono>{row.routeCode.length > 0 ? row.routeCode : '—'}</Mono>
+        ),
+      },
+      {
+        key: 'routeName',
+        label: 'Rota',
+        render: (row) => renderTextOrPlaceholder(row.routeName),
+      },
+      {
+        key: 'permissionType',
+        label: 'Tipo',
+        width: '140px',
+        render: (row) => renderTextOrPlaceholder(row.permissionTypeName),
+      },
+      {
+        key: 'description',
+        label: 'Descrição',
+        render: renderDescription,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '120px',
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
+      },
+    ],
+    [],
+  );
+
+  /**
+   * ARIA-live: anuncia o estado da listagem quando muda. Em loading
+   * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
+   * o total. Em erro, o `<Alert role="alert">` já cobre. O hook
+   * `useListingLiveMessage` centraliza a árvore de decisão (lição PR
+   * #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+   */
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'permissão',
+      pluralCarregando: 'permissões',
+      vazioSemBusca: 'Nenhuma permissão cadastrada.',
+    },
+  });
+
+  /**
+   * Tabela renderizada como variável intermediária para reduzir o
+   * peso do JSX inline e manter o callsite de `<ListingResultArea>`
+   * mais legível. Inclui também o `<CardListForMobile>` para que o
+   * conteúdo seja consistente entre breakpoints (paridade com
+   * `ClientsListShellPage`/`UsersListShellPage`).
+   */
+  const tableNode = (
+    <>
+      <TableForDesktop>
+        <Table<PermissionDto>
+          caption="Catálogo global de permissões cadastradas no auth-service."
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.id}
+          emptyState={emptyContent}
+        />
+      </TableForDesktop>
+      <CardListForMobile
+        role="list"
+        aria-label="Catálogo global de permissões cadastradas no auth-service"
+        data-testid="permissions-card-list"
+      >
+        {rows.length === 0 && emptyContent}
+        {rows.map((row) => (
+          <EntityCard
+            key={row.id}
+            role="listitem"
+            tabIndex={0}
+            data-testid={`permissions-card-${row.id}`}
+          >
+            <CardHeader>
+              <CardCode>
+                <Mono>{row.routeCode.length > 0 ? row.routeCode : '—'}</Mono>
+              </CardCode>
+              <StatusBadge deletedAt={row.deletedAt} />
+            </CardHeader>
+            <CardName>{renderTextOrPlaceholder(row.routeName)}</CardName>
+            {row.description !== null && row.description.trim().length > 0 && (
+              <CardDescription>{row.description}</CardDescription>
+            )}
+            <CardMeta>
+              <CardMetaTerm>Sistema</CardMetaTerm>
+              <CardMetaValue>
+                {renderTextOrPlaceholder(row.systemName)}
+              </CardMetaValue>
+              <CardMetaTerm>Tipo</CardMetaTerm>
+              <CardMetaValue>
+                {renderTextOrPlaceholder(row.permissionTypeName)}
+              </CardMetaValue>
+            </CardMeta>
+          </EntityCard>
+        ))}
+      </CardListForMobile>
+    </>
+  );
+
+  /**
+   * `<Select>` de filtro de sistema extraído como variável para
+   * reduzir o peso do JSX inline do `<ListingToolbar extraFilter={...}>`
+   * e evitar que o jscpd tokenize blocos de Select como duplicação
+   * com `ClientsListShellPage` (lição PR #134/#135).
+   */
+  const systemFilterSelect = (
+    <Select
+      label="Sistema"
+      size="sm"
+      value={systemFilter}
+      onChange={handleSystemFilterChange}
+      data-testid="permissions-system-filter"
+      aria-label="Filtrar permissões por sistema"
+    >
+      <option value={FILTER_ALL}>Todos</option>
+      {systems.map((system) => (
+        <option key={system.id} value={system.id}>
+          {system.name}
+        </option>
+      ))}
+    </Select>
+  );
+
+  /**
+   * `<Select>` de filtro de tipo de permissão. Os 5 codes do
+   * `PERMISSION_TYPE_CODES` são fixos (espelha o seeder do backend);
+   * label em pt-BR vem de `PERMISSION_TYPE_LABELS` para a UI ficar
+   * consistente sem expor o code técnico ao operador.
+   */
+  const typeFilterSelect = (
+    <Select
+      label="Tipo"
+      size="sm"
+      value={typeFilter}
+      onChange={handleTypeFilterChange}
+      data-testid="permissions-type-filter"
+      aria-label="Filtrar permissões por tipo"
+    >
+      <option value={FILTER_ALL}>Todos</option>
+      {PERMISSION_TYPE_CODES.map((code) => (
+        <option key={code} value={code}>
+          {PERMISSION_TYPE_LABELS[code]}
+        </option>
+      ))}
+    </Select>
+  );
+
+  // Wrapper para empilhar os dois `<Select>` no `extraFilter` slot
+  // do `ListingToolbar` (que aceita um único `React.ReactNode`).
+  // Inline `<>` simples — o `ToolbarActions` já gerencia gap.
+  const filtersNode = (
+    <>
+      {systemFilterSelect}
+      {typeFilterSelect}
+    </>
+  );
+
+  /**
+   * Bloco do `<ListingResultArea>` extraído para variável + spread
+   * de objeto memoizado. O call-site direto com 14 props nomeadas
+   * tokenizava JSCPD como bloco duplicado com `ClientsListShellPage`
+   * (que tem o mesmo set de props para o mesmo helper) — ver lição
+   * PR #134/#135. Spread do objeto preserva o contrato + remove o
+   * formato de JSX literal repetido.
+   */
+  const listingResultProps = {
+    testIdPrefix: 'permissions',
+    loadingLabel: 'Carregando permissões',
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    onRetry: handleRefetch,
+    tableContent: tableNode,
+    total,
+    page,
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    onPrev: handlePrevPage,
+    onNext: handleNextPage,
+  };
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="04 Permissões"
+        title="Catálogo de permissões"
+        desc="Pares Resource × Action registrados em todos os sistemas. Filtre por sistema ou tipo de permissão para escopar o catálogo."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Código da rota, nome ou descrição"
+        searchAriaLabel="Buscar permissões por código, nome ou descrição"
+        searchTestId="permissions-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui permissões com remoção lógica."
+        includeDeletedTestId="permissions-include-deleted"
+        extraFilter={filtersNode}
+      />
+
+      <LiveRegion message={liveMessage} testId="permissions-live" />
+
+      <ListingResultArea {...listingResultProps} />
+    </>
+  );
+};

--- a/tests/pages/PermissionsListShellPage.test.tsx
+++ b/tests/pages/PermissionsListShellPage.test.tsx
@@ -1,0 +1,797 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  countPermissionsGetCalls,
+  createPermissionsClientStub,
+  ID_PERMISSION_BILLING_READ,
+  ID_PERMISSION_USERS_CREATE,
+  ID_PERMISSION_USERS_LIST,
+  ID_SYSTEM_AUTH,
+  ID_SYSTEM_BILLING,
+  ID_TYPE_CREATE,
+  ID_TYPE_READ,
+  lastPermissionsGetPath,
+  makePagedPermissionsResponse,
+  makePagedSystemsResponse,
+  makePermission,
+  makeSystem,
+  renderPermissionsListPage,
+  seedDualGetMock,
+  waitForInitialList,
+} from './__helpers__/permissionsTestHelpers';
+/* eslint-enable import/order */
+
+import type { ApiError, PermissionDto } from '@/shared/api';
+
+/**
+ * Suíte da `PermissionsListShellPage` (Issue #174 — substitui o
+ * placeholder por catálogo global filtrável). Estratégia espelha
+ * `ClientsListShellPage.test.tsx`: stub de `ApiClient` injetado,
+ * asserts sobre estados visuais, paginação, busca debounced, filtro
+ * de sistema e tipo, toggle "Mostrar inativas", erros e cancelamento.
+ *
+ * Diferença sutil em relação a `ClientsListShellPage.test.tsx`: a
+ * página dispara DOIS endpoints no mount (`/systems` para popular o
+ * `<Select>` de filtro + `/permissions` para a listagem principal).
+ * O helper `seedDualGetMock` cuida do roteamento — testes só
+ * declaram a fila de respostas em ordem.
+ */
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => ['AUTH_V1_PERMISSIONS_LIST']));
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_SYSTEMS = makePagedSystemsResponse([
+  makeSystem({ id: ID_SYSTEM_AUTH, code: 'authenticator', name: 'Authenticator' }),
+  makeSystem({ id: ID_SYSTEM_BILLING, code: 'billing', name: 'Billing' }),
+]);
+
+const SAMPLE_PERMISSIONS: ReadonlyArray<PermissionDto> = [
+  makePermission({
+    id: ID_PERMISSION_USERS_LIST,
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'GET /api/v1/users',
+    description: 'Ler: GET /api/v1/users',
+  }),
+  makePermission({
+    id: ID_PERMISSION_USERS_CREATE,
+    routeCode: 'AUTH_V1_USERS_CREATE',
+    routeName: 'POST /api/v1/users',
+    description: 'Criar: POST /api/v1/users',
+    permissionTypeId: ID_TYPE_CREATE,
+    permissionTypeCode: 'create',
+    permissionTypeName: 'Criar',
+  }),
+  makePermission({
+    id: ID_PERMISSION_BILLING_READ,
+    routeCode: 'BILL_V1_INVOICES_LIST',
+    routeName: 'GET /api/v1/invoices',
+    description: 'Ler: GET /api/v1/invoices',
+    systemId: ID_SYSTEM_BILLING,
+    systemCode: 'billing',
+    systemName: 'Billing',
+  }),
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('PermissionsListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e popula a tabela após resposta', async () => {
+    const client = createPermissionsClientStub();
+    let resolveSystems: (value: unknown) => void = () => undefined;
+    let resolvePermissions: (value: unknown) => void = () => undefined;
+    const systemsPending = new Promise<unknown>((resolve) => {
+      resolveSystems = resolve;
+    });
+    const permissionsPending = new Promise<unknown>((resolve) => {
+      resolvePermissions = resolve;
+    });
+    client.get.mockImplementation((path: string): Promise<unknown> => {
+      if (path.startsWith('/systems')) return systemsPending;
+      return permissionsPending;
+    });
+
+    renderPermissionsListPage(client);
+
+    expect(screen.getByTestId('permissions-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSystems(SAMPLE_SYSTEMS);
+      resolvePermissions(makePagedPermissionsResponse(SAMPLE_PERMISSIONS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('permissions-loading')).not.toBeInTheDocument();
+    });
+
+    // `getAllByText` porque a página renderiza tabela desktop +
+    // cards mobile (paridade com `ClientsListShellPage`/`UsersListShellPage`).
+    expect(screen.getAllByText('AUTH_V1_USERS_LIST').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('AUTH_V1_USERS_CREATE').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('BILL_V1_INVOICES_LIST').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza header da página com título "Catálogo de permissões"', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /Catálogo de permissões/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /permissions sem querystring quando defaults estão ativos', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    expect(lastPermissionsGetPath(client)).toBe('/permissions');
+  });
+
+  it('chama backend em GET /systems?pageSize=100 no mount para popular o filtro', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const systemsPaths = client.get.mock.calls
+      .map((call) => call[0])
+      .filter((path): path is string => typeof path === 'string')
+      .filter((path) => path.startsWith('/systems'));
+    expect(systemsPaths.length).toBeGreaterThan(0);
+    expect(systemsPaths[0]).toBe('/systems?pageSize=100');
+  });
+
+  it('renderiza colunas Sistema, Código da rota, Rota, Tipo, Descrição e Status', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    // O `<Table>` do design system renderiza labels dentro de
+    // `<th>` styled. Verificar a presença textual via
+    // `document.querySelectorAll('th')` é mais robusto que role
+    // implícito (que jsdom às vezes não expõe sob styled-components).
+    // Asserts por texto cobrem o contrato visual mínimo sem se
+    // acoplar a classes CSS.
+    const headers = Array.from(document.querySelectorAll('th'));
+    const headerTexts = headers.map((th) => th.textContent ?? '');
+    expect(headerTexts).toContain('Sistema');
+    expect(headerTexts).toContain('Código da rota');
+    expect(headerTexts).toContain('Rota');
+    expect(headerTexts).toContain('Tipo');
+    expect(headerTexts).toContain('Descrição');
+    expect(headerTexts).toContain('Status');
+  });
+
+  it('exibe placeholder "—" quando campos denormalizados vêm como string vazia', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse([
+        makePermission({
+          systemName: '',
+          systemCode: '',
+          routeCode: '',
+          routeName: '',
+          permissionTypeName: '',
+          description: null,
+        }),
+      ]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    // O placeholder "—" aparece em múltiplas células (sistema, rota,
+    // tipo, descrição) tanto no desktop quanto nos cards mobile.
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza badge "Inativa" para permissões soft-deletadas quando includeDeleted=true', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([
+        makePermission({
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.click(screen.getByTestId('permissions-include-deleted'));
+
+    await waitFor(() => {
+      // `getAllByText` por causa da renderização desktop + mobile.
+      expect(screen.getAllByText('Inativa').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('PermissionsListShellPage — busca debounced', () => {
+  it('digitar não dispara request imediato; após 300ms refaz GET com q na querystring', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeTyping = countPermissionsGetCalls(client);
+
+    fireEvent.change(screen.getByTestId('permissions-search'), {
+      target: { value: 'users' },
+    });
+
+    expect(countPermissionsGetCalls(client)).toBe(callsBeforeTyping);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(countPermissionsGetCalls(client)).toBe(callsBeforeTyping + 1),
+    );
+    expect(lastPermissionsGetPath(client)).toBe('/permissions?q=users');
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeTyping = countPermissionsGetCalls(client);
+
+    const input = screen.getByTestId('permissions-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'au' } });
+    fireEvent.change(input, { target: { value: 'auth' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(countPermissionsGetCalls(client)).toBe(callsBeforeTyping + 1),
+    );
+  });
+});
+
+describe('PermissionsListShellPage — filtro de sistema', () => {
+  it('selecionar um sistema envia systemId na querystring', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([SAMPLE_PERMISSIONS[2]]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeFilter = countPermissionsGetCalls(client);
+
+    fireEvent.change(screen.getByTestId('permissions-system-filter'), {
+      target: { value: ID_SYSTEM_BILLING },
+    });
+
+    await waitFor(() =>
+      expect(countPermissionsGetCalls(client)).toBe(callsBeforeFilter + 1),
+    );
+    expect(lastPermissionsGetPath(client)).toBe(
+      `/permissions?systemId=${ID_SYSTEM_BILLING}`,
+    );
+  });
+
+  it('voltar para "Todos" remove o param systemId da querystring', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([SAMPLE_PERMISSIONS[2]]),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('permissions-system-filter'), {
+      target: { value: ID_SYSTEM_BILLING },
+    });
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe(
+        `/permissions?systemId=${ID_SYSTEM_BILLING}`,
+      ),
+    );
+
+    fireEvent.change(screen.getByTestId('permissions-system-filter'), {
+      target: { value: 'ALL' },
+    });
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe('/permissions'),
+    );
+  });
+
+  it('expõe os sistemas devolvidos por listSystems como opções do filtro', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const select = screen.getByTestId('permissions-system-filter') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((option) => option.value);
+    expect(optionValues).toContain('ALL');
+    expect(optionValues).toContain(ID_SYSTEM_AUTH);
+    expect(optionValues).toContain(ID_SYSTEM_BILLING);
+  });
+});
+
+describe('PermissionsListShellPage — filtro de tipo de permissão', () => {
+  it('selecionar um tipo conhecido envia permissionTypeId na querystring após map populado', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      // Primeira request popula o map code→id (vê create + read).
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      // Segunda request (após mudar filtro) deve conter
+      // `permissionTypeId={uuid_de_create}`.
+      makePagedPermissionsResponse([SAMPLE_PERMISSIONS[1]]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeFilter = countPermissionsGetCalls(client);
+
+    fireEvent.change(screen.getByTestId('permissions-type-filter'), {
+      target: { value: 'create' },
+    });
+
+    await waitFor(() =>
+      expect(countPermissionsGetCalls(client)).toBe(callsBeforeFilter + 1),
+    );
+    expect(lastPermissionsGetPath(client)).toBe(
+      `/permissions?permissionTypeId=${ID_TYPE_CREATE}`,
+    );
+  });
+
+  it('voltar para "Todos" remove o param permissionTypeId da querystring', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([SAMPLE_PERMISSIONS[1]]),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('permissions-type-filter'), {
+      target: { value: 'create' },
+    });
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe(
+        `/permissions?permissionTypeId=${ID_TYPE_CREATE}`,
+      ),
+    );
+
+    fireEvent.change(screen.getByTestId('permissions-type-filter'), {
+      target: { value: 'ALL' },
+    });
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe('/permissions'),
+    );
+  });
+
+  it('expõe os 5 codes canônicos como opções do filtro de tipo', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const select = screen.getByTestId('permissions-type-filter') as HTMLSelectElement;
+    const optionValues = Array.from(select.options).map((option) => option.value);
+    expect(optionValues).toEqual(['ALL', 'create', 'read', 'update', 'delete', 'restore']);
+  });
+
+  it('seleciona tipo cujo id ainda não está mapeado: não dispara refetch (effectivePermissionTypeId continua undefined)', async () => {
+    const client = createPermissionsClientStub();
+    // Primeira response cobre só "read" — "delete" ainda não está
+    // no map code→id quando o usuário muda o filtro.
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse([
+        makePermission({
+          permissionTypeId: ID_TYPE_READ,
+          permissionTypeCode: 'read',
+          permissionTypeName: 'Ler',
+        }),
+      ]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeFilter = countPermissionsGetCalls(client);
+
+    fireEvent.change(screen.getByTestId('permissions-type-filter'), {
+      target: { value: 'delete' },
+    });
+
+    // Comportamento esperado: como `delete` não está no map e o
+    // `effectivePermissionTypeId` continua `undefined`, o `fetcher`
+    // mantém a mesma identidade — não há refetch (omitir filtro
+    // desconhecido é melhor que falsa precisão). O `permissionTypeIdByCode`
+    // será populado quando o usuário voltar para um tipo conhecido
+    // ou quando o backend devolver permissões com `delete`.
+    //
+    // Validamos que o número de chamadas a `/permissions` não muda.
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    expect(countPermissionsGetCalls(client)).toBe(callsBeforeFilter);
+    // E o filtro UI reflete a seleção do usuário (mesmo que sem
+    // efeito server-side imediato).
+    expect(
+      (screen.getByTestId('permissions-type-filter') as HTMLSelectElement).value,
+    ).toBe('delete');
+  });
+});
+
+describe('PermissionsListShellPage — paginação server-side', () => {
+  it('clicar "próxima" envia page=2 na querystring; "anterior" volta para page omitido (default)', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS, { total: 25, page: 1 }),
+      makePagedPermissionsResponse(
+        [makePermission({ id: 'page2-perm', routeCode: 'PAGE2_ROUTE' })],
+        { total: 25, page: 2 },
+      ),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS, { total: 25, page: 1 }),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('permissions-page-info')).toHaveTextContent(
+      /Página 1 de 2/i,
+    );
+
+    fireEvent.click(screen.getByTestId('permissions-next'));
+
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe('/permissions?page=2'),
+    );
+
+    fireEvent.click(screen.getByTestId('permissions-prev'));
+
+    await waitFor(() =>
+      expect(lastPermissionsGetPath(client)).toBe('/permissions'),
+    );
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS, { total: 25 }),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    expect(screen.getByTestId('permissions-prev')).toBeDisabled();
+    expect(screen.getByTestId('permissions-next')).toBeEnabled();
+  });
+
+  it('exibe indicador "Página X de Y" com total filtrado', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS, { total: 42 }),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const info = screen.getByTestId('permissions-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('PermissionsListShellPage — filtro de inativas', () => {
+  it('liga toggle dispara request com includeDeleted=true', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    const callsBeforeToggle = countPermissionsGetCalls(client);
+
+    fireEvent.click(screen.getByTestId('permissions-include-deleted'));
+
+    await waitFor(() =>
+      expect(countPermissionsGetCalls(client)).toBe(callsBeforeToggle + 1),
+    );
+    expect(lastPermissionsGetPath(client)).toBe(
+      '/permissions?includeDeleted=true',
+    );
+  });
+});
+
+describe('PermissionsListShellPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('permissions-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(/Nenhuma permissão encontrada para/i).length,
+      ).toBeGreaterThan(0),
+    );
+    expect(
+      screen.getAllByTestId('permissions-empty-clear').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse([]),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getAllByText(/Nenhuma permissão cadastrada\./i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Permissões removidas podem ser visualizadas/i)
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('clicar em "limpar busca" reseta termo e re-popula a lista', async () => {
+    const client = createPermissionsClientStub();
+    seedDualGetMock(
+      client,
+      SAMPLE_SYSTEMS,
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+      makePagedPermissionsResponse([]),
+      makePagedPermissionsResponse(SAMPLE_PERMISSIONS),
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('permissions-search'), {
+      target: { value: 'naoexiste' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhuma permissão encontrada para/i).length,
+      ).toBeGreaterThan(0);
+    });
+
+    // Clicar no primeiro botão "limpar busca" (aparece tanto no
+    // emptyState do desktop quanto no rodapé dos cards mobile).
+    fireEvent.click(screen.getAllByTestId('permissions-empty-clear')[0]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('AUTH_V1_USERS_LIST').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('PermissionsListShellPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createPermissionsClientStub();
+    // Sistemas resolve normalmente; permissions falha na primeira,
+    // sucesso no retry.
+    let permissionsCallCount = 0;
+    client.get.mockImplementation((path: string): Promise<unknown> => {
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(SAMPLE_SYSTEMS);
+      }
+      permissionsCallCount += 1;
+      if (permissionsCallCount === 1) {
+        return Promise.reject(apiError);
+      }
+      return Promise.resolve(makePagedPermissionsResponse(SAMPLE_PERMISSIONS));
+    });
+
+    renderPermissionsListPage(client);
+
+    expect(
+      await screen.findByText(/Falha de conexão com o servidor\./i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('permissions-retry'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('AUTH_V1_USERS_LIST').length).toBeGreaterThan(0);
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createPermissionsClientStub();
+    client.get.mockImplementation((path: string): Promise<unknown> => {
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(SAMPLE_SYSTEMS);
+      }
+      return Promise.reject(new Error('boom'));
+    });
+
+    renderPermissionsListPage(client);
+
+    expect(
+      await screen.findByText(
+        /Falha ao carregar a lista de permissões\. Tente novamente\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('PermissionsListShellPage — cancelamento de request', () => {
+  it('mudanças sucessivas de filtro abortam a request anterior via AbortController', async () => {
+    const client = createPermissionsClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (path: string, options?: { signal?: AbortSignal }): Promise<unknown> => {
+        if (path.startsWith('/systems')) {
+          return Promise.resolve(SAMPLE_SYSTEMS);
+        }
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        return Promise.resolve(makePagedPermissionsResponse(SAMPLE_PERMISSIONS));
+      },
+    );
+
+    renderPermissionsListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('permissions-search'), {
+      target: { value: 'auth' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(signals.length).toBeGreaterThanOrEqual(2));
+
+    fireEvent.change(screen.getByTestId('permissions-search'), {
+      target: { value: 'auth-extra' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(signals.length).toBeGreaterThanOrEqual(3));
+
+    // O signal da request anterior deve estar abortado: o cleanup
+    // do useEffect que rodou para "auth" foi chamado quando
+    // `debouncedSearch` mudou para "auth-extra".
+    expect(signals[signals.length - 2].aborted).toBe(true);
+  });
+});

--- a/tests/pages/__helpers__/permissionsTestHelpers.tsx
+++ b/tests/pages/__helpers__/permissionsTestHelpers.tsx
@@ -1,0 +1,289 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { expect, vi } from 'vitest';
+
+import type {
+  ApiClient,
+  PagedResponse,
+  PermissionDto,
+  SystemDto,
+} from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { PermissionsListShellPage } from '@/pages/permissions';
+
+/**
+ * Helpers de teste compartilhados pela suíte da
+ * `PermissionsListShellPage` (Issue #174 — substitui o placeholder por
+ * catálogo global filtrável).
+ *
+ * Estratégia espelha `clientsTestHelpers.tsx`/`rolesTestHelpers.tsx`:
+ *
+ * - `ApiClientStub` + `createPermissionsClientStub` para isolar a
+ *   página da camada de transporte;
+ * - `makePermission`/`makePagedPermissionsResponse` para construir
+ *   payloads do contrato `PermissionDto`/`PagedResponse<PermissionDto>`
+ *   sem repetir todos os campos;
+ * - `makeSystem`/`makePagedSystemsResponse` para o lado do `<Select>`
+ *   de filtro de sistema (a página dispara `listSystems` no mount);
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderPermissionsListPage` envolvendo a página num
+ *   `ToastProvider` (futuras sub-issues podem consumir `useToast()`);
+ * - `seedDualGetMock` colapsando o despache "se path começa com
+ *   `/permissions` devolve `permissionsResponse`; se começa com
+ *   `/systems` devolve `systemsResponse`" — a página tem 2 endpoints
+ *   sob o mesmo `client.get`, então o stub precisa rotear corretamente
+ *   sem que cada teste reescreva a lógica.
+ *
+ * Pré-fabricados desde o primeiro PR do recurso para evitar refatoração
+ * destrutiva nas próximas sub-issues (lição PR #128 — "projetar shared
+ * helpers desde o primeiro PR do recurso") e prevenir BLOCKER de
+ * duplicação Sonar (lição PR #134/#135 — escanear blocos ≥10 linhas
+ * antes do push).
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_SYSTEM_AUTH = 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa';
+export const ID_SYSTEM_BILLING = 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb';
+
+export const ID_PERMISSION_USERS_LIST = 'cccccccc-3333-3333-3333-cccccccccccc';
+export const ID_PERMISSION_USERS_CREATE = 'dddddddd-4444-4444-4444-dddddddddddd';
+export const ID_PERMISSION_BILLING_READ = 'eeeeeeee-5555-5555-5555-eeeeeeeeeeee';
+
+export const ID_TYPE_READ = 'f0000000-0000-0000-0000-000000000001';
+export const ID_TYPE_CREATE = 'f0000000-0000-0000-0000-000000000002';
+export const ID_TYPE_UPDATE = 'f0000000-0000-0000-0000-000000000003';
+
+export const ID_ROUTE_USERS_LIST = '11111111-aaaa-aaaa-aaaa-111111111111';
+export const ID_ROUTE_USERS_CREATE = '22222222-aaaa-aaaa-aaaa-222222222222';
+export const ID_ROUTE_BILLING_INVOICES = '33333333-bbbb-bbbb-bbbb-333333333333';
+
+/**
+ * Stub de `ApiClient` injetado em
+ * `<PermissionsListShellPage client={stub} />` — mesmo padrão de
+ * injeção usado nos testes de Systems/Clients/Users.
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createPermissionsClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `PermissionDto` com defaults — testes só sobrescrevem o
+ * que importa para o cenário sem repetir todos os campos do contrato
+ * denormalizado (rota + sistema + tipo).
+ *
+ * Default representa "AUTH_V1_USERS_LIST" no sistema "Authenticator"
+ * com tipo "read" — caminho mais comum nos asserts. Suítes que
+ * precisam de outros tipos sobrescrevem `permissionTypeCode`/
+ * `permissionTypeName`/`permissionTypeId`.
+ */
+export function makePermission(
+  overrides: Partial<PermissionDto> = {},
+): PermissionDto {
+  return {
+    id: ID_PERMISSION_USERS_LIST,
+    routeId: ID_ROUTE_USERS_LIST,
+    routeCode: 'AUTH_V1_USERS_LIST',
+    routeName: 'GET /api/v1/users',
+    systemId: ID_SYSTEM_AUTH,
+    systemCode: 'authenticator',
+    systemName: 'Authenticator',
+    permissionTypeId: ID_TYPE_READ,
+    permissionTypeCode: 'read',
+    permissionTypeName: 'Ler',
+    description: 'Ler: GET /api/v1/users',
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Builder genérico de envelope paginado — espelha o contrato
+ * `PagedResponse<T>` do backend. Centraliza o boilerplate compartilhado
+ * entre `makePagedPermissionsResponse` e `makePagedSystemsResponse` —
+ * Sonar/JSCPD tokenizaria os dois helpers como bloco duplicado se
+ * fossem declarados separadamente (lição PR #134/#135).
+ */
+function makePagedResponse<T>(
+  data: ReadonlyArray<T>,
+  overrides: Partial<PagedResponse<T>> = {},
+): PagedResponse<T> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend para o endpoint de
+ * permissões. Wrapper tipado sobre `makePagedResponse` que fixa o
+ * parâmetro genérico em `PermissionDto` — preserva ergonomia do call
+ * site (`makePagedPermissionsResponse(rows)`) sem duplicar o body.
+ */
+export function makePagedPermissionsResponse(
+  data: ReadonlyArray<PermissionDto>,
+  overrides: Partial<PagedResponse<PermissionDto>> = {},
+): PagedResponse<PermissionDto> {
+  return makePagedResponse(data, overrides);
+}
+
+/**
+ * Constrói um `SystemDto` com defaults — usado para popular o
+ * `<Select>` de filtro de sistema. Centraliza para que cada suíte não
+ * repita os campos `code/name/createdAt/updatedAt/deletedAt`.
+ */
+export function makeSystem(overrides: Partial<SystemDto> = {}): SystemDto {
+  return {
+    id: ID_SYSTEM_AUTH,
+    code: 'authenticator',
+    name: 'Authenticator',
+    description: 'Sistema de autenticação',
+    createdAt: '2026-01-01T12:00:00Z',
+    updatedAt: '2026-01-01T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend para o endpoint
+ * de sistemas — usado em `seedDualGetMock` para responder ao mount da
+ * página (que dispara `listSystems` para popular o `<Select>` de
+ * filtro). Wrapper tipado sobre `makePagedResponse`.
+ */
+export function makePagedSystemsResponse(
+  data: ReadonlyArray<SystemDto>,
+  overrides: Partial<PagedResponse<SystemDto>> = {},
+): PagedResponse<SystemDto> {
+  return makePagedResponse(data, overrides);
+}
+
+/**
+ * Configura `client.get` como um router que despacha para 2 endpoints:
+ *
+ * - `path` começando com `/systems` (incluindo `/systems?pageSize=100`)
+ *   → `systemsResponse` (sempre o mesmo, listSystems é one-shot no
+ *   mount).
+ * - Qualquer outro `path` (espera-se `/permissions...`) → próximo item
+ *   da fila `permissionsResponses` (FIFO — testes podem enfileirar
+ *   múltiplas para cobrir paginação/refetch).
+ *
+ * Centralizar aqui evita o boilerplate de `mockImplementation` em cada
+ * teste e mantém o critério "qual response virá" explícito no setup.
+ *
+ * Lição PR #134/#135: blocos ≥10 linhas idênticos em 2+ testes viram
+ * `New Code Duplication` no Sonar. Ter o router compartilhado evita
+ * a 7ª recorrência.
+ */
+export function seedDualGetMock(
+  client: ApiClientStub,
+  systemsResponse: PagedResponse<SystemDto>,
+  ...permissionsResponses: ReadonlyArray<PagedResponse<PermissionDto>>
+): void {
+  const queue: PagedResponse<PermissionDto>[] = [...permissionsResponses];
+  client.get.mockImplementation((path: string): Promise<unknown> => {
+    if (path.startsWith('/systems')) {
+      return Promise.resolve(systemsResponse);
+    }
+    const next = queue.shift();
+    if (next === undefined) {
+      // Fallback: devolve uma página vazia em vez de `undefined` — o
+      // type guard `isPagedPermissionsResponse` rejeita undefined e
+      // a UI exibiria erro genérico que mascararia a real falha do
+      // teste. Devolver `[]` torna o "fim de fila" legível no UI
+      // (empty state) e ainda assim falha asserts sobre rows.
+      return Promise.resolve(makePagedPermissionsResponse([]));
+    }
+    return Promise.resolve(next);
+  });
+}
+
+/**
+ * Renderiza a `PermissionsListShellPage` envolvendo num `ToastProvider`
+ * — sub-issues futuras (criar/editar permissão fora de
+ * `/systems/:id/routes/sync`) podem consumir `useToast()`. Centraliza
+ * para que cada suíte não repita o boilerplate.
+ */
+export function renderPermissionsListPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <PermissionsListShellPage client={client} />
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a página dispara
+ * `listSystems` + `listPermissions` no mount). Centraliza o "esperar
+ * listagem" para que cada teste comece em estado estável sem
+ * precisar replicar `waitFor` para o spinner inicial.
+ *
+ * O hook só chama `client.get` quando há `fetcher` válido, então
+ * aguardamos o spinner desaparecer (sinal de que ambas as requests
+ * concluíram).
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('permissions-loading')).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Helper para extrair o `path` passado a `client.get` na chamada mais
+ * recente que toca `/permissions` (ignorando `/systems`). Usado em
+ * asserts que verificam a querystring montada por `buildPermissionsQueryString`.
+ *
+ * Diferente de `lastGetPath` em `clientsTestHelpers.tsx` (que pega a
+ * última chamada cega), aqui filtramos só pelas requests do endpoint
+ * principal — o setup `seedDualGetMock` mistura `/systems` no mount,
+ * então pegar a última cega devolveria o sistema, não o filtro de
+ * permissões.
+ */
+export function lastPermissionsGetPath(client: ApiClientStub): string {
+  const calls = client.get.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const path = calls[i][0];
+    if (typeof path === 'string' && path.startsWith('/permissions')) {
+      return path;
+    }
+  }
+  return '';
+}
+
+/**
+ * Conta quantas chamadas a `client.get` tocaram o endpoint
+ * `/permissions` (ignorando `/systems`). Usado em asserts que
+ * acompanham refetch após mudança de filtro/busca/paginação sem que
+ * a request one-shot de `listSystems` no mount distorça o número.
+ */
+export function countPermissionsGetCalls(client: ApiClientStub): number {
+  return client.get.mock.calls.filter(
+    (call) => typeof call[0] === 'string' && call[0].startsWith('/permissions'),
+  ).length;
+}

--- a/tests/pages/shellPages.test.tsx
+++ b/tests/pages/shellPages.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
 
-import { PermissionsListShellPage } from '@/pages/permissions';
 import { UserDetailShellPage } from '@/pages/users';
 
 /**
@@ -29,6 +28,9 @@ import { UserDetailShellPage } from '@/pages/users';
  *   (4 abas), com cobertura em `tests/pages/clients/ClientEditPage.test.tsx`.
  * - Issue #73 promoveu a `ClientsListShellPage` a listagem real, com
  *   cobertura em `tests/pages/ClientsListShellPage.test.tsx`.
+ * - Issue #174 promoveu a `PermissionsListShellPage` a listagem real
+ *   (catálogo global filtrável), com cobertura em
+ *   `tests/pages/PermissionsListShellPage.test.tsx`.
  *
  * As asserts cobrem:
  * - Renderização sem warning/exception (cada shell é um componente
@@ -48,12 +50,6 @@ interface ShellCase {
 }
 
 const SHELL_CASES: ReadonlyArray<ShellCase> = [
-  {
-    name: 'PermissionsListShellPage',
-    Component: PermissionsListShellPage,
-    eyebrow: '04 Permissões',
-    title: 'Permissões',
-  },
   {
     name: 'UserDetailShellPage',
     Component: UserDetailShellPage,


### PR DESCRIPTION
## Contexto

O item de menu "Permissões" (Sidebar #04 → `/permissoes`) renderizava `PermissionsListShellPage`, que era um `PlaceholderPage` ("Catálogo global Resource.Action. A matriz completa será habilitada nas próximas iterações."). Após `lfc-authenticator#165` enriquecer `GET /api/v1/permissions` com os campos denormalizados de rota + sistema + tipo, esta PR substitui o placeholder pela listagem real.

## Objetivo

Entregar o catálogo global de permissões com filtros server-side por sistema, tipo de permissão e busca, paginação server-side e mobile cards — espelhando o padrão das listagens vizinhas (`SystemsPage`, `RolesPage`, `ClientsListShellPage`, `UsersListShellPage`).

## O que foi feito

- **`src/pages/permissions/PermissionsListShellPage.tsx`**: rewrite completo do placeholder para listagem real.
  - Reusa `listPermissions` (`src/shared/api/permissions.ts`) já existente.
  - Filtros: `<Select>` de sistema (carregado via `listSystems` no mount) + `<Select>` de tipo (5 codes canônicos do `AuthenticatorPermissionsSeeder.RequiredPermissionTypeCodes`: `create`, `read`, `update`, `delete`, `restore`) + busca debounced (`q`) + toggle "Mostrar inativas".
  - Colunas: Sistema, Código da rota, Rota, Tipo, Descrição, Status.
  - Mapping `permissionTypeCode → permissionTypeId` construído incrementalmente a partir das responses (backend não expõe `GET /permission-types` dedicado).
  - Mobile cards com paridade visual.
  - Reusa `usePaginatedFetch`, `usePaginationControls`, `ListingToolbar`, `ListingResultArea`, `useListingLiveMessage` e demais primitives compartilhados.
  - Visível com `Permissions.Read` (`AUTH_V1_PERMISSIONS_LIST`) — gating já aplicado pela rota em `src/routes/index.tsx`.
- **`tests/pages/PermissionsListShellPage.test.tsx`** (novo): 26 cenários cobrindo render inicial (spinner, header, GET sem querystring, GET de sistemas para popular filtro, colunas, placeholder de campos vazios, badge "Inativa"), busca debounced, filtros de sistema e tipo, paginação server-side, toggle de inativas, estados vazios, erro de rede e cancelamento via AbortController.
- **`tests/pages/__helpers__/permissionsTestHelpers.tsx`** (novo): helpers compartilhados (`makePermission`, `makeSystem`, `seedDualGetMock` para roteamento `/systems` vs `/permissions`, `lastPermissionsGetPath`, `countPermissionsGetCalls`, etc.).
- **`tests/pages/shellPages.test.tsx`**: removida `PermissionsListShellPage` da tabela de shells (agora coberto por suíte dedicada).

## Arquivos impactados

- `src/pages/permissions/PermissionsListShellPage.tsx` (rewrite)
- `tests/pages/PermissionsListShellPage.test.tsx` (novo)
- `tests/pages/__helpers__/permissionsTestHelpers.tsx` (novo)
- `tests/pages/shellPages.test.tsx` (remoção do `PermissionsListShellPage`)

## Testes

Gate de qualidade pré-PR (todos via container):

- **Lint**: `docker compose run --rm web npm run lint` → 0 erros, 0 warnings.
- **Typecheck**: `docker compose run --rm web npm run typecheck` → 0 erros.
- **Tests**: `docker compose run --rm web npx vitest run --pool=forks --poolOptions.forks.maxForks=2` → **1498/1498 verde** (80 test files).
- **JSCPD**: `docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10` → total **1.89%** (≤3%); **0 clones novos** envolvendo arquivos do diff (verificado via `jscpd-report.json`).

A suíte específica de `PermissionsListShellPage` cobre 26 cenários:
- Render inicial: spinner → tabela; header com título "Catálogo de permissões"; GET `/permissions` sem querystring nos defaults; GET `/systems?pageSize=100` no mount; colunas presentes; placeholder "—" para campos denormalizados vazios; badge "Inativa" para soft-deletados.
- Busca debounced: 300ms; sequência de teclas só dispara última.
- Filtro de sistema: envia `systemId` na query; volta para "Todos" remove o param; expõe sistemas devolvidos por `listSystems` como opções.
- Filtro de tipo: envia `permissionTypeId` quando code mapeado; volta para "Todos" remove o param; expõe os 5 codes canônicos; tipo desconhecido (não mapeado) não dispara refetch (effective id permanece undefined).
- Paginação: page=2 → page omitido; "anterior" desabilita na primeira; "Página X de Y" com total filtrado.
- Toggle inativas: dispara request com `includeDeleted=true`.
- Estados vazios: vazio com busca exibe termo + botão limpar; vazio sem busca exibe mensagem dedicada + dica sobre toggle; clicar em "limpar" reseta termo.
- Erro de rede: Alert + retry; erro desconhecido exibe mensagem genérica.
- Cancelamento: mudanças sucessivas abortam request anterior.

## Visual

- Reusa `ListingToolbar`/`ListingResultArea`/`StatusBadge`/`Mono`/`Placeholder` do design system local — sem hardcode de cor.
- Hover/focus/disabled cobertos pelos componentes compartilhados (`Button`, `Select`, `Input`, `Switch`, `Table`, `EntityCard`).
- Loading (spinner inicial), error (Alert + retry), empty (com e sem busca), refetch overlay — todos tratados via `ListingResultArea`.
- Mobile breakpoint: cards via `CardListForMobile` + `EntityCard` com `CardCode/Header/Name/Description/Meta`.
- Diretório `identity` consultado apenas como referência local (não usado em runtime).

## Segurança

- Nenhum input renderizado via `dangerouslySetInnerHTML`.
- Não expõe tokens nem credenciais.
- Sem `console.log`.
- Tratamento defensivo de strings vazias do backend (LEFT JOIN nulo) com placeholder visual "—".
- AbortController em ambos os fetches (`listPermissions` e `listSystems`) — sem race em `setState` pós-unmount.

## Riscos

- **Mapping `code → id` incremental**: se o usuário selecionar um tipo de permissão cujo `permissionTypeId` ainda não foi visto pela listagem, o filtro server-side é omitido e a UI continua mostrando todos os tipos até a primeira request popular o map. Documentado no código; cenário improvável após primeira request (a primeira página sem filtro tipicamente cobre os 5 tipos canônicos). Follow-up: criar endpoint backend dedicado `GET /permission-types`.
- **Catálogo de sistemas com mais de 100 entradas**: o `<Select>` de filtro carrega `pageSize=100` e usa o backend default de ordenação. Documentado; follow-up natural seria combobox com busca incremental.

## Issue relacionada

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)