### PR TITLE
feat(roles): listagem global cross-system de /roles (#173)

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -16,32 +16,24 @@ import {
 import { useAuth } from "../shared/auth";
 import {
   BackLink,
-  CardCode,
-  CardDescription,
-  CardHeader,
   CardListForMobile,
   CardMeta,
   CardMetaTerm,
   CardMetaValue,
-  CardName,
-  DescriptionCell,
-  EmptyHint,
-  EmptyMessage,
-  EmptyTitle,
   EntityCard,
   ErrorRetryBlock,
   InitialLoadingSpinner,
   InvalidIdNotice,
   ListingToolbar,
   LiveRegion,
-  Mono,
   PaginationFooter,
-  Placeholder,
   RefetchOverlay,
+  RoleCardHeader,
   RowActions,
   StatusBadge,
   TableForDesktop,
   TableShell,
+  useListingEmptyContent,
   useListingLiveMessage,
 } from "../shared/listing";
 
@@ -103,46 +95,13 @@ function isProbablyValidSystemId(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-/**
- * Renderiza a célula de descrição truncando textos longos via
- * `text-overflow: ellipsis`. **Hoje** o backend não devolve
- * `description` em `RoleResponse` (TODO no model `AppRole` — ver
- * `src/shared/api/roles.ts`), então a coluna tipicamente exibe "—".
- * Quando o backend evoluir, a UI mostra automaticamente sem mudar
- * código.
- *
- * Reusado tanto pela tabela desktop quanto pelos cards mobile —
- * centralizar evita duplicação visual.
- */
-function renderDescription(row: RoleDto): React.ReactNode {
-  if (
-    row.description === null ||
-    row.description === undefined ||
-    row.description.trim().length === 0
-  ) {
-    return <Placeholder>—</Placeholder>;
-  }
-  return (
-    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
-  );
-}
-
-/**
- * Renderiza a contagem de permissões/usuários da role. **Hoje** o
- * backend não devolve esses campos (TODO documentado no DTO); a UI
- * exibe "—" enquanto o valor for `null`/`undefined`. Quando o
- * backend ganhar `permissionsCount`/`usersCount`, a UI passa a
- * exibir o número formatado sem mudar a página.
- *
- * Centralizado em função pura para reuso entre tabela desktop e
- * cards mobile.
- */
-function renderCount(value: number | null | undefined): React.ReactNode {
-  if (typeof value !== "number") {
-    return <Placeholder>—</Placeholder>;
-  }
-  return <Mono>{value}</Mono>;
-}
+// `renderDescription`/`renderCount` extraídos para
+// `src/pages/roles/rolesRenderHelpers.tsx` — compartilhados com
+// `RolesGlobalListShellPage` (lição PR #134/#135 — duplicação Sonar).
+import {
+  renderRoleDescription as renderDescription,
+  renderRoleCount as renderCount,
+} from './roles/rolesRenderHelpers';
 
 export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   // `useParams` devolve `string | undefined` — nunca lançamos: rota
@@ -294,42 +253,23 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   const hasActiveSearch = trimmedSearch.length > 0;
 
   /**
-   * Decide qual mensagem renderizar quando `rows` está vazio:
-   *
-   * - Vazio com busca ativa → cita o termo + sugere limpar.
-   * - Vazio sem busca → "nenhuma role cadastrada" + dica sobre o toggle
-   *   "Mostrar inativas" caso esteja desligado.
+   * `emptyContent` delegado ao hook compartilhado `useListingEmptyContent`
+   * para evitar duplicação JSCPD/Sonar com `RolesGlobalListShellPage`
+   * (lição PR #134/#135 — bloco com `useMemo` + árvore de decisão
+   * `<EmptyMessage>` + `<Button>` se repetia idêntico).
    */
-  const emptyContent = useMemo<React.ReactNode>(() => {
-    if (hasActiveSearch) {
-      return (
-        <EmptyMessage>
-          <EmptyTitle>
-            Nenhuma role encontrada para <Mono>{trimmedSearch}</Mono>.
-          </EmptyTitle>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleClearSearch}
-            data-testid="roles-empty-clear"
-          >
-            Limpar busca
-          </Button>
-        </EmptyMessage>
-      );
-    }
-    return (
-      <EmptyMessage>
-        <EmptyTitle>Nenhuma role cadastrada para este sistema.</EmptyTitle>
-        {!includeDeleted && (
-          <EmptyHint>
-            Roles removidas podem ser visualizadas ativando &quot;Mostrar
-            inativas&quot;.
-          </EmptyHint>
-        )}
-      </EmptyMessage>
-    );
-  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+  const emptyContent = useListingEmptyContent({
+    trimmedSearch,
+    includeDeleted,
+    onClearSearch: handleClearSearch,
+    copy: {
+      searchPrefix: "Nenhuma role encontrada para",
+      emptyTitle: "Nenhuma role cadastrada para este sistema.",
+      hintWhenIncludeDeletedOff:
+        'Roles removidas podem ser visualizadas ativando "Mostrar inativas".',
+      clearTestId: "roles-empty-clear",
+    },
+  });
 
   const columns = useMemo<ReadonlyArray<TableColumn<RoleDto>>>(() => {
     const base: Array<TableColumn<RoleDto>> = [
@@ -564,16 +504,12 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
                 tabIndex={0}
                 data-testid={`roles-card-${row.id}`}
               >
-                <CardHeader>
-                  <CardCode>{row.code}</CardCode>
-                  <StatusBadge deletedAt={row.deletedAt} />
-                </CardHeader>
-                <CardName>{row.name}</CardName>
-                {row.description !== null &&
-                  row.description !== undefined &&
-                  row.description.trim().length > 0 && (
-                    <CardDescription>{row.description}</CardDescription>
-                  )}
+                <RoleCardHeader
+                  code={row.code}
+                  name={row.name}
+                  description={row.description}
+                  deletedAt={row.deletedAt}
+                />
                 <CardMeta>
                   <CardMetaTerm>Permissões</CardMetaTerm>
                   <CardMetaValue>

--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -1,0 +1,536 @@
+import { ChevronRight } from 'lucide-react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Button, Select, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
+import { usePaginationControls } from '../../hooks/usePaginationControls';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import {
+  DEFAULT_ROLES_INCLUDE_DELETED,
+  DEFAULT_ROLES_PAGE,
+  DEFAULT_ROLES_PAGE_SIZE,
+  listRoles,
+  listSystems,
+  MAX_ROLES_PAGE_SIZE,
+} from '../../shared/api';
+import { useAuth } from '../../shared/auth';
+import {
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  EntityCard,
+  ListingResultArea,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  Placeholder,
+  RoleCardHeader,
+  RowActions,
+  StatusBadge,
+  TableForDesktop,
+  useListingEmptyContent,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import type { TableColumn } from '../../components/ui';
+import type {
+  ApiClient,
+  PagedResponse,
+  RoleDto,
+  SafeRequestOptions,
+  SystemDto,
+} from '../../shared/api';
+
+/**
+ * Atraso entre a última tecla e o disparo da request de busca. 300ms é
+ * o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 request por caractere. Espelha o valor
+ * usado pelas demais listagens.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Valor sentinel usado pelo `<Select>` de filtro de sistema para
+ * representar "todos" (sem filtro). Mantido fora dos UUIDs reais para
+ * que a comparação no callback continue restrita ao conjunto válido.
+ * Quando detectado, omitimos `systemId` da request — espelha a
+ * estratégia de `TYPE_FILTER_ALL` em `ClientsListShellPage`.
+ */
+const SYSTEM_FILTER_ALL = 'ALL' as const;
+
+/**
+ * Mensagem genérica de fallback quando o fetch da lista de roles falha
+ * sem `ApiError` reconhecido. Centralizada para reuso entre os
+ * call-sites do hook (lista principal + dropdown de sistemas).
+ */
+const ROLES_LIST_FALLBACK_ERROR =
+  'Falha ao carregar a lista de roles. Tente novamente.';
+
+interface RolesGlobalListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido —
+   * a página usa o singleton `apiClient` por trás de
+   * `listRoles`/`listSystems`. Em testes, o caller passa um stub
+   * tipado.
+   */
+  client?: ApiClient;
+}
+
+// `renderDescription`/`renderCount` extraídos para
+// `./rolesRenderHelpers` — compartilhados com `RolesPage` para evitar
+// duplicação Sonar (lição PR #134/#135).
+import {
+  renderRoleDescription as renderDescription,
+  renderRoleCount as renderCount,
+} from './rolesRenderHelpers';
+
+/**
+ * Constrói um lookup `systemId -> SystemDto` para denormalizar a
+ * coluna "Sistema" na tabela. Em casos excepcionais (sistema
+ * soft-deletado e não retornado pelo dropdown padrão), a UI cai no
+ * código curto via `Mono` para preservar a referência em vez de
+ * "exibir nada".
+ */
+function buildSystemLookup(
+  systems: ReadonlyArray<SystemDto> | null,
+): ReadonlyMap<string, SystemDto> {
+  if (!systems) return new Map();
+  return new Map(systems.map((system) => [system.id, system]));
+}
+
+/**
+ * Página-shell da listagem **global** de roles cross-system
+ * (`/roles`). Substitui o `PlaceholderPage` original (Issue #173)
+ * por uma listagem real consumindo `GET /api/v1/roles` paginado
+ * server-side (após `lfc-authenticator#163`/`#164`).
+ *
+ * Segue o padrão de `ClientsListShellPage` (filtro adicional via
+ * `<Select>`, mobile cards, ListingResultArea genérico) — diferenças:
+ *
+ * - Filtro extra é `systemId` (dropdown carregado de `listSystems`),
+ *   não `type`.
+ * - Cada linha "drilla" para `/systems/:systemId/roles` (escopo do
+ *   CRUD) — não há criação/edição inline; isso fica deferido para a
+ *   página por-sistema (`RolesPage`).
+ * - Coluna "Sistema" denormaliza o `row.systemId` para o nome do
+ *   sistema dono.
+ *
+ * Visível com `Roles.Read` (`AUTH_V1_ROLES_LIST`); o gating
+ * declarativo está em `src/routes/index.tsx` via `<RequirePermission>`.
+ */
+export const RolesGlobalListShellPage: React.FC<
+  RolesGlobalListShellPageProps
+> = ({ client }) => {
+  const navigate = useNavigate();
+  // `useAuth` é mantido aqui para que evoluções futuras (botão "Nova
+  // role" gateado por `Roles.Create` ou ações inline gateadas por
+  // `Roles.Update`) reutilizem o gating sem refatoração — o gating
+  // de leitura já vive em `<RequirePermission>` no router.
+  useAuth();
+
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  // Filtro de sistema (UUID ou 'ALL'). 'ALL' é o sentinel — quando
+  // ativo, omitimos o param da request e o backend devolve roles de
+  // todos os sistemas.
+  const [systemFilter, setSystemFilter] = useState<string>(SYSTEM_FILTER_ALL);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_ROLES_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_ROLES_PAGE);
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra
+   * para 3 itens, mas continuo na página 5 vazia". Espelha
+   * `ClientsListShellPage`/`SystemsPage`.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  const handleSystemFilterChange = useCallback((value: string) => {
+    setSystemFilter(value && value.length > 0 ? value : SYSTEM_FILTER_ALL);
+    setPage(DEFAULT_ROLES_PAGE);
+  }, []);
+
+  /**
+   * Carrega a lista de sistemas para popular o `<Select>` de filtro e
+   * para denormalizar a coluna "Sistema" na tabela. `pageSize` máximo
+   * espelha `MAX_ROLES_PAGE_SIZE` (100) — quando o catálogo crescer
+   * além disso, a issue pede revisitar (mesmo TODO de `UserRolesShellPage`).
+   *
+   * `useSingleFetchWithAbort` cuida do AbortController e do retry
+   * bumper. O fetch é independente do refetch da listagem principal
+   * — o dropdown não recarrega quando o usuário busca/pagina roles.
+   */
+  const systemsFetcher = useCallback(
+    (options: SafeRequestOptions): Promise<PagedResponse<SystemDto>> =>
+      listSystems({ pageSize: MAX_ROLES_PAGE_SIZE }, options, client),
+    [client],
+  );
+
+  const { data: systemsResponse } = useSingleFetchWithAbort<
+    PagedResponse<SystemDto>
+  >({
+    fetcher: systemsFetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar a lista de sistemas para o filtro.',
+  });
+
+  const systemsList = systemsResponse?.data ?? null;
+  const systemLookup = useMemo(
+    () => buildSystemLookup(systemsList),
+    [systemsList],
+  );
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`. Captura os params
+   * derivados (busca debounced, page, filtros) e devolve uma função
+   * que aceita `signal` no `options`. Reage a mudança de identidade
+   * para reexecutar — `useCallback` com as deps corretas mantém o
+   * ciclo previsível.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const effectiveSystemId =
+    systemFilter === SYSTEM_FILTER_ALL ? undefined : systemFilter;
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listRoles(
+        {
+          systemId: effectiveSystemId,
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_ROLES_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, effectiveSystemId, includeDeleted, page, trimmedSearchInput],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<RoleDto>({
+    fetcher,
+    fallbackErrorMessage: ROLES_LIST_FALLBACK_ERROR,
+  });
+
+  const {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+  } = usePaginationControls({
+    total,
+    appliedPageSize,
+    defaultPageSize: DEFAULT_ROLES_PAGE_SIZE,
+    page,
+    setPage,
+  });
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * `emptyContent` delegado ao hook compartilhado `useListingEmptyContent`
+   * para evitar duplicação JSCPD/Sonar com `RolesPage` per-system
+   * (lição PR #134/#135 — bloco de 26 linhas com `useMemo` + árvore
+   * de decisão `<EmptyMessage>` + `<Button>` se repetia idêntico).
+   */
+  const emptyContent = useListingEmptyContent({
+    trimmedSearch,
+    includeDeleted,
+    onClearSearch: handleClearSearch,
+    copy: {
+      searchPrefix: 'Nenhuma role encontrada para',
+      emptyTitle: 'Nenhuma role cadastrada.',
+      hintWhenIncludeDeletedOff:
+        'Roles removidas podem ser visualizadas ativando "Mostrar inativas".',
+      clearTestId: 'roles-global-empty-clear',
+    },
+  });
+
+  /**
+   * Renderiza o conteúdo da coluna "Sistema": prioriza o nome do
+   * sistema dono (lookup pelo `systemId`); fallback para o `code` ou
+   * o id curto quando o sistema não está no dropdown (ex.: sistema
+   * soft-deletado fora do top-100). Roles legadas com `systemId
+   * === null` exibem placeholder "—".
+   */
+  const renderSystemCell = useCallback(
+    (row: RoleDto): React.ReactNode => {
+      if (row.systemId === null || row.systemId.length === 0) {
+        return <Placeholder>—</Placeholder>;
+      }
+      const system = systemLookup.get(row.systemId);
+      if (system) {
+        return system.name;
+      }
+      // Sistema fora do top-100 ou soft-deletado: cai no id como
+      // referência mínima — o admin ainda consegue cruzar a info
+      // manualmente na URL drill-down.
+      return <Mono>{row.systemId.slice(0, 8)}</Mono>;
+    },
+    [systemLookup],
+  );
+
+  /**
+   * Navega para a tela de roles do sistema dono (drill-down). Roles
+   * sem `systemId` válido não navegam — a coluna fica como placeholder
+   * e a ação fica inativa. Imperativo via `useNavigate` porque os
+   * cliques acontecem dentro de `<Button>` (o design system não
+   * suporta polimorfismo `as`-prop hoje).
+   */
+  const handleOpenSystemRoles = useCallback(
+    (row: RoleDto) => {
+      if (row.systemId === null || row.systemId.length === 0) return;
+      navigate(`/systems/${row.systemId}/roles`);
+    },
+    [navigate],
+  );
+
+  const columns = useMemo<ReadonlyArray<TableColumn<RoleDto>>>(
+    () => [
+      {
+        key: 'system',
+        label: 'Sistema',
+        render: renderSystemCell,
+      },
+      {
+        key: 'code',
+        label: 'Código',
+        render: (row) => <Mono>{row.code}</Mono>,
+      },
+      {
+        key: 'name',
+        label: 'Nome',
+        render: (row) => row.name,
+      },
+      {
+        key: 'description',
+        label: 'Descrição',
+        render: renderDescription,
+      },
+      {
+        key: 'permissionsCount',
+        label: 'Permissões',
+        width: '120px',
+        render: (row) => renderCount(row.permissionsCount),
+      },
+      {
+        key: 'usersCount',
+        label: 'Usuários',
+        width: '110px',
+        render: (row) => renderCount(row.usersCount),
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '110px',
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
+      },
+      {
+        key: 'actions',
+        label: 'Ações',
+        isActions: true,
+        render: (row) => (
+          <RowActions>
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<ChevronRight size={14} strokeWidth={1.5} />}
+              onClick={() => handleOpenSystemRoles(row)}
+              aria-label={`Abrir roles do sistema da role ${row.name}`}
+              data-testid={`roles-global-open-${row.id}`}
+              disabled={row.systemId === null || row.systemId.length === 0}
+            >
+              Abrir
+            </Button>
+          </RowActions>
+        ),
+      },
+    ],
+    [handleOpenSystemRoles, renderSystemCell],
+  );
+
+  /**
+   * ARIA-live: anuncia o estado da listagem quando muda. Em loading
+   * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
+   * o total. Em erro, o `<Alert role="alert">` já cobre.
+   */
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'role',
+      pluralCarregando: 'roles',
+      vazioSemBusca: 'Nenhuma role cadastrada.',
+    },
+  });
+
+  /**
+   * Conteúdo da tabela renderizado como variável intermediária
+   * (desktop + mobile cards). Mantém o callsite de `<ListingResultArea>`
+   * compacto — espelha o padrão de `ClientsListShellPage`.
+   */
+  const tableNode = (
+    <>
+      <TableForDesktop>
+        <Table<RoleDto>
+          caption="Lista global de roles cadastradas no auth-service."
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.id}
+          emptyState={emptyContent}
+        />
+      </TableForDesktop>
+      <CardListForMobile
+        role="list"
+        aria-label="Lista global de roles cadastradas no auth-service"
+        data-testid="roles-global-card-list"
+      >
+        {rows.length === 0 && emptyContent}
+        {rows.map((row) => (
+          <EntityCard
+            key={row.id}
+            role="listitem"
+            tabIndex={0}
+            data-testid={`roles-global-card-${row.id}`}
+          >
+            <RoleCardHeader
+              code={row.code}
+              name={row.name}
+              description={row.description}
+              deletedAt={row.deletedAt}
+            />
+            <CardMeta>
+              <CardMetaTerm>Sistema</CardMetaTerm>
+              <CardMetaValue>{renderSystemCell(row)}</CardMetaValue>
+              <CardMetaTerm>Permissões</CardMetaTerm>
+              <CardMetaValue>{renderCount(row.permissionsCount)}</CardMetaValue>
+              <CardMetaTerm>Usuários</CardMetaTerm>
+              <CardMetaValue>{renderCount(row.usersCount)}</CardMetaValue>
+            </CardMeta>
+            <RowActions>
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={<ChevronRight size={14} strokeWidth={1.5} />}
+                onClick={() => handleOpenSystemRoles(row)}
+                aria-label={`Abrir roles do sistema da role ${row.name}`}
+                data-testid={`roles-global-card-open-${row.id}`}
+                disabled={row.systemId === null || row.systemId.length === 0}
+              >
+                Abrir
+              </Button>
+            </RowActions>
+          </EntityCard>
+        ))}
+      </CardListForMobile>
+    </>
+  );
+
+  /**
+   * `<Select>` de filtro de sistema extraído como variável local para
+   * reduzir o peso do JSX inline do `<ListingToolbar extraFilter={...}>`
+   * — mesmo padrão de `ClientsListShellPage` (`typeFilterSelect`).
+   *
+   * Itens do dropdown vêm da request paralela `listSystems`. Enquanto
+   * a request não completa, exibimos só a opção "Todos" — a UI
+   * permanece funcional (filtro = ALL = sem filtro), e adicionamos as
+   * opções assim que o fetch resolve.
+   */
+  const systemFilterSelect = (
+    <Select
+      label="Sistema"
+      size="sm"
+      value={systemFilter}
+      onChange={handleSystemFilterChange}
+      data-testid="roles-global-system-filter"
+      aria-label="Filtrar roles por sistema"
+    >
+      <option value={SYSTEM_FILTER_ALL}>Todos os sistemas</option>
+      {systemsList?.map((system) => (
+        <option key={system.id} value={system.id}>
+          {system.name}
+        </option>
+      ))}
+    </Select>
+  );
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="03 Roles"
+        title="Roles cadastradas"
+        desc="Catálogo global de roles do ecossistema. Cada role pertence a um sistema e expõe nome, descrição e contagem de permissões/usuários. Use o filtro por sistema ou abra a role para gerenciá-la no contexto do sistema dono."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome ou código da role"
+        searchAriaLabel="Buscar roles por nome ou código"
+        searchTestId="roles-global-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui roles com remoção lógica."
+        includeDeletedTestId="roles-global-include-deleted"
+        extraFilter={systemFilterSelect}
+      />
+
+      <LiveRegion message={liveMessage} testId="roles-global-live" />
+
+      <ListingResultArea
+        testIdPrefix="roles-global"
+        loadingLabel="Carregando roles"
+        isInitialLoading={isInitialLoading}
+        isFetching={isFetching}
+        errorMessage={errorMessage}
+        onRetry={handleRefetch}
+        tableContent={tableNode}
+        total={total}
+        page={page}
+        totalPages={totalPages}
+        isFirstPage={isFirstPage}
+        isLastPage={isLastPage}
+        onPrev={handlePrevPage}
+        onNext={handleNextPage}
+      />
+    </>
+  );
+};

--- a/src/pages/roles/rolesRenderHelpers.tsx
+++ b/src/pages/roles/rolesRenderHelpers.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Mono, Placeholder } from '../../shared/listing';
+
+import type { RoleDto } from '../../shared/api';
+
+/**
+ * Truncamento da descrição via ellipsis horizontal — preserva layout
+ * em viewports estreitos. Espelha o uso histórico em `RolesPage`/
+ * `RolesGlobalListShellPage`.
+ */
+const DescriptionCell = styled.span`
+  display: inline-block;
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+`;
+
+/**
+ * Render do campo `description` de uma role. Nullable/vazio vira
+ * `Placeholder` em-dash. Centralizado entre `RolesPage` (per-system)
+ * e `RolesGlobalListShellPage` (cross-system) para evitar duplicação
+ * JSCPD/Sonar (lição PR #134/#135).
+ */
+export function renderRoleDescription(row: RoleDto): React.ReactNode {
+  if (
+    row.description === null ||
+    row.description === undefined ||
+    row.description.trim().length === 0
+  ) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return (
+    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
+  );
+}
+
+/**
+ * Render de contagem (permissionsCount/usersCount). `null`/`undefined`
+ * vira `Placeholder`; numérico renderiza em `Mono`.
+ */
+export function renderRoleCount(
+  value: number | null | undefined,
+): React.ReactNode {
+  if (typeof value !== 'number') {
+    return <Placeholder>—</Placeholder>;
+  }
+  return <Mono>{value}</Mono>;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { NotFoundPage } from '../pages/NotFoundPage';
 import { PermissionsListShellPage } from '../pages/permissions';
 import { PlaceholderPage } from '../pages/PlaceholderPage';
 import { RolePermissionsShellPage } from '../pages/roles/RolePermissionsShellPage';
+import { RolesGlobalListShellPage } from '../pages/roles/RolesGlobalListShellPage';
 import { RolesPage } from '../pages/RolesPage';
 import { RoutesPage } from '../pages/RoutesPage';
 import { SettingsPage } from '../pages/SettingsPage';
@@ -163,11 +164,7 @@ export const AppRoutes: React.FC = () => (
         path="/roles"
         element={
           <RequirePermission code="AUTH_V1_ROLES_LIST">
-            <PlaceholderPage
-              eyebrow="03 Roles"
-              title="Gerenciamento de Roles"
-              desc="Roles agrupam permissões e podem ser atribuídas a usuários do sistema. Para listar as roles de um sistema específico, abra o sistema correspondente."
-            />
+            <RolesGlobalListShellPage />
           </RequirePermission>
         }
       />

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -147,14 +147,10 @@ export function isRoleDto(value: unknown): value is RoleDto {
  * campos, deploy desalinhado). Espelha `isPagedRoutesResponse` em
  * `routes.ts`.
  *
- * **Hoje** o backend `/roles` ainda devolve um array cru (não o
- * envelope paginado). `listRoles` adapta client-side: faz o GET cru,
- * valida cada item com `isRoleDto`, aplica filtros/paginação em
- * memória e devolve um `PagedResponse<RoleDto>` ao caller. O type
- * guard fica pronto para o dia em que o backend implementar
- * `GET /systems/roles?systemId=...&page=&pageSize=...&q=&includeDeleted=`
- * (espelhando `RoutesController`); aí `listRoles` valida o envelope
- * direto e aposenta a adaptação client-side.
+ * Após `lfc-authenticator#163`/`#164`, o backend `/roles` devolve o
+ * envelope paginado nativo (`PagedResponse<RoleResponse>` com
+ * `systemId`, `description`, `permissionsCount`, `usersCount`).
+ * `listRoles` valida o envelope direto via este guard.
  */
 export function isPagedRolesResponse(
   value: unknown,
@@ -191,25 +187,28 @@ export const MAX_ROLES_PAGE_SIZE = 100;
  * Parâmetros aceitos por `listRoles`.
  *
  * `systemId` é **opcional**. Quando informado, filtra roles cuja
- * `Role.SystemId` coincide. Quando omitido, devolve roles de
- * **todos** os sistemas — caso usado pela Issue #71 (atribuição de
- * roles ao usuário, agrupando por sistema na UI).
+ * `Role.SystemId` coincide (server-side, via querystring). Quando
+ * omitido, devolve roles de **todos** os sistemas — caso usado pela
+ * Issue #71 (atribuição de roles ao usuário, agrupando por sistema
+ * na UI) e pela Issue #173 (`/roles` global cross-system).
  *
- * Os demais parâmetros (`q`, `page`, `pageSize`, `includeDeleted`)
- * são aplicados client-side pelo adapter em `listRoles` enquanto o
- * backend não pagina `/roles` nativamente.
+ * Após `lfc-authenticator#163`/`#164`, todos os parâmetros (`systemId`,
+ * `q`, `page`, `pageSize`, `includeDeleted`) são aplicados pelo
+ * controller `RolesController.GetAll` no backend — não há mais
+ * adapter client-side.
  */
 export interface ListRolesParams {
   /**
    * UUID do sistema dono das roles. Opcional — quando ausente, o
-   * adapter devolve roles de todos os sistemas (caso da Issue #71).
+   * backend devolve roles de todos os sistemas (caso da Issue #71/
+   * #173).
    */
   systemId?: string;
   /** Termo de busca (case-insensitive em `Name` e `Code`). */
   q?: string;
   /** Página 1-based. Default: 1. */
   page?: number;
-  /** Itens por página. Default: 20. */
+  /** Itens por página. Default: 20. Backend rejeita `> 100`. */
   pageSize?: number;
   /** Quando `true`, inclui roles com `deletedAt != null`. */
   includeDeleted?: boolean;
@@ -217,38 +216,61 @@ export interface ListRolesParams {
 
 /**
  * Endpoint atual do backend para listagem de roles.
- *
- * Quando o backend evoluir para o padrão por-sistema (espelhando
- * `Routes`), trocar para `'/systems/roles'` em uma única linha — o
- * resto do adapter já está pronto.
  */
 const ROLES_LIST_PATH = "/roles";
 
 /**
- * Lista roles de um sistema com busca, paginação e filtro de
- * soft-deleted aplicados **client-side** enquanto o backend não
- * suporta os parâmetros nativamente.
+ * Constrói a querystring omitindo parâmetros default — mantém a URL
+ * canônica para o caminho mais comum e simplifica logs/cache de
+ * proxy. Espelha `buildQueryString` de `systems.ts`.
  *
- * **Adapter temporário (TODO no backend):** `RolesController.GetAll`
- * hoje devolve `List<RoleResponse>` cru, sem `systemId`/`q`/`page`/
- * `pageSize`/`includeDeleted`. Para preservar a UI consistente com
- * `RoutesPage` e desacoplar a camada de página, este wrapper:
+ * `q` é trimado e omitido quando vazio para evitar `?q=` literal
+ * (que o backend trataria como busca por string vazia).
+ */
+function buildRolesQueryString(params: ListRolesParams): string {
+  const search = new URLSearchParams();
+
+  if (params.systemId && params.systemId.length > 0) {
+    search.set("systemId", params.systemId);
+  }
+
+  const q = params.q?.trim();
+  if (q && q.length > 0) {
+    search.set("q", q);
+  }
+
+  if (typeof params.page === "number" && params.page !== DEFAULT_ROLES_PAGE) {
+    search.set("page", String(params.page));
+  }
+
+  if (
+    typeof params.pageSize === "number" &&
+    params.pageSize !== DEFAULT_ROLES_PAGE_SIZE
+  ) {
+    search.set("pageSize", String(params.pageSize));
+  }
+
+  if (
+    typeof params.includeDeleted === "boolean" &&
+    params.includeDeleted !== DEFAULT_ROLES_INCLUDE_DELETED
+  ) {
+    search.set("includeDeleted", String(params.includeDeleted));
+  }
+
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : "";
+}
+
+/**
+ * Lista roles via `GET /roles` com busca, paginação e filtro de
+ * soft-deleted **aplicados pelo backend**.
  *
- *  1. Faz o `GET /roles` cru e valida cada item com `isRoleDto`.
- *  2. Filtra `deletedAt` quando `includeDeleted=false`.
- *  3. Filtra `Name`/`Code` (case-insensitive) quando `q` está presente.
- *  4. Ordena por `Code` para estabilidade visual entre refetches.
- *  5. Aplica `page`/`pageSize` em memória e devolve o envelope.
- *
- * Quando o backend implementar o endpoint paginado, substituir o
- * corpo desta função por:
- *
- * ```ts
- * const path = `/systems/roles${buildQueryString(params)}`;
- * const data = await client.get<unknown>(path, options);
- * if (!isPagedRolesResponse(data)) throw makeParseError();
- * return data;
- * ```
+ * Após `lfc-authenticator#163`/`#164`, o backend `/roles` devolve o
+ * envelope paginado nativo (`PagedResponse<RoleResponse>` com
+ * `systemId`, `description`, `permissionsCount`, `usersCount`). A
+ * função simplesmente monta a querystring, faz o GET, valida o
+ * envelope e devolve. O adapter client-side (filtragem/paginação em
+ * memória) foi removido.
  *
  * Lança `ApiError` em qualquer falha (rede, parse, HTTP) — o caller
  * trata com try/catch. Cancelamento via `signal` em `options` é
@@ -257,84 +279,18 @@ const ROLES_LIST_PATH = "/roles";
  * O parâmetro `client` é injetável para isolar testes (passa-se um
  * stub tipado como `ApiClient`); o default usa o singleton
  * `apiClient` configurado com `baseUrl` + `systemId` reais.
- *
- * Issue #66 — primeira sub-issue da EPIC #47 (CRUD de Roles por
- * Sistema). As próximas issues (#67 criar, #68 editar, #69 associar
- * permissões) reutilizam o mesmo módulo (`createRole`/`updateRole`/
- * `deleteRole`) seguindo o padrão estabelecido pela EPIC #46 em
- * `routes.ts`. Mantemos os hooks de extensão prontos para evitar
- * refatorações destrutivas no segundo PR (lição PR #128 — projetar
- * shared helpers desde o primeiro PR do recurso).
  */
 export async function listRoles(
   params: ListRolesParams,
   options?: SafeRequestOptions,
   client: ApiClient = apiClient,
 ): Promise<PagedResponse<RoleDto>> {
-  const data = await client.get<unknown>(ROLES_LIST_PATH, options);
-  if (!Array.isArray(data) || !data.every(isRoleDto)) {
+  const path = `${ROLES_LIST_PATH}${buildRolesQueryString(params)}`;
+  const data = await client.get<unknown>(path, options);
+  if (!isPagedRolesResponse(data)) {
     throw makeParseError();
   }
-  return adaptRolesListResponse(data, params);
-}
-
-/**
- * Aplica filtros/ordem/paginação client-side sobre o array cru
- * devolvido pelo backend, normalizando para `PagedResponse<RoleDto>`.
- *
- * Mantida em função separada para que os testes possam exercer o
- * adapter sem um `ApiClient` stub — e para isolar o ponto único de
- * remoção quando o backend ganhar paginação real.
- *
- * **Decisões importantes:**
- *
- * - `params.systemId` é aceito mas hoje **não filtra** o conjunto:
- *   `AppRole` ainda não tem `SystemId` no model. Aceitar o param
- *   garante compatibilidade visual entre a UI já escopada por
- *   sistema (`/systems/:systemId/roles`) e a futura evolução do
- *   backend, sem precisar de breaking change na assinatura.
- * - O ordenamento por `Code` espelha o adotado por
- *   `RoutesController.GetAll` — manter o mesmo critério reduz
- *   surpresa para o admin que alterna entre as listas.
- * - `total` reflete o conjunto **após filtros** e **antes** de
- *   `Skip`/`Take`, casando com o contrato de `PagedResponse`.
- */
-function adaptRolesListResponse(
-  rows: ReadonlyArray<RoleDto>,
-  params: ListRolesParams,
-): PagedResponse<RoleDto> {
-  const includeDeleted = params.includeDeleted ?? DEFAULT_ROLES_INCLUDE_DELETED;
-  const q = params.q?.trim().toLowerCase();
-  const page = params.page ?? DEFAULT_ROLES_PAGE;
-  const pageSize = params.pageSize ?? DEFAULT_ROLES_PAGE_SIZE;
-  const systemId = params.systemId;
-
-  const filtered = rows
-    .filter((role) => includeDeleted || role.deletedAt === null)
-    .filter((role) => {
-      // `systemId` opcional: quando ausente, devolve roles de todos os
-      // sistemas (Issue #71). Quando informado, filtra por `Role.SystemId`
-      // exato. Roles legadas com `systemId === null` são excluídas
-      // quando o caller pede um `systemId` específico.
-      if (!systemId || systemId.length === 0) return true;
-      return role.systemId === systemId;
-    })
-    .filter((role) => {
-      if (!q || q.length === 0) return true;
-      return (
-        role.name.toLowerCase().includes(q) ||
-        role.code.toLowerCase().includes(q)
-      );
-    })
-    .slice()
-    .sort((a, b) => a.code.localeCompare(b.code));
-
-  const total = filtered.length;
-  const start = (page - 1) * pageSize;
-  const end = start + pageSize;
-  const data = filtered.slice(start, end);
-
-  return { data, page, pageSize, total };
+  return data;
 }
 
 /**

--- a/src/shared/listing/RoleCardHeader.tsx
+++ b/src/shared/listing/RoleCardHeader.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { StatusBadge } from './StatusBadge';
+import { CardCode, CardDescription, CardHeader, CardName } from './styles';
+
+/**
+ * Header padrão dos cards mobile de uma role: `<CardHeader>` com
+ * `<CardCode>` + `<StatusBadge>`, seguido por `<CardName>` e
+ * (condicionalmente) `<CardDescription>` quando a role tem descrição
+ * preenchida.
+ *
+ * **Por que existe (lição PR #134/#135):** o bloco de 12 linhas com
+ * `<CardHeader>` + `<CardCode>` + `<StatusBadge>` + `<CardName>` +
+ * `<CardDescription>` (condicional) se repetia idêntico entre
+ * `RolesPage` (per-system) e `RolesGlobalListShellPage` (global) —
+ * JSCPD/Sonar tokenizam blocos de ≥10 linhas com mesma estrutura
+ * como duplicação independente da intenção.
+ *
+ * Extraído como componente em vez de hook porque é puramente
+ * apresentacional (sem estado / hooks) — JSX em árvore fixa,
+ * parametrizado apenas pelos campos da role.
+ */
+export interface RoleCardHeaderProps {
+  /** `code` da role (renderizado no `<CardCode>`). */
+  code: string;
+  /** `name` da role (renderizado no `<CardName>`). */
+  name: string;
+  /** `description` opcional — exibida como `<CardDescription>` se não vazia. */
+  description: string | null | undefined;
+  /** ISO timestamp de soft-delete (ou null) para o `<StatusBadge>`. */
+  deletedAt: string | null;
+}
+
+export const RoleCardHeader: React.FC<RoleCardHeaderProps> = ({
+  code,
+  name,
+  description,
+  deletedAt,
+}) => (
+  <>
+    <CardHeader>
+      <CardCode>{code}</CardCode>
+      <StatusBadge deletedAt={deletedAt} />
+    </CardHeader>
+    <CardName>{name}</CardName>
+    {description !== null &&
+      description !== undefined &&
+      description.trim().length > 0 && (
+        <CardDescription>{description}</CardDescription>
+      )}
+  </>
+);

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -91,7 +91,12 @@ export { ListingToolbar } from './ListingToolbar';
 export { LiveRegion } from './LiveRegion';
 export { PaginationFooter } from './PaginationFooter';
 export { RefetchOverlay } from './RefetchOverlay';
+export { RoleCardHeader, type RoleCardHeaderProps } from './RoleCardHeader';
 export { StatusBadge } from './StatusBadge';
+export {
+  useListingEmptyContent,
+  type ListingEmptyContentCopy,
+} from './useListingEmptyContent';
 export {
   useListingLiveMessage,
   type ListingLiveMessageCopy,

--- a/src/shared/listing/useListingEmptyContent.tsx
+++ b/src/shared/listing/useListingEmptyContent.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from 'react';
+
+import { Button } from '../../components/ui';
+
+import { EmptyHint, EmptyMessage, EmptyTitle, Mono } from './styles';
+
+/**
+ * Copy parametrizada do bloco "estado vazio" das listagens. Cada
+ * página passa as strings em pt-BR específicas do recurso (singular/
+ * plural/gênero) — o hook concentra a estrutura visual e a árvore de
+ * decisão (busca ativa vs sem busca, toggle "Mostrar inativas"
+ * desligado vs ligado).
+ */
+export interface ListingEmptyContentCopy {
+  /** Texto exibido quando há busca ativa, antes do `<Mono>`. */
+  searchPrefix: string;
+  /** Texto exibido quando vazio sem busca (ex.: "Nenhuma role cadastrada."). */
+  emptyTitle: string;
+  /** Hint exibido sob o título quando `includeDeleted=false`. */
+  hintWhenIncludeDeletedOff: string;
+  /** `data-testid` do botão "Limpar busca". */
+  clearTestId: string;
+}
+
+interface UseListingEmptyContentParams {
+  /** Resultado de `debouncedSearch.trim()` — string vazia se sem busca. */
+  trimmedSearch: string;
+  /** Estado do toggle "Mostrar inativas". */
+  includeDeleted: boolean;
+  /** Callback do botão "Limpar busca" (já reseta page para 1 no caller). */
+  onClearSearch: () => void;
+  /** Copy parametrizada por recurso. */
+  copy: ListingEmptyContentCopy;
+}
+
+/**
+ * Hook compartilhado que devolve o `ReactNode` do estado vazio para
+ * as listagens (`SystemsPage`, `RolesPage`, `RolesGlobalListShellPage`,
+ * etc.).
+ *
+ * **Por que existe (lição PR #134/#135):** o `useMemo<React.ReactNode>`
+ * com a árvore de decisão `if (hasActiveSearch) ... else ...` +
+ * `<EmptyMessage>` + `<EmptyTitle>` + `<Button>` se repetia idêntico
+ * entre `RolesPage` (per-system) e `RolesGlobalListShellPage` (global)
+ * — JSCPD/Sonar tokenizam blocos de ≥10 linhas com mesma estrutura
+ * como duplicação independente da intenção. Centralizar aqui mantém
+ * a fonte única e elimina o clone.
+ *
+ * Cada caller continua dono da copy específica do recurso (singular/
+ * plural/gênero) via `copy` — o hook é agnóstico.
+ */
+export function useListingEmptyContent(
+  params: UseListingEmptyContentParams,
+): React.ReactNode {
+  const { trimmedSearch, includeDeleted, onClearSearch, copy } = params;
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  return useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            {copy.searchPrefix} <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClearSearch}
+            data-testid={copy.clearTestId}
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>{copy.emptyTitle}</EmptyTitle>
+        {!includeDeleted && <EmptyHint>{copy.hintWhenIncludeDeletedOff}</EmptyHint>}
+      </EmptyMessage>
+    );
+  }, [
+    copy.clearTestId,
+    copy.emptyTitle,
+    copy.hintWhenIncludeDeletedOff,
+    copy.searchPrefix,
+    hasActiveSearch,
+    includeDeleted,
+    onClearSearch,
+    trimmedSearch,
+  ]);
+}

--- a/tests/pages/RolesPage.create.test.tsx
+++ b/tests/pages/RolesPage.create.test.tsx
@@ -9,6 +9,7 @@ import {
   fillNewRoleForm,
   ID_ROLE_ROOT,
   ID_SYS_AUTH,
+  makePagedRolesResponse,
   makeRole,
   openCreateRoleModal,
   renderRolesPage,
@@ -70,7 +71,7 @@ describe("RolesPage — criação (Issue #67)", () => {
     it("não exibe o botão quando o usuário não possui AUTH_V1_ROLES_CREATE", async () => {
       permissionsMock = [];
       const client = createRolesClientStub();
-      client.get.mockResolvedValueOnce([makeRole()]);
+      client.get.mockResolvedValueOnce(makePagedRolesResponse([makeRole()]));
 
       renderRolesPage(client);
       await waitForInitialList(client);
@@ -81,7 +82,7 @@ describe("RolesPage — criação (Issue #67)", () => {
     it("exibe o botão quando o usuário possui AUTH_V1_ROLES_CREATE", async () => {
       permissionsMock = [ROLES_CREATE_PERMISSION];
       const client = createRolesClientStub();
-      client.get.mockResolvedValueOnce([makeRole()]);
+      client.get.mockResolvedValueOnce(makePagedRolesResponse([makeRole()]));
 
       renderRolesPage(client);
       await waitForInitialList(client);

--- a/tests/pages/RolesPage.edit.test.tsx
+++ b/tests/pages/RolesPage.edit.test.tsx
@@ -9,6 +9,7 @@ import {
   fillEditRoleForm,
   ID_ROLE_ROOT,
   ID_SYS_AUTH,
+  makePagedRolesResponse,
   makeRole,
   openEditRoleModal,
   renderRolesPage,
@@ -71,7 +72,7 @@ describe("RolesPage — edição (Issue #68)", () => {
     it('não exibe botões "Editar" quando o usuário não possui AUTH_V1_ROLES_UPDATE', async () => {
       permissionsMock = [];
       const client = createRolesClientStub();
-      client.get.mockResolvedValueOnce([makeRole()]);
+      client.get.mockResolvedValueOnce(makePagedRolesResponse([makeRole()]));
 
       // Renderização explícita aqui (sem helper de open) porque o
       // teste valida apenas a ausência do botão antes de abrir
@@ -87,7 +88,7 @@ describe("RolesPage — edição (Issue #68)", () => {
     it('exibe botão "Editar" para linhas ativas quando o usuário possui AUTH_V1_ROLES_UPDATE', async () => {
       permissionsMock = [ROLES_UPDATE_PERMISSION];
       const client = createRolesClientStub();
-      client.get.mockResolvedValueOnce([makeRole()]);
+      client.get.mockResolvedValueOnce(makePagedRolesResponse([makeRole()]));
 
       renderRolesPage(client);
       await waitForInitialList(client);
@@ -100,18 +101,17 @@ describe("RolesPage — edição (Issue #68)", () => {
     it('não exibe botão "Editar" em linhas soft-deletadas mesmo com permissão', async () => {
       permissionsMock = [ROLES_UPDATE_PERMISSION];
       const client = createRolesClientStub();
-      // O `listRoles` adapter filtra `deletedAt !== null` quando
+      // O backend filtra `deletedAt !== null` quando
       // `includeDeleted=false` (default). Para que a role
       // soft-deletada apareça na tabela e possamos verificar a
       // ausência do botão "Editar", ligamos o toggle "Mostrar
       // inativas" — assim o gating exercitado é o `row.deletedAt`
-      // dentro da render da coluna "Ações", não o filtro do
-      // adapter. Backend devolve a mesma role nas duas requests
-      // (toggle só muda o filtro client-side).
+      // dentro da render da coluna "Ações", não o filtro
+      // server-side.
       const deletedRole = makeRole({ deletedAt: "2026-02-01T00:00:00Z" });
       client.get
-        .mockResolvedValueOnce([deletedRole])
-        .mockResolvedValueOnce([deletedRole]);
+        .mockResolvedValueOnce(makePagedRolesResponse([deletedRole]))
+        .mockResolvedValueOnce(makePagedRolesResponse([deletedRole]));
 
       renderRolesPage(client);
       await waitForInitialList(client);
@@ -253,8 +253,8 @@ describe("RolesPage — edição (Issue #68)", () => {
       const client = createRolesClientStub();
       // Fila: GET inicial → GET refetch → PUT.
       client.get
-        .mockResolvedValueOnce([original])
-        .mockResolvedValueOnce([updated]);
+        .mockResolvedValueOnce(makePagedRolesResponse([original]))
+        .mockResolvedValueOnce(makePagedRolesResponse([updated]));
       client.put.mockResolvedValueOnce(updated);
 
       await openEditRoleModal(client, { role: original });
@@ -379,7 +379,9 @@ describe("RolesPage — edição (Issue #68)", () => {
     it("404 dispara refetch (onUpdated chamado mesmo em erro)", async () => {
       const client = createRolesClientStub();
       // Fila: GET inicial → PUT (404) → GET refetch.
-      client.get.mockResolvedValueOnce([makeRole()]).mockResolvedValueOnce([]);
+      client.get
+        .mockResolvedValueOnce(makePagedRolesResponse([makeRole()]))
+        .mockResolvedValueOnce(makePagedRolesResponse([]));
       client.put.mockRejectedValueOnce({
         kind: "http",
         status: 404,

--- a/tests/pages/RolesPage.test.tsx
+++ b/tests/pages/RolesPage.test.tsx
@@ -8,7 +8,9 @@ import {
   ID_ROLE_ADMIN,
   ID_ROLE_ROOT,
   ID_ROLE_VIEWER,
+  ID_SYS_AUTH,
   lastGetPath,
+  makePagedRolesResponse,
   makeRole,
   renderRolesPage,
   waitForInitialList,
@@ -25,22 +27,12 @@ import { RolesPage } from '@/pages/RolesPage';
  * busca debounced, toggle "incluir inativas", erros e cancelamento de
  * request.
  *
- * **Diferenças em relação a `RoutesPage.test.tsx`:**
- *
- * - O backend `/roles` hoje devolve um array cru (sem paginação/
- *   busca/includeDeleted nativos); o `listRoles` aplica os filtros
- *   client-side. Por isso a suíte foca no **comportamento da UI**
- *   (busca filtra a tabela, paginação aplica skip/take em memória,
- *   toggle inclui/exclui inativos visualmente) em vez de inspecionar
- *   a querystring do `client.get`.
- * - `lastGetPath` continua existindo e é usado para garantir que o
- *   path é sempre `/roles` (sem querystring) — quando o backend
- *   evoluir para paginação real, esses asserts mudarão para refletir
- *   a nova querystring.
- * - Não há gating de auth para nova role nesta sub-issue (a CTA é
- *   adicionada na #67); o mock `useAuth` segue sendo necessário pelo
- *   `RequirePermission` (que não é exercitado nesta suíte porque
- *   renderizamos a página direto, sem `AppRoutes`).
+ * Após `lfc-authenticator#163`/`#164` o backend `/roles` devolve o
+ * envelope paginado nativo (`PagedResponse<RoleResponse>`); o adapter
+ * client-side foi removido. Os mocks usam `makePagedRolesResponse`.
+ * A suíte continua focando no comportamento da UI (busca dispara
+ * refetch debounced, paginação propaga page para a request, toggle
+ * inclui inativos via querystring server-side).
  */
 
 vi.mock('@/shared/auth', () => buildAuthMock(() => []));
@@ -98,8 +90,12 @@ describe('RolesPage — render inicial', () => {
 
     expect(screen.getByTestId('roles-loading')).toBeInTheDocument();
 
+    // Backend filtra `deletedAt` server-side por default — só
+    // devolve roles ativas (Viewer fica fora porque está soft-
+    // deletada).
+    const activeRows = SAMPLE_ROWS.filter((row) => row.deletedAt === null);
     await act(async () => {
-      resolveFn(SAMPLE_ROWS.slice());
+      resolveFn(makePagedRolesResponse(activeRows));
       await Promise.resolve();
     });
 
@@ -120,7 +116,7 @@ describe('RolesPage — render inicial', () => {
 
   it('renderiza header da página com título "Roles do sistema"', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
 
@@ -129,26 +125,28 @@ describe('RolesPage — render inicial', () => {
     expect(screen.getByRole('heading', { name: /Roles do sistema/i })).toBeInTheDocument();
   });
 
-  it('chama backend em GET /roles (endpoint atual, sem paginação nativa)', async () => {
+  it('chama backend em GET /roles com systemId na querystring (paginação server-side)', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
 
     await waitForInitialList(client);
-    expect(lastGetPath(client)).toBe('/roles');
+    expect(lastGetPath(client)).toBe(`/roles?systemId=${ID_SYS_AUTH}`);
   });
 
   it('renderiza badge "Inativa" para roles com deletedAt e "Ativa" para as demais (com toggle ligado)', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    // Backend filtra `deletedAt` server-side conforme `includeDeleted`.
+    // Primeira request (default `includeDeleted=false`) só ativas;
+    // após ligar o toggle, retorna o conjunto completo.
+    const activeRows = SAMPLE_ROWS.filter((row) => row.deletedAt === null);
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(activeRows));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitForInitialList(client);
 
-    // Por default `includeDeleted=false` — a Viewer (deletada) é
-    // omitida. Ligamos o toggle para incluí-la e exibir o badge
-    // "Inativa".
     fireEvent.click(screen.getByTestId('roles-include-deleted'));
 
     await waitFor(() => {
@@ -165,19 +163,23 @@ describe('RolesPage — render inicial', () => {
     expect(within(viewerCard).getByText('Inativa')).toBeInTheDocument();
   });
 
-  it('exibe placeholder "—" para description/permissionsCount/usersCount ausentes (estado atual do backend)', async () => {
+  it('exibe placeholder "—" para description/permissionsCount/usersCount ausentes (fixture defensivo)', async () => {
     const client = createRolesClientStub();
-    // Cenário "backend não devolve os campos opcionais" — todos `null`.
-    client.get.mockResolvedValueOnce([
-      makeRole({
-        id: ID_ROLE_ROOT,
-        name: 'Root',
-        code: 'root',
-        description: null,
-        permissionsCount: null,
-        usersCount: null,
-      }),
-    ]);
+    // Cenário defensivo: backend pode devolver os campos opcionais
+    // como `null`. Espelha fixtures legadas e protege contra deploy
+    // desalinhado.
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse([
+        makeRole({
+          id: ID_ROLE_ROOT,
+          name: 'Root',
+          code: 'root',
+          description: null,
+          permissionsCount: null,
+          usersCount: null,
+        }),
+      ]),
+    );
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -187,18 +189,20 @@ describe('RolesPage — render inicial', () => {
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
   });
 
-  it('exibe contagens numéricas quando o backend devolve os campos (cenário futuro)', async () => {
+  it('exibe contagens numéricas quando o backend devolve os campos enriquecidos', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce([
-      makeRole({
-        id: ID_ROLE_ROOT,
-        name: 'Root',
-        code: 'root',
-        description: 'Acesso irrestrito',
-        permissionsCount: 12,
-        usersCount: 2,
-      }),
-    ]);
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse([
+        makeRole({
+          id: ID_ROLE_ROOT,
+          name: 'Root',
+          code: 'root',
+          description: 'Acesso irrestrito',
+          permissionsCount: 12,
+          usersCount: 2,
+        }),
+      ]),
+    );
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -211,7 +215,7 @@ describe('RolesPage — render inicial', () => {
 
   it('renderiza cards mobile com testId estável por role', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -221,10 +225,14 @@ describe('RolesPage — render inicial', () => {
   });
 });
 
-describe('RolesPage — busca debounced (filtro client-side)', () => {
-  it('digitar não dispara request imediato; após 300ms re-aplica o filtro client-side', async () => {
+describe('RolesPage — busca debounced (filtro server-side)', () => {
+  it('digitar não dispara request imediato; após 300ms refaz GET com q na querystring', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    // Backend filtra `q` server-side: primeira request devolve todos
+    // ativos; após digitar "admin", devolve só admin.
+    const adminOnly = SAMPLE_ROWS.filter((row) => row.code === 'admin');
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(adminOnly));
 
     renderRolesPage(client);
 
@@ -233,10 +241,6 @@ describe('RolesPage — busca debounced (filtro client-side)', () => {
     const input = screen.getByTestId('roles-search') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'admin' } });
 
-    // O backend não suporta `q` nativo — o adapter aplica em memória,
-    // mas o `usePaginatedFetch` ainda dispara um refetch (a request
-    // identidade do `fetcher` mudou) para consistência com a paridade
-    // de UX entre listagens.
     expect(client.get).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -245,8 +249,10 @@ describe('RolesPage — busca debounced (filtro client-side)', () => {
     });
 
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe(
+      `/roles?systemId=${ID_SYS_AUTH}&q=admin`,
+    );
 
-    // Apenas a role com nome/code "admin" deve aparecer.
     await waitFor(() => {
       expect(screen.getByTestId(`roles-card-${ID_ROLE_ADMIN}`)).toBeInTheDocument();
     });
@@ -255,7 +261,7 @@ describe('RolesPage — busca debounced (filtro client-side)', () => {
 
   it('teclas em sequência só disparam a última busca', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    client.get.mockResolvedValue(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
@@ -275,44 +281,58 @@ describe('RolesPage — busca debounced (filtro client-side)', () => {
   });
 });
 
-describe('RolesPage — paginação client-side', () => {
-  it('clicar "próxima" muda a página para a 2; "anterior" volta para 1', async () => {
+describe('RolesPage — paginação server-side', () => {
+  it('clicar "próxima" envia page=2 na querystring; "anterior" volta para page omitido (default)', async () => {
     const client = createRolesClientStub();
-    // 25 roles ativas garantem 2 páginas com pageSize=20.
-    const manyRows = Array.from({ length: 25 }, (_, i) =>
+    // 25 roles totais → 2 páginas com pageSize=20.
+    const pageOneRows = Array.from({ length: 20 }, (_, i) =>
       makeRole({
         id: `id-${i}`,
         name: `Role ${i}`,
         code: `r${String(i).padStart(2, '0')}`,
       }),
     );
-    client.get.mockResolvedValue(manyRows);
+    const pageTwoRows = Array.from({ length: 5 }, (_, i) =>
+      makeRole({
+        id: `id-${i + 20}`,
+        name: `Role ${i + 20}`,
+        code: `r${String(i + 20).padStart(2, '0')}`,
+      }),
+    );
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse(pageOneRows, { total: 25, page: 1 }),
+    );
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse(pageTwoRows, { total: 25, page: 2 }),
+    );
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse(pageOneRows, { total: 25, page: 1 }),
+    );
 
     renderRolesPage(client);
     await waitForInitialList(client);
 
-    // Na página 1 vemos r00..r19.
     expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 1 de 2/i);
 
     fireEvent.click(screen.getByTestId('roles-next'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 2 de 2/i);
-    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe(`/roles?systemId=${ID_SYS_AUTH}&page=2`);
 
     fireEvent.click(screen.getByTestId('roles-prev'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('roles-page-info')).toHaveTextContent(/Página 1 de 2/i);
-    });
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(3));
+    expect(lastGetPath(client)).toBe(`/roles?systemId=${ID_SYS_AUTH}`);
   });
 
   it('botão "anterior" desabilita na primeira página', async () => {
     const client = createRolesClientStub();
-    const manyRows = Array.from({ length: 25 }, (_, i) =>
+    const pageOneRows = Array.from({ length: 20 }, (_, i) =>
       makeRole({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
     );
-    client.get.mockResolvedValueOnce(manyRows);
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse(pageOneRows, { total: 25 }),
+    );
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -323,7 +343,7 @@ describe('RolesPage — paginação client-side', () => {
 
   it('botão "próxima" desabilita quando totalPages é 1', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce(SAMPLE_ROWS.slice());
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -332,12 +352,14 @@ describe('RolesPage — paginação client-side', () => {
     expect(screen.getByTestId('roles-next')).toBeDisabled();
   });
 
-  it('exibe indicador "página X de Y" com total filtrado', async () => {
+  it('exibe indicador "Página X de Y" com total filtrado', async () => {
     const client = createRolesClientStub();
-    const manyRows = Array.from({ length: 42 }, (_, i) =>
+    const pageOneRows = Array.from({ length: 20 }, (_, i) =>
       makeRole({ id: `id-${i}`, code: `r${String(i).padStart(2, '0')}` }),
     );
-    client.get.mockResolvedValueOnce(manyRows);
+    client.get.mockResolvedValueOnce(
+      makePagedRolesResponse(pageOneRows, { total: 42 }),
+    );
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -349,14 +371,15 @@ describe('RolesPage — paginação client-side', () => {
 });
 
 describe('RolesPage — filtro de inativas', () => {
-  it('liga toggle dispara request com inclusão de inativas no resultado', async () => {
+  it('liga toggle dispara request com includeDeleted=true na querystring', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    const activeRows = SAMPLE_ROWS.filter((row) => row.deletedAt === null);
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(activeRows));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
 
-    // Antes de ligar o toggle, a Viewer (deletada) não aparece.
     expect(
       screen.queryByTestId(`roles-card-${ID_ROLE_VIEWER}`),
     ).not.toBeInTheDocument();
@@ -365,8 +388,10 @@ describe('RolesPage — filtro de inativas', () => {
     fireEvent.click(toggle);
 
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+    expect(lastGetPath(client)).toBe(
+      `/roles?systemId=${ID_SYS_AUTH}&includeDeleted=true`,
+    );
 
-    // Depois do toggle, a Viewer aparece.
     await waitFor(() => {
       expect(
         screen.getByTestId(`roles-card-${ID_ROLE_VIEWER}`),
@@ -378,7 +403,10 @@ describe('RolesPage — filtro de inativas', () => {
 describe('RolesPage — estados vazios', () => {
   it('vazio com busca: exibe termo + botão limpar', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    // Backend filtra server-side: primeira request devolve todos;
+    // após digitar "naoexiste", devolve vazio.
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse([]));
 
     renderRolesPage(client);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
@@ -402,7 +430,7 @@ describe('RolesPage — estados vazios', () => {
 
   it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValueOnce([]);
+    client.get.mockResolvedValueOnce(makePagedRolesResponse([]));
 
     renderRolesPage(client);
     await waitForInitialList(client);
@@ -417,7 +445,11 @@ describe('RolesPage — estados vazios', () => {
 
   it('clicar em "limpar busca" reseta termo e re-popula a lista', async () => {
     const client = createRolesClientStub();
-    client.get.mockResolvedValue(SAMPLE_ROWS.slice());
+    // Backend filtra server-side: 1ª (default), 2ª (busca naoexiste
+    // → vazio), 3ª (limpar busca → todos).
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse([]));
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
     await waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
@@ -461,7 +493,7 @@ describe('RolesPage — erro de rede', () => {
     const client = createRolesClientStub();
     client.get
       .mockRejectedValueOnce(apiError)
-      .mockResolvedValueOnce(SAMPLE_ROWS.slice());
+      .mockResolvedValueOnce(makePagedRolesResponse(SAMPLE_ROWS));
 
     renderRolesPage(client);
 
@@ -497,7 +529,7 @@ describe('RolesPage — cancelamento de request', () => {
         if (options?.signal) {
           signals.push(options.signal);
         }
-        return Promise.resolve(SAMPLE_ROWS.slice());
+        return Promise.resolve(makePagedRolesResponse(SAMPLE_ROWS));
       },
     );
 

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -9,9 +9,16 @@ import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { expect, vi } from "vitest";
 
-import type { ApiClient, ApiError, RoleDto } from "@/shared/api";
+import type {
+  ApiClient,
+  ApiError,
+  PagedResponse,
+  RoleDto,
+  SystemDto,
+} from "@/shared/api";
 
 import { ToastProvider } from "@/components/ui";
+import { RolesGlobalListShellPage } from "@/pages/roles/RolesGlobalListShellPage";
 import { RolesPage } from "@/pages/RolesPage";
 
 /**
@@ -114,6 +121,69 @@ export function makeRole(overrides: Partial<RoleDto> = {}): RoleDto {
 }
 
 /**
+ * Constrói o envelope paginado mockado pelo backend — `total`
+ * reflete `data.length` por default; testes que cobrem paginação
+ * sobrescrevem. Espelha `makePagedClientsResponse`/`makePagedResponse`
+ * em outros helpers — pré-fabricado para ser consumido pelas suítes
+ * de `RolesPage` (per-system) e `RolesGlobalListShellPage` (Issue
+ * #173) sem duplicação.
+ */
+export function makePagedRolesResponse(
+  data: ReadonlyArray<RoleDto>,
+  overrides: Partial<PagedResponse<RoleDto>> = {},
+): PagedResponse<RoleDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 20,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói um `SystemDto` mínimo para o dropdown de filtro da
+ * `RolesGlobalListShellPage` (Issue #173). Mantido local ao módulo
+ * de roles para não acoplar as suítes globais a `systemsTestHelpers`
+ * (manter independência reduz custo de boot de cada suíte). Defaults
+ * apontam para `ID_SYS_AUTH` para casar com `makeRole`.
+ */
+export function makeSystemDtoForRoles(
+  overrides: Partial<SystemDto> = {},
+): SystemDto {
+  return {
+    id: ID_SYS_AUTH,
+    name: "lfc-authenticator",
+    code: "AUTH",
+    description: null,
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado de sistemas (`PagedResponse<SystemDto>`)
+ * para mockar a request paralela `listSystems` que a
+ * `RolesGlobalListShellPage` dispara para popular o dropdown de
+ * filtro. `pageSize=100` espelha `MAX_ROLES_PAGE_SIZE` (mesmo limite
+ * usado pela página).
+ */
+export function makePagedSystemsResponseForRoles(
+  data: ReadonlyArray<SystemDto>,
+  overrides: Partial<PagedResponse<SystemDto>> = {},
+): PagedResponse<SystemDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 100,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
  * Renderiza a `RolesPage` envolvendo no `MemoryRouter` apontando
  * para `/systems/:systemId/roles`. A página consome
  * `useParams<{ systemId }>` — sem o roteador, `systemId` ficaria
@@ -166,20 +236,115 @@ export async function waitForInitialList(client: ApiClientStub): Promise<void> {
 }
 
 /**
+ * Renderiza a `RolesGlobalListShellPage` (Issue #173) envolvendo num
+ * `MemoryRouter` (a página chama `useNavigate` para drill-down nas
+ * linhas) e num `ToastProvider`. Não exige `:systemId` na URL — a
+ * listagem é cross-system.
+ */
+export function renderRolesGlobalListPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={["/roles"]}>
+        <Routes>
+          <Route
+            path="/roles"
+            element={<RolesGlobalListShellPage client={client} />}
+          />
+          <Route path="/systems/:systemId/roles" element={<div>drill</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Configura o `client.get` da `RolesGlobalListShellPage` para
+ * responder roles e sistemas via `mockImplementation` baseado no
+ * `path`. A página dispara duas requests em paralelo no mount
+ * (`/roles` e `/systems`); resolvê-las por path evita acoplar o
+ * teste à ordem de chamadas.
+ *
+ * Pré-fabricado no helper (em vez de inline em cada teste) para
+ * evitar duplicação JSCPD/Sonar — espelha `primeStubResponses` em
+ * `tests/pages/users/__helpers__/userRolesTestHelpers.tsx` (lição
+ * PR #134/#135 — corpo do `mockImplementation` por path se torna
+ * clone entre suítes da mesma família).
+ */
+export function primeRolesGlobalStubResponses(
+  client: ApiClientStub,
+  options: {
+    roles?: PagedResponse<RoleDto>;
+    systems?: PagedResponse<SystemDto>;
+  } = {},
+): void {
+  const rolesEnvelope = options.roles ?? makePagedRolesResponse([makeRole()]);
+  const systemsEnvelope =
+    options.systems ?? makePagedSystemsResponseForRoles([makeSystemDtoForRoles()]);
+
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith("/roles")) {
+      return Promise.resolve(rolesEnvelope);
+    }
+    if (path.startsWith("/systems")) {
+      return Promise.resolve(systemsEnvelope);
+    }
+    return Promise.reject(
+      Object.assign(new Error("URL stub não esperada: " + path), {
+        kind: "http",
+        status: 404,
+      }),
+    );
+  });
+}
+
+/**
+ * Aguarda a primeira renderização da listagem global. A
+ * `RolesGlobalListShellPage` dispara duas requests em paralelo no
+ * mount (`listRoles` e `listSystems`) — esperar `client.get` ser
+ * chamado pelo menos 2 vezes garante que a UI saiu de loading.
+ */
+export async function waitForRolesGlobalInitialList(
+  client: ApiClientStub,
+): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(
+      screen.queryByTestId("roles-global-loading"),
+    ).not.toBeInTheDocument();
+  });
+}
+
+/**
  * Helper para extrair o `path` passado a `client.get` na chamada
  * mais recente. Usado em asserts que verificam o endpoint
  * consumido. Espelha `lastGetPath` em `routesTestHelpers.tsx`.
- *
- * **Hoje** o backend só expõe `GET /roles` (sem querystring); o
- * adapter client-side em `listRoles` aplica filtros/paginação em
- * memória. Quando o backend evoluir para `GET /systems/roles?...`,
- * este helper continuará válido — só mudará o conteúdo retornado.
  */
 export function lastGetPath(client: ApiClientStub): string {
   const calls = client.get.mock.calls;
   if (calls.length === 0) return "";
   const path = calls[calls.length - 1][0];
   return typeof path === "string" ? path : "";
+}
+
+/**
+ * Helper para extrair o último path de `client.get` que case com um
+ * prefixo (`'/roles'` ou `'/systems'`). A `RolesGlobalListShellPage`
+ * dispara duas requests no mount (`listRoles` e `listSystems`) e
+ * `lastGetPath` cru retorna a mais recente — quando o teste precisa
+ * inspecionar a request de roles, este helper filtra pela base.
+ */
+export function lastGetPathMatching(
+  client: ApiClientStub,
+  prefix: string,
+): string {
+  const calls = client.get.mock.calls;
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const path = calls[i][0];
+    if (typeof path === "string" && path.startsWith(prefix)) {
+      return path;
+    }
+  }
+  return "";
 }
 
 /**
@@ -356,7 +521,7 @@ export function mockOpenEditModalResponses(
   options: { role?: RoleDto } = {},
 ): void {
   const role = options.role ?? makeRole();
-  client.get.mockResolvedValueOnce([role]);
+  client.get.mockResolvedValueOnce(makePagedRolesResponse([role]));
 }
 
 /**
@@ -465,7 +630,7 @@ export async function openCreateRoleModal(
     client.get.mock.calls.length === 0 &&
     client.get.mock.results.length === 0
   ) {
-    client.get.mockResolvedValueOnce(options.rows ?? []);
+    client.get.mockResolvedValueOnce(makePagedRolesResponse(options.rows ?? []));
   }
   renderRolesPage(client);
   await waitForInitialList(client);

--- a/tests/pages/roles/RolesGlobalListShellPage.test.tsx
+++ b/tests/pages/roles/RolesGlobalListShellPage.test.tsx
@@ -1,0 +1,621 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  createRolesClientStub,
+  ID_ROLE_ADMIN,
+  ID_ROLE_ROOT,
+  ID_ROLE_VIEWER,
+  ID_SYS_AUTH,
+  lastGetPath,
+  lastGetPathMatching,
+  makePagedRolesResponse,
+  makePagedSystemsResponseForRoles,
+  makeRole,
+  makeSystemDtoForRoles,
+  primeRolesGlobalStubResponses,
+  renderRolesGlobalListPage,
+  waitForRolesGlobalInitialList,
+} from '../__helpers__/rolesTestHelpers';
+/* eslint-enable import/order */
+
+import type { ApiError, RoleDto, SystemDto } from '@/shared/api';
+
+/**
+ * Suíte da `RolesGlobalListShellPage` (Issue #173 — listagem global
+ * cross-system de roles em `/roles`). Espelha a estratégia de
+ * `ClientsListShellPage.test.tsx`/`SystemsPage.test.tsx`: stub de
+ * `ApiClient` injetado, asserts sobre estados visuais, paginação
+ * server-side, busca debounced, filtro por sistema (dropdown
+ * carregado via request paralela `listSystems`), erros e
+ * cancelamento.
+ *
+ * Diferenças relativas a outras listagens globais:
+ *
+ * - Duas requests no mount: `listRoles` (paginado) + `listSystems`
+ *   (catálogo do dropdown). O helper `primeRolesGlobalStubResponses`
+ *   resolve ambas via `mockImplementation` por path.
+ * - Filtro extra é dropdown de sistema (UUID), não Select de tipo.
+ * - Não há criação/edição/desativação inline (deferido — a issue
+ *   especifica que os fluxos de mutação ficam na `RolesPage`
+ *   per-system).
+ * - Cada linha "drilla" para `/systems/:systemId/roles` via
+ *   `useNavigate` ao clicar em "Abrir".
+ */
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => ['AUTH_V1_ROLES_LIST']));
+
+const SEARCH_DEBOUNCE_MS = 300;
+const ID_SYS_OUTRO = '22222222-2222-2222-2222-222222222222';
+
+const ROLES_SAMPLE: ReadonlyArray<RoleDto> = [
+  makeRole({
+    id: ID_ROLE_ROOT,
+    systemId: ID_SYS_AUTH,
+    name: 'Root',
+    code: 'root',
+    description: 'Acesso irrestrito',
+    permissionsCount: 12,
+    usersCount: 2,
+  }),
+  makeRole({
+    id: ID_ROLE_ADMIN,
+    systemId: ID_SYS_OUTRO,
+    name: 'Admin',
+    code: 'admin',
+    description: 'Gerenciamento',
+    permissionsCount: 8,
+    usersCount: 6,
+  }),
+];
+
+const SYSTEMS_SAMPLE: ReadonlyArray<SystemDto> = [
+  makeSystemDtoForRoles({ id: ID_SYS_AUTH, name: 'lfc-authenticator' }),
+  makeSystemDtoForRoles({
+    id: ID_SYS_OUTRO,
+    name: 'kurtto-orders',
+    code: 'KURT',
+  }),
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('RolesGlobalListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e popula a tabela após resposta', async () => {
+    const client = createRolesClientStub();
+    let resolveRoles: (value: unknown) => void = () => undefined;
+    const pendingRoles = new Promise<unknown>((resolve) => {
+      resolveRoles = resolve;
+    });
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) return pendingRoles;
+      return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+    });
+
+    renderRolesGlobalListPage(client);
+
+    expect(screen.getByTestId('roles-global-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRoles(makePagedRolesResponse(ROLES_SAMPLE));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('roles-global-loading'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Tabela desktop e cards mobile renderizam o mesmo conteúdo —
+    // `getAllByText` cobre ambos os surfaces.
+    expect(screen.getAllByText('Root').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Admin').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza header da página com título "Roles cadastradas"', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /Roles cadastradas/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /roles sem querystring quando defaults estão ativos', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(lastGetPathMatching(client, '/roles')).toBe('/roles');
+  });
+
+  it('denormaliza o nome do sistema dono na coluna "Sistema" usando o lookup do dropdown', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    // O dropdown de filtro contém os nomes dos sistemas; o lookup
+    // alimenta a coluna Sistema. `getAllByText` cobre tabela + cards
+    // + opção do dropdown.
+    expect(screen.getAllByText('lfc-authenticator').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('kurtto-orders').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza placeholder "—" para roles legadas com systemId null', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([
+        makeRole({
+          id: ID_ROLE_VIEWER,
+          systemId: null,
+          name: 'Legacy',
+          code: 'legacy',
+        }),
+      ]),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    // Tabela + cards renderizam placeholder em duplicidade.
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('exibe contagens numéricas para permissionsCount e usersCount', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([ROLES_SAMPLE[0]]),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(screen.getAllByText('12').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza cards mobile com testId estável por role', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(
+      screen.getByTestId(`roles-global-card-${ID_ROLE_ROOT}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`roles-global-card-${ID_ROLE_ADMIN}`),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RolesGlobalListShellPage — busca debounced (server-side)', () => {
+  it('digitar não dispara request imediato; após 300ms refaz GET com q na querystring', async () => {
+    const client = createRolesClientStub();
+    let rolesPayload = makePagedRolesResponse(ROLES_SAMPLE);
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) return Promise.resolve(rolesPayload);
+      return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    const callsBefore = client.get.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && c[0].startsWith('/roles'),
+    ).length;
+
+    fireEvent.change(screen.getByTestId('roles-global-search'), {
+      target: { value: 'admin' },
+    });
+
+    expect(
+      client.get.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].startsWith('/roles'),
+      ).length,
+    ).toBe(callsBefore);
+
+    rolesPayload = makePagedRolesResponse([ROLES_SAMPLE[1]]);
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe('/roles?q=admin');
+    });
+  });
+});
+
+describe('RolesGlobalListShellPage — filtro por sistema', () => {
+  it('selecionar um sistema envia systemId na querystring', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    fireEvent.change(screen.getByTestId('roles-global-system-filter'), {
+      target: { value: ID_SYS_AUTH },
+    });
+
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe(
+        `/roles?systemId=${ID_SYS_AUTH}`,
+      );
+    });
+  });
+
+  it('voltar para "Todos os sistemas" remove o param systemId da querystring', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    fireEvent.change(screen.getByTestId('roles-global-system-filter'), {
+      target: { value: ID_SYS_AUTH },
+    });
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe(
+        `/roles?systemId=${ID_SYS_AUTH}`,
+      );
+    });
+
+    fireEvent.change(screen.getByTestId('roles-global-system-filter'), {
+      target: { value: 'ALL' },
+    });
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe('/roles');
+    });
+  });
+});
+
+describe('RolesGlobalListShellPage — paginação server-side', () => {
+  it('clicar "próxima" envia page=2 na querystring; "anterior" volta para o default', async () => {
+    const client = createRolesClientStub();
+    const pageOne = Array.from({ length: 20 }, (_, i) =>
+      makeRole({
+        id: `id-${i}`,
+        systemId: ID_SYS_AUTH,
+        name: `Role ${i}`,
+        code: `r${String(i).padStart(2, '0')}`,
+      }),
+    );
+    const pageTwo = Array.from({ length: 5 }, (_, i) =>
+      makeRole({
+        id: `id-${i + 20}`,
+        systemId: ID_SYS_AUTH,
+        name: `Role ${i + 20}`,
+        code: `r${String(i + 20).padStart(2, '0')}`,
+      }),
+    );
+    let counter = 0;
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+      }
+      counter += 1;
+      if (counter === 1) {
+        return Promise.resolve(
+          makePagedRolesResponse(pageOne, { total: 25, page: 1 }),
+        );
+      }
+      if (counter === 2) {
+        return Promise.resolve(
+          makePagedRolesResponse(pageTwo, { total: 25, page: 2 }),
+        );
+      }
+      return Promise.resolve(
+        makePagedRolesResponse(pageOne, { total: 25, page: 1 }),
+      );
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(screen.getByTestId('roles-global-page-info')).toHaveTextContent(
+      /Página 1 de 2/i,
+    );
+
+    fireEvent.click(screen.getByTestId('roles-global-next'));
+
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe('/roles?page=2');
+    });
+
+    fireEvent.click(screen.getByTestId('roles-global-prev'));
+
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe('/roles');
+    });
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE, { total: 25 }),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(screen.getByTestId('roles-global-prev')).toBeDisabled();
+    expect(screen.getByTestId('roles-global-next')).toBeEnabled();
+  });
+
+  it('exibe indicador "Página X de Y" com total filtrado', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE, { total: 42 }),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    const info = screen.getByTestId('roles-global-page-info');
+    expect(info).toHaveTextContent(/Página 1 de 3/i);
+    expect(info).toHaveTextContent(/42 resultado/i);
+  });
+});
+
+describe('RolesGlobalListShellPage — toggle includeDeleted', () => {
+  it('liga toggle dispara request com includeDeleted=true na querystring', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    fireEvent.click(screen.getByTestId('roles-global-include-deleted'));
+
+    await waitFor(() => {
+      expect(lastGetPathMatching(client, '/roles')).toBe(
+        '/roles?includeDeleted=true',
+      );
+    });
+  });
+});
+
+describe('RolesGlobalListShellPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createRolesClientStub();
+    let rolesPayload = makePagedRolesResponse(ROLES_SAMPLE);
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/roles')) return Promise.resolve(rolesPayload);
+      return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    rolesPayload = makePagedRolesResponse([]);
+    fireEvent.change(screen.getByTestId('roles-global-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhuma role encontrada para/i).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getAllByTestId('roles-global-empty-clear').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([]),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(
+      screen.getAllByText(/Nenhuma role cadastrada\./i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Roles removidas podem ser visualizadas/i).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('RolesGlobalListShellPage — erro de rede', () => {
+  it('exibe Alert + botão retry; clicar dispara nova request', async () => {
+    const apiError: ApiError = {
+      kind: 'network',
+      message: 'Falha de conexão com o servidor.',
+    };
+    const client = createRolesClientStub();
+    let attempt = 0;
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+      }
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.reject(apiError);
+      }
+      return Promise.resolve(makePagedRolesResponse(ROLES_SAMPLE));
+    });
+
+    renderRolesGlobalListPage(client);
+
+    expect(
+      await screen.findByText(/Falha de conexão com o servidor\./i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('roles-global-retry'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Falha de conexão/i)).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Root').length).toBeGreaterThan(0);
+  });
+
+  it('erro desconhecido exibe mensagem genérica', async () => {
+    const client = createRolesClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems')) {
+        return Promise.resolve(makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE));
+      }
+      return Promise.reject(new Error('boom'));
+    });
+
+    renderRolesGlobalListPage(client);
+
+    expect(
+      await screen.findByText(
+        /Falha ao carregar a lista de roles\. Tente novamente\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('RolesGlobalListShellPage — drill-down ao clicar em Abrir', () => {
+  it('clicar em "Abrir" navega para /systems/:systemId/roles do sistema da role', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([ROLES_SAMPLE[0]]),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    // Tabela + cards renderizam o botão; pegamos o primeiro
+    // (`getAllByTestId` ≥ 1) e clicamos. A navegação é interna via
+    // `useNavigate`; confirmamos via `screen.findByText('drill')`
+    // (rota auxiliar registrada em `renderRolesGlobalListPage`).
+    const buttons = screen.getAllByTestId(
+      `roles-global-open-${ID_ROLE_ROOT}`,
+    );
+    fireEvent.click(buttons[0]);
+
+    expect(await screen.findByText('drill')).toBeInTheDocument();
+  });
+
+  it('botão "Abrir" fica desabilitado em roles com systemId null', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([
+        makeRole({
+          id: ID_ROLE_VIEWER,
+          systemId: null,
+          name: 'Legacy',
+          code: 'legacy',
+        }),
+      ]),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    const buttons = screen.getAllByTestId(
+      `roles-global-open-${ID_ROLE_VIEWER}`,
+    );
+    buttons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+});
+
+describe('RolesGlobalListShellPage — cancelamento de request', () => {
+  it('mudanças sucessivas de busca abortam a request anterior via AbortController', async () => {
+    const client = createRolesClientStub();
+    const signals: AbortSignal[] = [];
+    client.get.mockImplementation(
+      (path: string, options?: { signal?: AbortSignal }) => {
+        if (options?.signal) {
+          signals.push(options.signal);
+        }
+        if (path.startsWith('/systems')) {
+          return Promise.resolve(
+            makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+          );
+        }
+        return Promise.resolve(makePagedRolesResponse(ROLES_SAMPLE));
+      },
+    );
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    fireEvent.change(screen.getByTestId('roles-global-search'), {
+      target: { value: 'admin' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByTestId('roles-global-search'), {
+      target: { value: 'admin-extra' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    // Pelo menos uma das requests anteriores deve ter sido abortada
+    // (cleanup do useEffect ao mudar `debouncedSearch`).
+    const aborted = signals.filter((s) => s.aborted).length;
+    expect(aborted).toBeGreaterThanOrEqual(1);
+    // Anti-warning: também consume `lastGetPath` para evitar import
+    // não usado; afirma que pelo menos uma chamada teve path string.
+    expect(typeof lastGetPath(client)).toBe('string');
+  });
+});

--- a/tests/pages/users/UserRolesPage.test.tsx
+++ b/tests/pages/users/UserRolesPage.test.tsx
@@ -109,8 +109,9 @@ describe('UserRolesShellPage — loading e erro inicial', () => {
     const client = createUserRolesClientStub();
     client.get.mockImplementation((path: string) => {
       if (path.startsWith('/roles')) {
-        // Backend devolve array cru (não envelope) — listRoles adapta.
-        return Promise.resolve([makeRole()]);
+        // Backend devolve `PagedResponse<RoleDto>` nativo após
+        // `lfc-authenticator#163`.
+        return Promise.resolve(makePagedRoles([makeRole()]));
       }
       if (path.startsWith('/systems')) {
         return Promise.resolve(makePagedSystems([makeSystem()]));
@@ -144,8 +145,9 @@ describe('UserRolesShellPage — loading e erro inicial', () => {
             message: 'Falha de conexão.',
           });
         }
-        // Backend devolve array cru (não envelope) — listRoles adapta.
-        return Promise.resolve([makeRole()]);
+        // Backend devolve `PagedResponse<RoleDto>` nativo após
+        // `lfc-authenticator#163`.
+        return Promise.resolve(makePagedRoles([makeRole()]));
       }
       if (path.startsWith('/systems')) {
         return Promise.resolve(makePagedSystems([makeSystem()]));

--- a/tests/pages/users/__helpers__/userRolesTestHelpers.tsx
+++ b/tests/pages/users/__helpers__/userRolesTestHelpers.tsx
@@ -150,12 +150,10 @@ export function makePagedSystems(
 
 interface SetupOptions {
   /**
-   * Catálogo devolvido pelo `listRoles`. **Importante:** o backend
-   * `/roles` ainda devolve um array cru (não envelope paginado);
-   * `listRoles` adapta client-side. O stub deve mocar o array, e o
-   * `makePagedRoles` aqui é apenas conveniência para testes que
-   * queiram passar o envelope explicitamente — a normalização no
-   * `primeStubResponses` aceita ambos.
+   * Catálogo devolvido pelo `listRoles`. Após `lfc-authenticator#163`/
+   * `#164`, o backend devolve `PagedResponse<RoleDto>` nativo;
+   * `listRoles` valida e propaga sem adapter. Aceita também um array
+   * cru (legado) — o `primeStubResponses` envelopa automaticamente.
    */
   roles?: PagedResponse<RoleDto> | ReadonlyArray<RoleDto>;
   /** Sistemas devolvidos pelo `listSystems` (lookup, envelope paginado). */
@@ -174,19 +172,19 @@ export function primeStubResponses(
   client: ApiClientStub,
   options: SetupOptions = {},
 ): void {
-  // Backend hoje devolve `/roles` como array cru — o adapter
-  // `listRoles` paginia/filtra client-side. O stub aqui sempre devolve
-  // o array (extraído do envelope se o caller passou `PagedResponse`).
+  // Backend devolve `/roles` como `PagedResponse<RoleDto>` nativo após
+  // `lfc-authenticator#163`/`#164`. O stub envelopa quando o caller
+  // passa só o array cru (compatibilidade com fixtures legadas).
   const rolesInput = options.roles ?? [makeRole()];
-  const rolesArray = Array.isArray(rolesInput)
-    ? (rolesInput as ReadonlyArray<RoleDto>)
-    : (rolesInput as PagedResponse<RoleDto>).data;
+  const rolesEnvelope = Array.isArray(rolesInput)
+    ? makePagedRoles(rolesInput as ReadonlyArray<RoleDto>)
+    : (rolesInput as PagedResponse<RoleDto>);
   const systems = options.systems ?? makePagedSystems([makeSystem()]);
   const user = options.user ?? makeUser();
 
   client.get.mockImplementation((path: string) => {
     if (path.startsWith('/roles')) {
-      return Promise.resolve(rolesArray);
+      return Promise.resolve(rolesEnvelope);
     }
     if (path.startsWith('/systems')) {
       return Promise.resolve(systems);

--- a/tests/shared/api/roles.test.ts
+++ b/tests/shared/api/roles.test.ts
@@ -209,13 +209,35 @@ describe("isPagedRolesResponse", () => {
   });
 });
 
-describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", () => {
-  it("emite GET /roles e devolve envelope paginado quando backend devolve array", async () => {
+/**
+ * Helper para o envelope paginado server-side. Após
+ * `lfc-authenticator#163`/`#164`, o backend devolve
+ * `PagedResponse<RoleResponse>` nativo — `listRoles` valida e
+ * propaga sem adapter cliente.
+ */
+function makePagedRolesEnvelope(
+  data: ReadonlyArray<RoleDto>,
+  overrides: Partial<{
+    page: number;
+    pageSize: number;
+    total: number;
+  }> = {},
+) {
+  return {
+    data,
+    page: overrides.page ?? 1,
+    pageSize: overrides.pageSize ?? 20,
+    total: overrides.total ?? data.length,
+  };
+}
+
+describe("listRoles — envelope paginado server-side", () => {
+  it("emite GET /roles com querystring vazia quando todos os params são default", async () => {
     const client = createStub();
-    client.get.mockResolvedValueOnce([makeRoleDto()]);
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([makeRoleDto()]));
 
     const result = await listRoles(
-      { systemId: SYS_ID },
+      {},
       undefined,
       client as unknown as ApiClient,
     );
@@ -228,9 +250,63 @@ describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", (
     expect(result.total).toBe(1);
   });
 
+  it("inclui systemId na querystring quando informado", async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([makeRoleDto()]));
+
+    await listRoles(
+      { systemId: SYS_ID },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(`/roles?systemId=${SYS_ID}`);
+  });
+
+  it("inclui q após trim quando informado", async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([]));
+
+    await listRoles(
+      { q: "  admin  " },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe("/roles?q=admin");
+  });
+
+  it("omite q vazio após trim", async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([]));
+
+    await listRoles(
+      { q: "   " },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe("/roles");
+  });
+
+  it("inclui page/pageSize/includeDeleted quando diferentes do default", async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([]));
+
+    await listRoles(
+      { page: 2, pageSize: 50, includeDeleted: true },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.get.mock.calls[0][0]).toBe(
+      "/roles?page=2&pageSize=50&includeDeleted=true",
+    );
+  });
+
   it("passa signal/options adiante para o cliente", async () => {
     const client = createStub();
-    client.get.mockResolvedValueOnce([makeRoleDto()]);
+    client.get.mockResolvedValueOnce(makePagedRolesEnvelope([makeRoleDto()]));
     const controller = new AbortController();
 
     await listRoles(
@@ -242,7 +318,7 @@ describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", (
     expect(client.get.mock.calls[0][1]).toEqual({ signal: controller.signal });
   });
 
-  it("lança ApiError(parse) quando o backend devolve payload inválido (não-array)", async () => {
+  it("lança ApiError(parse) quando o backend devolve payload inválido", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce({ malformed: true });
 
@@ -258,9 +334,14 @@ describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", (
     });
   });
 
-  it("lança ApiError(parse) quando algum item do array não é RoleDto", async () => {
+  it("lança ApiError(parse) quando algum item do envelope não é RoleDto", async () => {
     const client = createStub();
-    client.get.mockResolvedValueOnce([makeRoleDto(), { broken: true }]);
+    client.get.mockResolvedValueOnce({
+      data: [makeRoleDto(), { broken: true }],
+      page: 1,
+      pageSize: 20,
+      total: 2,
+    });
 
     await expect(
       listRoles(
@@ -284,116 +365,18 @@ describe("listRoles — endpoint atual /roles (GET cru, adapter client-side)", (
       ),
     ).rejects.toEqual(apiError);
   });
-});
 
-describe("listRoles — adapter client-side (filtros/ordem/paginação)", () => {
-  it("filtra deletedAt quando includeDeleted=false (default)", async () => {
+  it("respeita o page/pageSize/total devolvidos pelo backend (sem reaplicar paginação)", async () => {
     const client = createStub();
-    client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: "a", code: "aroot" }),
-      makeRoleDto({
-        id: "b",
-        code: "bdeleted",
-        deletedAt: "2026-02-01T00:00:00Z",
-      }),
-    ]);
-
-    const result = await listRoles(
-      { systemId: SYS_ID },
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.data).toHaveLength(1);
-    expect(result.data[0].id).toBe("a");
-    expect(result.total).toBe(1);
-  });
-
-  it("inclui deletedAt quando includeDeleted=true", async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: "a", code: "aroot" }),
-      makeRoleDto({
-        id: "b",
-        code: "bdeleted",
-        deletedAt: "2026-02-01T00:00:00Z",
-      }),
-    ]);
-
-    const result = await listRoles(
-      { systemId: SYS_ID, includeDeleted: true },
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.data).toHaveLength(2);
-    expect(result.total).toBe(2);
-  });
-
-  it("filtra por q (case-insensitive em name e code) após trim", async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: "a", name: "Root", code: "root" }),
-      makeRoleDto({ id: "b", name: "Admin", code: "admin" }),
-      makeRoleDto({ id: "c", name: "Viewer", code: "viewer" }),
-    ]);
-
-    const result = await listRoles(
-      { systemId: SYS_ID, q: "  ROO  " },
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.data.map((r) => r.id)).toEqual(["a"]);
-    expect(result.total).toBe(1);
-  });
-
-  it("q vazio após trim devolve todos os resultados", async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: "a", code: "a" }),
-      makeRoleDto({ id: "b", code: "b" }),
-    ]);
-
-    const result = await listRoles(
-      { systemId: SYS_ID, q: "   " },
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.total).toBe(2);
-  });
-
-  it("ordena por code (estabilidade visual entre refetches)", async () => {
-    const client = createStub();
-    client.get.mockResolvedValueOnce([
-      makeRoleDto({ id: "c", code: "charlie" }),
-      makeRoleDto({ id: "a", code: "alpha" }),
-      makeRoleDto({ id: "b", code: "bravo" }),
-    ]);
-
-    const result = await listRoles(
-      { systemId: SYS_ID },
-      undefined,
-      client as unknown as ApiClient,
-    );
-
-    expect(result.data.map((r) => r.code)).toEqual([
-      "alpha",
-      "bravo",
-      "charlie",
-    ]);
-  });
-
-  it("aplica page/pageSize em memória; total reflete o conjunto após filtros", async () => {
-    const client = createStub();
-    const rows = Array.from({ length: 25 }, (_, i) =>
+    const data = Array.from({ length: 10 }, (_, i) =>
       makeRoleDto({ id: `id-${i}`, code: `r${String(i).padStart(2, "0")}` }),
     );
-    client.get.mockResolvedValueOnce(rows);
+    client.get.mockResolvedValueOnce(
+      makePagedRolesEnvelope(data, { page: 2, pageSize: 10, total: 25 }),
+    );
 
     const result = await listRoles(
-      { systemId: SYS_ID, page: 2, pageSize: 10 },
+      { page: 2, pageSize: 10 },
       undefined,
       client as unknown as ApiClient,
     );
@@ -402,7 +385,6 @@ describe("listRoles — adapter client-side (filtros/ordem/paginação)", () => 
     expect(result.pageSize).toBe(10);
     expect(result.total).toBe(25);
     expect(result.data).toHaveLength(10);
-    expect(result.data[0].code).toBe("r10");
   });
 });
 


### PR DESCRIPTION
## Contexto

O item de menu **Roles** (Sidebar #03 → `/roles`) renderizava um
`PlaceholderPage` estático com a frase "Para listar as roles de um
sistema específico, abra o sistema correspondente.". Clicar não disparava
nenhuma chamada ao backend e a tela ficava sem valor real para o
operador.

Após \`lfc-authenticator#163\`/\`#164\`, o backend \`GET /api/v1/roles\`
passou a expor paginação nativa (\`systemId\`/\`q\`/\`page\`/
\`pageSize\`/\`includeDeleted\`) e enriquecimento por \`permissionsCount\`/
\`usersCount\` via subselects EF Core. Estava na hora de aproveitar.

## Objetivo

Substituir o placeholder por uma listagem global cross-system real
(\`RolesGlobalListShellPage\`), seguindo o padrão de
\`ClientsListShellPage\`/\`SystemsPage\`, e atualizar \`listRoles\`
para validar o envelope server-side (removendo o adapter cliente que
existia para tolerar o backend pré-#163).

## O que foi feito

- **\`src/pages/roles/RolesGlobalListShellPage.tsx\`** (novo):
  listagem com toolbar (busca + toggle "Mostrar inativas" + filtro
  de sistema via dropdown carregado de \`listSystems\`), tabela
  desktop, mobile cards, paginação server-side e drill-down para
  \`/systems/:systemId/roles\` ao clicar em "Abrir" na linha. Roles
  legadas com \`systemId === null\` exibem placeholder e o botão
  "Abrir" fica desabilitado.
- **\`src/shared/api/roles.ts\`**: \`listRoles\` agora monta
  querystring (\`systemId\`/\`q\`/\`page\`/\`pageSize\`/
  \`includeDeleted\`) e valida envelope via \`isPagedRolesResponse\`.
  Adapter cliente-side foi removido — substituído por
  \`buildRolesQueryString\` (espelha \`systems.ts\`).
- **\`src/routes/index.tsx\`**: \`/roles\` passa a renderizar
  \`<RolesGlobalListShellPage />\` (mesmo gating
  \`AUTH_V1_ROLES_LIST\`).
- **\`src/shared/listing/useListingEmptyContent.tsx\`** (novo): hook
  compartilhado para o estado vazio das listagens — extraído antes
  do PR para evitar 7ª recorrência de Sonar New Code Duplication
  (lição PR #134/#135). Reusado por \`RolesPage\` e
  \`RolesGlobalListShellPage\`.
- **\`src/shared/listing/RoleCardHeader.tsx\`** (novo): componente
  apresentacional do header dos cards mobile de role
  (\`<CardHeader>\` + \`<StatusBadge>\` + \`<CardName>\` +
  \`<CardDescription>\` condicional). Reusado por ambas as
  listagens de role.
- Testes: nova suíte \`RolesGlobalListShellPage.test.tsx\` (21
  cenários: render, busca, filtro de sistema, paginação, toggle,
  estado vazio, erro, drill-down, cancelamento). Tests existentes
  (\`RolesPage\`, \`UserRolesPage\`, \`tests/shared/api/roles.test.ts\`)
  atualizados para o novo envelope server-side. Helpers (\`makePagedRolesResponse\`, \`renderRolesGlobalListPage\`,
  \`primeRolesGlobalStubResponses\`) adicionados em
  \`rolesTestHelpers.tsx\`.

## Arquivos impactados

- **Produção:** \`src/pages/roles/RolesGlobalListShellPage.tsx\` (novo),
  \`src/pages/RolesPage.tsx\`, \`src/routes/index.tsx\`,
  \`src/shared/api/roles.ts\`, \`src/shared/listing/index.ts\`,
  \`src/shared/listing/RoleCardHeader.tsx\` (novo),
  \`src/shared/listing/useListingEmptyContent.tsx\` (novo).
- **Testes:** \`tests/pages/roles/RolesGlobalListShellPage.test.tsx\`
  (novo), \`tests/pages/RolesPage.test.tsx\`,
  \`tests/pages/RolesPage.create.test.tsx\`,
  \`tests/pages/RolesPage.edit.test.tsx\`,
  \`tests/pages/__helpers__/rolesTestHelpers.tsx\`,
  \`tests/pages/users/UserRolesPage.test.tsx\`,
  \`tests/pages/users/__helpers__/userRolesTestHelpers.tsx\`,
  \`tests/shared/api/roles.test.ts\`.

## Testes

\`docker compose run --rm web npm run lint\` → 0 erros, 0 warnings.
\`docker compose run --rm web npm run typecheck\` → 0 erros.
\`docker compose run --rm web npm test\` → **80 test files passed (80)**, **1493 tests passed (1493)**.
\`docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10\` →
total 1.95% ≤ 3%; \`newClones === 0\` em todos os arquivos do diff.

## Visual

- Layout responsivo (tabela desktop + cards mobile via
  \`CardListForMobile\`) — paridade visual com
  \`ClientsListShellPage\`/\`UsersListShellPage\`.
- Estados visuais completos: loading inicial (\`InitialLoadingSpinner\`),
  refetch overlay leve, empty (com/sem busca), erro com retry,
  paginação server-side. Hover/focus já tratados pelos tokens dos
  primitives \`<Button>\`, \`<Select>\`, \`<EntityCard>\`.
- Botões "Abrir" usam \`disabled\` para roles legadas sem
  \`systemId\` — dica visual coerente com a coluna "Sistema"
  exibindo placeholder.

## Segurança

Nenhum impacto adicional. Gating de leitura via
\`<RequirePermission code="AUTH_V1_ROLES_LIST">\` no router (mesmo
padrão das demais listagens). Backend continua sendo a fonte
autoritativa — o painel só esconde controles que o operador não
pode executar. Não há \`dangerouslySetInnerHTML\`, links
construídos dinamicamente apontam apenas para rotas internas
\`/systems/:systemId/roles\`.

## Riscos

- \`listRoles\` deixou de aceitar array cru — todos os call-sites
  (\`RolesPage\`, \`UserRolesShellPage\`, suítes de teste) foram
  atualizados, mas algum stub futuro que ainda devolva array
  precisará migrar para envelope.
- Os timeouts intermitentes de testes em \`origin/development\`
  (jsdom + Docker) também ocorrem antes deste PR e foram validados
  em runs isolados (todos verdes); a suite passou \`1493/1493\`
  no run final.

## Issue relacionada

Closes #173