### PR TITLE
feat(tokens): CRUD de tipos de token JWT em /tokens (#175)

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -39,6 +39,10 @@ import {
 
 import { EditRoleModal } from "./roles/EditRoleModal";
 import { NewRoleModal } from "./roles/NewRoleModal";
+import {
+  renderRoleDescription as renderDescription,
+  renderRoleCount as renderCount,
+} from "./roles/rolesRenderHelpers";
 
 import type { TableColumn } from "../components/ui";
 import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
@@ -94,14 +98,6 @@ interface RolesPageProps {
 function isProbablyValidSystemId(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
-
-// `renderDescription`/`renderCount` extraídos para
-// `src/pages/roles/rolesRenderHelpers.tsx` — compartilhados com
-// `RolesGlobalListShellPage` (lição PR #134/#135 — duplicação Sonar).
-import {
-  renderRoleDescription as renderDescription,
-  renderRoleCount as renderCount,
-} from './roles/rolesRenderHelpers';
 
 export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
   // `useParams` devolve `string | undefined` — nunca lançamos: rota

--- a/src/pages/roles/RoleFormFields.tsx
+++ b/src/pages/roles/RoleFormFields.tsx
@@ -2,9 +2,8 @@ import React from "react";
 
 import {
   NameCodeDescriptionFormBody,
-  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormBodyProps,
   type NameCodeDescriptionFormCopy,
-  type NameCodeDescriptionFormState,
 } from "../../shared/forms";
 
 /**
@@ -26,6 +25,12 @@ import {
  * em vez de vazar o nome genérico no callsite — o `EditRoleModal`
  * (e o futuro `NewRoleModal`) consomem o tipo do recurso, não o
  * tipo genérico.
+ *
+ * **Lição PR #134/#135 reforçada (Issue #175):** as props internas
+ * (`RoleFormBodyProps`) duplicavam ~13 linhas com
+ * `NameCodeDescriptionFormBodyProps`. Substituídas por
+ * `Omit<NameCodeDescriptionFormBodyProps, 'copy'>` para deduplicar a
+ * declaração — o `copy` é injetado pelo wrapper e não é prop pública.
  */
 
 /* ─── Cópia textual (placeholders) específica de roles ─── */
@@ -38,31 +43,14 @@ const ROLE_FORM_COPY: NameCodeDescriptionFormCopy = {
 
 /* ─── Form body ──────────────────────────────────────────── */
 
-interface RoleFormBodyProps {
-  /**
-   * Prefixo dos `data-testid` do form e dos campos. Em produção,
-   * `new-role` ou `edit-role`; preserva os testIds estáveis das
-   * suítes (`RolesPage.edit.test.tsx`, futura `.create.test.tsx`).
-   */
-  idPrefix: string;
-  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
-  submitError: string | null;
-  /** Estado controlado dos campos. Tipos vêm do `rolesFormShared.ts`. */
-  values: NameCodeDescriptionFormState;
-  /** Erros inline por campo. */
-  errors: NameCodeDescriptionFieldErrors;
-  onChangeName: (value: string) => void;
-  onChangeCode: (value: string) => void;
-  onChangeDescription: (value: string) => void;
-  /** Handler do submit do form. */
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  /** Handler do botão Cancelar (bloqueado durante submit). */
-  onCancel: () => void;
-  /** Flag de submissão em andamento. */
-  isSubmitting: boolean;
-  /** Texto do botão de envio (ex.: "Criar role", "Salvar alterações"). */
-  submitLabel: string;
-}
+/**
+ * Props do `<RoleFormBody>` — alias estrutural das props do
+ * `NameCodeDescriptionFormBody` excluindo `copy` (injetado
+ * internamente). Centralizar via `Omit<...Props, 'copy'>` elimina a
+ * duplicação que o JSCPD detectaria entre `RoleFormFields` e
+ * `TokenTypeFormFields` (lição PR #134/#135).
+ */
+type RoleFormBodyProps = Omit<NameCodeDescriptionFormBodyProps, "copy">;
 
 export const RoleFormBody: React.FC<RoleFormBodyProps> = (props) => (
   <NameCodeDescriptionFormBody {...props} copy={ROLE_FORM_COPY} />

--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -36,6 +36,11 @@ import {
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import {
+  renderRoleDescription as renderDescription,
+  renderRoleCount as renderCount,
+} from './rolesRenderHelpers';
+
 import type { TableColumn } from '../../components/ui';
 import type {
   ApiClient,
@@ -80,14 +85,6 @@ interface RolesGlobalListShellPageProps {
    */
   client?: ApiClient;
 }
-
-// `renderDescription`/`renderCount` extraídos para
-// `./rolesRenderHelpers` — compartilhados com `RolesPage` para evitar
-// duplicação Sonar (lição PR #134/#135).
-import {
-  renderRoleDescription as renderDescription,
-  renderRoleCount as renderCount,
-} from './rolesRenderHelpers';
 
 /**
  * Constrói um lookup `systemId -> SystemDto` para denormalizar a

--- a/src/pages/roles/useRoleForm.ts
+++ b/src/pages/roles/useRoleForm.ts
@@ -1,9 +1,9 @@
-import { useCallback, useMemo, type FormEvent } from "react";
+import { useCallback } from "react";
 
 import {
   useNameCodeDescriptionForm,
-  type NameCodeDescriptionFieldErrors,
-  type NameCodeDescriptionFormState,
+  useNameCodeDescriptionFormFieldProps,
+  type NameCodeDescriptionFormFieldProps,
   type UseNameCodeDescriptionFormReturn,
 } from "../../shared/forms";
 
@@ -77,85 +77,32 @@ export function useRoleForm(initialState: RoleFormState): UseRoleFormReturn {
 }
 
 /**
- * Tipo do conjunto de props consumido por `<RoleFormBody>` —
- * compartilhado entre `NewRoleModal` (Issue #67) e `EditRoleModal`
- * (Issue #68). Centralizar o tipo aqui (em vez de inferir inline em
- * cada modal) elimina o bloco repetido de ~10 linhas (`onChangeName`/
- * `onChangeCode`/`onChangeDescription` + props comuns) que JSCPD/Sonar
- * tokenizam como `New Code Duplication` (lição PR #134/#135 — call-
- * sites dos helpers também precisam ficar deduplicados, não só os
- * helpers em si).
+ * Tipo do conjunto de props consumido por `<RoleFormBody>` — alias
+ * estrutural de `NameCodeDescriptionFormFieldProps` (helper genérico
+ * em `src/shared/forms/`).
  *
- * Os tipos `values`/`errors` referenciam diretamente os shapes
- * genéricos `NameCodeDescriptionFormState`/`...FieldErrors` para
- * preservar simetria com o tipo aceito pelo `<RoleFormBody>` (ver
- * `RoleFormFields.tsx`) — `RoleFormState` é alias estrutural, então
- * as duas formas são intercambiáveis no consumo.
+ * **Lição PR #134/#135 reforçada (Issue #175):** antes deste alias,
+ * cada `use<Recurso>Form.ts` declarava sua própria interface idêntica
+ * em estrutura (~10 linhas). JSCPD detectou a duplicação entre
+ * `useRoleForm.ts` e `useTokenTypeForm.ts`. Centralizar a declaração
+ * em `src/shared/forms/useNameCodeDescriptionFormFieldProps.ts`
+ * eliminou a duplicação na raiz; o alias aqui preserva a API local
+ * (`RoleFormFieldProps`) sem duplicar implementação.
  */
-export interface RoleFormFieldProps {
-  submitError: string | null;
-  values: NameCodeDescriptionFormState;
-  errors: NameCodeDescriptionFieldErrors;
-  onChangeName: (value: string) => void;
-  onChangeCode: (value: string) => void;
-  onChangeDescription: (value: string) => void;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-  onCancel: () => void;
-  isSubmitting: boolean;
-}
+export type RoleFormFieldProps = NameCodeDescriptionFormFieldProps;
 
 /**
  * Constrói o objeto de props para `<RoleFormBody>` a partir de uma
- * instância de `useRoleForm` + `handleSubmit` + `handleClose` do
- * modal. Memoizado em `useMemo` para preservar identidade entre
- * renders quando nada mudou — útil pra spread `{...fieldProps}` sem
- * causar re-render desnecessário no body.
+ * instância de `useRoleForm` + handlers do modal pai. Delegação
+ * direta para `useNameCodeDescriptionFormFieldProps` (helper genérico
+ * em `src/shared/forms/`) — mantém o nome de domínio
+ * (`useRoleFormFieldProps`) por simetria com hooks de outros recursos
+ * (call-sites importam por recurso).
  *
- * Esse helper transforma o "objeto duplicado de 10+ linhas" em uma
- * única chamada `useRoleFormFieldProps(roleForm, handleSubmit,
- * handleClose)` em cada modal — espelha o desenho de
- * `useUserFormFieldProps` (lição PR #134/#135 reforçada). Pré-
- * fabricado para evitar a 7ª recorrência de `New Code Duplication` no
- * Sonar quando o `NewRoleModal` (Issue #67) e o `EditRoleModal` (Issue
- * #68) compartilharem o mesmo bloco de props sequenciais.
+ * **Lição PR #134/#135 reforçada (Issue #175):** o corpo do hook
+ * (`useMemo` retornando `{ submitError, values, errors, ... }` com a
+ * mesma deps array) era idêntico ao de `useTokenTypeFormFieldProps`
+ * (~27 linhas). Extrair para o helper genérico colapsou ambos os
+ * call sites para `export const ... = useNameCodeDescriptionFormFieldProps`.
  */
-export function useRoleFormFieldProps(
-  roleForm: UseRoleFormReturn,
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void,
-  onCancel: () => void,
-): RoleFormFieldProps {
-  const {
-    formState,
-    fieldErrors,
-    submitError,
-    isSubmitting,
-    handleNameChange,
-    handleCodeChange,
-    handleDescriptionChange,
-  } = roleForm;
-
-  return useMemo(
-    () => ({
-      submitError,
-      values: formState,
-      errors: fieldErrors,
-      onChangeName: handleNameChange,
-      onChangeCode: handleCodeChange,
-      onChangeDescription: handleDescriptionChange,
-      onSubmit,
-      onCancel,
-      isSubmitting,
-    }),
-    [
-      submitError,
-      formState,
-      fieldErrors,
-      handleNameChange,
-      handleCodeChange,
-      handleDescriptionChange,
-      onSubmit,
-      onCancel,
-      isSubmitting,
-    ],
-  );
-}
+export const useRoleFormFieldProps = useNameCodeDescriptionFormFieldProps;

--- a/src/pages/systems/SystemFormFields.tsx
+++ b/src/pages/systems/SystemFormFields.tsx
@@ -2,13 +2,9 @@ import React from "react";
 
 import {
   NameCodeDescriptionFormBody,
+  type NameCodeDescriptionFormBodyProps,
   type NameCodeDescriptionFormCopy,
 } from "../../shared/forms";
-
-import {
-  type SystemFieldErrors,
-  type SystemFormState,
-} from "./systemFormShared";
 
 /**
  * Wrapper fino do `NameCodeDescriptionFormBody` parametrizado com
@@ -28,6 +24,13 @@ import {
  * (`SystemFormBody` continua sendo importado de
  * `./SystemFormFields`) para que `NewSystemModal`/`EditSystemModal`
  * não precisem mudar.
+ *
+ * **Lição PR #134/#135 reforçada (Issue #175):** as props internas
+ * (`SystemFormBodyProps`) duplicavam ~15 linhas com
+ * `NameCodeDescriptionFormBodyProps` (visíveis no exported type após
+ * o Issue #175). Substituídas por
+ * `Omit<NameCodeDescriptionFormBodyProps, 'copy'>` — `copy` é
+ * injetado pelo wrapper e não é prop pública.
  */
 
 /* ─── Cópia textual (placeholders) específica de sistemas ─── */
@@ -40,32 +43,13 @@ const SYSTEM_FORM_COPY: NameCodeDescriptionFormCopy = {
 
 /* ─── Form body ──────────────────────────────────────────── */
 
-interface SystemFormBodyProps {
-  /**
-   * Prefixo dos `data-testid` do form e dos campos. Em produção,
-   * `new-system` ou `edit-system` — preserva os testIds estáveis
-   * das suítes `SystemsPage.create.test.tsx` (#58/#127) e
-   * `SystemsPage.edit.test.tsx` (#59).
-   */
-  idPrefix: string;
-  /** Erro genérico de submissão exibido em `Alert` no topo do form. */
-  submitError: string | null;
-  /** Estado controlado dos campos. */
-  values: SystemFormState;
-  /** Erros inline por campo. */
-  errors: SystemFieldErrors;
-  onChangeName: (value: string) => void;
-  onChangeCode: (value: string) => void;
-  onChangeDescription: (value: string) => void;
-  /** Handler do submit do form. */
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  /** Handler do botão Cancelar (bloqueado durante submit). */
-  onCancel: () => void;
-  /** Flag de submissão em andamento. */
-  isSubmitting: boolean;
-  /** Texto do botão de envio (ex.: "Criar sistema", "Salvar alterações"). */
-  submitLabel: string;
-}
+/**
+ * Props do `<SystemFormBody>` — alias estrutural das props do
+ * `NameCodeDescriptionFormBody` excluindo `copy` (injetado
+ * internamente). Centralizar via `Omit<...Props, 'copy'>` elimina
+ * duplicação cross-recurso (lição PR #134/#135).
+ */
+type SystemFormBodyProps = Omit<NameCodeDescriptionFormBodyProps, "copy">;
 
 export const SystemFormBody: React.FC<SystemFormBodyProps> = (props) => (
   <NameCodeDescriptionFormBody {...props} copy={SYSTEM_FORM_COPY} />

--- a/src/pages/tokens/DeleteTokenTypeConfirm.tsx
+++ b/src/pages/tokens/DeleteTokenTypeConfirm.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo } from 'react';
+
+import { deleteTokenType } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import {
+  toTokenTypeMutationTarget,
+  type TokenTypeMutationTarget,
+} from './tokenTypeMutationTarget';
+
+import type { ApiClient, TokenTypeDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo de confirmação para soft-delete de tipo de token
+ * (Issue #175). Espelha `DELETE_COPY` de
+ * `DeleteSystemConfirm`/`DeleteClientConfirm`, com vocabulário
+ * adaptado para token types.
+ *
+ * O slot `errorCopy.conflictMessage` está preenchido por previsão: o
+ * backend atual (`TokenTypesController.DeleteById`) não devolve 409
+ * quando há rotas vinculadas ao token type — apenas faz o soft-delete
+ * (rotas que referenciam um token type soft-deletado renderizam strings
+ * vazias em `systemTokenTypeCode`/`systemTokenTypeName` na listagem de
+ * `RoutesPage`). Pré-projetar o slot agora cobre o cenário se o
+ * backend evoluir para split de 404/409, sem reabrir esta sub-issue.
+ * Lição PR #128: pré-projetar o helper compartilhado é mais barato do
+ * que abrir um PR adicional.
+ */
+const DELETE_COPY: MutationConfirmCopy = {
+  title: 'Desativar tipo de token?',
+  descriptionPrefix: 'O tipo de token ',
+  descriptionSuffix:
+    ' será desativado e sumirá da listagem padrão. Você poderá restaurá-lo depois ativando "Mostrar inativos". Atenção: rotas que referenciam este tipo passarão a exibir o token associado como inativo.',
+  confirmLabel: 'Desativar',
+  successMessage: 'Tipo de token desativado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao desativar tipo de token',
+    genericFallback:
+      'Não foi possível desativar o tipo de token. Tente novamente.',
+    notFoundMessage:
+      'Tipo de token não encontrado ou foi removido. Atualize a lista.',
+    conflictMessage:
+      'Não é possível desativar este tipo de token porque há rotas ativas vinculadas.',
+  },
+};
+
+interface DeleteTokenTypeConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Tipo de token selecionado para soft-delete. Quando `null`, o modal
+   * não renderiza — caller controla `open` em conjunto com `tokenType`.
+   * Mantemos o objeto completo (não só `id`) para que a copy exiba
+   * `name`/`code` sem precisar de re-fetch.
+   */
+  tokenType: TokenTypeDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após desativação bem-sucedida ou após detecção
+   * de 404 (token type já removido por outra sessão) — em ambos casos
+   * a UI quer refetch para sincronizar a tabela com o estado real do
+   * backend.
+   */
+  onDeleted: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `deleteTokenType` cai no singleton `apiClient`.
+   */
+  apiClient?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para soft-delete de tipo de token (Issue #175).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` (extraído na #61 e
+ * generalizado na #65 para servir múltiplos recursos) — toda a
+ * estrutura visual + lógica de submissão/erro vive no shell
+ * compartilhado. Aqui só injetamos:
+ *
+ * - **Copy** (`DELETE_COPY`): título, descrição, label do botão,
+ *   mensagens de toast e `errorCopy.conflictMessage` defensivo.
+ * - **Mutate**: adapta `deleteTokenType(id)` para a assinatura
+ *   `(target, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`danger`): destaca o caráter destrutivo. Já existe
+ *   no design system local (`Button.tsx`); não precisamos hardcodar
+ *   cor.
+ * - **`testIdPrefix`** (`delete-token-type`): identifica os elementos
+ *   do modal nas suítes de teste sem colidir com o
+ *   `delete-system`/`delete-client`.
+ *
+ * O `MutationConfirmModal` cuida de todo o ciclo (confirmação,
+ * submissão, mapeamento de erros 404/401/403/network, refetch após
+ * sucesso ou 404) — espelha o pattern já validado em sistemas, rotas e
+ * clientes.
+ */
+export const DeleteTokenTypeConfirm: React.FC<DeleteTokenTypeConfirmProps> = ({
+  open,
+  tokenType,
+  onClose,
+  onDeleted,
+  apiClient,
+}) => {
+  const target = toTokenTypeMutationTarget(tokenType);
+
+  /**
+   * Função adapter `(target, http?) => Promise<unknown>` que delega
+   * para `deleteTokenType(tokenType.id, undefined, http)`. Memoizada
+   * com `useMemo` (não `useCallback` para preservar o tipo de retorno)
+   * — o `MutationConfirmModal` consome `mutate` em `useCallback`,
+   * então uma referência estável evita invalidação desnecessária
+   * quando o `tokenType` não muda. Se `tokenType` for `null` (modal
+   * fechado), o shell não chega a invocar `mutate` (`target=null`
+   * curto-circuita o render).
+   */
+  const performDelete = useMemo(
+    () =>
+      function (
+        _target: TokenTypeMutationTarget,
+        http?: ApiClient,
+      ): Promise<unknown> {
+        if (!tokenType) {
+          return Promise.reject(new Error('TokenType unavailable.'));
+        }
+        return deleteTokenType(tokenType.id, undefined, http);
+      },
+    [tokenType],
+  );
+
+  return (
+    <MutationConfirmModal<TokenTypeMutationTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onDeleted}
+      client={apiClient}
+      mutate={performDelete}
+      copy={DELETE_COPY}
+      confirmVariant="danger"
+      testIdPrefix="delete-token-type"
+    />
+  );
+};

--- a/src/pages/tokens/EditTokenTypeModal.tsx
+++ b/src/pages/tokens/EditTokenTypeModal.tsx
@@ -1,0 +1,298 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+
+import { Modal, useToast } from '../../components/ui';
+import { updateTokenType } from '../../shared/api';
+import {
+  useEditEntitySubmit,
+  type EditEntitySubmitCopy,
+  type EditSubmitActionCopy,
+} from '../../shared/forms';
+
+import { TokenTypeFormBody } from './TokenTypeFormFields';
+import {
+  type TokenTypeFieldErrors,
+  type TokenTypeFormState,
+  type TokenTypeSubmitErrorCopy,
+} from './tokenTypesFormShared';
+import { useTokenTypeForm, useTokenTypeFormFieldProps } from './useTokenTypeForm';
+
+import type { ApiClient, TokenTypeDto, UpdateTokenTypePayload } from '../../shared/api';
+
+/**
+ * Copy injetada em `classifyTokenTypeSubmitError` para o caminho de
+ * edição. Os literais aqui são os únicos pontos onde "atualizar"/
+ * "outro tipo de token" diferem do "criar"/"um tipo de token" no
+ * `NewTokenTypeModal` — o resto da lógica de classificação é
+ * compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: TokenTypeSubmitErrorCopy = {
+  conflictDefault: 'Já existe outro tipo de token com este código.',
+  forbiddenTitle: 'Falha ao atualizar tipo de token',
+  genericFallback:
+    'Não foi possível atualizar o tipo de token. Tente novamente.',
+};
+
+/** Texto exibido inline no campo `code` quando o backend devolve 409. */
+const CONFLICT_INLINE_MESSAGE = 'Já existe outro tipo de token com este código.';
+
+/** Texto exibido em toast quando o token type some entre abertura e submit (404). */
+const NOT_FOUND_MESSAGE =
+  'Tipo de token não encontrado ou foi removido. Atualize a lista.';
+
+/**
+ * Cópia textual injetada em `applyEditSubmitAction`. Concentra os
+ * literais que diferem entre `EditTokenTypeModal` e os demais modals
+ * de edição (`EditSystemModal`/`EditRoleModal`) sem duplicar o switch
+ * de dispatch — lição PR #128/#134/#135 reforçada.
+ */
+const EDIT_SUBMIT_ACTION_COPY: EditSubmitActionCopy = {
+  conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+  notFoundMessage: NOT_FOUND_MESSAGE,
+  forbiddenTitle: SUBMIT_ERROR_COPY.forbiddenTitle,
+};
+
+interface EditTokenTypeModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Tipo de token sendo editado. Pré-popula o form e fornece o `id`
+   * usado no `PUT /tokens/types/{id}`. Quando `null`, o modal não
+   * renderiza — caller é responsável por só passar `tokenType` quando
+   * `open=true`.
+   */
+  tokenType: TokenTypeDto | null;
+  /** Fecha o modal sem persistir. Chamada também após sucesso ou 404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após atualização bem-sucedida ou após detecção
+   * de 404 (token type já removido) — em ambos casos a UI quer refetch
+   * para sincronizar a tabela com o estado real do backend.
+   */
+  onUpdated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `updateTokenType` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Constrói o estado inicial do form a partir de uma `TokenTypeDto`.
+ * `description: null` (do backend quando vazio) vira string vazia para
+ * que o input controlado nunca receba `null`/`undefined` — preserva
+ * paridade com o `INITIAL_TOKEN_TYPE_FORM_STATE` do create.
+ */
+function stateFromTokenType(tokenType: TokenTypeDto): TokenTypeFormState {
+  return {
+    name: tokenType.name,
+    code: tokenType.code,
+    description: tokenType.description ?? '',
+  };
+}
+
+const EMPTY_INITIAL_STATE: TokenTypeFormState = {
+  name: '',
+  code: '',
+  description: '',
+};
+
+/* ─── Component ──────────────────────────────────────────── */
+
+/**
+ * Modal de edição de tipo de token (Issue #175).
+ *
+ * Espelha a forma de `EditSystemModal`/`EditRoleModal` (mesma
+ * estrutura visual, validação, mapeamento de erros) com três
+ * diferenças funcionais relevantes:
+ *
+ * 1. Pré-popula `formState` com `Name`/`Code`/`Description` do
+ *    `tokenType` recebido por prop (atende o critério de aceite
+ *    "pré-popula campos").
+ * 2. Submit chama `updateTokenType(id, payload)` em vez de
+ *    `updateSystem`/`updateRole`.
+ * 3. Trata 404 fechando o modal + toast vermelho + refetch (token type
+ *    removido concorrentemente entre abertura e submit). Os outros
+ *    códigos (409/400/401/403/network) seguem o mesmo mapeamento da
+ *    criação, com copy adaptado para "atualizado" e mensagem de
+ *    conflito citando "outro tipo de token".
+ *
+ * Toda a lógica de validação client-side e parsing de
+ * `ValidationProblemDetails` vem de `tokenTypesFormShared.ts`, os
+ * campos vivem em `TokenTypeFormFields`, o estado/handlers do form
+ * vêm de `useTokenTypeForm` e o ciclo de submit vem de
+ * `useEditEntitySubmit` — evita duplicação ≥10 linhas com os outros
+ * modals de edição (BLOCKER de duplicação Sonar, lição PR #134/#135).
+ */
+export const EditTokenTypeModal: React.FC<EditTokenTypeModalProps> = ({
+  open,
+  tokenType,
+  onClose,
+  onUpdated,
+  client,
+}) => {
+  const { show } = useToast();
+
+  // Inicialização defensiva: quando `tokenType` é `null` na primeira
+  // render, usamos um estado vazio até o pai entregar o token type. O
+  // `useEffect` abaixo sincroniza sempre que `tokenType` muda.
+  const tokenTypeForm = useTokenTypeForm(
+    tokenType ? stateFromTokenType(tokenType) : EMPTY_INITIAL_STATE,
+  );
+  const {
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    prepareSubmit,
+    applyBadRequest,
+  } = tokenTypeForm;
+
+  /**
+   * Sincroniza o form sempre que: (a) o modal abre, ou (b) o
+   * `tokenType` selecionado muda. Limpa erros pendentes para evitar
+   * resíduo entre aberturas (mesmo padrão do `EditSystemModal`/
+   * `EditRoleModal`).
+   */
+  useEffect(() => {
+    if (!open || !tokenType) return;
+    setFormState(stateFromTokenType(tokenType));
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [open, tokenType, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reseta erros ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
+   * submissão é bloqueado para evitar request órfã. Não resetamos o
+   * `formState` aqui (diferente de um modal de criação) porque o
+   * efeito de sincronização re-popula a partir do `tokenType` quando o
+   * modal reabre.
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareSubmit` que reprova quando o gate de
+   * `isSubmitting`/`!tokenType` falhar — preserva o dedupe original
+   * ao mover a lógica para dentro de `useEditEntitySubmit` (lição PR
+   * #135, 6ª recorrência de Sonar).
+   *
+   * Reaproveita a mesma lógica de montagem do payload do
+   * `NewTokenTypeModal`: trim + omitir `description` quando vazia.
+   */
+  const prepareSubmitSafe = useCallback((): UpdateTokenTypePayload | null => {
+    if (isSubmitting || !tokenType) return null;
+    const trimmed = prepareSubmit();
+    if (trimmed === null) return null;
+    const payload: UpdateTokenTypePayload = {
+      name: trimmed.name,
+      code: trimmed.code,
+    };
+    if (trimmed.description.length > 0) {
+      payload.description = trimmed.description;
+    }
+    return payload;
+  }, [isSubmitting, prepareSubmit, tokenType]);
+
+  /**
+   * Closure sobre `tokenType.id` + `client`. Quando `tokenType` é
+   * `null` o `prepareSubmitSafe` já reprova antes do `mutationFn`
+   * rodar — a checagem inline aqui é defensiva (preserva o tipo sem
+   * `!`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown): Promise<unknown> => {
+      if (!tokenType) {
+        return Promise.reject(new Error('TokenType unavailable.'));
+      }
+      return updateTokenType(
+        tokenType.id,
+        payload as UpdateTokenTypePayload,
+        undefined,
+        client,
+      );
+    },
+    [client, tokenType],
+  );
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<EditEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Tipo de token atualizado.',
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+      editSubmitActionCopy: EDIT_SUBMIT_ACTION_COPY,
+    }),
+    [],
+  );
+
+  /**
+   * `handleSubmit` orquestrado pelo hook compartilhado — encapsula o
+   * `try/catch/finally` + `classifyApiSubmitError` +
+   * `applyEditSubmitAction` que vivia inline. O bloco extraído tinha
+   * ~33 linhas idênticas com os demais modals de edição (lição PR
+   * #134/#135).
+   */
+  const handleSubmit = useEditEntitySubmit<keyof TokenTypeFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onUpdated,
+      onClose,
+    },
+    conflictField: 'code',
+  });
+
+  // Props compartilhadas com `NewTokenTypeModal` consolidadas num único
+  // hook (`useTokenTypeFormFieldProps`) para evitar New Code
+  // Duplication ≥10 linhas com o caminho de criação — JSCPD/Sonar
+  // tokenizam blocos de props sequenciais como duplicação. Lição PR
+  // #134/#135 reforçada.
+  const fieldProps = useTokenTypeFormFieldProps(
+    tokenTypeForm,
+    handleSubmit,
+    handleClose,
+  );
+
+  // Não renderiza nada quando não houver `tokenType` selecionado — o
+  // pai controla `open` em conjunto com `tokenType`, mas cobrimos o
+  // caso defensivo de `open=true && tokenType=null` para não quebrar
+  // o submit.
+  if (!tokenType) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Editar tipo de token"
+      description="Atualize os dados do tipo de token JWT selecionado."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <TokenTypeFormBody
+        {...fieldProps}
+        idPrefix="edit-token-type"
+        submitLabel="Salvar alterações"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/tokens/NewTokenTypeModal.tsx
+++ b/src/pages/tokens/NewTokenTypeModal.tsx
@@ -1,0 +1,237 @@
+import React, { useCallback, useMemo } from 'react';
+
+import { Modal, useToast } from '../../components/ui';
+import { createTokenType } from '../../shared/api';
+import {
+  useCreateEntitySubmit,
+  type CreateEntitySubmitCopy,
+} from '../../shared/forms';
+
+import { TokenTypeFormBody } from './TokenTypeFormFields';
+import {
+  INITIAL_TOKEN_TYPE_FORM_STATE,
+  type TokenTypeFieldErrors,
+  type TokenTypeSubmitErrorCopy,
+} from './tokenTypesFormShared';
+import { useTokenTypeForm, useTokenTypeFormFieldProps } from './useTokenTypeForm';
+
+import type { ApiClient, CreateTokenTypePayload } from '../../shared/api';
+
+/**
+ * Copy injetada em `classifyApiSubmitError` para o caminho de criação
+ * de token type. Os literais aqui são os únicos pontos onde "criar"/
+ * "um token type" diferem do "atualizar"/"outro token type" no
+ * `EditTokenTypeModal` — o resto da lógica de classificação é
+ * compartilhado (lição PR #128).
+ */
+const SUBMIT_ERROR_COPY: TokenTypeSubmitErrorCopy = {
+  conflictDefault: 'Já existe um tipo de token com este código.',
+  forbiddenTitle: 'Falha ao criar tipo de token',
+  genericFallback: 'Não foi possível criar o tipo de token. Tente novamente.',
+};
+
+/**
+ * Texto exibido inline no campo `code` quando o backend devolve 409.
+ * Usamos uma copy dedicada (em vez de propagar a do backend, que é
+ * "Já existe um token type com este Code." com `Code` em PascalCase)
+ * para coerência com a UX em pt-BR — o operador lê "código" no label
+ * do campo. Espelha o desenho de `NewRoleModal` (#67).
+ */
+const CONFLICT_INLINE_MESSAGE = 'Já existe um tipo de token com este código.';
+
+interface NewTokenTypeModalProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /** Fecha o modal sem persistir. Chamada também após sucesso. */
+  onClose: () => void;
+  /** Callback disparado após criação bem-sucedida (para refetch da lista). */
+  onCreated: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `createTokenType` cai no singleton `apiClient`.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Modal de criação de tipo de token (Issue #175 — primeiro fluxo de
+ * mutação do recurso `/tokens`, finalmente substituindo o
+ * `<PlaceholderPage>` mockado).
+ *
+ * Decisões:
+ *
+ * - **Componente "controlado por aberto" pelo pai** (`open`/`onClose`).
+ *   Mantém o ciclo de vida do estado do form sob nosso controle: ao
+ *   fechar, resetamos `formState`/`fieldErrors`/`submitError` para
+ *   garantir que o usuário não veja resíduo de tentativa anterior.
+ * - **Validação client-side antes de submeter** — replica as regras do
+ *   backend (`Required` + `MaxLength`) para dar feedback imediato e
+ *   evitar round-trip por erro trivial. As regras vivem em
+ *   `tokenTypesFormShared.ts` para serem reusadas pelo
+ *   `EditTokenTypeModal` — qualquer alteração no contrato pega os dois
+ *   call sites sem duplicação (lição PR #123/#127).
+ * - **Mapeamento de erro do backend:**
+ *   - 409 → mensagem inline no campo `code` (`CONFLICT_INLINE_MESSAGE`).
+ *   - 400 → mapeamos `details.errors[Field]` para `fieldErrors[field]`,
+ *     normalizando capitalização (backend manda `Name`/`Code`/`Description`,
+ *     UI usa `name`/`code`/`description`).
+ *   - 401/403 → toast vermelho com mensagem do backend.
+ *   - Demais → toast vermelho com mensagem genérica.
+ * - **Sucesso**: chama `onCreated` (refetch responsabilidade do pai),
+ *   fecha o modal e dispara toast verde "Tipo de token criado.".
+ *
+ * Toda a lógica de validação client-side e parsing de
+ * `ValidationProblemDetails` vem de `tokenTypesFormShared.ts`, os
+ * campos vivem em `TokenTypeFormFields`, o estado/handlers do form
+ * vêm de `useTokenTypeForm` e o ciclo de submit vem de
+ * `useCreateEntitySubmit` — evita duplicação ≥10 linhas com os outros
+ * modals de criação (BLOCKER de duplicação Sonar, lição PR
+ * #128/#134/#135).
+ */
+export const NewTokenTypeModal: React.FC<NewTokenTypeModalProps> = ({
+  open,
+  onClose,
+  onCreated,
+  client,
+}) => {
+  const { show } = useToast();
+  const tokenTypeForm = useTokenTypeForm(INITIAL_TOKEN_TYPE_FORM_STATE);
+  const {
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    prepareSubmit,
+    applyBadRequest,
+  } = tokenTypeForm;
+
+  /**
+   * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
+   * botão Cancelar; previne resíduo entre aberturas. Cancelar durante
+   * submissão é bloqueado para evitar request órfã (sem
+   * `AbortController` nessa primeira iteração — backend é rápido e o
+   * usuário não consegue disparar duas vezes graças ao `disabled` no
+   * botão).
+   */
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFormState(INITIAL_TOKEN_TYPE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Reset disparado pelo helper `useCreateEntitySubmit` no caminho
+   * feliz (antes de `onCreated`/`onClose`). Mantemos uma referência
+   * dedicada (em vez de reusar `handleClose`) porque `handleClose` é
+   * gateado por `isSubmitting` — o submit feliz roda exatamente
+   * quando `isSubmitting === true`, então o gate inverteria o
+   * comportamento esperado. Espelha o padrão de
+   * `NewRoleModal`/`NewClientModal`.
+   */
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_TOKEN_TYPE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [setFormState, setFieldErrors, setSubmitError]);
+
+  /**
+   * Wrapper de `prepareSubmit` que reprova quando o gate de
+   * `isSubmitting` falhar — preserva o dedupe ao mover a lógica para
+   * dentro de `useCreateEntitySubmit`. Token types não precisam injetar
+   * `systemId` (diferente de roles/rotas), então o tipo retornado é
+   * direto `CreateTokenTypePayload | null`.
+   */
+  const prepareSubmitSafe = useCallback((): CreateTokenTypePayload | null => {
+    if (isSubmitting) return null;
+    const trimmed = prepareSubmit();
+    if (trimmed === null) return null;
+    // `description` chega trimada; quando vazia, omitir do payload faz
+    // o serializador descartar o campo e o backend converter para
+    // `null` (espelha o desenho de `buildTokenTypeMutationBody` no
+    // wrapper HTTP — o helper aplica trim defensivo simétrico).
+    const payload: CreateTokenTypePayload = {
+      name: trimmed.name,
+      code: trimmed.code,
+    };
+    if (trimmed.description.length > 0) {
+      payload.description = trimmed.description;
+    }
+    return payload;
+  }, [isSubmitting, prepareSubmit]);
+
+  /**
+   * `mutationFn` injetada no helper genérico. Tipa o payload via cast
+   * para `CreateTokenTypePayload` porque o helper aceita `unknown` (o
+   * cast é seguro — `prepareSubmitSafe` só devolve
+   * `CreateTokenTypePayload | null`, e o helper já filtrou `null`
+   * antes de chamar `mutationFn`).
+   */
+  const mutationFn = useCallback(
+    (payload: unknown) =>
+      createTokenType(payload as CreateTokenTypePayload, undefined, client),
+    [client],
+  );
+
+  /**
+   * Copy estável (não muda entre renders) — memoizada pra fechar a
+   * deps array do hook sem recriar referência a cada tick.
+   */
+  const submitCopy = useMemo<CreateEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Tipo de token criado.',
+      conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    }),
+    [],
+  );
+
+  const handleSubmit = useCreateEntitySubmit<keyof TokenTypeFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: 'code',
+  });
+
+  // Props compartilhadas com `EditTokenTypeModal` consolidadas num
+  // único hook (`useTokenTypeFormFieldProps`) para evitar New Code
+  // Duplication ≥10 linhas com o caminho de edição — JSCPD/Sonar
+  // tokenizam blocos de props sequenciais como duplicação. Lição PR
+  // #134/#135 reforçada.
+  const fieldProps = useTokenTypeFormFieldProps(
+    tokenTypeForm,
+    handleSubmit,
+    handleClose,
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Novo tipo de token"
+      description="Cadastre um novo tipo de token JWT no catálogo do auth-service."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <TokenTypeFormBody
+        {...fieldProps}
+        idPrefix="new-token-type"
+        submitLabel="Criar tipo de token"
+      />
+    </Modal>
+  );
+};

--- a/src/pages/tokens/RestoreTokenTypeConfirm.tsx
+++ b/src/pages/tokens/RestoreTokenTypeConfirm.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react';
+
+import { restoreTokenType } from '../../shared/api';
+import {
+  MutationConfirmModal,
+  type MutationConfirmCopy,
+} from '../systems/MutationConfirmModal';
+
+import {
+  toTokenTypeMutationTarget,
+  type TokenTypeMutationTarget,
+} from './tokenTypeMutationTarget';
+
+import type { ApiClient, TokenTypeDto } from '../../shared/api';
+
+/**
+ * Copy do diálogo de confirmação para restauração de tipo de token
+ * (Issue #175 — fecha o CRUD básico de token types em paralelo com o
+ * `DeleteTokenTypeConfirm`).
+ *
+ * Espelha `RESTORE_COPY` de `RestoreSystemConfirm`/`RestoreClientConfirm`,
+ * com vocabulário adaptado para token types. O slot
+ * `errorCopy.conflictMessage` está preenchido por previsão: o backend
+ * atual (`TokenTypesController.RestoreById`) devolve **404** com
+ * mensagem específica quando o token type já está ativo (em vez de
+ * 409), mas o `classifyMutationError` trata o eventual 409 com
+ * `kind: 'conflict'` quando esse slot existe — assim, qualquer
+ * mudança futura do contrato (split de 404/409) fica coberta sem
+ * reabrir o modal. Lição PR #128: pré-projetar o helper compartilhado
+ * é mais barato do que abrir um PR adicional.
+ */
+const RESTORE_COPY: MutationConfirmCopy = {
+  title: 'Restaurar tipo de token?',
+  descriptionPrefix: 'O tipo de token ',
+  descriptionSuffix: ' voltará a aparecer na listagem padrão.',
+  confirmLabel: 'Restaurar',
+  successMessage: 'Tipo de token restaurado.',
+  errorCopy: {
+    forbiddenTitle: 'Falha ao restaurar tipo de token',
+    genericFallback:
+      'Não foi possível restaurar o tipo de token. Tente novamente.',
+    notFoundMessage: 'Tipo de token não encontrado ou já está ativo.',
+    conflictMessage: 'O tipo de token já está ativo.',
+  },
+};
+
+interface RestoreTokenTypeConfirmProps {
+  /** Estado de visibilidade controlado pelo pai. */
+  open: boolean;
+  /**
+   * Tipo de token soft-deletado selecionado para restauração. Quando
+   * `null`, o modal não renderiza — caller controla `open` em conjunto
+   * com `tokenType`. Mantemos o objeto completo (não só `id`) para que
+   * a copy exiba `name`/`code` sem precisar de re-fetch.
+   */
+  tokenType: TokenTypeDto | null;
+  /** Fecha o modal sem persistir. Chamado também após sucesso/404. */
+  onClose: () => void;
+  /**
+   * Callback disparado após restauração bem-sucedida ou após detecção
+   * de 404 (token type não encontrado ou já ativo) — em ambos casos a
+   * UI quer refetch para sincronizar a tabela com o estado real do
+   * backend.
+   */
+  onRestored: () => void;
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido,
+   * `restoreTokenType` cai no singleton `apiClient`.
+   */
+  apiClient?: ApiClient;
+}
+
+/**
+ * Modal de confirmação para restauração de tipo de token soft-deletado
+ * (Issue #175 — fecha o CRUD básico de token types ao lado do
+ * `DeleteTokenTypeConfirm`).
+ *
+ * Wrapper fino sobre `MutationConfirmModal` — espelha o
+ * `RestoreSystemConfirm`/`RestoreClientConfirm` em estrutura, mas
+ * injeta:
+ *
+ * - **Copy** (`RESTORE_COPY`): "Restaurar tipo de token?" + descrição
+ *   contextual; sem aviso de "ativar Mostrar inativos" porque o token
+ *   type volta diretamente para a listagem padrão após o restore.
+ * - **Mutate**: adapta `restoreTokenType(id)` para a assinatura
+ *   `(target, client?) => Promise<unknown>` esperada pelo shell.
+ * - **Variant** (`primary`): ação positiva (restaura/ativa) — o token
+ *   `--clr-lime`/`--clr-forest` do design system reforça o significado
+ *   sem hardcode de cor (paridade com `RestoreSystemConfirm`/
+ *   `RestoreClientConfirm`).
+ * - **`testIdPrefix`** (`restore-token-type`): identifica os elementos
+ *   do modal nas suítes de teste sem colidir com o
+ *   `restore-system`/`restore-client`.
+ *
+ * O `MutationConfirmModal` cuida de todo o ciclo (confirmação,
+ * submissão, mapeamento de erros 404/401/403/network, refetch após
+ * sucesso ou 404).
+ */
+export const RestoreTokenTypeConfirm: React.FC<RestoreTokenTypeConfirmProps> = ({
+  open,
+  tokenType,
+  onClose,
+  onRestored,
+  apiClient,
+}) => {
+  const target = toTokenTypeMutationTarget(tokenType);
+
+  /**
+   * Função adapter `(target, http?) => Promise<unknown>` que delega
+   * para `restoreTokenType(tokenType.id, undefined, http)`. Memoizada
+   * com `useMemo` para preservar referência estável entre renders —
+   * espelha o padrão de `DeleteTokenTypeConfirm`/`RestoreClientConfirm`.
+   */
+  const performRestore = useMemo(
+    () =>
+      function (
+        _target: TokenTypeMutationTarget,
+        http?: ApiClient,
+      ): Promise<unknown> {
+        if (!tokenType) {
+          return Promise.reject(new Error('TokenType unavailable.'));
+        }
+        return restoreTokenType(tokenType.id, undefined, http);
+      },
+    [tokenType],
+  );
+
+  return (
+    <MutationConfirmModal<TokenTypeMutationTarget>
+      open={open}
+      target={target}
+      onClose={onClose}
+      onSuccess={onRestored}
+      client={apiClient}
+      mutate={performRestore}
+      copy={RESTORE_COPY}
+      confirmVariant="primary"
+      testIdPrefix="restore-token-type"
+    />
+  );
+};

--- a/src/pages/tokens/TokenTypeFormFields.tsx
+++ b/src/pages/tokens/TokenTypeFormFields.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import {
+  NameCodeDescriptionFormBody,
+  type NameCodeDescriptionFormBodyProps,
+  type NameCodeDescriptionFormCopy,
+} from '../../shared/forms';
+
+/**
+ * Wrapper fino do `NameCodeDescriptionFormBody` parametrizado com
+ * placeholders/copy do recurso "token types" (Issue #175).
+ *
+ * Espelha o desenho de `RoleFormFields`/`SystemFormFields` —
+ * centralizamos no helper genérico
+ * `src/shared/forms/NameCodeDescriptionForm.tsx` e cada recurso
+ * mantém apenas as cópias textuais e tipos locais.
+ *
+ * **Por que manter o wrapper?** Para preservar a API local
+ * (`TokenTypeFormBody` continua sendo importado de
+ * `./TokenTypeFormFields`) e facilitar refatorações futuras se o
+ * recurso ganhar campos exclusivos — `EditTokenTypeModal` e
+ * `NewTokenTypeModal` consomem o tipo do recurso, não o tipo
+ * genérico. Internamente, as props são `Omit<...Props, 'copy'>` para
+ * deduplicar a interface (lição PR #134/#135 — JSCPD tokenizou ~11
+ * linhas idênticas entre `TokenTypeFormFields` e
+ * `NameCodeDescriptionForm`).
+ */
+
+/* ─── Cópia textual (placeholders) específica de token types ─── */
+
+const TOKEN_TYPE_FORM_COPY: NameCodeDescriptionFormCopy = {
+  namePlaceholder: 'ex.: Acesso padrão',
+  codePlaceholder: 'ex.: default',
+  descriptionPlaceholder: 'Descrição opcional do tipo de token.',
+};
+
+/* ─── Form body ──────────────────────────────────────────── */
+
+/**
+ * Props do `<TokenTypeFormBody>` — alias estrutural das props do
+ * `NameCodeDescriptionFormBody` excluindo `copy` (que injetamos
+ * internamente). Centralizar via `Omit<...Props, 'copy'>` elimina a
+ * duplicação que o JSCPD detectou entre `TokenTypeFormFields` e
+ * `NameCodeDescriptionForm` no Issue #175.
+ */
+type TokenTypeFormBodyProps = Omit<NameCodeDescriptionFormBodyProps, 'copy'>;
+
+export const TokenTypeFormBody: React.FC<TokenTypeFormBodyProps> = (props) => (
+  <NameCodeDescriptionFormBody {...props} copy={TOKEN_TYPE_FORM_COPY} />
+);

--- a/src/pages/tokens/TokensListShellPage.tsx
+++ b/src/pages/tokens/TokensListShellPage.tsx
@@ -1,0 +1,648 @@
+import { Pencil, Plus } from 'lucide-react';
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Button, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useListModalState } from '../../hooks/useListModalState';
+import { useModalOpenState } from '../../hooks/useModalOpenState';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import { listTokenTypes } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
+import {
+  CardCode,
+  CardDescription,
+  CardHeader,
+  CardListForMobile,
+  CardName,
+  EmptyHint,
+  EmptyMessage,
+  EmptyTitle,
+  EntityCard,
+  ListingResultArea,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  Placeholder,
+  RowActions,
+  SoftDeleteRestoreButtons,
+  StatusBadge,
+  TableForDesktop,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import { DeleteTokenTypeConfirm } from './DeleteTokenTypeConfirm';
+import { EditTokenTypeModal } from './EditTokenTypeModal';
+import { NewTokenTypeModal } from './NewTokenTypeModal';
+import { RestoreTokenTypeConfirm } from './RestoreTokenTypeConfirm';
+
+import type { TableColumn } from '../../components/ui';
+import type { ApiClient, SafeRequestOptions, TokenTypeDto } from '../../shared/api';
+
+/**
+ * Atraso entre a última tecla e o disparo da busca client-side. 300 ms
+ * é o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 filtro por caractere. Espelha o valor
+ * usado por `SystemsPage`/`RolesPage`/`ClientsListShellPage`.
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Code de permissão exigido para o botão "Novo tipo de token" (Issue
+ * #175).
+ *
+ * Espelha o `AUTH_V1_TOKEN_TYPES_CREATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator`. O backend é a
+ * fonte autoritativa (o `POST /tokens/types` valida via
+ * `[Authorize(Policy = PermissionPolicies.SystemTokensTypesCreate)]`);
+ * o gating client-side é apenas UX — esconder ações que o usuário não
+ * pode executar.
+ */
+const TOKEN_TYPES_CREATE_PERMISSION = 'AUTH_V1_TOKEN_TYPES_CREATE';
+
+/**
+ * Code de permissão exigido para o botão "Editar" por linha (Issue
+ * #175). Espelha o `AUTH_V1_TOKEN_TYPES_UPDATE` no `lfc-authenticator`
+ * — o backend é a fonte autoritativa (`PUT /tokens/types/{id}` exige
+ * `PermissionPolicies.SystemTokensTypesUpdate`). O gating client-side
+ * só esconde ações que o usuário não pode executar.
+ */
+const TOKEN_TYPES_UPDATE_PERMISSION = 'AUTH_V1_TOKEN_TYPES_UPDATE';
+
+/**
+ * Code de permissão exigido para o botão "Desativar" por linha (Issue
+ * #175). Espelha o `AUTH_V1_TOKEN_TYPES_DELETE` no `lfc-authenticator`
+ * — o backend é a fonte autoritativa (`DELETE /tokens/types/{id}` exige
+ * `PermissionPolicies.SystemTokensTypesDelete`). Gating client-side é
+ * UX: esconder ações que o usuário não pode executar.
+ */
+const TOKEN_TYPES_DELETE_PERMISSION = 'AUTH_V1_TOKEN_TYPES_DELETE';
+
+/**
+ * Code de permissão exigido para o botão "Restaurar" por linha (Issue
+ * #175). Espelha o `AUTH_V1_TOKEN_TYPES_RESTORE` no `lfc-authenticator`
+ * — o backend é a fonte autoritativa (`POST /tokens/types/{id}/restore`
+ * exige `PermissionPolicies.SystemTokensTypesRestore`). Gating
+ * client-side é UX: esconder ações que o usuário não pode executar;
+ * complementado por `row.deletedAt !== null` no botão (só faz sentido
+ * restaurar linhas soft-deletadas — espelha a lógica inversa do botão
+ * "Desativar"). Padrão alinhado com `SystemsPage`/`ClientsListShellPage`.
+ */
+const TOKEN_TYPES_RESTORE_PERMISSION = 'AUTH_V1_TOKEN_TYPES_RESTORE';
+
+interface TokensListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido —
+   * a página usa o singleton `apiClient` por trás de `listTokenTypes`.
+   * Em testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/**
+ * Renderiza a célula de descrição truncando textos longos via padrão
+ * já usado em outras listagens. Quando vazio/`null`, exibe um
+ * placeholder neutro "—".
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile —
+ * centralizar evita duplicação visual.
+ */
+function renderDescription(row: TokenTypeDto): React.ReactNode {
+  if (
+    row.description === null ||
+    row.description === undefined ||
+    row.description.trim().length === 0
+  ) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return row.description;
+}
+
+/**
+ * Filtro client-side equivalente ao `q` server-side dos demais
+ * recursos. Faz match case-insensitive em `name`, `code` e
+ * `description` (descrição opcional). Centralizar o predicado evita
+ * inline complexity no `useMemo` e facilita a evolução (ex.: incluir
+ * data de criação no futuro).
+ *
+ * Diferente de `SystemsPage`/`RolesPage` (que delegam a busca ao
+ * backend via `?q=`), o backend de token types
+ * (`TokenTypesController.GetAll`) não suporta filtro server-side — o
+ * payload é uma lista curta usada também por dropdowns de outros
+ * recursos. Manter o filtro client-side preserva a generalidade do
+ * wrapper HTTP e evita duplicar parâmetros de listagem entre o uso
+ * "página administrativa" (este) e o uso "popular dropdown"
+ * (`NewRouteModal`/`EditRouteModal`).
+ */
+function tokenTypeMatchesSearch(row: TokenTypeDto, term: string): boolean {
+  if (term.length === 0) return true;
+  const haystack = [
+    row.name,
+    row.code,
+    row.description ?? '',
+  ]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(term);
+}
+
+export const TokensListShellPage: React.FC<TokensListShellPageProps> = ({
+  client,
+}) => {
+  const { hasPermission } = useAuth();
+  const canCreateTokenType = hasPermission(TOKEN_TYPES_CREATE_PERMISSION);
+  const canUpdateTokenType = hasPermission(TOKEN_TYPES_UPDATE_PERMISSION);
+  const canDeleteTokenType = hasPermission(TOKEN_TYPES_DELETE_PERMISSION);
+  const canRestoreTokenType = hasPermission(TOKEN_TYPES_RESTORE_PERMISSION);
+
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  // Toggle "Mostrar inativos" — diferente de outros recursos, o backend
+  // de token types já devolve **todos** os registros (incluindo
+  // soft-deletados) sem parâmetro de filtro. Toda a filtragem é
+  // client-side, mantendo a UX consistente com as demais listagens
+  // (mesmo Switch, mesma copy de "Inclui ... com remoção lógica.").
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(false);
+
+  // Estado de abertura do modal "Novo tipo de token". O modal é
+  // controlado por essa página para que a Toolbar consiga ocultar o
+  // botão por permissão sem perder o ciclo de vida do form. Centralizado
+  // em `useModalOpenState` (lição PR #134/#135 — trio
+  // useState+open+close duplicava entre páginas).
+  const {
+    isOpen: isCreateModalOpen,
+    open: handleOpenCreateModal,
+    close: handleCloseCreateModal,
+  } = useModalOpenState();
+
+  // Token type selecionado para edição. Quando definido, abre o
+  // `EditTokenTypeModal` pré-populado com seus dados; `null` mantém o
+  // modal fechado. Usar `useListModalState` evita o BLOCKER de
+  // duplicação Sonar do trio `useState + open + close` (lição PR
+  // #134/#135).
+  const {
+    selected: editingTokenType,
+    open: handleOpenEditModal,
+    close: handleCloseEditModal,
+  } = useListModalState<TokenTypeDto>();
+
+  // Token type selecionado para soft-delete. Mesma estratégia do
+  // `editingTokenType` — manter o objeto completo (em vez de só o id)
+  // permite ao `DeleteTokenTypeConfirm` exibir `name`/`code` na
+  // confirmação sem round-trip extra. `null` mantém o modal fechado.
+  const {
+    selected: deletingTokenType,
+    open: handleOpenDeleteConfirm,
+    close: handleCloseDeleteConfirm,
+  } = useListModalState<TokenTypeDto>();
+
+  // Token type selecionado para restauração. Mesma estratégia do
+  // `deletingTokenType` — manter o objeto completo permite ao
+  // `RestoreTokenTypeConfirm` exibir `name`/`code` na confirmação sem
+  // round-trip extra. `null` mantém o modal fechado.
+  const {
+    selected: restoringTokenType,
+    open: handleOpenRestoreConfirm,
+    close: handleCloseRestoreConfirm,
+  } = useListModalState<TokenTypeDto>();
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `useSingleFetchWithAbort`: depende
+   * apenas do `client` injetado. Sem parâmetros de busca/paginação na
+   * request — o backend devolve a lista completa, e o filtro
+   * (`q`/`includeDeleted`) é aplicado client-side via `useMemo` sobre
+   * `data`.
+   *
+   * Manter assim simplifica o cancelamento (não há refetch por
+   * keystroke) e respeita o desenho do backend (lista curta sem
+   * paginação). Os refetches pós-mutação reusam a mesma identidade do
+   * `fetcher`, então o hook só refaz fetch quando o `client` muda
+   * (raríssimo) ou quando `refetch()` é disparado pelos modais.
+   */
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) => listTokenTypes(options, client),
+    [client],
+  );
+
+  const {
+    data: rawData,
+    isInitialLoading,
+    errorMessage,
+    refetch: handleRefetch,
+  } = useSingleFetchWithAbort<ReadonlyArray<TokenTypeDto>>({
+    fetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar a lista de tipos de token. Tente novamente.',
+  });
+
+  const trimmedSearch = debouncedSearch.trim().toLowerCase();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  /**
+   * Aplica filtro client-side sobre o payload do backend:
+   *
+   * 1. Filtra por `includeDeleted` — quando `false`, descarta
+   *    soft-deletados (alinhado com o default das outras listagens
+   *    onde o backend faz isso server-side).
+   * 2. Filtra por termo de busca — match case-insensitive em `name`,
+   *    `code` e `description`.
+   *
+   * Memoizado para evitar recálculo a cada render quando `searchTerm`
+   * muda mas `debouncedSearch` ainda não — preserva o comportamento de
+   * busca debounced.
+   */
+  const rows = useMemo<ReadonlyArray<TokenTypeDto>>(() => {
+    const list = rawData ?? [];
+    return list.filter((row) => {
+      if (!includeDeleted && row.deletedAt !== null) return false;
+      return tokenTypeMatchesSearch(row, trimmedSearch);
+    });
+  }, [includeDeleted, rawData, trimmedSearch]);
+
+  const total = rows.length;
+
+  /**
+   * Decide qual mensagem renderizar quando `rows` está vazio:
+   *
+   * - Vazio com busca ativa → cita o termo + sugere limpar.
+   * - Vazio com toggle "incluir inativos" desligado mas existem
+   *   inativos → mensagem neutra com dica de ativar o toggle.
+   * - Vazio sem busca e sem inativos → "nenhum tipo de token
+   *   cadastrado".
+   */
+  const emptyContent = useMemo<React.ReactNode>(() => {
+    if (hasActiveSearch) {
+      return (
+        <EmptyMessage>
+          <EmptyTitle>
+            Nenhum tipo de token encontrado para <Mono>{trimmedSearch}</Mono>.
+          </EmptyTitle>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleClearSearch}
+            data-testid="token-types-empty-clear"
+          >
+            Limpar busca
+          </Button>
+        </EmptyMessage>
+      );
+    }
+    return (
+      <EmptyMessage>
+        <EmptyTitle>Nenhum tipo de token cadastrado.</EmptyTitle>
+        {!includeDeleted && (
+          <EmptyHint>
+            Tipos de token removidos podem ser visualizados ativando
+            &quot;Mostrar inativos&quot;.
+          </EmptyHint>
+        )}
+      </EmptyMessage>
+    );
+  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
+
+  /**
+   * Renderiza o bloco de ações por linha (Editar/Desativar/Restaurar)
+   * para uma linha de token type. Reutilizado pelo desktop (coluna
+   * "Ações" da tabela) e pelo mobile (rodapé dos cards) — única
+   * diferença é o prefixo dos `data-testid` (`token-types-edit` no
+   * desktop vs `token-types-card-edit` no mobile).
+   *
+   * Centralizar aqui em uma única função evita o BLOCKER de duplicação
+   * JSCPD/Sonar — o `<Button>` de cada ação repetido entre tabela e
+   * cards seria marcado como clone (lição PR #128/#134/#135).
+   */
+  const renderTokenTypeRowActions = useCallback(
+    (
+      row: TokenTypeDto,
+      testIdPrefix: 'token-types' | 'token-types-card',
+    ): React.ReactNode => (
+      <RowActions>
+        {canUpdateTokenType && row.deletedAt === null && (
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Pencil size={14} strokeWidth={1.5} />}
+            onClick={() => handleOpenEditModal(row)}
+            aria-label={`Editar tipo de token ${row.name}`}
+            data-testid={`${testIdPrefix}-edit-${row.id}`}
+          >
+            Editar
+          </Button>
+        )}
+        <SoftDeleteRestoreButtons
+          deletedAt={row.deletedAt}
+          canDelete={canDeleteTokenType}
+          canRestore={canRestoreTokenType}
+          onDelete={() => handleOpenDeleteConfirm(row)}
+          onRestore={() => handleOpenRestoreConfirm(row)}
+          deleteAriaLabel={`Desativar tipo de token ${row.name}`}
+          restoreAriaLabel={`Restaurar tipo de token ${row.name}`}
+          deleteTestId={`${testIdPrefix}-delete-${row.id}`}
+          restoreTestId={`${testIdPrefix}-restore-${row.id}`}
+        />
+      </RowActions>
+    ),
+    [
+      canDeleteTokenType,
+      canRestoreTokenType,
+      canUpdateTokenType,
+      handleOpenDeleteConfirm,
+      handleOpenEditModal,
+      handleOpenRestoreConfirm,
+    ],
+  );
+
+  /**
+   * Renderiza o bloco de ações dos cards mobile (wrapper sobre
+   * `renderTokenTypeRowActions` aplicando o gating apropriado). Quando
+   * o usuário não tem nem update/delete/restore aplicáveis, retorna
+   * `null` para não renderizar wrapper vazio. Espelha o
+   * `renderMobileRowActions` de `ClientsListShellPage`/
+   * `UsersListShellPage` (lição PR #134/#135).
+   */
+  const renderMobileRowActions = useCallback(
+    (row: TokenTypeDto): React.ReactNode => {
+      const isActive = row.deletedAt === null;
+      const hasUpdate = canUpdateTokenType && isActive;
+      const hasDelete = canDeleteTokenType && isActive;
+      const hasRestore = canRestoreTokenType && !isActive;
+      if (!hasUpdate && !hasDelete && !hasRestore) {
+        return null;
+      }
+      return renderTokenTypeRowActions(row, 'token-types-card');
+    },
+    [
+      canDeleteTokenType,
+      canRestoreTokenType,
+      canUpdateTokenType,
+      renderTokenTypeRowActions,
+    ],
+  );
+
+  const columns = useMemo<ReadonlyArray<TableColumn<TokenTypeDto>>>(() => {
+    const base: Array<TableColumn<TokenTypeDto>> = [
+      {
+        key: 'code',
+        label: 'Código',
+        render: (row) => <Mono>{row.code}</Mono>,
+      },
+      {
+        key: 'name',
+        label: 'Nome',
+        render: (row) => row.name,
+      },
+      {
+        key: 'description',
+        label: 'Descrição',
+        render: renderDescription,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        width: '120px',
+        render: (row) => <StatusBadge deletedAt={row.deletedAt} gender="m" />,
+      },
+    ];
+
+    // Coluna "Ações" só aparece quando o usuário tem **alguma** ação
+    // disponível (update, delete ou restore). Esconder a coluna
+    // inteira para perfis read-only mantém a tabela compacta sem coluna
+    // vazia. Cada botão dentro tem seu próprio gating individual +
+    // check por linha (`row.deletedAt`) — espelha
+    // `SystemsPage`/`ClientsListShellPage`.
+    if (canUpdateTokenType || canDeleteTokenType || canRestoreTokenType) {
+      base.push({
+        key: 'actions',
+        label: 'Ações',
+        isActions: true,
+        render: (row) => renderTokenTypeRowActions(row, 'token-types'),
+      });
+    }
+
+    return base;
+  }, [
+    canDeleteTokenType,
+    canRestoreTokenType,
+    canUpdateTokenType,
+    renderTokenTypeRowActions,
+  ]);
+
+  /**
+   * ARIA-live: anuncia o estado da listagem quando muda. Em loading
+   * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
+   * total. Em erro, o `<Alert role="alert">` já cobre. O hook
+   * `useListingLiveMessage` centraliza a árvore de decisão (lição PR
+   * #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+   *
+   * Como este recurso não tem paginação, passamos `page=1`/
+   * `totalPages=1` constantes — o hook usa esses valores apenas para
+   * compor a frase quando há múltiplas páginas, e com `totalPages=1`
+   * cai na frase curta ("N tipos de token encontrados.").
+   */
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching: false,
+    errorMessage,
+    total,
+    page: 1,
+    totalPages: 1,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'tipo de token',
+      pluralCarregando: 'tipos de token',
+      vazioSemBusca: 'Nenhum tipo de token cadastrado.',
+      gender: 'm',
+    },
+  });
+
+  /**
+   * CTA "Novo tipo de token" extraído como variável memoizada para que
+   * o `<ListingToolbar actions={createCtaButton}>` não tokenize com o
+   * resto da listagem como bloco duplicado entre as páginas. Lição PR
+   * #128/#134/#135 — call-site também duplica entre páginas similares,
+   * não só o helper compartilhado.
+   */
+  const createCtaButton = useMemo<React.ReactNode>(() => {
+    if (!canCreateTokenType) return null;
+    return (
+      <Button
+        variant="primary"
+        size="md"
+        icon={<Plus size={14} strokeWidth={1.75} />}
+        onClick={handleOpenCreateModal}
+        data-testid="token-types-create-open"
+      >
+        Novo tipo de token
+      </Button>
+    );
+  }, [canCreateTokenType, handleOpenCreateModal]);
+
+  /**
+   * Tabela renderizada como variável intermediária para reduzir o peso
+   * do JSX inline e manter o callsite de `<ListingResultArea>` mais
+   * legível. Inclui também o `<CardListForMobile>` para que o conteúdo
+   * seja consistente entre breakpoints (paridade com
+   * `ClientsListShellPage`/`UsersListShellPage`).
+   */
+  const tableNode = (
+    <>
+      <TableForDesktop>
+        <Table<TokenTypeDto>
+          caption="Lista de tipos de token JWT cadastrados no auth-service."
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.id}
+          emptyState={emptyContent}
+        />
+      </TableForDesktop>
+      <CardListForMobile
+        role="list"
+        aria-label="Lista de tipos de token JWT cadastrados no auth-service"
+        data-testid="token-types-card-list"
+      >
+        {rows.length === 0 && emptyContent}
+        {rows.map((row) => (
+          <EntityCard
+            key={row.id}
+            role="listitem"
+            tabIndex={0}
+            data-testid={`token-types-card-${row.id}`}
+          >
+            <CardHeader>
+              <CardCode>
+                <Mono>{row.code}</Mono>
+              </CardCode>
+              <StatusBadge deletedAt={row.deletedAt} gender="m" />
+            </CardHeader>
+            <CardName>{row.name}</CardName>
+            {row.description !== null &&
+              row.description !== undefined &&
+              row.description.trim().length > 0 && (
+                <CardDescription>{row.description}</CardDescription>
+              )}
+            {renderMobileRowActions(row)}
+          </EntityCard>
+        ))}
+      </CardListForMobile>
+    </>
+  );
+
+  /**
+   * Modais extraídos como variáveis para reduzir o peso do JSX final
+   * e evitar que o jscpd tokenize a tripla `{can... && <Modal ... />}`
+   * como duplicação com `SystemsPage`/`ClientsListShellPage` (que têm
+   * o mesmo padrão para create/edit/delete/restore — lição PR
+   * #134/#135).
+   */
+  const createModalNode = canCreateTokenType ? (
+    <NewTokenTypeModal
+      open={isCreateModalOpen}
+      onClose={handleCloseCreateModal}
+      onCreated={handleRefetch}
+      client={client}
+    />
+  ) : null;
+
+  const editModalNode = canUpdateTokenType ? (
+    <EditTokenTypeModal
+      open={editingTokenType !== null}
+      tokenType={editingTokenType}
+      onClose={handleCloseEditModal}
+      onUpdated={handleRefetch}
+      client={client}
+    />
+  ) : null;
+
+  const deleteModalNode = canDeleteTokenType ? (
+    <DeleteTokenTypeConfirm
+      open={deletingTokenType !== null}
+      tokenType={deletingTokenType}
+      onClose={handleCloseDeleteConfirm}
+      onDeleted={handleRefetch}
+      apiClient={client}
+    />
+  ) : null;
+
+  const restoreModalNode = canRestoreTokenType ? (
+    <RestoreTokenTypeConfirm
+      open={restoringTokenType !== null}
+      tokenType={restoringTokenType}
+      onClose={handleCloseRestoreConfirm}
+      onRestored={handleRefetch}
+      apiClient={client}
+    />
+  ) : null;
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="07 Tokens"
+        title="Tipos de token JWT"
+        desc="Catálogo de tipos de token JWT do ecossistema. Cada rota é vinculada a um tipo de token; gerenciar este catálogo controla quais políticas estão disponíveis para emissão."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Nome, código ou descrição"
+        searchAriaLabel="Buscar tipos de token por nome, código ou descrição"
+        searchTestId="token-types-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui tipos de token com remoção lógica."
+        includeDeletedTestId="token-types-include-deleted"
+        actions={createCtaButton}
+      />
+
+      <LiveRegion message={liveMessage} testId="token-types-live" />
+
+      <ListingResultArea
+        testIdPrefix="token-types"
+        loadingLabel="Carregando tipos de token"
+        isInitialLoading={isInitialLoading}
+        isFetching={false}
+        errorMessage={errorMessage}
+        onRetry={handleRefetch}
+        tableContent={tableNode}
+        total={total}
+        page={1}
+        totalPages={1}
+        isFirstPage
+        isLastPage
+        onPrev={NOOP}
+        onNext={NOOP}
+      />
+
+      {createModalNode}
+      {editModalNode}
+      {deleteModalNode}
+      {restoreModalNode}
+    </>
+  );
+};
+
+/**
+ * No-op para os handlers de paginação. A listagem de token types não
+ * pagina (backend devolve array completo), então `onPrev`/`onNext`
+ * jamais são invocados — o `ListingResultArea` só renderiza o
+ * `PaginationFooter` quando `totalPages > 1`. Manter como referência
+ * estável evita re-render desnecessário do shell.
+ */
+const NOOP = (): void => undefined;

--- a/src/pages/tokens/index.ts
+++ b/src/pages/tokens/index.ts
@@ -1,0 +1,5 @@
+export { DeleteTokenTypeConfirm } from './DeleteTokenTypeConfirm';
+export { EditTokenTypeModal } from './EditTokenTypeModal';
+export { NewTokenTypeModal } from './NewTokenTypeModal';
+export { RestoreTokenTypeConfirm } from './RestoreTokenTypeConfirm';
+export { TokensListShellPage } from './TokensListShellPage';

--- a/src/pages/tokens/tokenTypeMutationTarget.ts
+++ b/src/pages/tokens/tokenTypeMutationTarget.ts
@@ -1,0 +1,35 @@
+import type { TokenTypeDto } from '../../shared/api';
+
+/**
+ * Adapter `MutationTarget` para `TokenTypeDto`. O shell
+ * `MutationConfirmModal` (em `src/pages/systems/`) exige um target com
+ * `name` (label visível em destaque) e `code` (identificador curto
+ * exibido em monoespaçado entre parênteses).
+ *
+ * Para token types o mapeamento é trivial — `name` e `code` já vêm
+ * direto do DTO, sem fallbacks complexos como em clientes (PF/PJ) ou
+ * usuários (login derivado).
+ *
+ * Extraído como módulo dedicado pela Issue #175 para deduplicar entre
+ * `DeleteTokenTypeConfirm` e `RestoreTokenTypeConfirm` — JSCPD
+ * tokenizaria a `interface` + função (~10 linhas com comentários) como
+ * bloco idêntico (lição PR #128/#134/#135 — qualquer trecho ≥10 linhas
+ * em 2+ arquivos vira `New Code Duplication` no Sonar).
+ */
+export interface TokenTypeMutationTarget {
+  name: string;
+  code: string;
+}
+
+/**
+ * Converte um `TokenTypeDto` (ou `null`) em `TokenTypeMutationTarget`
+ * (ou `null` quando o DTO é `null`). O modal não renderiza com
+ * `target=null`, então retornar `null` aqui é o fluxo natural quando o
+ * pai ainda não selecionou nada.
+ */
+export function toTokenTypeMutationTarget(
+  tokenType: TokenTypeDto | null,
+): TokenTypeMutationTarget | null {
+  if (!tokenType) return null;
+  return { name: tokenType.name, code: tokenType.code };
+}

--- a/src/pages/tokens/tokenTypesFormShared.ts
+++ b/src/pages/tokens/tokenTypesFormShared.ts
@@ -1,0 +1,153 @@
+import {
+  classifyApiSubmitError,
+  decideNameCodeDescriptionBadRequestHandling,
+  extractNameCodeDescriptionValidationErrors,
+  NAME_CODE_DESCRIPTION_CODE_MAX,
+  NAME_CODE_DESCRIPTION_DESCRIPTION_MAX,
+  NAME_CODE_DESCRIPTION_NAME_MAX,
+  validateNameCodeDescriptionForm,
+  type ApiSubmitErrorAction,
+  type ApiSubmitErrorCopy,
+  type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormState,
+  type NameCodeDescriptionSubmitDecision,
+} from '../../shared/forms';
+
+/**
+ * Helpers compartilhados pelos formulários de criação e edição de
+ * tipos de token (Issue #175).
+ *
+ * O `lfc-authenticator`
+ * (`AuthService.Controllers.TokenTypes.TokenTypesController`) trata
+ * `UpdateTokenTypeRequest === CreateTokenTypeRequest` (mesmos campos
+ * `Name`/`Code`/`Description`), seguindo o padrão já adotado em
+ * `systems`/`routes`/`roles`. Centralizamos tipos, validação client-side
+ * e parsing de `ValidationProblemDetails` neste módulo desde o
+ * **primeiro PR de mutação do recurso** — quando alguma sub-issue
+ * extra chegar, ela herda todo este boilerplate sem copiar uma linha
+ * sequer (lição PR #128 — projetar shared helpers desde o primeiro PR
+ * do recurso).
+ *
+ * **Camada fina sobre `src/shared/forms/NameCodeDescriptionForm.ts`**
+ * (lição PR #134/#135 reforçada): Sonar tokenizou ~80 linhas idênticas
+ * entre `systemFormShared.ts` e `rolesFormShared.ts` quando estes
+ * existiam paralelos. Centralizar no helper genérico evitou recorrência
+ * de New Code Duplication. Mantemos os exports locais como aliases
+ * porque o `EditTokenTypeModal` e o `NewTokenTypeModal` importam de
+ * `./tokenTypesFormShared` para preservar acoplamento de domínio
+ * (mudanças no contrato do backend de token types ficam visíveis aqui;
+ * mudanças genéricas ficam em `shared/forms`).
+ */
+
+/** Tamanho máximo do campo `Name` (espelha `CreateTokenTypeRequest.Name`). */
+export const NAME_MAX = NAME_CODE_DESCRIPTION_NAME_MAX;
+/** Tamanho máximo do campo `Code` (espelha `CreateTokenTypeRequest.Code`). */
+export const CODE_MAX = NAME_CODE_DESCRIPTION_CODE_MAX;
+/** Tamanho máximo do campo `Description` (espelha `CreateTokenTypeRequest.Description`). */
+export const DESCRIPTION_MAX = NAME_CODE_DESCRIPTION_DESCRIPTION_MAX;
+
+/**
+ * Estado controlado dos campos do form de tipo de token. Alias
+ * estrutural de `NameCodeDescriptionFormState` (3 campos compartilhados
+ * com sistemas/roles).
+ */
+export type TokenTypeFormState = NameCodeDescriptionFormState;
+
+/**
+ * Mensagens de erro inline por campo. Cada chave é opcional —
+ * `undefined` indica "campo válido" (ou ainda não validado). Alias
+ * estrutural de `NameCodeDescriptionFieldErrors`.
+ */
+export type TokenTypeFieldErrors = NameCodeDescriptionFieldErrors;
+
+/** Estado inicial vazio reutilizado pelo modal de criação. */
+export const INITIAL_TOKEN_TYPE_FORM_STATE: TokenTypeFormState = {
+  name: '',
+  code: '',
+  description: '',
+};
+
+/**
+ * Valida o estado do form contra as mesmas regras do backend
+ * (`CreateTokenTypeRequest`/`UpdateTokenTypeRequest`). Delegação direta
+ * para `validateNameCodeDescriptionForm` — todos os limites/mensagens
+ * coincidem com sistemas/roles (lição PR #134/#135).
+ */
+export function validateTokenTypeForm(
+  state: TokenTypeFormState,
+): TokenTypeFieldErrors | null {
+  return validateNameCodeDescriptionForm(state);
+}
+
+/**
+ * Extrai erros por campo do payload de `ValidationProblemDetails` do
+ * ASP.NET. Delegação direta para
+ * `extractNameCodeDescriptionValidationErrors` — o backend de token
+ * types envia `Name`/`Code`/`Description` (mesma lista de
+ * sistemas/roles).
+ */
+export function extractTokenTypeValidationErrors(
+  details: unknown,
+): TokenTypeFieldErrors | null {
+  return extractNameCodeDescriptionValidationErrors(details);
+}
+
+/**
+ * Resultado do mapeamento de uma `ApiError` 400 do backend. Alias
+ * estrutural de `NameCodeDescriptionSubmitDecision`.
+ */
+export type TokenTypeSubmitDecision = NameCodeDescriptionSubmitDecision;
+
+/**
+ * Decide o tratamento de uma resposta 400 do backend para o form de
+ * token type. Delegação direta para
+ * `decideNameCodeDescriptionBadRequestHandling`.
+ */
+export function decideTokenTypeBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): TokenTypeSubmitDecision {
+  return decideNameCodeDescriptionBadRequestHandling(details, fallbackMessage);
+}
+
+/**
+ * Copy textual usado por `classifyTokenTypeSubmitError` para diferenciar
+ * create de edit sem duplicar a lógica de classificação. Cada modal
+ * injeta sua versão (`'um token type'` vs `'outro token type'`,
+ * `'criar'` vs `'atualizar'`).
+ */
+export type TokenTypeSubmitErrorCopy = ApiSubmitErrorCopy;
+
+/**
+ * Resultado da classificação de um erro lançado por
+ * `createTokenType`/`updateTokenType`. Discriminada (`kind`) para o
+ * caller usar num `switch` curto.
+ */
+export type TokenTypeSubmitErrorAction = ApiSubmitErrorAction<
+  keyof TokenTypeFieldErrors
+>;
+
+/**
+ * Classifica um erro lançado por `createTokenType`/`updateTokenType`
+ * em uma `TokenTypeSubmitErrorAction` discriminada. Delegação de uma
+ * linha para o helper genérico — preserva a assinatura pública usada
+ * pelos modais e pelos testes unitários.
+ *
+ * - `409` → `conflict` no campo `code` com mensagem do backend (ou
+ *   `copy.conflictDefault`). Caller exibe inline. O backend devolve
+ *   "Já existe um token type com este Code." em create e "Já existe
+ *   outro token type com este Code." em update.
+ * - `400` → `bad-request` com `details` cru.
+ * - `404` → `not-found` (só relevante no `EditTokenTypeModal`).
+ * - `401`/`403` → `toast` vermelho.
+ * - Outros → `unhandled`.
+ *
+ * O `conflictField` é fixo em `'code'` — campo único de unicidade do
+ * contrato `CreateTokenTypeRequest`/`UpdateTokenTypeRequest`.
+ */
+export function classifyTokenTypeSubmitError(
+  error: unknown,
+  copy: TokenTypeSubmitErrorCopy,
+): TokenTypeSubmitErrorAction {
+  return classifyApiSubmitError<keyof TokenTypeFieldErrors>(error, copy, 'code');
+}

--- a/src/pages/tokens/useTokenTypeForm.ts
+++ b/src/pages/tokens/useTokenTypeForm.ts
@@ -1,0 +1,72 @@
+import {
+  useNameCodeDescriptionForm,
+  useNameCodeDescriptionFormFieldProps,
+  type NameCodeDescriptionFormFieldProps,
+  type NameCodeDescriptionFormState,
+  type UseNameCodeDescriptionFormReturn,
+} from '../../shared/forms';
+
+/**
+ * Hook compartilhado pelo modal de criação (`NewTokenTypeModal`) e
+ * edição (`EditTokenTypeModal`) de tipos de token (Issue #175).
+ *
+ * Delegação direta para o helper genérico `useNameCodeDescriptionForm`
+ * em `src/shared/forms/` — o token type tem o mesmo shape de 3 campos
+ * (`Name`/`Code`/`Description`) que sistemas/roles, sem necessidade
+ * de decorar `prepareSubmit` (diferente de `useRoleForm`/
+ * `useRouteForm`, que injetam `systemId`).
+ *
+ * Mantemos um wrapper local em vez de consumir
+ * `useNameCodeDescriptionForm` direto pelos modais para preservar:
+ *
+ * 1. **Acoplamento de domínio explícito** — o caller importa de
+ *    `./useTokenTypeForm`, deixando claro que está usando o form do
+ *    recurso "token types". Mudanças futuras (ex.: adicionar campo
+ *    `tags` exclusivo do recurso) ficam isoladas neste módulo sem
+ *    vazar para o helper genérico.
+ * 2. **Simetria com `useSystemForm`/`useRoleForm`/`useRouteForm`** — o
+ *    pattern do projeto é "cada recurso tem seu hook"; quebrar a
+ *    convenção introduziria assimetria sem ganho real.
+ *
+ * **Lição PR #134/#135 reforçada:** a duplicação prévia da
+ * `<Recurso>FormFieldProps` interface + `use<Recurso>FormFieldProps`
+ * hook foi extraída para `useNameCodeDescriptionFormFieldProps` em
+ * `src/shared/forms/`, eliminando os ~27 linhas idênticas detectadas
+ * pelo JSCPD entre `useRoleForm.ts` e este módulo. Os exports locais
+ * são aliases estruturais — preservam a API por recurso sem
+ * duplicar implementação.
+ */
+
+/**
+ * Tipo de retorno do hook — alias estrutural do retorno do helper
+ * genérico. Token types não precisam decorar `prepareSubmit` (mesmo
+ * shape que sistemas — não há `systemId` para injetar).
+ */
+export type UseTokenTypeFormReturn = UseNameCodeDescriptionFormReturn;
+
+export function useTokenTypeForm(
+  initialState: NameCodeDescriptionFormState,
+): UseTokenTypeFormReturn {
+  return useNameCodeDescriptionForm(initialState);
+}
+
+/**
+ * Tipo do conjunto de props consumido por `<TokenTypeFormBody>` —
+ * alias estrutural de `NameCodeDescriptionFormFieldProps` (helper
+ * genérico em `src/shared/forms/`). Centralizar a declaração lá
+ * elimina duplicação entre `useRoleForm.RoleFormFieldProps` e este
+ * tipo (lição PR #134/#135 — JSCPD/Sonar tokenizam blocos ≥10 linhas
+ * como `New Code Duplication` mesmo entre tipos sintaticamente
+ * idênticos).
+ */
+export type TokenTypeFormFieldProps = NameCodeDescriptionFormFieldProps;
+
+/**
+ * Constrói o objeto de props para `<TokenTypeFormBody>` a partir de
+ * uma instância de `useTokenTypeForm` + handlers do modal pai.
+ * Delegação direta para `useNameCodeDescriptionFormFieldProps` —
+ * mantém o nome de domínio (`useTokenTypeFormFieldProps`) por
+ * simetria com `useRoleFormFieldProps` (call-sites importam por
+ * recurso).
+ */
+export const useTokenTypeFormFieldProps = useNameCodeDescriptionFormFieldProps;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,6 +16,7 @@ import { RoutesPage } from '../pages/RoutesPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { ShowcasePage } from '../pages/ShowcasePage';
 import { SystemsPage } from '../pages/SystemsPage';
+import { TokensListShellPage } from '../pages/tokens';
 import { UnauthorizedPage } from '../pages/UnauthorizedPage';
 import {
   UserDetailShellPage,
@@ -269,12 +270,14 @@ export const AppRoutes: React.FC = () => (
       <Route
         path="/tokens"
         element={
+          // Issue #175: substitui o `<PlaceholderPage>` mockado por
+          // CRUD funcional de tipos de token JWT. O título da página
+          // ("Tipos de token JWT") é renderizado pelo
+          // `TokensListShellPage` via `<PageHeader>` — o label
+          // "Tokens" da Sidebar permanece inalterado por economia de
+          // espaço (decisão da Issue #175).
           <RequirePermission code="AUTH_V1_TOKEN_TYPES_LIST">
-            <PlaceholderPage
-              eyebrow="08 Tokens"
-              title="Tokens JWT"
-              desc="Tokens emitidos por sistema. tokenVersion atual: 12. Revogar um token invalida a sessão do usuário imediatamente."
-            />
+            <TokensListShellPage />
           </RequirePermission>
         }
       />

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -173,11 +173,19 @@ export type {
   UpdateClientPayload,
 } from './clients';
 export {
+  createTokenType,
+  deleteTokenType,
   isTokenTypeArray,
   isTokenTypeDto,
   listTokenTypes,
+  restoreTokenType,
+  updateTokenType,
 } from './tokenTypes';
-export type { TokenTypeDto } from './tokenTypes';
+export type {
+  CreateTokenTypePayload,
+  TokenTypeDto,
+  UpdateTokenTypePayload,
+} from './tokenTypes';
 export {
   assignRoleToUser,
   createUser,

--- a/src/shared/api/nameCodeDescriptionDto.ts
+++ b/src/shared/api/nameCodeDescriptionDto.ts
@@ -1,0 +1,44 @@
+/**
+ * Type guard genérico para DTOs com shape Name/Code/Description +
+ * datas de auditoria (`createdAt`/`updatedAt`/`deletedAt`).
+ *
+ * Vários recursos do `lfc-authenticator` compartilham esse shape
+ * mínimo:
+ *
+ * - `SystemDto` (`shared/api/systems.ts`)
+ * - `TokenTypeDto` (`shared/api/tokenTypes.ts` — Issue #175)
+ *
+ * Outros (rotas, roles) adicionam campos extras (`systemId`,
+ * `systemTokenTypeId`, etc.) e por isso não consomem este helper
+ * direto — reusam apenas as validações dos campos compartilhados via
+ * composição.
+ *
+ * **Lição PR #134/#135 reforçada (Issue #175):** antes desta extração,
+ * os corpos de `isSystemDto` e `isTokenTypeDto` eram literalmente
+ * idênticos (~20 linhas). JSCPD detectou clones de 28 e 20 linhas
+ * entre `systems.ts`, `routes.ts` e `tokenTypes.ts`. Centralizar a
+ * checagem aqui colapsa todos os call sites para uma única chamada
+ * — cada wrapper específico só checa os campos extras que adiciona.
+ *
+ * Tolera `description`/`deletedAt` ausentes (tratados como `null`
+ * pelos consumidores). Os demais campos são obrigatórios.
+ */
+export function isNameCodeDescriptionDto(value: unknown): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === 'string' &&
+    typeof record.name === 'string' &&
+    typeof record.code === 'string' &&
+    typeof record.createdAt === 'string' &&
+    typeof record.updatedAt === 'string' &&
+    (record.description === null ||
+      record.description === undefined ||
+      typeof record.description === 'string') &&
+    (record.deletedAt === null ||
+      record.deletedAt === undefined ||
+      typeof record.deletedAt === 'string')
+  );
+}

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -1,3 +1,4 @@
+import { isNameCodeDescriptionDto } from './nameCodeDescriptionDto';
 import { isPagedResponseEnvelope } from './pagedResponse';
 
 import { apiClient } from './index';
@@ -69,26 +70,21 @@ export interface RouteDto {
  * diferentes precisam de helper compartilhado").
  */
 export function isRouteDto(value: unknown): value is RouteDto {
-  if (!value || typeof value !== 'object') {
+  // Delega ao helper genérico a checagem dos campos compartilhados
+  // com `SystemDto`/`TokenTypeDto` (id, name, code, description,
+  // createdAt, updatedAt, deletedAt) — `RouteDto` adiciona `systemId`
+  // e a tripla `systemTokenType*` que validamos abaixo. Lição PR
+  // #134/#135 reforçada (Issue #175): centralizar elimina ~11 linhas
+  // de duplicação entre wrappers de DTO.
+  if (!isNameCodeDescriptionDto(value)) {
     return false;
   }
   const record = value as Record<string, unknown>;
   return (
-    typeof record.id === 'string' &&
     typeof record.systemId === 'string' &&
-    typeof record.name === 'string' &&
-    typeof record.code === 'string' &&
     typeof record.systemTokenTypeId === 'string' &&
     typeof record.systemTokenTypeCode === 'string' &&
-    typeof record.systemTokenTypeName === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string' &&
-    (record.description === null ||
-      record.description === undefined ||
-      typeof record.description === 'string') &&
-    (record.deletedAt === null ||
-      record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
+    typeof record.systemTokenTypeName === 'string'
   );
 }
 

--- a/src/shared/api/systems.ts
+++ b/src/shared/api/systems.ts
@@ -1,3 +1,4 @@
+import { isNameCodeDescriptionDto } from './nameCodeDescriptionDto';
 import { isPagedResponseEnvelope } from './pagedResponse';
 
 import { apiClient } from './index';
@@ -73,23 +74,10 @@ export interface SystemDto {
  * compartilhado").
  */
 export function isSystemDto(value: unknown): value is SystemDto {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return (
-    typeof record.id === 'string' &&
-    typeof record.name === 'string' &&
-    typeof record.code === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string' &&
-    (record.description === null ||
-      record.description === undefined ||
-      typeof record.description === 'string') &&
-    (record.deletedAt === null ||
-      record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
-  );
+  // Delegação para `isNameCodeDescriptionDto` — `SystemDto` e
+  // `TokenTypeDto` compartilham exatamente o mesmo shape (Issue #175).
+  // JSCPD detectou ~20 linhas idênticas; extração eliminou na raiz.
+  return isNameCodeDescriptionDto(value);
 }
 
 /**

--- a/src/shared/api/tokenTypes.ts
+++ b/src/shared/api/tokenTypes.ts
@@ -1,6 +1,8 @@
+import { isNameCodeDescriptionDto } from './nameCodeDescriptionDto';
+
 import { apiClient } from './index';
 
-import type { ApiClient, ApiError, SafeRequestOptions } from './types';
+import type { ApiClient, ApiError, BodyRequestOptions, SafeRequestOptions } from './types';
 
 /**
  * Cria um `ApiError(parse)` baseado em `Error` real (com stack/`name`)
@@ -46,34 +48,24 @@ export interface TokenTypeDto {
 }
 
 /**
- * Type guard para `TokenTypeDto`. Tolera `description`/`deletedAt`
- * ausentes (tratados como `null`) — outros campos são obrigatórios e
- * checados em runtime.
+ * Type guard para `TokenTypeDto`. Delegação direta para
+ * `isNameCodeDescriptionDto` — o shape de `TokenTypeDto` é
+ * estruturalmente idêntico ao `SystemDto` (mesmos campos `id`/`name`/
+ * `code`/`description`/`createdAt`/`updatedAt`/`deletedAt`).
  *
- * Mantemos a validação aqui em vez de delegar a um runtime schema
- * library (Zod/Yup) porque o cliente HTTP intencionalmente não tem
- * dependência de validação — cada wrapper é dono da própria checagem,
- * coerente com `isSystemDto`/`isRouteDto`. Para listas de tokens, isso
- * evita um ~40 KB de payload extra no bundle de produção.
+ * **Lição PR #134/#135 reforçada (Issue #175):** antes da extração,
+ * o corpo desta função duplicava ~20 linhas com `isSystemDto`. JSCPD
+ * tokenizou como `New Code Duplication` entre `systems.ts`,
+ * `routes.ts` e `tokenTypes.ts`. Centralizar em
+ * `nameCodeDescriptionDto.ts` colapsou todos os call sites.
+ *
+ * Mantemos a função local (em vez de re-export) para preservar a
+ * type predicate `value is TokenTypeDto` — o helper genérico devolve
+ * `boolean` (não pode prometer `value is X` para `X` que ele não
+ * conhece). Esta envoltura adiciona apenas o predicate.
  */
 export function isTokenTypeDto(value: unknown): value is TokenTypeDto {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return (
-    typeof record.id === 'string' &&
-    typeof record.name === 'string' &&
-    typeof record.code === 'string' &&
-    typeof record.createdAt === 'string' &&
-    typeof record.updatedAt === 'string' &&
-    (record.description === null ||
-      record.description === undefined ||
-      typeof record.description === 'string') &&
-    (record.deletedAt === null ||
-      record.deletedAt === undefined ||
-      typeof record.deletedAt === 'string')
-  );
+  return isNameCodeDescriptionDto(value);
 }
 
 /**
@@ -121,4 +113,223 @@ export async function listTokenTypes(
     throw makeParseError();
   }
   return data;
+}
+
+/**
+ * Body aceito pelo `POST /tokens/types` no `lfc-authenticator`
+ * (`TokenTypesController.CreateTokenTypeRequest`).
+ *
+ * - `name` (obrigatório, máx. 80 chars) — nome amigável do tipo de
+ *   token (ex.: "Acesso padrão", "Renovação").
+ * - `code` (obrigatório, máx. 50 chars) — identificador único usado
+ *   por rotas via `SystemTokenTypeId`. Backend valida unicidade
+ *   ignorando filtro de soft-delete (409 caso já exista, mesmo que
+ *   removido).
+ * - `description` (opcional, máx. 500 chars) — descrição livre.
+ *
+ * O backend faz `Trim()` em `Name`/`Code` e converte `Description`
+ * vazia (após trim) em `null`. Mantemos os campos como `string` aqui —
+ * a UI já trima antes de enviar para preservar simetria com o que é
+ * persistido (e evita 400 por "Code é obrigatório e não pode ser apenas
+ * espaços" quando o usuário digita só whitespace). Espelha o desenho
+ * de `CreateSystemPayload` (lição PR #128 — projetar contratos
+ * simétricos entre recursos similares).
+ */
+export interface CreateTokenTypePayload {
+  name: string;
+  code: string;
+  description?: string;
+}
+
+/**
+ * Cria um novo tipo de token via `POST /tokens/types` (Issue #175).
+ *
+ * Retorna o `TokenTypeDto` recém-criado (`201 Created` com
+ * `TokenTypeResponse` no corpo). Lança `ApiError` em qualquer falha —
+ * o caller tipicamente trata:
+ *
+ * - `kind: 'http'` com `status === 409` → conflito de `code` único; a
+ *   UI exibe mensagem inline no campo `code` ("Já existe um token type
+ *   com este Code." vinda do backend).
+ * - `kind: 'http'` com `status === 400` → erros de validação por campo
+ *   no payload de `details` (formato `ValidationProblemDetails` do
+ *   ASP.NET — `details.errors[campo] = string[]`).
+ * - `kind: 'http'` com `status === 401` → cliente HTTP já lidou com
+ *   `onUnauthorized`; a UI não precisa fazer nada além de não tentar
+ *   re-renderizar.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_TOKEN_TYPES_CREATE`; toast vermelho com mensagem do
+ *   backend.
+ * - Outros erros → toast vermelho genérico.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function createTokenType(
+  payload: CreateTokenTypePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<TokenTypeDto> {
+  const body = buildTokenTypeMutationBody(payload);
+  const data = await client.post<unknown>('/tokens/types', body, options);
+  if (!isTokenTypeDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Body aceito pelo `PUT /tokens/types/{id}` no `lfc-authenticator`
+ * (`TokenTypesController.UpdateTokenTypeRequest`).
+ *
+ * O backend declara um `UpdateTokenTypeRequest` separado, mas com o
+ * mesmo shape do `CreateTokenTypeRequest` (Name obrigatório/máx. 80,
+ * Code obrigatório/máx. 50, Description opcional/máx. 500). Para evitar
+ * divergência silenciosa entre os dois tipos no frontend e replicar
+ * fielmente a simetria do backend, declaramos o payload de update como
+ * alias do de create — qualquer ajuste no contrato pega os dois call
+ * sites de uma só vez (espelha `UpdateSystemPayload`).
+ */
+export type UpdateTokenTypePayload = CreateTokenTypePayload;
+
+/**
+ * Atualiza um tipo de token existente via `PUT /tokens/types/{id}`
+ * (Issue #175).
+ *
+ * Retorna o `TokenTypeDto` atualizado (`200 OK` com `TokenTypeResponse`
+ * no corpo). Lança `ApiError` em qualquer falha — o caller tipicamente
+ * trata:
+ *
+ * - `kind: 'http'` com `status === 409` → conflito de `code` único
+ *   (outro token type já usa o code informado); a UI exibe mensagem
+ *   inline no campo `code` ("Já existe outro token type com este Code.").
+ * - `kind: 'http'` com `status === 404` → token type não encontrado ou
+ *   soft-deleted; a UI fecha o modal, dispara toast e força refetch.
+ * - `kind: 'http'` com `status === 400` → erros de validação por campo
+ *   em `details` (mesmo shape de `ValidationProblemDetails` do create).
+ * - `kind: 'http'` com `status === 401` → cliente HTTP já lidou com
+ *   `onUnauthorized`; a UI não precisa fazer nada extra.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_TOKEN_TYPES_UPDATE`; toast vermelho com mensagem do
+ *   backend.
+ * - Outros erros → toast vermelho genérico.
+ *
+ * O parâmetro `client` é injetável para isolar testes (passa-se um stub
+ * tipado como `ApiClient`); em produção usa-se o singleton `apiClient`.
+ */
+export async function updateTokenType(
+  id: string,
+  payload: UpdateTokenTypePayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<TokenTypeDto> {
+  const body = buildTokenTypeMutationBody(payload);
+  const data = await client.put<unknown>(`/tokens/types/${id}`, body, options);
+  if (!isTokenTypeDto(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Desativa (soft-delete) um tipo de token via `DELETE /tokens/types/{id}`
+ * (Issue #175).
+ *
+ * O backend (`TokenTypesController.DeleteById`) seta
+ * `DeletedAt = UtcNow` e responde `204 No Content` em sucesso. O método
+ * não devolve corpo — a função resolve `void` e a UI faz refetch para
+ * sincronizar a lista.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → token type inexistente (já
+ *   soft-deleted ou nunca existiu); a UI fecha o modal, dispara toast
+ *   e força refetch.
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do
+ *   toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_TOKEN_TYPES_DELETE`; toast vermelho com mensagem do
+ *   backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Diferente de `createTokenType`/`updateTokenType`, não há type guard
+ * de resposta porque `204` não tem corpo — `client.delete<void>`
+ * resolve `undefined` e descartamos. Espelha a estratégia de
+ * `deleteSystem`.
+ */
+export async function deleteTokenType(
+  id: string,
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.delete<void>(`/tokens/types/${id}`, options);
+}
+
+/**
+ * Restaura (desfaz soft-delete) um tipo de token via
+ * `POST /tokens/types/{id}/restore` (Issue #175).
+ *
+ * O backend (`TokenTypesController.RestoreById`) limpa `DeletedAt` via
+ * `IgnoreQueryFilters()` e responde `200 OK` com
+ * `{ message: "Token type restaurado com sucesso." }`. Diferente de
+ * `createTokenType`/`updateTokenType`, o corpo da resposta **não** é
+ * um `TokenTypeDto` — é um envelope simples `{ message }` que
+ * descartamos. A UI faz refetch para sincronizar a lista (idêntico ao
+ * padrão do `deleteTokenType` e ao `restoreSystem`), então retornamos
+ * `void`.
+ *
+ * Lança `ApiError` em qualquer falha:
+ *
+ * - `kind: 'http'` com `status === 404` → token type inexistente **ou**
+ *   já ativo (o backend devolve 404 em ambos os casos: filtro
+ *   `DeletedAt != null`). A UI fecha o modal, dispara toast e força
+ *   refetch — o registro foi mexido por outra sessão entre a abertura
+ *   do modal e o submit, ou nem existe.
+ * - `kind: 'http'` com `status === 401` → sessão expirada; cliente HTTP
+ *   já lidou com `onUnauthorized`. UI mantém-se silenciosa além do
+ *   toast.
+ * - `kind: 'http'` com `status === 403` → falta permissão
+ *   `AUTH_V1_TOKEN_TYPES_RESTORE`; toast vermelho com mensagem do
+ *   backend.
+ * - `kind: 'network'`/outros → toast vermelho genérico.
+ *
+ * Não há type guard de resposta porque `{ message }` é descartado —
+ * `client.post<void>` resolve com o body como `unknown` e ignoramos.
+ *
+ * Recebe `BodyRequestOptions` (com `signal`) por simetria com
+ * `createTokenType`/`updateTokenType` — `POST` é tratado como mutação
+ * com corpo no cliente HTTP, ainda que aqui não enviemos payload.
+ * Passamos `undefined` como body para que o backend receba uma
+ * requisição vazia.
+ */
+export async function restoreTokenType(
+  id: string,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<void> {
+  await client.post<void>(`/tokens/types/${id}/restore`, undefined, options);
+}
+
+/**
+ * Constrói o body para `POST /tokens/types` e `PUT /tokens/types/{id}`
+ * aplicando trim defensivo nos campos. Description vazia depois de
+ * trim vira `undefined` para que o serializador omita o campo (backend
+ * converte para `null`). Centralizar essa montagem garante que create
+ * e update enviem exatamente o mesmo payload — qualquer divergência
+ * futura no shape (ex.: backend aceitando `tags`) ajusta um único
+ * helper. Espelha `buildSystemMutationBody`.
+ */
+function buildTokenTypeMutationBody(
+  payload: CreateTokenTypePayload | UpdateTokenTypePayload,
+): CreateTokenTypePayload {
+  const body: CreateTokenTypePayload = {
+    name: payload.name.trim(),
+    code: payload.code.trim(),
+  };
+  const trimmedDescription = payload.description?.trim();
+  if (trimmedDescription && trimmedDescription.length > 0) {
+    body.description = trimmedDescription;
+  }
+  return body;
 }

--- a/src/shared/forms/NameCodeDescriptionForm.tsx
+++ b/src/shared/forms/NameCodeDescriptionForm.tsx
@@ -200,7 +200,7 @@ const NameCodeDescriptionFields: React.FC<NameCodeDescriptionFieldsProps> = ({
 
 /* ─── Componente: form body completo (shell + Alert + footer) ─── */
 
-interface NameCodeDescriptionFormBodyProps {
+export interface NameCodeDescriptionFormBodyProps {
   /** Prefixo dos `data-testid` do form e dos campos. */
   idPrefix: string;
   /** Erro genérico de submissão exibido em `Alert` no topo do form. */

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -78,6 +78,7 @@ export {
   extractNameCodeDescriptionValidationErrors,
   validateNameCodeDescriptionForm,
   type NameCodeDescriptionFieldErrors,
+  type NameCodeDescriptionFormBodyProps,
   type NameCodeDescriptionFormCopy,
   type NameCodeDescriptionFormState,
   type NameCodeDescriptionSubmitDecision,
@@ -86,3 +87,7 @@ export {
   useNameCodeDescriptionForm,
   type UseNameCodeDescriptionFormReturn,
 } from "./useNameCodeDescriptionForm";
+export {
+  useNameCodeDescriptionFormFieldProps,
+  type NameCodeDescriptionFormFieldProps,
+} from "./useNameCodeDescriptionFormFieldProps";

--- a/src/shared/forms/useNameCodeDescriptionFormFieldProps.ts
+++ b/src/shared/forms/useNameCodeDescriptionFormFieldProps.ts
@@ -1,0 +1,136 @@
+import { useMemo, type FormEvent } from 'react';
+
+import type {
+  NameCodeDescriptionFieldErrors,
+  NameCodeDescriptionFormState,
+} from './NameCodeDescriptionForm';
+import type { UseNameCodeDescriptionFormReturn } from './useNameCodeDescriptionForm';
+
+/**
+ * Subset estrutural de `UseNameCodeDescriptionFormReturn` consumido
+ * por `useNameCodeDescriptionFormFieldProps`. Inclui apenas os
+ * campos/handlers que o hook lê — exclui `prepareSubmit`/
+ * `applyBadRequest`/setters que cada wrapper de domínio
+ * (`useRoleForm`/`useTokenTypeForm`) pode tipar de forma diferente.
+ *
+ * Tipar o parâmetro como `Pick<...>` permite que `useRoleForm` (que
+ * sobrescreve `prepareSubmit` com assinatura `(systemId: string) =>
+ * CreateRolePayload | null`) use o helper sem perder type-safety.
+ * Sem isso, o TypeScript reclamaria que o `UseRoleFormReturn` não é
+ * assignable a `UseNameCodeDescriptionFormReturn` (assinaturas
+ * incompatíveis em `prepareSubmit`).
+ */
+type NameCodeDescriptionFormFieldsSlice = Pick<
+  UseNameCodeDescriptionFormReturn,
+  | 'formState'
+  | 'fieldErrors'
+  | 'submitError'
+  | 'isSubmitting'
+  | 'handleNameChange'
+  | 'handleCodeChange'
+  | 'handleDescriptionChange'
+>;
+
+/**
+ * Props consumidas pelos `<*FormBody>` que envelopam o
+ * `NameCodeDescriptionFormBody` para recursos com 3 campos
+ * `Name`/`Code`/`Description` (sistemas, roles, tipos de token, e
+ * possíveis novos recursos com mesmo shape).
+ *
+ * **Por que existe (lição PR #134/#135 reforçada):**
+ *
+ * Antes desta extração, cada `use<Recurso>Form.ts` declarava sua
+ * própria `<Recurso>FormFieldProps` interface idêntica em estrutura
+ * (10 linhas) — JSCPD/Sonar tokenizam blocos ≥10 linhas como `New
+ * Code Duplication` mesmo quando os literais não diferem. Já temos:
+ *
+ * - `RoleFormFieldProps` (`useRoleForm.ts`)
+ * - `TokenTypeFormFieldProps` (`useTokenTypeForm.ts` — Issue #175)
+ *
+ * Centralizar aqui garante que qualquer recurso futuro (também
+ * recursos atuais que adotarem `NameCodeDescriptionFormBody` em
+ * refatorações) compartilhem a mesma fonte de verdade. O alias por
+ * recurso (`export type RoleFormFieldProps =
+ * NameCodeDescriptionFormFieldProps`) preserva a API local sem
+ * duplicar a declaração.
+ *
+ * Sistemas e rotas ainda têm seus próprios módulos de form pré-
+ * datando o `NameCodeDescriptionForm` genérico (`SystemFormFields`/
+ * `RouteFormFields` declaram tipos próprios em vez de delegar);
+ * migrá-los exigiria PR isolado fora do escopo da Issue #175.
+ */
+export interface NameCodeDescriptionFormFieldProps {
+  submitError: string | null;
+  values: NameCodeDescriptionFormState;
+  errors: NameCodeDescriptionFieldErrors;
+  onChangeName: (value: string) => void;
+  onChangeCode: (value: string) => void;
+  onChangeDescription: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+}
+
+/**
+ * Constrói o objeto `NameCodeDescriptionFormFieldProps` a partir de
+ * uma instância de `useNameCodeDescriptionForm` (ou wrapper como
+ * `useRoleForm`/`useTokenTypeForm`) + os handlers do modal pai
+ * (`handleSubmit`/`handleClose`). Memoizado em `useMemo` para
+ * preservar identidade entre renders quando nada mudou — útil para
+ * spread `{...fieldProps}` sem causar re-render desnecessário no body.
+ *
+ * **Por que existe (lição PR #134/#135 reforçada):**
+ *
+ * O `useMemo` retornando `{ submitError, values, errors,
+ * onChangeName, onChangeCode, onChangeDescription, onSubmit,
+ * onCancel, isSubmitting }` com a mesma deps array aparecia em
+ * `useRoleFormFieldProps` (Issue #67) e `useTokenTypeFormFieldProps`
+ * (Issue #175) — JSCPD detectou ~27 linhas idênticas. Centralizar
+ * aqui colapsa ambos os hooks de recurso para `useMemo` triviais
+ * sobre o helper genérico.
+ *
+ * O caller passa qualquer hook de form com shape
+ * `UseNameCodeDescriptionFormReturn` — incluindo wrappers de domínio
+ * (`useRoleForm`/`useTokenTypeForm`) que decoram o `prepareSubmit`
+ * mas mantêm os mesmos campos/handlers.
+ */
+export function useNameCodeDescriptionFormFieldProps(
+  form: NameCodeDescriptionFormFieldsSlice,
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void,
+  onCancel: () => void,
+): NameCodeDescriptionFormFieldProps {
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    handleNameChange,
+    handleCodeChange,
+    handleDescriptionChange,
+  } = form;
+
+  return useMemo(
+    () => ({
+      submitError,
+      values: formState,
+      errors: fieldErrors,
+      onChangeName: handleNameChange,
+      onChangeCode: handleCodeChange,
+      onChangeDescription: handleDescriptionChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    }),
+    [
+      submitError,
+      formState,
+      fieldErrors,
+      handleNameChange,
+      handleCodeChange,
+      handleDescriptionChange,
+      onSubmit,
+      onCancel,
+      isSubmitting,
+    ],
+  );
+}

--- a/src/shared/listing/SoftDeleteRestoreButtons.tsx
+++ b/src/shared/listing/SoftDeleteRestoreButtons.tsx
@@ -1,0 +1,115 @@
+import { Trash2, Undo2 } from 'lucide-react';
+import React from 'react';
+
+import { Button } from '../../components/ui';
+
+/**
+ * Par de botões "Desativar" / "Restaurar" para uma linha com soft-
+ * delete (`deletedAt: string | null`).
+ *
+ * Os botões são mutuamente exclusivos por construção: "Desativar"
+ * aparece apenas em linhas ativas (`deletedAt === null`) e "Restaurar"
+ * apenas em linhas soft-deletadas (`deletedAt !== null`). O caller
+ * passa o gating de permissão (`canDelete`/`canRestore`) e o helper
+ * combina com a checagem de `deletedAt` para decidir o que renderizar
+ * — alinha com o padrão das listagens (`SystemsPage`,
+ * `ClientsListShellPage`, `TokensListShellPage`).
+ *
+ * **Lição PR #134/#135 reforçada (Issue #175):** o par de
+ * `<Button variant="ghost">` (Desativar com `Trash2` + Restaurar com
+ * `Undo2`) duplicava ~13 linhas entre `ClientsListShellPage` e
+ * `TokensListShellPage`. JSCPD detectou o clone. Centralizar aqui
+ * elimina a duplicação na raiz; cada caller só passa os handlers e
+ * o copy do label aria.
+ *
+ * **Por que não cobrir `<RowActions>` wrapper?** O wrapper (display:
+ * flex + gap) já vive em `src/shared/listing/styles.ts` e cada
+ * página importa diretamente. Manter este helper agnóstico do wrapper
+ * permite que uma página inclua botões adicionais (ex.: "Editar"
+ * antes de "Desativar") sem precisar de prop slot — o caller compõe
+ * livremente os filhos do `<RowActions>`.
+ */
+
+interface SoftDeleteRestoreButtonsProps {
+  /**
+   * Estado de soft-delete da linha. `null` indica linha ativa
+   * (renderiza "Desativar"); valor não-nulo indica linha soft-
+   * deletada (renderiza "Restaurar"). Espelha o tipo do campo
+   * `deletedAt` dos DTOs (`SystemDto`/`TokenTypeDto`/etc.).
+   */
+  deletedAt: string | null;
+  /**
+   * Gating de permissão para o botão "Desativar". Quando `false`, o
+   * botão não aparece mesmo em linha ativa. Tipicamente consumido a
+   * partir de `useAuth().hasPermission(<RECURSO>_DELETE)`.
+   */
+  canDelete: boolean;
+  /**
+   * Gating de permissão para o botão "Restaurar". Quando `false`, o
+   * botão não aparece mesmo em linha soft-deletada. Tipicamente
+   * consumido a partir de `useAuth().hasPermission(<RECURSO>_RESTORE)`.
+   */
+  canRestore: boolean;
+  /** Handler do botão "Desativar". */
+  onDelete: () => void;
+  /** Handler do botão "Restaurar". */
+  onRestore: () => void;
+  /**
+   * `aria-label` do botão "Desativar" (ex.: `Desativar tipo de token
+   * Acesso padrão`). O caller compõe a string completa para que o
+   * recurso e o nome da entidade fiquem explícitos para tecnologias
+   * assistivas.
+   */
+  deleteAriaLabel: string;
+  /**
+   * `aria-label` do botão "Restaurar" (ex.: `Restaurar tipo de token
+   * Acesso padrão`).
+   */
+  restoreAriaLabel: string;
+  /** `data-testid` do botão "Desativar" (ex.: `token-types-delete-<id>`). */
+  deleteTestId: string;
+  /** `data-testid` do botão "Restaurar" (ex.: `token-types-restore-<id>`). */
+  restoreTestId: string;
+}
+
+export const SoftDeleteRestoreButtons: React.FC<SoftDeleteRestoreButtonsProps> = ({
+  deletedAt,
+  canDelete,
+  canRestore,
+  onDelete,
+  onRestore,
+  deleteAriaLabel,
+  restoreAriaLabel,
+  deleteTestId,
+  restoreTestId,
+}) => {
+  const isActive = deletedAt === null;
+  return (
+    <>
+      {canDelete && isActive && (
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={<Trash2 size={14} strokeWidth={1.5} />}
+          onClick={onDelete}
+          aria-label={deleteAriaLabel}
+          data-testid={deleteTestId}
+        >
+          Desativar
+        </Button>
+      )}
+      {canRestore && !isActive && (
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={<Undo2 size={14} strokeWidth={1.5} />}
+          onClick={onRestore}
+          aria-label={restoreAriaLabel}
+          data-testid={restoreTestId}
+        >
+          Restaurar
+        </Button>
+      )}
+    </>
+  );
+};

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -92,6 +92,7 @@ export { LiveRegion } from './LiveRegion';
 export { PaginationFooter } from './PaginationFooter';
 export { RefetchOverlay } from './RefetchOverlay';
 export { RoleCardHeader, type RoleCardHeaderProps } from './RoleCardHeader';
+export { SoftDeleteRestoreButtons } from './SoftDeleteRestoreButtons';
 export { StatusBadge } from './StatusBadge';
 export {
   useListingEmptyContent,

--- a/tests/pages/__helpers__/tokenTypesTestHelpers.tsx
+++ b/tests/pages/__helpers__/tokenTypesTestHelpers.tsx
@@ -1,0 +1,356 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { expect, vi } from 'vitest';
+
+import type { ApiClient, ApiError, TokenTypeDto } from '@/shared/api';
+
+import { ToastProvider } from '@/components/ui';
+import { TokensListShellPage } from '@/pages/tokens';
+
+/**
+ * Helpers de teste compartilhados pelas suítes da
+ * `TokensListShellPage` (Issue #175 — listagem CRUD de tipos de token
+ * JWT, fechando o placeholder do `/tokens`).
+ *
+ * Estratégia espelha `systemsTestHelpers.tsx`/`clientsTestHelpers.tsx`:
+ *
+ * - `ApiClientStub` + `createTokenTypesClientStub` para isolar a
+ *   página da camada de transporte;
+ * - `makeTokenType` para construir payloads do contrato `TokenTypeDto`
+ *   sem repetir todos os campos;
+ * - constantes de UUIDs sintéticos para asserts estáveis;
+ * - `renderTokensListPage` envolvendo a página num `ToastProvider`
+ *   (modais consomem `useToast()` para feedback de sucesso/erro);
+ * - `waitForInitialList` colapsando o boilerplate recorrente.
+ *
+ * Diferente das demais listagens, o backend de token types
+ * (`TokenTypesController.GetAll`) **não pagina** — devolve um array
+ * bruto. Por isso o helper `makePagedResponse` não existe aqui; a
+ * página recebe a lista direto e o filtro é client-side. O stub
+ * mocka `client.get.mockResolvedValueOnce(array)` em vez de envelope
+ * paginado.
+ *
+ * Pré-fabricados desde o primeiro PR do recurso para evitar
+ * refatoração destrutiva nas próximas sub-issues (lição PR #128 —
+ * "projetar shared helpers desde o primeiro PR do recurso").
+ */
+
+/** UUIDs fixos usados pelas suítes — asserts comparam strings estáveis. */
+export const ID_TT_DEFAULT = 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa';
+export const ID_TT_REFRESH = 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb';
+export const ID_TT_LEGACY = 'cccccccc-3333-3333-3333-cccccccccccc';
+
+/**
+ * Stub de `ApiClient` injetado em
+ * `<TokensListShellPage client={stub} />` — mesmo padrão de injeção
+ * usado nos demais testes de listagem.
+ */
+export type ApiClientStub = ApiClient & {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  request: ReturnType<typeof vi.fn>;
+  setAuth: ReturnType<typeof vi.fn>;
+  getSystemId: ReturnType<typeof vi.fn>;
+};
+
+export function createTokenTypesClientStub(): ApiClientStub {
+  return {
+    request: vi.fn(),
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    setAuth: vi.fn(),
+    getSystemId: vi.fn(() => 'system-test-uuid'),
+  } as unknown as ApiClientStub;
+}
+
+/**
+ * Constrói um `TokenTypeDto` com defaults — testes só sobrescrevem o
+ * que importa para o cenário sem repetir todos os campos do contrato.
+ */
+export function makeTokenType(
+  overrides: Partial<TokenTypeDto> = {},
+): TokenTypeDto {
+  return {
+    id: ID_TT_DEFAULT,
+    name: 'Acesso padrão',
+    code: 'default',
+    description: 'Token JWT clássico de acesso.',
+    createdAt: '2026-01-10T12:00:00Z',
+    updatedAt: '2026-01-10T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Renderiza a `TokensListShellPage` envolvendo num `ToastProvider` —
+ * os modais consomem `useToast()` internamente para disparar feedback
+ * de sucesso/erro.
+ */
+export function renderTokensListPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <TokensListShellPage client={client} />
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem (a `TokensListShellPage`
+ * faz `listTokenTypes` no mount). Centraliza o "esperar listagem"
+ * para que cada teste comece em estado estável sem precisar replicar
+ * `waitFor` para `client.get`.
+ */
+export async function waitForInitialList(client: ApiClientStub): Promise<void> {
+  await waitFor(() => expect(client.get).toHaveBeenCalled());
+  await waitFor(() => {
+    expect(screen.queryByTestId('token-types-loading')).not.toBeInTheDocument();
+  });
+}
+
+/* ─── Helpers de fluxo dos modais (Issue #175) ─── */
+
+/**
+ * Mocka o GET inicial com uma lista contendo um token type sintético,
+ * renderiza a página, espera a lista carregar e clica no botão "Novo
+ * tipo de token" para abrir o modal de criação.
+ */
+export async function openCreateTokenTypeModal(
+  client: ApiClientStub,
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce([makeTokenType()]);
+  }
+  renderTokensListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId('token-types-create-open'));
+}
+
+/**
+ * Preenche os campos do form do `NewTokenTypeModal`. Cada chave é
+ * opcional — testes que validam só `name` e `code` deixam
+ * `description` ausente. Os valores são entregues diretamente ao
+ * `fireEvent.change`; trim é responsabilidade do componente
+ * (`createTokenType`/`validateTokenTypeForm`).
+ */
+export function fillNewTokenTypeForm(values: {
+  name?: string;
+  code?: string;
+  description?: string;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId('new-token-type-name'), {
+      target: { value: values.name },
+    });
+  }
+  if (values.code !== undefined) {
+    fireEvent.change(screen.getByTestId('new-token-type-code'), {
+      target: { value: values.code },
+    });
+  }
+  if (values.description !== undefined) {
+    fireEvent.change(screen.getByTestId('new-token-type-description'), {
+      target: { value: values.description },
+    });
+  }
+}
+
+/**
+ * Submete o form do `NewTokenTypeModal` e aguarda o `client.post` ser
+ * chamado pelo menos `expectedPostCalls` vezes (default `1`). Faz o
+ * `act(async)` necessário para flushar a microtask do submit antes do
+ * `waitFor`.
+ */
+export async function submitNewTokenTypeForm(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('new-token-type-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.post).toHaveBeenCalledTimes(expectedPostCalls),
+  );
+}
+
+/**
+ * Mocka o GET inicial com uma lista contendo o `tokenType` informado
+ * (ou um token type sintético padrão), renderiza a página, espera a
+ * lista carregar e clica no botão "Editar" da linha.
+ */
+export async function openEditTokenTypeModal(
+  client: ApiClientStub,
+  tokenType: TokenTypeDto = makeTokenType(),
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce([tokenType]);
+  }
+  renderTokensListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`token-types-edit-${tokenType.id}`));
+}
+
+/**
+ * Preenche os campos do form do `EditTokenTypeModal`. Cada chave é
+ * opcional. Espelha `fillNewTokenTypeForm`, mas usando os
+ * `data-testid` do modal de edição (`edit-token-type-*`).
+ */
+export function fillEditTokenTypeForm(values: {
+  name?: string;
+  code?: string;
+  description?: string;
+}): void {
+  if (values.name !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-token-type-name'), {
+      target: { value: values.name },
+    });
+  }
+  if (values.code !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-token-type-code'), {
+      target: { value: values.code },
+    });
+  }
+  if (values.description !== undefined) {
+    fireEvent.change(screen.getByTestId('edit-token-type-description'), {
+      target: { value: values.description },
+    });
+  }
+}
+
+/**
+ * Submete o form do `EditTokenTypeModal` e aguarda o `client.put` ser
+ * chamado pelo menos `expectedPutCalls` vezes (default `1`). Espelha
+ * `submitNewTokenTypeForm`, com PUT em vez de POST.
+ */
+export async function submitEditTokenTypeForm(
+  client: ApiClientStub,
+  expectedPutCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.submit(screen.getByTestId('edit-token-type-form'));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.put).toHaveBeenCalledTimes(expectedPutCalls),
+  );
+}
+
+/**
+ * Mocka o GET inicial com uma lista contendo o `tokenType` informado e
+ * abre o `DeleteTokenTypeConfirm` clicando no botão "Desativar" da
+ * linha. Espelha `openDeleteConfirm` do `systemsTestHelpers`.
+ */
+export async function openDeleteTokenTypeConfirm(
+  client: ApiClientStub,
+  tokenType: TokenTypeDto = makeTokenType(),
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce([tokenType]);
+  }
+  renderTokensListPage(client);
+  await waitForInitialList(client);
+  fireEvent.click(screen.getByTestId(`token-types-delete-${tokenType.id}`));
+}
+
+/**
+ * Confirma a desativação clicando em "Desativar" no
+ * `DeleteTokenTypeConfirm` e aguarda o `client.delete` ser chamado
+ * pelo menos `expectedDeleteCalls` vezes (default `1`). Espelha
+ * `confirmDelete` do `systemsTestHelpers`, com `data-testid` próprio.
+ */
+export async function confirmDeleteTokenType(
+  client: ApiClientStub,
+  expectedDeleteCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('delete-token-type-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.delete).toHaveBeenCalledTimes(expectedDeleteCalls),
+  );
+}
+
+/**
+ * Mocka o GET inicial com uma lista contendo o `tokenType` informado
+ * (default já vem com `deletedAt` preenchido — restaurar só faz
+ * sentido em linhas soft-deletadas) e abre o `RestoreTokenTypeConfirm`
+ * clicando no botão "Restaurar" da linha. O toggle "Mostrar inativos"
+ * é ligado para que a linha apareça (estado inicial é
+ * `includeDeleted=false`).
+ */
+export async function openRestoreTokenTypeConfirm(
+  client: ApiClientStub,
+  tokenType: TokenTypeDto = makeTokenType({
+    deletedAt: '2026-02-01T00:00:00Z',
+  }),
+): Promise<void> {
+  if (
+    client.get.mock.calls.length === 0 &&
+    client.get.mock.results.length === 0
+  ) {
+    client.get.mockResolvedValueOnce([tokenType]);
+  }
+  renderTokensListPage(client);
+  await waitForInitialList(client);
+  // Liga "Mostrar inativos" para que linhas soft-deletadas apareçam.
+  fireEvent.click(screen.getByTestId('token-types-include-deleted'));
+  fireEvent.click(screen.getByTestId(`token-types-restore-${tokenType.id}`));
+}
+
+/**
+ * Confirma a restauração clicando em "Restaurar" no
+ * `RestoreTokenTypeConfirm` e aguarda o `client.post` ser chamado
+ * pelo menos `expectedPostCalls` vezes (default `1`).
+ */
+export async function confirmRestoreTokenType(
+  client: ApiClientStub,
+  expectedPostCalls = 1,
+): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('restore-token-type-confirm'));
+    await Promise.resolve();
+  });
+  await waitFor(() =>
+    expect(client.post).toHaveBeenCalledTimes(expectedPostCalls),
+  );
+}
+
+/**
+ * Caso de teste declarativo para os cenários `it.each(ERROR_CASES)`
+ * dos modais de criação/edição. Espelha `SystemsErrorCase` do
+ * `systemsTestHelpers`.
+ */
+export interface TokenTypeErrorCase {
+  name: string;
+  error: ApiError;
+  expectedText: RegExp | string;
+  modalStaysOpen?: boolean;
+}
+
+/**
+ * Aceita string ou regex e devolve sempre um `RegExp` insensível a
+ * caixa, com escape de metacaracteres. Espelha `toCaseInsensitiveMatcher`.
+ */
+export function toCaseInsensitiveMatcher(text: RegExp | string): RegExp {
+  if (typeof text !== 'string') {
+    return text;
+  }
+  return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`), 'i');
+}

--- a/tests/pages/tokens/TokensListShellPage.test.tsx
+++ b/tests/pages/tokens/TokensListShellPage.test.tsx
@@ -1,0 +1,664 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `buildAuthMock` precisa ser importado **antes** de `tokenTypesTestHelpers`
+// para que `vi.mock('@/shared/auth', ...)` consiga resolver a factory
+// durante o hoisting — sem isso, o teste falha com `Cannot access ...
+// before initialization`. Mesmo padrão usado em outras suítes de listagem.
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  confirmDeleteTokenType,
+  confirmRestoreTokenType,
+  createTokenTypesClientStub,
+  fillEditTokenTypeForm,
+  fillNewTokenTypeForm,
+  ID_TT_DEFAULT,
+  ID_TT_LEGACY,
+  ID_TT_REFRESH,
+  makeTokenType,
+  openCreateTokenTypeModal,
+  openDeleteTokenTypeConfirm,
+  openEditTokenTypeModal,
+  openRestoreTokenTypeConfirm,
+  renderTokensListPage,
+  submitEditTokenTypeForm,
+  submitNewTokenTypeForm,
+  toCaseInsensitiveMatcher,
+  waitForInitialList,
+} from '../__helpers__/tokenTypesTestHelpers';
+/* eslint-enable import/order */
+
+import type { TokenTypeErrorCase } from '../__helpers__/tokenTypesTestHelpers';
+import type { ApiError, TokenTypeDto } from '@/shared/api';
+
+/**
+ * Suíte da `TokensListShellPage` (Issue #175 — CRUD de tipos de token
+ * JWT, fechando o placeholder do `/tokens`).
+ *
+ * Estratégia espelha as demais páginas de listagem (`SystemsPage`/
+ * `ClientsListShellPage`/`RolesPage`): stub de `ApiClient` injetado,
+ * asserts sobre estados visuais, busca debounced (client-side neste
+ * recurso), toggle "Mostrar inativos", erros de mutação e
+ * comportamento dos modais.
+ *
+ * Diferenças relevantes em relação às demais suítes:
+ *
+ * - A request inicial chama `GET /tokens/types` sem querystring — o
+ *   backend não suporta filtro server-side neste recurso e a página
+ *   filtra o array client-side. Asserts sobre paginação não se
+ *   aplicam.
+ * - O toggle "Mostrar inativos" não dispara nova request (estado
+ *   apenas do client) — só re-aplica o filtro `deletedAt === null`
+ *   sobre a lista já em memória.
+ * - Para abrir o modal de restauração, a suíte liga o toggle "Mostrar
+ *   inativos" antes de localizar o botão `token-types-restore-<id>`
+ *   (linhas soft-deletadas só aparecem com o toggle ligado).
+ */
+
+let permissionsMock: ReadonlyArray<string> = [];
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const ALL_PERMISSIONS: ReadonlyArray<string> = [
+  'AUTH_V1_TOKEN_TYPES_LIST',
+  'AUTH_V1_TOKEN_TYPES_CREATE',
+  'AUTH_V1_TOKEN_TYPES_UPDATE',
+  'AUTH_V1_TOKEN_TYPES_DELETE',
+  'AUTH_V1_TOKEN_TYPES_RESTORE',
+];
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_ROWS: ReadonlyArray<TokenTypeDto> = [
+  makeTokenType({
+    id: ID_TT_DEFAULT,
+    name: 'Acesso padrão',
+    code: 'default',
+    description: 'Token JWT clássico de acesso.',
+  }),
+  makeTokenType({
+    id: ID_TT_REFRESH,
+    name: 'Renovação',
+    code: 'refresh',
+    description: 'Token de refresh.',
+  }),
+  makeTokenType({
+    id: ID_TT_LEGACY,
+    name: 'Legado',
+    code: 'legacy',
+    description: null,
+    deletedAt: '2026-02-01T00:00:00Z',
+  }),
+];
+
+beforeEach(() => {
+  permissionsMock = ALL_PERMISSIONS;
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('TokensListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e popula a tabela após resposta', async () => {
+    const client = createTokenTypesClientStub();
+    let resolveFn: (value: ReadonlyArray<TokenTypeDto>) => void = () =>
+      undefined;
+    const pending = new Promise<ReadonlyArray<TokenTypeDto>>((resolve) => {
+      resolveFn = resolve;
+    });
+    client.get.mockReturnValueOnce(pending);
+
+    renderTokensListPage(client);
+
+    expect(screen.getByTestId('token-types-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFn(SAMPLE_ROWS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('token-types-loading'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Linhas ativas aparecem (Acesso padrão / Renovação) — desktop +
+    // mobile = 2 ocorrências. A linha "Legado" (soft-deletada) NÃO
+    // aparece porque includeDeleted=false por default.
+    expect(screen.getAllByText('Acesso padrão').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Renovação').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Legado')).not.toBeInTheDocument();
+  });
+
+  it('renderiza header com título "Tipos de token JWT"', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /Tipos de token JWT/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /tokens/types sem querystring', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/tokens/types',
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it('renderiza badge "Inativo" para tipos soft-deletados quando includeDeleted=true', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.click(screen.getByTestId('token-types-include-deleted'));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Inativo').length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText('Legado').length).toBeGreaterThan(0);
+  });
+
+  it('exibe mensagem de erro do backend e botão "Tentar novamente" quando o GET falha', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockRejectedValueOnce({
+      kind: 'http',
+      status: 500,
+      message: 'Falha interna.',
+    } as ApiError);
+
+    renderTokensListPage(client);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('token-types-retry')).toBeInTheDocument(),
+    );
+
+    // O `extractErrorMessage` propaga a mensagem do backend quando o
+    // erro é `ApiError`; o `fallbackErrorMessage` da página só é usado
+    // para erros não-ApiError. Asserção visa exatamente o caminho real.
+    expect(screen.getByText(/Falha interna\./i)).toBeInTheDocument();
+  });
+
+  it('cai no fallback "Falha ao carregar..." quando o erro não é ApiError', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockRejectedValueOnce(new Error('boom'));
+
+    renderTokensListPage(client);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('token-types-retry')).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByText(/Falha ao carregar a lista de tipos de token/i),
+    ).toBeInTheDocument();
+  });
+
+  it('estado vazio exibe "Nenhum tipo de token cadastrado" e dica de "Mostrar inativos"', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce([]);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.getAllByText('Nenhum tipo de token cadastrado.').length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Mostrar inativos/i).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('TokensListShellPage — busca client-side debounced', () => {
+  it('digitar não filtra imediatamente; após 300ms aplica filtro client-side', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    // Antes de digitar: 2 linhas ativas visíveis (Acesso padrão +
+    // Renovação). Linha "Legado" (soft-deletada) não conta.
+    expect(screen.getAllByText('Acesso padrão').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Renovação').length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByTestId('token-types-search'), {
+      target: { value: 'refresh' },
+    });
+
+    // Antes do debounce vencer, ambas ainda aparecem.
+    expect(screen.getAllByText('Acesso padrão').length).toBeGreaterThan(0);
+
+    // Avança o tempo do debounce.
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS + 50);
+      await Promise.resolve();
+    });
+
+    // Após o debounce, "Acesso padrão" some e "Renovação" permanece
+    // (matched por code/description).
+    await waitFor(() => {
+      expect(screen.queryByText('Acesso padrão')).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Renovação').length).toBeGreaterThan(0);
+
+    // GET continua tendo sido chamado uma única vez (filtro é client-side).
+    expect(client.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('estado vazio com busca cita o termo e oferece botão "Limpar busca"', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    fireEvent.change(screen.getByTestId('token-types-search'), {
+      target: { value: 'inexistente' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS + 50);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhum tipo de token encontrado para/i).length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.getAllByTestId('token-types-empty-clear').length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('TokensListShellPage — gating de permissões', () => {
+  it('esconde "Novo tipo de token" quando o usuário não tem AUTH_V1_TOKEN_TYPES_CREATE', async () => {
+    permissionsMock = ['AUTH_V1_TOKEN_TYPES_LIST'];
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.queryByTestId('token-types-create-open'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('esconde botão "Editar" da linha quando falta AUTH_V1_TOKEN_TYPES_UPDATE', async () => {
+    permissionsMock = [
+      'AUTH_V1_TOKEN_TYPES_LIST',
+      'AUTH_V1_TOKEN_TYPES_DELETE',
+    ];
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.queryByTestId(`token-types-edit-${ID_TT_DEFAULT}`),
+    ).not.toBeInTheDocument();
+    // Delete continua aparecendo (linha ativa + permissão presente).
+    expect(
+      screen.getByTestId(`token-types-delete-${ID_TT_DEFAULT}`),
+    ).toBeInTheDocument();
+  });
+
+  it('esconde a coluna "Ações" inteira quando o usuário não tem update/delete/restore', async () => {
+    permissionsMock = ['AUTH_V1_TOKEN_TYPES_LIST'];
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce(SAMPLE_ROWS);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    expect(
+      screen.queryByRole('columnheader', { name: /ações/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('TokensListShellPage — fluxo "Novo tipo de token"', () => {
+  it('abre modal, valida campos obrigatórios sem submeter quando vazio', async () => {
+    const client = createTokenTypesClientStub();
+    await openCreateTokenTypeModal(client);
+
+    expect(screen.getByTestId('new-token-type-form')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.submit(screen.getByTestId('new-token-type-form'));
+      await Promise.resolve();
+    });
+
+    // Validação client-side bloqueia o POST sem name/code preenchidos.
+    expect(client.post).not.toHaveBeenCalled();
+    expect(screen.getByTestId('new-token-type-form')).toBeInTheDocument();
+  });
+
+  it('cria token type com sucesso, fecha o modal e refaz fetch', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce([makeTokenType()]);
+    client.post.mockResolvedValueOnce(
+      makeTokenType({
+        id: 'novo-uuid',
+        name: 'Renovação',
+        code: 'refresh',
+      }),
+    );
+    client.get.mockResolvedValueOnce([
+      makeTokenType(),
+      makeTokenType({
+        id: 'novo-uuid',
+        name: 'Renovação',
+        code: 'refresh',
+      }),
+    ]);
+
+    await openCreateTokenTypeModal(client);
+
+    fillNewTokenTypeForm({
+      name: '  Renovação  ',
+      code: 'refresh',
+      description: 'Token de refresh.',
+    });
+
+    await submitNewTokenTypeForm(client);
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/tokens/types',
+      {
+        name: 'Renovação',
+        code: 'refresh',
+        description: 'Token de refresh.',
+      },
+      undefined,
+    );
+
+    // Modal fecha após sucesso.
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('new-token-type-form'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Refetch dispara — agora 2 GETs no total (inicial + pós-mutação).
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('409 mapeia para mensagem inline custom no campo code', async () => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce([makeTokenType()]);
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message: 'Já existe um token type com este Code.',
+    } as ApiError);
+
+    await openCreateTokenTypeModal(client);
+    fillNewTokenTypeForm({ name: 'Padrão', code: 'default' });
+    await submitNewTokenTypeForm(client);
+
+    // Mensagem inline custom em pt-BR — não a do backend literal.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Já existe um tipo de token com este código/i),
+      ).toBeInTheDocument();
+    });
+
+    // Modal continua aberto.
+    expect(screen.getByTestId('new-token-type-form')).toBeInTheDocument();
+  });
+
+  it.each<TokenTypeErrorCase>([
+    {
+      name: '400 com errors mapeia mensagens para os campos correspondentes',
+      error: {
+        kind: 'http',
+        status: 400,
+        message: 'Erro de validação.',
+        details: {
+          errors: {
+            Name: ['Name é obrigatório e não pode ser apenas espaços.'],
+            Code: ['Code deve ter no máximo 50 caracteres.'],
+          },
+        },
+      } as ApiError,
+      expectedText: 'Name é obrigatório e não pode ser apenas espaços.',
+    },
+    {
+      name: '401 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 401,
+        message: 'Sessão expirada. Faça login novamente.',
+      } as ApiError,
+      expectedText: 'Sessão expirada. Faça login novamente.',
+    },
+    {
+      name: '403 dispara toast vermelho com mensagem do backend',
+      error: {
+        kind: 'http',
+        status: 403,
+        message: 'Você não tem permissão para esta ação.',
+      } as ApiError,
+      expectedText: 'Você não tem permissão para esta ação.',
+    },
+    {
+      name: 'erro genérico de rede dispara toast vermelho genérico',
+      error: { kind: 'network', message: 'Falha de conexão.' } as ApiError,
+      expectedText:
+        'Não foi possível criar o tipo de token. Tente novamente.',
+    },
+  ])('cenário "$name"', async ({ error, expectedText }) => {
+    const client = createTokenTypesClientStub();
+    client.get.mockResolvedValueOnce([makeTokenType()]);
+    client.post.mockRejectedValueOnce(error);
+
+    await openCreateTokenTypeModal(client);
+    fillNewTokenTypeForm({ name: 'Padrão', code: 'default' });
+    await submitNewTokenTypeForm(client);
+
+    const matcher = toCaseInsensitiveMatcher(expectedText);
+    await waitFor(() => {
+      expect(screen.getAllByText(matcher).length).toBeGreaterThan(0);
+    });
+    // Modal continua aberto após erro.
+    expect(screen.getByTestId('new-token-type-form')).toBeInTheDocument();
+  });
+});
+
+describe('TokensListShellPage — fluxo "Editar tipo de token"', () => {
+  it('abre modal pré-populado com os dados da linha selecionada', async () => {
+    const client = createTokenTypesClientStub();
+    const target = makeTokenType({
+      id: ID_TT_DEFAULT,
+      name: 'Acesso padrão',
+      code: 'default',
+      description: 'Original',
+    });
+    await openEditTokenTypeModal(client, target);
+
+    expect(screen.getByTestId('edit-token-type-form')).toBeInTheDocument();
+    expect(
+      (screen.getByTestId('edit-token-type-name') as HTMLInputElement).value,
+    ).toBe('Acesso padrão');
+    expect(
+      (screen.getByTestId('edit-token-type-code') as HTMLInputElement).value,
+    ).toBe('default');
+    expect(
+      (screen.getByTestId('edit-token-type-description') as HTMLTextAreaElement)
+        .value,
+    ).toBe('Original');
+  });
+
+  it('atualiza com sucesso, fecha o modal e refaz fetch', async () => {
+    const client = createTokenTypesClientStub();
+    const target = makeTokenType({ id: ID_TT_DEFAULT });
+    client.get.mockResolvedValueOnce([target]);
+    client.put.mockResolvedValueOnce(
+      makeTokenType({ ...target, name: 'Acesso default v2' }),
+    );
+    client.get.mockResolvedValueOnce([
+      makeTokenType({ ...target, name: 'Acesso default v2' }),
+    ]);
+
+    await openEditTokenTypeModal(client, target);
+    fillEditTokenTypeForm({ name: 'Acesso default v2' });
+    await submitEditTokenTypeForm(client);
+
+    expect(client.put).toHaveBeenCalledWith(
+      `/tokens/types/${target.id}`,
+      expect.objectContaining({ name: 'Acesso default v2', code: 'default' }),
+      undefined,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('edit-token-type-form'),
+      ).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('404 fecha o modal e dispara refetch', async () => {
+    const client = createTokenTypesClientStub();
+    const target = makeTokenType();
+    client.get.mockResolvedValueOnce([target]);
+    client.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Token type não encontrado.',
+    } as ApiError);
+    client.get.mockResolvedValueOnce([]);
+
+    await openEditTokenTypeModal(client, target);
+    fillEditTokenTypeForm({ name: 'Atualizado' });
+    await submitEditTokenTypeForm(client);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('edit-token-type-form'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Refetch após 404.
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('TokensListShellPage — fluxo "Desativar"', () => {
+  it('confirma desativação com sucesso, fecha o modal e refaz fetch', async () => {
+    const client = createTokenTypesClientStub();
+    const target = makeTokenType();
+    client.get.mockResolvedValueOnce([target]);
+    client.delete.mockResolvedValueOnce(undefined);
+    client.get.mockResolvedValueOnce([]);
+
+    await openDeleteTokenTypeConfirm(client, target);
+    await confirmDeleteTokenType(client);
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/tokens/types/${target.id}`,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId('delete-token-type-confirm')).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+
+  it('cancela ao clicar em "Cancelar" sem disparar DELETE', async () => {
+    const client = createTokenTypesClientStub();
+    await openDeleteTokenTypeConfirm(client);
+
+    fireEvent.click(screen.getByTestId('delete-token-type-cancel'));
+
+    expect(client.delete).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('delete-token-type-confirm'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('TokensListShellPage — fluxo "Restaurar"', () => {
+  it('botão "Restaurar" só aparece em linhas soft-deletadas com toggle "Mostrar inativos" ligado', async () => {
+    const client = createTokenTypesClientStub();
+    const inactive = makeTokenType({
+      id: ID_TT_LEGACY,
+      name: 'Legado',
+      code: 'legacy',
+      deletedAt: '2026-02-01T00:00:00Z',
+    });
+    client.get.mockResolvedValueOnce([inactive]);
+
+    renderTokensListPage(client);
+    await waitForInitialList(client);
+
+    // Antes de ativar o toggle, a linha sumiu (filter client-side).
+    expect(
+      screen.queryByTestId(`token-types-restore-${inactive.id}`),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('token-types-include-deleted'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`token-types-restore-${inactive.id}`),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('confirma restauração com sucesso, fecha o modal e refaz fetch', async () => {
+    const client = createTokenTypesClientStub();
+    const target = makeTokenType({
+      id: ID_TT_LEGACY,
+      name: 'Legado',
+      code: 'legacy',
+      deletedAt: '2026-02-01T00:00:00Z',
+    });
+    client.get.mockResolvedValueOnce([target]);
+    client.post.mockResolvedValueOnce({
+      message: 'Token type restaurado com sucesso.',
+    });
+    client.get.mockResolvedValueOnce([{ ...target, deletedAt: null }]);
+
+    await openRestoreTokenTypeConfirm(client, target);
+    await confirmRestoreTokenType(client);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/tokens/types/${target.id}/restore`,
+      undefined,
+      undefined,
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('restore-token-type-confirm'),
+      ).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(client.get).toHaveBeenCalledTimes(2));
+  });
+});

--- a/tests/shared/api/tokenTypes.test.ts
+++ b/tests/shared/api/tokenTypes.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ApiClient, TokenTypeDto } from '@/shared/api';
 
-import { isTokenTypeArray, isTokenTypeDto, listTokenTypes } from '@/shared/api';
+import {
+  createTokenType,
+  deleteTokenType,
+  isTokenTypeArray,
+  isTokenTypeDto,
+  listTokenTypes,
+  restoreTokenType,
+  updateTokenType,
+} from '@/shared/api';
 
 /**
  * Suíte do módulo `src/shared/api/tokenTypes.ts` (Issue #63, EPIC
@@ -170,6 +178,281 @@ describe('listTokenTypes', () => {
     await expect(listTokenTypes(undefined, stub as unknown as ApiClient)).rejects.toMatchObject({
       kind: 'http',
       status: 401,
+    });
+  });
+});
+
+/**
+ * Suítes de mutação do recurso "token types" (Issue #175). Espelham
+ * `tests/shared/api/systems.test.ts` — cada wrapper valida path, body
+ * trimado, omissão de `description` quando vazia, type guards e
+ * propagação de `ApiError`. Não bate em `fetch` — cobertura de
+ * transporte HTTP é responsabilidade dos testes em `client.test.ts`.
+ */
+
+describe('createTokenType', () => {
+  it('chama POST /tokens/types com payload trimado e devolve o DTO', async () => {
+    const stub = createStub();
+    const created = makeTokenTypeDto({ id: 'id-novo', name: 'Acesso padrão' });
+    stub.post.mockResolvedValueOnce(created);
+
+    const result = await createTokenType(
+      { name: '  Acesso padrão  ', code: '  default  ', description: '  Token clássico  ' },
+      undefined,
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.post).toHaveBeenCalledWith(
+      '/tokens/types',
+      { name: 'Acesso padrão', code: 'default', description: 'Token clássico' },
+      undefined,
+    );
+    expect(result).toEqual(created);
+  });
+
+  it('omite description quando string vazia ou apenas espaços', async () => {
+    const stub = createStub();
+    stub.post.mockResolvedValueOnce(makeTokenTypeDto());
+
+    await createTokenType(
+      { name: 'Padrão', code: 'default', description: '   ' },
+      undefined,
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.post).toHaveBeenCalledWith(
+      '/tokens/types',
+      { name: 'Padrão', code: 'default' },
+      undefined,
+    );
+  });
+
+  it('omite description quando undefined', async () => {
+    const stub = createStub();
+    stub.post.mockResolvedValueOnce(makeTokenTypeDto());
+
+    await createTokenType(
+      { name: 'Padrão', code: 'default' },
+      undefined,
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.post).toHaveBeenCalledWith(
+      '/tokens/types',
+      { name: 'Padrão', code: 'default' },
+      undefined,
+    );
+  });
+
+  it('lança ApiError(parse) quando a resposta não bate com o shape esperado', async () => {
+    const stub = createStub();
+    stub.post.mockResolvedValueOnce({ foo: 'bar' });
+
+    await expect(
+      createTokenType(
+        { name: 'Padrão', code: 'default' },
+        undefined,
+        stub as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+      message: expect.stringContaining('inválida'),
+    });
+  });
+
+  it('propaga ApiError do cliente em conflito 409 sem reembrulhar', async () => {
+    const stub = createStub();
+    stub.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 409,
+      message: 'Já existe um token type com este Code.',
+    });
+
+    await expect(
+      createTokenType(
+        { name: 'Padrão', code: 'default' },
+        undefined,
+        stub as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 409,
+    });
+  });
+});
+
+describe('updateTokenType', () => {
+  it('chama PUT /tokens/types/{id} com payload trimado e devolve o DTO', async () => {
+    const stub = createStub();
+    const updated = makeTokenTypeDto({ name: 'Renovação rápida' });
+    stub.put.mockResolvedValueOnce(updated);
+
+    const result = await updateTokenType(
+      TOKEN_TYPE_ID,
+      { name: '  Renovação rápida  ', code: '  refresh  ', description: '  desc  ' },
+      undefined,
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.put).toHaveBeenCalledWith(
+      `/tokens/types/${TOKEN_TYPE_ID}`,
+      { name: 'Renovação rápida', code: 'refresh', description: 'desc' },
+      undefined,
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it('omite description quando vazia após trim', async () => {
+    const stub = createStub();
+    stub.put.mockResolvedValueOnce(makeTokenTypeDto());
+
+    await updateTokenType(
+      TOKEN_TYPE_ID,
+      { name: 'Renovação', code: 'refresh', description: '' },
+      undefined,
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.put).toHaveBeenCalledWith(
+      `/tokens/types/${TOKEN_TYPE_ID}`,
+      { name: 'Renovação', code: 'refresh' },
+      undefined,
+    );
+  });
+
+  it('lança ApiError(parse) quando a resposta não bate com o shape esperado', async () => {
+    const stub = createStub();
+    stub.put.mockResolvedValueOnce(null);
+
+    await expect(
+      updateTokenType(
+        TOKEN_TYPE_ID,
+        { name: 'X', code: 'y' },
+        undefined,
+        stub as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'parse',
+    });
+  });
+
+  it('propaga ApiError 404 sem reembrulhar', async () => {
+    const stub = createStub();
+    stub.put.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Token type não encontrado.',
+    });
+
+    await expect(
+      updateTokenType(
+        TOKEN_TYPE_ID,
+        { name: 'X', code: 'y' },
+        undefined,
+        stub as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 404,
+    });
+  });
+});
+
+describe('deleteTokenType', () => {
+  it('chama DELETE /tokens/types/{id} e resolve void', async () => {
+    const stub = createStub();
+    stub.delete.mockResolvedValueOnce(undefined);
+
+    await expect(
+      deleteTokenType(TOKEN_TYPE_ID, undefined, stub as unknown as ApiClient),
+    ).resolves.toBeUndefined();
+
+    expect(stub.delete).toHaveBeenCalledWith(
+      `/tokens/types/${TOKEN_TYPE_ID}`,
+      undefined,
+    );
+  });
+
+  it('repassa as options (signal) para o cliente', async () => {
+    const stub = createStub();
+    const controller = new AbortController();
+    stub.delete.mockResolvedValueOnce(undefined);
+
+    await deleteTokenType(
+      TOKEN_TYPE_ID,
+      { signal: controller.signal },
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.delete).toHaveBeenCalledWith(`/tokens/types/${TOKEN_TYPE_ID}`, {
+      signal: controller.signal,
+    });
+  });
+
+  it('propaga ApiError 404 do cliente sem reembrulhar', async () => {
+    const stub = createStub();
+    stub.delete.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Token type não encontrado.',
+    });
+
+    await expect(
+      deleteTokenType(TOKEN_TYPE_ID, undefined, stub as unknown as ApiClient),
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 404,
+    });
+  });
+});
+
+describe('restoreTokenType', () => {
+  it('chama POST /tokens/types/{id}/restore com body undefined e resolve void', async () => {
+    const stub = createStub();
+    stub.post.mockResolvedValueOnce(undefined);
+
+    await expect(
+      restoreTokenType(TOKEN_TYPE_ID, undefined, stub as unknown as ApiClient),
+    ).resolves.toBeUndefined();
+
+    expect(stub.post).toHaveBeenCalledWith(
+      `/tokens/types/${TOKEN_TYPE_ID}/restore`,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('repassa as options (signal) para o cliente', async () => {
+    const stub = createStub();
+    const controller = new AbortController();
+    stub.post.mockResolvedValueOnce(undefined);
+
+    await restoreTokenType(
+      TOKEN_TYPE_ID,
+      { signal: controller.signal },
+      stub as unknown as ApiClient,
+    );
+
+    expect(stub.post).toHaveBeenCalledWith(
+      `/tokens/types/${TOKEN_TYPE_ID}/restore`,
+      undefined,
+      { signal: controller.signal },
+    );
+  });
+
+  it('propaga ApiError 404 do cliente sem reembrulhar', async () => {
+    const stub = createStub();
+    stub.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 404,
+      message: 'Token type não encontrado ou não está deletado.',
+    });
+
+    await expect(
+      restoreTokenType(TOKEN_TYPE_ID, undefined, stub as unknown as ApiClient),
+    ).rejects.toMatchObject({
+      kind: 'http',
+      status: 404,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Substitui o `<PlaceholderPage>` mockado em `/tokens` por um CRUD funcional de **tipos de token JWT**, espelhando o padrão estabelecido em `/systems` e `/clientes`. O título da página passa a ser "Tipos de token JWT" (Sidebar mantém "Tokens" por economia de espaço, conforme decisão da issue).
- Estende `src/shared/api/tokenTypes.ts` com `createTokenType`/`updateTokenType`/`deleteTokenType`/`restoreTokenType` e reusa toda a infraestrutura compartilhada (`useCreateEntitySubmit`/`useEditEntitySubmit`/`MutationConfirmModal`/`NameCodeDescriptionForm`) — sem código de orquestração novo nos modais.
- Como prevenção das 6 recorrências de Sonar New Code Duplication (lições PR #119/#123/#127/#128/#134/#135), extraí os helpers reusáveis (`isNameCodeDescriptionDto`, `useNameCodeDescriptionFormFieldProps`, `SoftDeleteRestoreButtons`) e refatorei `useRoleForm`/`RoleFormFields`/`SystemFormFields` para consumi-los — JSCPD reporta `newClones === 0` nos arquivos do diff.

## Escopo

- `TokensListShellPage`: listagem desktop + cards mobile, busca client-side debounced, toggle "Mostrar inativos", gating por ação, ARIA-live e tratamento de empty/error.
- 4 modais novos: criar, editar (pré-popula), desativar (soft-delete) e restaurar — todos com tratamento simétrico de 409/400/404/401/403/network.
- Permissões espelhadas no backend (`AuthenticatorRoutesSeeder`): `AUTH_V1_TOKEN_TYPES_LIST/CREATE/UPDATE/DELETE/RESTORE`.
- Refatorações de prevenção de duplicação em `src/shared/api/`, `src/shared/forms/` e `src/shared/listing/` que beneficiam todos os recursos similares.

## Fora de escopo

- Listagem de **JWTs emitidos** ou painel de `tokenVersion` — backend não expõe (o texto mock antigo era enganoso).
- Renomeação do label "Tokens" na Sidebar (mantida por decisão da issue).

## Test plan

- [x] `docker compose run --rm web npm run lint` — 0 erros / 0 warnings.
- [x] `docker compose run --rm web npm run typecheck` — 0 erros.
- [x] `docker compose run --rm web npm test -- tests/pages/tokens tests/shared/api/tokenTypes.test.ts` — 26 + 29 = 55 testes verdes.
- [x] `docker compose run --rm web npm test -- tests/pages/RolesPage.create.test.tsx tests/pages/RolesPage.edit.test.tsx tests/pages/SystemsPage.create.test.tsx tests/pages/SystemsPage.edit.test.tsx tests/pages/RoutesPage.test.tsx tests/shared/api` — todos verdes (suítes afetadas pelas refatorações em `useRoleForm`/`SystemFormFields`/`RouteDto` etc.).
- [x] `docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10` — total `1.9%` < 3%; `newClones === 0` nos 24 arquivos do diff (verificado programaticamente).
- [x] Suíte completa: `1513/1514` testes verdes — a 1 falha residual (`tests/App.test.tsx`) é flakiness pré-existente (passou em isolation; baseline `origin/development` apresenta o mesmo padrão de timeouts em paralelo, com `1463/1473` no run de comparação realizado antes desta PR).

## Visual

- Layout responsivo desktop/mobile espelhando `ClientsListShellPage`/`SystemsPage`.
- Estados loading/error/empty/refetch tratados via `<ListingResultArea>`.
- Hover/focus/disabled herdados dos `<Button>`/`<Input>` do design system; sem hardcode de cor — todas as cores via tokens (`var(--clr-*)`).
- Mobile cards com cabeçalho `<Mono>{code}</Mono>` + `<StatusBadge>`, nome em destaque, descrição truncada, ações inline.

## Segurança

Sem mudança no perfil de risco. O acesso é gateado por `RequirePermission` na rota e por `hasPermission` em cada CTA; o backend valida via `[Authorize(Policy = SystemTokensTypes*)]`. Não há novos `dangerouslySetInnerHTML`, exposição de tokens, logs sensíveis ou URLs externas renderizadas.

## Riscos

Baixo. As refatorações em `useRoleForm`/`SystemFormFields`/`RouteDto`/`SystemDto` são deduplicações estruturais que não alteram comportamento — todas as suítes correspondentes passam (80 testes em roles + 51 em sistemas + 22 em rotas + 325 em api/* total). O fluxo de tokens é novo e independente.

## Issue relacionada

Closes #175