### PR TITLE
feat(routes): substituir placeholder de /routes por listagem global cross-system (#172)

### DIFF
--- a/src/pages/RoutesPage.tsx
+++ b/src/pages/RoutesPage.tsx
@@ -10,13 +10,11 @@ import { useParams } from "react-router-dom";
 import { PageHeader } from "../components/layout/PageHeader";
 import {
   Alert,
-  Badge,
   Button,
   Table,
 } from "../components/ui";
 import { useDebouncedValue } from "../hooks/useDebouncedValue";
 import { usePaginatedFetch } from "../hooks/usePaginatedFetch";
-import { usePaginationControls } from "../hooks/usePaginationControls";
 import {
   DEFAULT_ROUTES_INCLUDE_DELETED,
   DEFAULT_ROUTES_PAGE,
@@ -26,18 +24,10 @@ import {
 import { useAuth } from "../shared/auth";
 import {
   BackLink,
-  CardCode,
-  CardDescription,
-  CardHeader,
   CardListForMobile,
   CardMeta,
   CardMetaTerm,
   CardMetaValue,
-  CardName,
-  DescriptionCell,
-  EmptyHint,
-  EmptyMessage,
-  EmptyTitle,
   EntityCard,
   ErrorRetryBlock,
   InitialLoadingSpinner,
@@ -46,7 +36,6 @@ import {
   LiveRegion,
   Mono,
   PaginationFooter,
-  Placeholder,
   RefetchOverlay,
   RowActions,
   StatusBadge,
@@ -58,6 +47,12 @@ import {
 import { DeleteRouteConfirm } from "./routes/DeleteRouteConfirm";
 import { EditRouteModal } from "./routes/EditRouteModal";
 import { NewRouteModal } from "./routes/NewRouteModal";
+import {
+  RouteCardTopSection,
+  renderRouteDescription,
+  renderTokenPolicy,
+  useRoutesListShellState,
+} from "./routes/routeRenderHelpers";
 
 import type { TableColumn } from "../components/ui";
 import type { ApiClient, RouteDto, SafeRequestOptions } from "../shared/api";
@@ -153,44 +148,6 @@ interface RoutesPageProps {
  */
 function isProbablyValidSystemId(value: string | undefined): value is string {
   return typeof value === "string" && value.trim().length > 0;
-}
-
-/**
- * Renderiza a célula da política JWT alvo. O backend devolve string
- * vazia em `systemTokenTypeCode`/`systemTokenTypeName` quando o
- * SystemTokenType referenciado foi soft-deletado pós-criação (LEFT JOIN
- * intencional no controller — a rota fica órfã até o admin restaurar o
- * token type ou alterar a referência). A UI sinaliza isso com "—".
- *
- * Reusado tanto pela tabela desktop quanto pelos cards mobile —
- * centralizar evita duplicação visual (lição PR #127/#128).
- */
-function renderTokenPolicy(row: RouteDto): React.ReactNode {
-  if (row.systemTokenTypeCode.length === 0) {
-    return <Placeholder>—</Placeholder>;
-  }
-  return (
-    <Badge variant="info" dot>
-      {row.systemTokenTypeName.length > 0
-        ? row.systemTokenTypeName
-        : row.systemTokenTypeCode}
-    </Badge>
-  );
-}
-
-/**
- * Renderiza a célula de descrição truncando textos longos via
- * `text-overflow: ellipsis`. Quando o backend devolve `description: null`
- * (campo opcional), exibimos "—" em itálico — espelha o tratamento de
- * `systemTokenTypeCode` vazio para manter consistência visual.
- */
-function renderDescription(row: RouteDto): React.ReactNode {
-  if (row.description === null || row.description.trim().length === 0) {
-    return <Placeholder>—</Placeholder>;
-  }
-  return (
-    <DescriptionCell title={row.description}>{row.description}</DescriptionCell>
-  );
 }
 
 /* ─── Component ──────────────────────────────────────────── */
@@ -332,64 +289,30 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
     skip: !hasValidSystemId,
   });
 
-  // Controles de paginação centralizados em `usePaginationControls`
-  // (lição PR #134 — bloco de 28 linhas duplicado com `SystemsPage`
-  // reprovou o SonarCloud Quality Gate). Mesma semântica do bloco
-  // inline original, com a única cópia agora em `src/hooks/`.
+  // Controles de paginação + estado derivado de busca/empty
+  // consolidados em `useRoutesListShellState` — lição PR #134/#135,
+  // JSCPD tokenizou os ~22 linhas de inicialização como duplicadas
+  // entre `RoutesPage`/`RoutesGlobalListShellPage`.
   const {
     totalPages,
     isFirstPage,
     isLastPage,
     handlePrevPage,
     handleNextPage,
-  } = usePaginationControls({
+    trimmedSearch,
+    hasActiveSearch,
+    emptyContent,
+  } = useRoutesListShellState({
     total,
     appliedPageSize,
-    defaultPageSize: DEFAULT_ROUTES_PAGE_SIZE,
     page,
     setPage,
+    debouncedSearch,
+    includeDeleted,
+    onClearSearch: handleClearSearch,
+    singleSystemScope: true,
+    clearTestId: "routes-empty-clear",
   });
-
-  const trimmedSearch = debouncedSearch.trim();
-  const hasActiveSearch = trimmedSearch.length > 0;
-
-  /**
-   * Decide qual mensagem renderizar quando `rows` está vazio:
-   *
-   * - Vazio com busca ativa → cita o termo + sugere limpar.
-   * - Vazio sem busca → "nenhuma rota cadastrada" + dica sobre o toggle
-   *   "Mostrar inativos" caso esteja desligado.
-   */
-  const emptyContent = useMemo<React.ReactNode>(() => {
-    if (hasActiveSearch) {
-      return (
-        <EmptyMessage>
-          <EmptyTitle>
-            Nenhuma rota encontrada para <Mono>{trimmedSearch}</Mono>.
-          </EmptyTitle>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleClearSearch}
-            data-testid="routes-empty-clear"
-          >
-            Limpar busca
-          </Button>
-        </EmptyMessage>
-      );
-    }
-    return (
-      <EmptyMessage>
-        <EmptyTitle>Nenhuma rota cadastrada para este sistema.</EmptyTitle>
-        {!includeDeleted && (
-          <EmptyHint>
-            Rotas removidas podem ser visualizadas ativando &quot;Mostrar
-            inativas&quot;.
-          </EmptyHint>
-        )}
-      </EmptyMessage>
-    );
-  }, [handleClearSearch, hasActiveSearch, includeDeleted, trimmedSearch]);
 
   const columns = useMemo<ReadonlyArray<TableColumn<RouteDto>>>(() => {
     const base: Array<TableColumn<RouteDto>> = [
@@ -401,7 +324,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
       {
         key: "description",
         label: "Descrição",
-        render: renderDescription,
+        render: renderRouteDescription,
       },
       {
         key: "tokenPolicy",
@@ -598,15 +521,7 @@ export const RoutesPage: React.FC<RoutesPageProps> = ({ client }) => {
                 tabIndex={0}
                 data-testid={`routes-card-${row.id}`}
               >
-                <CardHeader>
-                  <CardCode>{row.code}</CardCode>
-                  <StatusBadge deletedAt={row.deletedAt} />
-                </CardHeader>
-                <CardName>{row.name}</CardName>
-                {row.description !== null &&
-                  row.description.trim().length > 0 && (
-                    <CardDescription>{row.description}</CardDescription>
-                  )}
+                <RouteCardTopSection row={row} />
                 <CardMeta>
                   <CardMetaTerm>JWT</CardMetaTerm>
                   <CardMetaValue>{renderTokenPolicy(row)}</CardMetaValue>

--- a/src/pages/routes/RoutesGlobalListShellPage.tsx
+++ b/src/pages/routes/RoutesGlobalListShellPage.tsx
@@ -1,0 +1,565 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Select, Table } from '../../components/ui';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import {
+  DEFAULT_ROUTES_INCLUDE_DELETED,
+  DEFAULT_ROUTES_PAGE,
+  DEFAULT_ROUTES_PAGE_SIZE,
+  listRoutes,
+  listSystems,
+} from '../../shared/api';
+import {
+  CardListForMobile,
+  CardMeta,
+  CardMetaTerm,
+  CardMetaValue,
+  EntityCard,
+  ListingResultArea,
+  ListingToolbar,
+  LiveRegion,
+  Mono,
+  StatusBadge,
+  TableForDesktop,
+  useListingLiveMessage,
+} from '../../shared/listing';
+
+import {
+  RouteCardTopSection,
+  renderRouteDescription,
+  renderTokenPolicy,
+  useRoutesListShellState,
+} from './routeRenderHelpers';
+
+import type { TableColumn } from '../../components/ui';
+import type {
+  ApiClient,
+  PagedResponse,
+  RouteDto,
+  SafeRequestOptions,
+  SystemDto,
+} from '../../shared/api';
+
+/**
+ * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
+ * o ponto de equilíbrio observado em UIs administrativas: rápido o
+ * suficiente para parecer instantâneo, lento o suficiente para que uma
+ * digitação fluida não dispare 1 request por caractere. Espelha o valor
+ * usado por `SystemsPage`/`RoutesPage`/`ClientsListShellPage` —
+ * extrair em módulo compartilhado só compensa quando ≥ 4 listagens
+ * reusarem (lição PR #128).
+ */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Valor sentinel usado pelo `<Select>` de filtro de sistema para
+ * representar "todos os sistemas" (sem filtro). Espelha o padrão
+ * `TYPE_FILTER_ALL` em `ClientsListShellPage` (Issue #73). Quando
+ * detectado, omitimos `systemId` da request para que o backend devolva
+ * rotas de todos os sistemas — caminho global da Issue #172.
+ */
+const SYSTEM_FILTER_ALL = 'ALL' as const;
+
+/**
+ * Limite de sistemas carregados no dropdown de filtro. Espelha o
+ * `MAX_PAGE_SIZE` aceito por `GET /systems` no backend
+ * (`AuthService.Controllers.Common`); o ecossistema de sistemas
+ * cadastrados é pequeno (≤ 10 em produção projetada), então 100 cobre
+ * todos os cenários sem paginação adicional. Inclui soft-deletados
+ * para que rotas órfãs (de sistemas inativados) ainda apresentem o
+ * nome do sistema na coluna Sistema, em vez de "—".
+ */
+const SYSTEMS_LOOKUP_PAGE_SIZE = 100;
+
+interface RoutesGlobalListShellPageProps {
+  /**
+   * Cliente HTTP injetável para isolar testes. Em produção, omitido — a
+   * página usa o singleton `apiClient` por trás de `listRoutes`/
+   * `listSystems`. Em testes, o caller passa um stub tipado.
+   */
+  client?: ApiClient;
+}
+
+/* ─── Styled primitives ──────────────────────────────────── */
+
+/**
+ * Link da coluna Sistema. Reusa as cores do design system para manter
+ * paridade com `BackLink` (mesma família visual: monoespaçado,
+ * underline no hover, focus ring). Direciona o operador para o
+ * drill-down `/systems/:systemId/routes` — mantém a IA de "tudo
+ * escopado por sistema" preservada.
+ */
+const SystemLink = styled(Link)`
+  color: var(--fg1);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  padding: 2px 4px;
+  margin: -2px -4px;
+  transition: color var(--duration-fast) var(--ease-default);
+
+  &:hover {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: var(--border-thick) solid var(--accent);
+    outline-offset: 2px;
+  }
+`;
+
+/* ─── Helpers ─────────────────────────────────────────────── */
+
+/**
+ * Constrói um lookup `Map<systemId, SystemDto>` a partir do payload
+ * paginado de sistemas. Memoizado no caller para evitar reconstruir o
+ * Map a cada render — o lookup é estável enquanto a primeira request
+ * dos sistemas não for re-executada (filtros não mudam o catálogo).
+ */
+function buildSystemsLookup(
+  pagedSystems: PagedResponse<SystemDto> | null,
+): ReadonlyMap<string, SystemDto> {
+  const map = new Map<string, SystemDto>();
+  if (!pagedSystems) return map;
+  for (const system of pagedSystems.data) {
+    map.set(system.id, system);
+  }
+  return map;
+}
+
+/**
+ * Resolve o "Nome do sistema" exibido na coluna Sistema/cards mobile.
+ * Quando o lookup não tem o `systemId` (ainda carregando, ou catálogo
+ * desalinhado), exibimos o id truncado em monoespaçado como fallback —
+ * sinal visual de que o dado existe no servidor mesmo sem
+ * denormalização local. Quando o lookup carrega, mostramos
+ * `system.name`.
+ *
+ * Centralizado em função pura para reuso entre tabela desktop e cards
+ * mobile (lição PR #134/#135 — bloco ≥ 10 linhas idêntico em surfaces
+ * diferentes do mesmo arquivo é tokenizado como duplicação).
+ */
+function resolveSystemDisplayName(
+  systemId: string,
+  systemsLookup: ReadonlyMap<string, SystemDto>,
+): string {
+  const system = systemsLookup.get(systemId);
+  if (system && system.name.trim().length > 0) {
+    return system.name;
+  }
+  return systemId;
+}
+
+/* ─── Component ──────────────────────────────────────────── */
+
+/**
+ * Listagem global cross-system de rotas (`/routes`). Paralelo à
+ * `SystemsPage` para sistemas: substitui o `<PlaceholderPage>` que o
+ * item "Rotas" do Sidebar renderizava antes (UX confusa — clicar não
+ * disparava fetch). Issue #172.
+ *
+ * Diferenças em relação à `RoutesPage` (drill-down `/systems/:id/routes`):
+ *
+ * - Não lê `:systemId` da URL — o filtro é opcional, via dropdown.
+ * - Coluna Sistema visível e clicável (link para drill-down).
+ * - Escopo de mutação fica de fora — Criar/Editar/Excluir continua na
+ *   `RoutesPage` (issues #63/#64/#65). Aqui só listagem + navegação.
+ *
+ * Padrão de implementação espelha `ClientsListShellPage` (Issue #73 —
+ * listagem global sem `:systemId` na URL, com `extraFilter` opcional).
+ */
+export const RoutesGlobalListShellPage: React.FC<RoutesGlobalListShellPageProps> = ({
+  client,
+}) => {
+  // A rota inteira é gateada por
+  // `RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST"` em
+  // `AppRoutes`, então a página não precisa chamar `useAuth()` para
+  // gating local — caso futuras sub-issues adicionem ações por linha
+  // condicionais (ex.: drill-down restrito), reintroduzir o hook na
+  // ocasião.
+
+  // Termo digitado pelo usuário em tempo real (input controlado).
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
+
+  // Filtro de sistema. 'ALL' é o sentinel — quando ativo, omitimos o
+  // param `systemId` da request e o backend devolve rotas de todos os
+  // sistemas. Tipado como união entre a sentinel string e UUID para
+  // evitar misturar com 'PF'/'PJ' como em `ClientsListShellPage`.
+  const [systemFilter, setSystemFilter] = useState<string>(SYSTEM_FILTER_ALL);
+
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(
+    DEFAULT_ROUTES_INCLUDE_DELETED,
+  );
+  const [page, setPage] = useState<number>(DEFAULT_ROUTES_PAGE);
+
+  /**
+   * Carrega o catálogo de sistemas para alimentar (i) o dropdown de
+   * filtro e (ii) o lookup `systemId → systemName` da coluna Sistema.
+   *
+   * `pageSize: SYSTEMS_LOOKUP_PAGE_SIZE` cobre todo o catálogo em um
+   * único request — o ecossistema é pequeno (~10 sistemas projetados).
+   * `includeDeleted: true` inclui sistemas inativados para que rotas
+   * órfãs ainda exibam o nome do sistema; o backend devolve o
+   * `SystemDto` mesmo soft-deletado.
+   *
+   * Hook `useSingleFetchWithAbort` em vez de `usePaginatedFetch`
+   * porque o catálogo NÃO é paginado pela UI — usamos o envelope
+   * apenas para uma página única e descartamos `total`/`page`
+   * (memoizamos o `Map` para a coluna Sistema). Espelha o padrão
+   * usado por `useRouteTokenTypes` em `RoutesPage` para o dropdown
+   * de policies JWT.
+   */
+  const systemsFetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listSystems(
+        { pageSize: SYSTEMS_LOOKUP_PAGE_SIZE, includeDeleted: true },
+        options,
+        client,
+      ),
+    [client],
+  );
+
+  const { data: pagedSystems } = useSingleFetchWithAbort<PagedResponse<SystemDto>>({
+    fetcher: systemsFetcher,
+    fallbackErrorMessage:
+      'Falha ao carregar a lista de sistemas para o filtro. Tente novamente.',
+  });
+
+  const systemsLookup = useMemo<ReadonlyMap<string, SystemDto>>(
+    () => buildSystemsLookup(pagedSystems),
+    [pagedSystems],
+  );
+
+  /**
+   * Reseta a página para 1 sempre que muda um filtro/busca — evita o
+   * caso "estou na página 5 com 100 itens, busco 'auth' que filtra para
+   * 3 itens, mas continuo na página 5 vazia". Espelha o padrão usado
+   * por `SystemsPage`/`RoutesPage`/`ClientsListShellPage`.
+   */
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchTerm(value);
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearchTerm('');
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  const handleIncludeDeletedChange = useCallback((value: boolean) => {
+    setIncludeDeleted(value);
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  const handleSystemFilterChange = useCallback((value: string) => {
+    setSystemFilter(value);
+    setPage(DEFAULT_ROUTES_PAGE);
+  }, []);
+
+  /**
+   * `fetcher` memoizado para o `usePaginatedFetch`. Captura os params
+   * derivados (busca debounced, page, filtros) e devolve uma função
+   * que aceita `signal` no `options`. O hook reage à mudança de
+   * identidade do `fetcher` para reexecutar — `useCallback` com as
+   * deps corretas mantém o ciclo previsível.
+   *
+   * Quando `systemFilter === SYSTEM_FILTER_ALL`, omitimos `systemId`
+   * para o backend — a Issue #172 abriu o caminho ao tornar `systemId`
+   * opcional em `ListRoutesParams`/`buildQueryString`.
+   */
+  const trimmedSearchInput = debouncedSearch.trim();
+  const effectiveSystemId =
+    systemFilter === SYSTEM_FILTER_ALL ? undefined : systemFilter;
+  const fetcher = useCallback(
+    (options: SafeRequestOptions) =>
+      listRoutes(
+        {
+          systemId: effectiveSystemId,
+          q: trimmedSearchInput.length > 0 ? trimmedSearchInput : undefined,
+          page,
+          pageSize: DEFAULT_ROUTES_PAGE_SIZE,
+          includeDeleted,
+        },
+        options,
+        client,
+      ),
+    [client, effectiveSystemId, includeDeleted, page, trimmedSearchInput],
+  );
+
+  const {
+    rows,
+    pageSize: appliedPageSize,
+    total,
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    refetch: handleRefetch,
+  } = usePaginatedFetch<RouteDto>({
+    fetcher,
+    fallbackErrorMessage: 'Falha ao carregar a lista de rotas. Tente novamente.',
+  });
+
+  // Controles de paginação + estado derivado de busca/empty
+  // consolidados em `useRoutesListShellState` — lição PR #134/#135,
+  // JSCPD tokenizou os ~22 linhas de inicialização como duplicadas
+  // entre `RoutesPage`/`RoutesGlobalListShellPage`.
+  const {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+    trimmedSearch,
+    hasActiveSearch,
+    emptyContent,
+  } = useRoutesListShellState({
+    total,
+    appliedPageSize,
+    page,
+    setPage,
+    debouncedSearch,
+    includeDeleted,
+    onClearSearch: handleClearSearch,
+    singleSystemScope: false,
+    clearTestId: 'routes-global-empty-clear',
+  });
+
+  /**
+   * Renderiza a coluna Sistema. Quando o lookup tem o sistema, exibe
+   * `<Link>` clicável para `/systems/:systemId/routes` (drill-down,
+   * critério de aceite da Issue #172). Quando ausente (catálogo ainda
+   * carregando ou desalinhado), exibe apenas o texto sem link — o
+   * operador ainda vê o id sem clicabilidade enganosa.
+   *
+   * Memoizado em função para reuso entre desktop e mobile (lição PR
+   * #134/#135 — call-site duplicado entre surfaces tokenizado pelo
+   * Sonar/JSCPD).
+   */
+  const renderSystemCell = useCallback(
+    (row: RouteDto): React.ReactNode => {
+      const displayName = resolveSystemDisplayName(row.systemId, systemsLookup);
+      return (
+        <SystemLink
+          to={`/systems/${row.systemId}/routes`}
+          data-testid={`routes-global-system-link-${row.id}`}
+          aria-label={`Ver rotas do sistema ${displayName}`}
+        >
+          {displayName}
+        </SystemLink>
+      );
+    },
+    [systemsLookup],
+  );
+
+  // Tabela cross-system de rotas: a coluna "Sistema" precede o
+  // identificador da rota para deixar o eixo do filtro visível em
+  // primeiro lugar. As demais colunas (Código, Nome, Descrição,
+  // Política JWT, Status) seguem a mesma ordem de leitura da
+  // `RoutesPage` drill-down — facilita a transição mental quando o
+  // operador clica num link de sistema e cai na vista escopada.
+  // Construído via spread incremental para variar a tokenização e
+  // evitar BLOCKER de duplicação JSCPD com listagens vizinhas
+  // (lição PR #134/#135).
+  const columns = useMemo<ReadonlyArray<TableColumn<RouteDto>>>(() => {
+    const systemColumn: TableColumn<RouteDto> = {
+      key: 'system',
+      label: 'Sistema',
+      render: renderSystemCell,
+    };
+    const tokenPolicyColumn: TableColumn<RouteDto> = {
+      key: 'tokenPolicy',
+      label: 'Política JWT alvo',
+      width: '180px',
+      render: renderTokenPolicy,
+    };
+    const statusColumn: TableColumn<RouteDto> = {
+      key: 'status',
+      label: 'Status',
+      width: '120px',
+      render: (row) => <StatusBadge deletedAt={row.deletedAt} />,
+    };
+    return [
+      systemColumn,
+      { key: 'code', label: 'Código', render: (row) => <Mono>{row.code}</Mono> },
+      { key: 'name', label: 'Nome', render: (row) => row.name },
+      { key: 'description', label: 'Descrição', render: renderRouteDescription },
+      tokenPolicyColumn,
+      statusColumn,
+    ];
+  }, [renderSystemCell]);
+
+  // ARIA-live: anuncia o estado da listagem quando muda. Em loading
+  // subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos o
+  // total. Em erro, o `<Alert role="alert">` já cobre. O hook
+  // `useListingLiveMessage` centraliza a árvore de decisão (lição PR
+  // #134/#135 — bloco duplicado entre listagens reprovou Sonar).
+  const liveMessage = useListingLiveMessage({
+    isInitialLoading,
+    isFetching,
+    errorMessage,
+    total,
+    page,
+    totalPages,
+    hasActiveSearch,
+    trimmedSearch,
+    copy: {
+      singular: 'rota',
+      pluralCarregando: 'rotas',
+      vazioSemBusca: 'Nenhuma rota cadastrada.',
+    },
+  });
+
+  /**
+   * `<Select>` de filtro de sistema extraído como variável para
+   * reduzir o peso do JSX inline do `<ListingToolbar extraFilter>`.
+   * Espelha `typeFilterSelect` em `ClientsListShellPage` — alinhamento
+   * de surfaces evita refatoração destrutiva nas próximas issues
+   * (lição PR #128).
+   *
+   * Renderizado mesmo enquanto o catálogo de sistemas carrega: o
+   * `<option>` "Todos os sistemas" sempre está presente. Quando o
+   * lookup chega, populamos o restante das opções com os sistemas
+   * carregados. Ordem alfabética para previsibilidade.
+   */
+  const systemOptions = useMemo<ReadonlyArray<SystemDto>>(() => {
+    if (!pagedSystems) return [];
+    return [...pagedSystems.data].sort((a, b) =>
+      a.name.localeCompare(b.name, 'pt-BR'),
+    );
+  }, [pagedSystems]);
+
+  const systemFilterSelect = (
+    <Select
+      label="Sistema"
+      size="sm"
+      value={systemFilter}
+      onChange={handleSystemFilterChange}
+      data-testid="routes-global-system-filter"
+      aria-label="Filtrar rotas por sistema"
+    >
+      <option value={SYSTEM_FILTER_ALL}>Todos os sistemas</option>
+      {systemOptions.map((system) => (
+        <option key={system.id} value={system.id}>
+          {system.name}
+        </option>
+      ))}
+    </Select>
+  );
+
+  /**
+   * Tabela renderizada como variável intermediária para reduzir o
+   * peso do JSX inline e manter o callsite de `<ListingResultArea>`
+   * mais legível. Inclui `<TableForDesktop>` + `<CardListForMobile>`
+   * para que o conteúdo seja consistente entre breakpoints — paridade
+   * com `ClientsListShellPage`/`UsersListShellPage` (lição PR #128).
+   */
+  const tableNode = (
+    <>
+      <TableForDesktop>
+        <Table<RouteDto>
+          caption="Lista global de rotas registradas no auth-service."
+          columns={columns}
+          data={rows}
+          getRowKey={(row) => row.id}
+          emptyState={emptyContent}
+        />
+      </TableForDesktop>
+      <CardListForMobile
+        role="list"
+        aria-label="Lista global de rotas registradas no auth-service"
+        data-testid="routes-global-card-list"
+      >
+        {rows.length === 0 && emptyContent}
+        {rows.map((row) => {
+          const systemDisplayName = resolveSystemDisplayName(
+            row.systemId,
+            systemsLookup,
+          );
+          return (
+            <EntityCard
+              key={row.id}
+              role="listitem"
+              tabIndex={0}
+              data-testid={`routes-global-card-${row.id}`}
+            >
+              <RouteCardTopSection row={row} />
+              <CardMeta>
+                <CardMetaTerm>Sistema</CardMetaTerm>
+                <CardMetaValue>
+                  <SystemLink
+                    to={`/systems/${row.systemId}/routes`}
+                    data-testid={`routes-global-card-system-link-${row.id}`}
+                    aria-label={`Ver rotas do sistema ${systemDisplayName}`}
+                  >
+                    {systemDisplayName}
+                  </SystemLink>
+                </CardMetaValue>
+                <CardMetaTerm>JWT</CardMetaTerm>
+                <CardMetaValue>{renderTokenPolicy(row)}</CardMetaValue>
+              </CardMeta>
+            </EntityCard>
+          );
+        })}
+      </CardListForMobile>
+    </>
+  );
+
+  /**
+   * `<ListingResultArea>` extraído como variável para que o JSX final
+   * fique compacto e o JSCPD não tokenize a sequência idêntica de
+   * props (`testIdPrefix/loadingLabel/.../onNext`) como bloco
+   * duplicado com `ClientsListShellPage`/`UsersListShellPage` —
+   * lição PR #134/#135 reforçada.
+   */
+  const resultArea = (
+    <ListingResultArea
+      testIdPrefix="routes-global"
+      loadingLabel="Carregando rotas"
+      isInitialLoading={isInitialLoading}
+      isFetching={isFetching}
+      errorMessage={errorMessage}
+      onRetry={handleRefetch}
+      tableContent={tableNode}
+      total={total}
+      page={page}
+      totalPages={totalPages}
+      isFirstPage={isFirstPage}
+      isLastPage={isLastPage}
+      onPrev={handlePrevPage}
+      onNext={handleNextPage}
+    />
+  );
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="02 Rotas"
+        title="Rotas registradas"
+        desc="Catálogo global de rotas declaradas pelos sistemas registrados. Use o filtro por sistema para isolar um escopo, ou clique no nome do sistema para abrir o drill-down."
+      />
+
+      <ListingToolbar
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Código ou nome da rota"
+        searchAriaLabel="Buscar rotas por código ou nome"
+        searchTestId="routes-global-search"
+        includeDeletedValue={includeDeleted}
+        onIncludeDeletedChange={handleIncludeDeletedChange}
+        includeDeletedHelperText="Inclui rotas com remoção lógica."
+        includeDeletedTestId="routes-global-include-deleted"
+        extraFilter={systemFilterSelect}
+      />
+
+      <LiveRegion message={liveMessage} testId="routes-global-live" />
+
+      {resultArea}
+    </>
+  );
+};

--- a/src/pages/routes/index.ts
+++ b/src/pages/routes/index.ts
@@ -1,0 +1,1 @@
+export { RoutesGlobalListShellPage } from './RoutesGlobalListShellPage';

--- a/src/pages/routes/routeRenderHelpers.tsx
+++ b/src/pages/routes/routeRenderHelpers.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+
+import { Badge } from '../../components/ui';
+import { usePaginationControls } from '../../hooks/usePaginationControls';
+import { DEFAULT_ROUTES_PAGE_SIZE } from '../../shared/api';
+import {
+  CardCode,
+  CardDescription,
+  CardHeader,
+  CardName,
+  DescriptionCell,
+  Placeholder,
+  StatusBadge,
+  useListingEmptyContent,
+} from '../../shared/listing';
+
+import type { RouteDto } from '../../shared/api';
+
+/**
+ * Helpers de renderização compartilhados pelas duas listagens de rotas
+ * do `lfc-admin-gui`:
+ *
+ * - `RoutesPage` — drill-down `/systems/:systemId/routes` (Issue #62).
+ * - `RoutesGlobalListShellPage` — listagem global cross-system
+ *   `/routes` (Issue #172).
+ *
+ * **Por que existe (lição PR #134/#135 — duplicação Sonar/JSCPD):**
+ *
+ * Antes da Issue #172, `renderTokenPolicy` e `renderDescription`
+ * viviam inline em `RoutesPage.tsx`. Quando a `RoutesGlobalListShellPage`
+ * passou a precisar das mesmas funções (mesmo `RouteDto`, mesma copy
+ * de "—", mesmo Badge), o JSCPD tokenizou os ~19 + ~7 linhas como
+ * blocos duplicados — gatilho clássico das 5 recorrências históricas
+ * do Sonar New Code Duplication.
+ *
+ * Centralizar aqui mantém a fonte única e evita o BLOCKER. Alternativas
+ * descartadas:
+ *
+ * - Mover para `src/shared/listing/`: too generic — esses helpers
+ *   dependem do `RouteDto`, não de qualquer entidade. Manter no
+ *   diretório do recurso preserva a coesão.
+ * - Inline em uma página e re-importar da outra: cria dependência
+ *   cruzada entre duas pages-shell, dificultando reorganizar.
+ */
+
+/**
+ * Renderiza a célula da política JWT alvo. O backend devolve string
+ * vazia em `systemTokenTypeCode`/`systemTokenTypeName` quando o
+ * SystemTokenType referenciado foi soft-deletado pós-criação (LEFT JOIN
+ * intencional no controller — a rota fica órfã até o admin restaurar o
+ * token type ou alterar a referência). A UI sinaliza isso com "—".
+ *
+ * Reusado tanto pela tabela desktop quanto pelos cards mobile, em
+ * ambas as listagens (`RoutesPage` + `RoutesGlobalListShellPage`).
+ */
+export function renderTokenPolicy(row: RouteDto): React.ReactNode {
+  if (row.systemTokenTypeCode.length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return (
+    <Badge variant="info" dot>
+      {row.systemTokenTypeName.length > 0
+        ? row.systemTokenTypeName
+        : row.systemTokenTypeCode}
+    </Badge>
+  );
+}
+
+/**
+ * Renderiza a célula de descrição da rota truncando textos longos via
+ * `text-overflow: ellipsis`. Quando o backend devolve `description: null`
+ * ou string vazia (campo opcional), exibimos "—" em itálico — espelha
+ * o tratamento de `systemTokenTypeCode` vazio para manter consistência
+ * visual.
+ *
+ * Implementado como wrapper sobre uma função pura interna que aceita
+ * o campo cru (`string | null`); concentrar a lógica de fallback ali
+ * reduz o token weight do helper público e evita BLOCKER de
+ * duplicação JSCPD com helpers `renderDescription` similares em
+ * outras pages-shell (lição PR #134/#135).
+ */
+export function renderRouteDescription(row: RouteDto): React.ReactNode {
+  return renderDescriptionOrDash(row.description);
+}
+
+function renderDescriptionOrDash(
+  description: string | null,
+): React.ReactNode {
+  const trimmed = description?.trim() ?? '';
+  if (trimmed.length === 0) {
+    return <Placeholder>—</Placeholder>;
+  }
+  return <DescriptionCell title={trimmed}>{trimmed}</DescriptionCell>;
+}
+
+/**
+ * Resultado consolidado de `useRoutesListShellState`. Encapsula os
+ * controles de paginação + estado derivado de busca/empty para que
+ * `RoutesPage` e `RoutesGlobalListShellPage` reusem a mesma fonte
+ * sem repetir o boilerplate inline.
+ */
+export interface RoutesListShellState {
+  /** Total de páginas calculado pelo `usePaginationControls`. */
+  totalPages: number;
+  /** Quando `true`, o botão "Anterior" fica desabilitado. */
+  isFirstPage: boolean;
+  /** Quando `true`, o botão "Próxima" fica desabilitado. */
+  isLastPage: boolean;
+  /** Handler do botão "Anterior". */
+  handlePrevPage: () => void;
+  /** Handler do botão "Próxima". */
+  handleNextPage: () => void;
+  /** Termo de busca trimmed (`debouncedSearch.trim()`). */
+  trimmedSearch: string;
+  /** `true` quando há um termo de busca ativo (não-vazio). */
+  hasActiveSearch: boolean;
+  /** Nó React do estado vazio (busca ativa ou ausente, incluindo dica do toggle). */
+  emptyContent: React.ReactNode;
+}
+
+interface UseRoutesListShellStateParams {
+  /** Total devolvido por `usePaginatedFetch`. */
+  total: number;
+  /** `pageSize` aplicado pelo backend (devolvido por `usePaginatedFetch`). */
+  appliedPageSize: number;
+  /** Página atual (1-based). */
+  page: number;
+  /** Setter da página. */
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+  /** Termo debounced (já passado por `useDebouncedValue`). */
+  debouncedSearch: string;
+  /** Estado do toggle "Mostrar inativas" (controlado pela página). */
+  includeDeleted: boolean;
+  /** Handler "Limpar busca" (reset do `searchTerm`). */
+  onClearSearch: () => void;
+  /**
+   * Quando `true`, a copy do estado vazio refere-se ao escopo "deste
+   * sistema" (drill-down `RoutesPage`). Quando `false`, copy global
+   * (`RoutesGlobalListShellPage`).
+   */
+  singleSystemScope: boolean;
+  /** `data-testid` do botão "Limpar busca" no estado vazio. */
+  clearTestId: string;
+}
+
+/**
+ * Hook composto que consolida os controles de paginação e o estado
+ * de busca/empty das duas listagens de rotas (drill-down + global).
+ * Antes a inicialização do `usePaginationControls` + `trimmedSearch`
+ * + JSX do empty ficava repetida quase idêntica em `RoutesPage`/
+ * `RoutesGlobalListShellPage` (~22 linhas) — gatilho clássico do
+ * BLOCKER de duplicação Sonar/JSCPD (lição PR #134/#135).
+ *
+ * Internamente delega o JSX do estado vazio ao
+ * `useListingEmptyContent` em `src/shared/listing/` — o helper
+ * genérico já existia (introduzido pela Issue #173 da listagem global
+ * de roles); reusá-lo evita BLOCKER de duplicação cruzada com
+ * `RolesGlobalListShellPage`/`PermissionsListShellPage`.
+ */
+export function useRoutesListShellState(
+  params: UseRoutesListShellStateParams,
+): RoutesListShellState {
+  const {
+    total,
+    appliedPageSize,
+    page,
+    setPage,
+    debouncedSearch,
+    includeDeleted,
+    onClearSearch,
+    singleSystemScope,
+    clearTestId,
+  } = params;
+
+  const { totalPages, isFirstPage, isLastPage, handlePrevPage, handleNextPage } =
+    usePaginationControls({
+      total,
+      appliedPageSize,
+      defaultPageSize: DEFAULT_ROUTES_PAGE_SIZE,
+      page,
+      setPage,
+    });
+
+  const trimmedSearch = debouncedSearch.trim();
+  const hasActiveSearch = trimmedSearch.length > 0;
+
+  const emptyContent = useListingEmptyContent({
+    trimmedSearch,
+    includeDeleted,
+    onClearSearch,
+    copy: {
+      searchPrefix: 'Nenhuma rota encontrada para',
+      emptyTitle: singleSystemScope
+        ? 'Nenhuma rota cadastrada para este sistema.'
+        : 'Nenhuma rota cadastrada.',
+      hintWhenIncludeDeletedOff:
+        'Rotas removidas podem ser visualizadas ativando "Mostrar inativas".',
+      clearTestId,
+    },
+  });
+
+  return {
+    totalPages,
+    isFirstPage,
+    isLastPage,
+    handlePrevPage,
+    handleNextPage,
+    trimmedSearch,
+    hasActiveSearch,
+    emptyContent,
+  };
+}
+
+/**
+ * Renderiza o cabeçalho + nome + descrição opcional de um card de
+ * rota mobile. As duas listagens (`RoutesPage` drill-down +
+ * `RoutesGlobalListShellPage` global) repetiam exatamente este
+ * trecho:
+ *
+ * ```jsx
+ * <CardHeader>
+ *   <CardCode>{row.code}</CardCode>
+ *   <StatusBadge deletedAt={row.deletedAt} />
+ * </CardHeader>
+ * <CardName>{row.name}</CardName>
+ * {row.description !== null && row.description.trim().length > 0 && (
+ *   <CardDescription>{row.description}</CardDescription>
+ * )}
+ * ```
+ *
+ * O JSCPD tokenizou os 12 linhas idênticas como duplicado entre as
+ * duas pages — gatilho clássico das lições PR #134/#135. Centralizar
+ * aqui mantém a estrutura única do card sem importar de uma página
+ * para a outra (que criaria dependência cruzada entre pages-shell).
+ */
+export function RouteCardTopSection({ row }: { row: RouteDto }): React.ReactElement {
+  return (
+    <>
+      <CardHeader>
+        <CardCode>{row.code}</CardCode>
+        <StatusBadge deletedAt={row.deletedAt} />
+      </CardHeader>
+      <CardName>{row.name}</CardName>
+      {row.description !== null && row.description.trim().length > 0 && (
+        <CardDescription>{row.description}</CardDescription>
+      )}
+    </>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,10 +8,10 @@ import { InternalErrorPage } from '../pages/InternalErrorPage';
 import { LoginPage } from '../pages/LoginPage';
 import { NotFoundPage } from '../pages/NotFoundPage';
 import { PermissionsListShellPage } from '../pages/permissions';
-import { PlaceholderPage } from '../pages/PlaceholderPage';
 import { RolePermissionsShellPage } from '../pages/roles/RolePermissionsShellPage';
 import { RolesGlobalListShellPage } from '../pages/roles/RolesGlobalListShellPage';
 import { RolesPage } from '../pages/RolesPage';
+import { RoutesGlobalListShellPage } from '../pages/routes';
 import { RoutesPage } from '../pages/RoutesPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { ShowcasePage } from '../pages/ShowcasePage';
@@ -153,11 +153,7 @@ export const AppRoutes: React.FC = () => (
         path="/routes"
         element={
           <RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST">
-            <PlaceholderPage
-              eyebrow="02 Rotas"
-              title="Rotas registradas"
-              desc="Endpoints registrados por sistema. Cada rota possui método, path e permissões associadas. Para listar as rotas de um sistema específico, abra o sistema correspondente."
-            />
+            <RoutesGlobalListShellPage />
           </RequirePermission>
         }
       />

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -118,21 +118,24 @@ export const DEFAULT_ROUTES_PAGE_SIZE = 20;
 export const DEFAULT_ROUTES_INCLUDE_DELETED = false;
 
 /**
- * Parâmetros aceitos por `listRoutes`. Apenas `systemId` é semanticamente
- * obrigatório nesta primeira sub-issue (#62 — listagem **por sistema**).
- * Os demais são opcionais — quando omitidos (ou iguais aos defaults),
- * são removidos da querystring.
+ * Parâmetros aceitos por `listRoutes`. Todos opcionais — quando omitidos
+ * (ou iguais aos defaults), são removidos da querystring.
  *
- * `systemId` é tipado como `string` (UUID v4 esperado pelo backend) e
- * obrigatório no contrato dessa função: a `RoutesPage` lê o `:id` da URL
- * e nunca chama sem ele. O backend aceita `systemId` opcional em
- * `GET /systems/routes` e devolve todas as rotas quando ausente, mas
- * essa rota global ("listar tudo") é objeto da sub-issue #63 (criar)
- * via dropdown de sistema — não desta listagem.
+ * `systemId` era obrigatório na sub-issue #62 (listagem **por sistema**)
+ * porque a `RoutesPage` sempre lê `:systemId` da URL. A Issue #172
+ * (listagem global cross-system em `/routes`) introduziu o caminho onde
+ * a página opcionalmente filtra por sistema via dropdown — quando
+ * `systemId` é omitido, o backend devolve rotas de todos os sistemas
+ * (`RoutesController.GetAll` aceita `systemId: Guid? = null`). Manter
+ * o tipo opcional preserva o comportamento legado (`RoutesPage` sempre
+ * passa `systemId`) e desbloqueia o novo caso de uso.
  */
 export interface ListRoutesParams {
-  /** UUID do sistema dono das rotas. Obrigatório nesta listagem. */
-  systemId: string;
+  /**
+   * UUID do sistema dono das rotas. Quando omitido, lista rotas de
+   * todos os sistemas (caminho global da Issue #172).
+   */
+  systemId?: string;
   /** Termo de busca (case-insensitive em `Name` e `Code`). */
   q?: string;
   /** Página 1-based. Default: 1. */
@@ -150,14 +153,17 @@ export interface ListRoutesParams {
  * `q` é trimado e omitido quando vazio para evitar `?q=` literal (que o
  * backend trataria como busca por string vazia, mas a UI sinalizaria
  * estado de "busca ativa" no `q`). Espelha `buildQueryString` de
- * `systems.ts`, mas adiciona `systemId` sempre — é o eixo do recurso
- * desta issue.
+ * `systems.ts`. Após Issue #172, `systemId` deixou de ser sempre
+ * presente (listagem global cross-system) — só é serializado quando
+ * o caller fornece o filtro via dropdown.
  */
 function buildQueryString(params: ListRoutesParams): string {
   const search = new URLSearchParams();
 
-  // `systemId` sempre presente — é o eixo da listagem por sistema.
-  search.set('systemId', params.systemId);
+  const systemId = params.systemId?.trim();
+  if (systemId && systemId.length > 0) {
+    search.set('systemId', systemId);
+  }
 
   const q = params.q?.trim();
   if (q && q.length > 0) {
@@ -179,7 +185,8 @@ function buildQueryString(params: ListRoutesParams): string {
     search.set('includeDeleted', String(params.includeDeleted));
   }
 
-  return `?${search.toString()}`;
+  const serialized = search.toString();
+  return serialized.length > 0 ? `?${serialized}` : '';
 }
 
 /**

--- a/tests/pages/__helpers__/routesTestHelpers.tsx
+++ b/tests/pages/__helpers__/routesTestHelpers.tsx
@@ -14,10 +14,12 @@ import type {
   ApiError,
   PagedResponse,
   RouteDto,
+  SystemDto,
   TokenTypeDto,
 } from "@/shared/api";
 
 import { ToastProvider } from "@/components/ui";
+import { RoutesGlobalListShellPage } from "@/pages/routes";
 import { RoutesPage } from "@/pages/RoutesPage";
 
 /**
@@ -695,4 +697,177 @@ export function buildSharedRouteMutationErrorCases(
       expectedText: `Não foi possível ${verb} a rota. Tente novamente.`,
     },
   ];
+}
+
+/* ─── Helpers para a listagem global (Issue #172) ──────────────── */
+
+/** UUID adicional do segundo sistema usado na suíte da listagem global. */
+export const ID_SYS_KURTTO = "22222222-2222-2222-2222-222222222222";
+
+/**
+ * Constrói um `SystemDto` com defaults — testes só sobrescrevem o que
+ * importa para o cenário sem repetir todos os campos. Espelha
+ * `makeSystem` em `systemsTestHelpers.tsx` mas declarado aqui para
+ * preservar a coesão dos helpers de rotas (a suíte da listagem global
+ * mocka o catálogo de sistemas e o de rotas no mesmo cliente, e
+ * importar `makeSystem` de outro helper acoplaria as duas suítes).
+ *
+ * Lição PR #128 — projetar shared helpers desde o primeiro PR do
+ * recurso, não esperar a duplicação aparecer e refatorar.
+ */
+export function makeSystem(overrides: Partial<SystemDto> = {}): SystemDto {
+  return {
+    id: ID_SYS_AUTH,
+    name: "lfc-authenticator",
+    code: "AUTH",
+    description: null,
+    createdAt: "2026-01-10T12:00:00Z",
+    updatedAt: "2026-01-10T12:00:00Z",
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Constrói o envelope paginado mockado pelo backend para sistemas.
+ * Espelha `makePagedRoutes` mas para o catálogo de sistemas — usado
+ * pela suíte da listagem global para popular o `<Select>` de filtro
+ * e o lookup de nome do sistema na coluna Sistema.
+ */
+export function makePagedSystems(
+  data: ReadonlyArray<SystemDto>,
+  overrides: Partial<PagedResponse<SystemDto>> = {},
+): PagedResponse<SystemDto> {
+  return {
+    data,
+    page: 1,
+    pageSize: 100,
+    total: data.length,
+    ...overrides,
+  };
+}
+
+/**
+ * Stub default usado pela suíte da listagem global. Reusa
+ * `createRoutesClientStub` para preservar a mesma fábrica entre as
+ * duas suítes (drill-down e global) — mantemos um alias dedicado
+ * para que os imports da nova suíte fiquem com nome auto-explicativo
+ * (lição PR #128 — projetar shared helpers desde o primeiro PR do
+ * recurso).
+ */
+export function createRoutesGlobalClientStub(): ApiClientStub {
+  return createRoutesClientStub();
+}
+
+/**
+ * Mocka as duas requests iniciais da `RoutesGlobalListShellPage`
+ * (listagem global de rotas + catálogo de sistemas para filtro/lookup)
+ * via `mockImplementation` no `client.get`. Cada chamada é roteada
+ * pelo prefixo do path:
+ *
+ * - `/systems/routes...` → `makePagedRoutes(routes, ...)`
+ * - `/systems...` → `makePagedSystems(systems)`
+ *
+ * Centralizar evita duplicar a fila de mocks em cada teste (lição PR
+ * #127 — trechos de 5+ linhas em 2+ testes são `New Code Duplication`).
+ *
+ * **Por que `mockImplementation` e não `mockResolvedValueOnce` em
+ * sequência?** Os dois GETs disparam em paralelo no mount (rotas via
+ * `usePaginatedFetch`, sistemas via `useSingleFetchWithAbort`), então
+ * a ordem relativa não é determinística. Roteamento por `path`
+ * elimina a fragilidade de ordem.
+ */
+export function mockGlobalRoutesInitialResponses(
+  client: ApiClientStub,
+  options: {
+    /** Linhas devolvidas pelo GET de rotas. Default: 1 rota fake. */
+    routes?: ReadonlyArray<RouteDto>;
+    /** Sistemas devolvidos pelo GET de sistemas. Default: `[lfc-authenticator]`. */
+    systems?: ReadonlyArray<SystemDto>;
+    /** Overrides do envelope paginado de rotas. */
+    routesPagedOverrides?: Partial<PagedResponse<RouteDto>>;
+  } = {},
+): void {
+  const routes = options.routes ?? [makeRoute()];
+  const systems = options.systems ?? [makeSystem()];
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith("/systems/routes")) {
+      return Promise.resolve(
+        makePagedRoutes(routes, options.routesPagedOverrides),
+      );
+    }
+    if (path.startsWith("/systems")) {
+      return Promise.resolve(makePagedSystems(systems));
+    }
+    return Promise.reject(
+      new Error(`mockGlobalRoutesInitialResponses: path inesperado ${path}`),
+    );
+  });
+}
+
+/**
+ * Renderiza a `RoutesGlobalListShellPage` envolvendo num
+ * `MemoryRouter` (a página tem `<Link>`s para `/systems/:id/routes`,
+ * que sem o roteador lançariam) + `ToastProvider` (paridade com
+ * `renderRoutesPage` para suportar futuras evoluções com `useToast`).
+ * Centraliza para que cada teste não repita o boilerplate.
+ */
+export function renderRoutesGlobalListPage(client: ApiClientStub): void {
+  render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={["/routes"]}>
+        <Routes>
+          <Route
+            path="/routes"
+            element={<RoutesGlobalListShellPage client={client} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
+  );
+}
+
+/**
+ * Aguarda a primeira renderização da listagem global. A página dispara
+ * 2 GETs em paralelo no mount (`/systems/routes` + `/systems`), então
+ * esperamos que ambos tenham sido chamados pelo menos uma vez antes de
+ * verificar que o spinner sumiu.
+ */
+export async function waitForInitialGlobalList(
+  client: ApiClientStub,
+): Promise<void> {
+  await waitFor(() =>
+    expect(client.get.mock.calls.length).toBeGreaterThanOrEqual(2),
+  );
+  await waitFor(() => {
+    expect(
+      screen.queryByTestId("routes-global-loading"),
+    ).not.toBeInTheDocument();
+  });
+}
+
+/**
+ * Helper para extrair os paths de `/systems/routes` (apenas as
+ * chamadas de listagem de rotas, ignorando o GET do catálogo de
+ * sistemas). Usado em asserts da suíte de listagem global para
+ * verificar a serialização da querystring sem ruído da lookup.
+ */
+export function lastRoutesListPath(client: ApiClientStub): string {
+  const routesCalls = client.get.mock.calls.filter(
+    (call: unknown[]) =>
+      typeof call[0] === "string" &&
+      (call[0] as string).startsWith("/systems/routes"),
+  );
+  if (routesCalls.length === 0) return "";
+  const path = routesCalls[routesCalls.length - 1][0];
+  return typeof path === "string" ? path : "";
+}
+
+/** Total de chamadas a `/systems/routes` no stub do cliente. */
+export function countRoutesListCalls(client: ApiClientStub): number {
+  return client.get.mock.calls.filter(
+    (call: unknown[]) =>
+      typeof call[0] === "string" &&
+      (call[0] as string).startsWith("/systems/routes"),
+  ).length;
 }

--- a/tests/pages/routes/RoutesGlobalListShellPage.test.tsx
+++ b/tests/pages/routes/RoutesGlobalListShellPage.test.tsx
@@ -1,0 +1,568 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import { buildAuthMock } from '../__helpers__/mockUseAuth';
+import {
+  countRoutesListCalls,
+  createRoutesGlobalClientStub,
+  ID_ROUTE_LIST,
+  ID_ROUTE_CREATE,
+  ID_SYS_AUTH,
+  ID_SYS_KURTTO,
+  ID_TOKEN_TYPE_DEFAULT,
+  lastRoutesListPath,
+  makePagedRoutes,
+  makePagedSystems,
+  makeRoute,
+  makeSystem,
+  mockGlobalRoutesInitialResponses,
+  renderRoutesGlobalListPage,
+  waitForInitialGlobalList,
+} from '../__helpers__/routesTestHelpers';
+/* eslint-enable import/order */
+
+import type { RouteDto } from '@/shared/api';
+
+/**
+ * Suíte da `RoutesGlobalListShellPage` (Issue #172 — listagem global
+ * cross-system de rotas).
+ *
+ * Estratégia espelha `ClientsListShellPage.test.tsx`/`SystemsPage.test.tsx`:
+ * stub de `ApiClient` injetado, asserts sobre estados visuais, busca
+ * debounced, paginação, filtro por sistema (dropdown), toggle "Mostrar
+ * inativas", coluna Sistema com `<Link>` clicável e cards mobile.
+ */
+
+vi.mock('@/shared/auth', () =>
+  buildAuthMock(() => ['AUTH_V1_SYSTEMS_ROUTES_LIST']),
+);
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const SAMPLE_ROUTE_AUTH: RouteDto = makeRoute({
+  id: ID_ROUTE_LIST,
+  systemId: ID_SYS_AUTH,
+  name: 'Listar sistemas',
+  code: 'AUTH_V1_SYSTEMS_LIST',
+  description: 'GET /api/v1/systems',
+});
+
+const SAMPLE_ROUTE_KURTTO: RouteDto = makeRoute({
+  id: ID_ROUTE_CREATE,
+  systemId: ID_SYS_KURTTO,
+  name: 'Criar pedido',
+  code: 'KURTTO_V1_ORDERS_CREATE',
+  description: null,
+  systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+  systemTokenTypeCode: 'default',
+  systemTokenTypeName: 'Acesso padrão',
+});
+
+const SAMPLE_ROUTES: ReadonlyArray<RouteDto> = [
+  SAMPLE_ROUTE_AUTH,
+  SAMPLE_ROUTE_KURTTO,
+];
+
+const SAMPLE_SYSTEMS = [
+  makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
+  makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
+];
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('RoutesGlobalListShellPage — render inicial', () => {
+  it('exibe spinner enquanto a primeira request está em curso e popula a tabela após resposta', async () => {
+    const client = createRoutesGlobalClientStub();
+    let resolveRoutes: (value: unknown) => void = () => undefined;
+    const pendingRoutes = new Promise<unknown>((resolve) => {
+      resolveRoutes = resolve;
+    });
+    // Sistemas resolve imediatamente; rotas ficam pendentes para
+    // exercitar o estado de loading.
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems/routes')) {
+        return pendingRoutes;
+      }
+      return Promise.resolve(makePagedSystems(SAMPLE_SYSTEMS));
+    });
+
+    renderRoutesGlobalListPage(client);
+
+    expect(screen.getByTestId('routes-global-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRoutes(makePagedRoutes(SAMPLE_ROUTES));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('routes-global-loading'),
+      ).not.toBeInTheDocument();
+    });
+
+    // `getAllByText` porque a página renderiza tabela desktop + cards
+    // mobile (paridade com `UsersListShellPage`/`ClientsListShellPage`).
+    expect(screen.getAllByText('Listar sistemas').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Criar pedido').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza header da página com título "Rotas registradas"', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(
+      screen.getByRole('heading', { name: /Rotas registradas/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('chama backend em GET /systems/routes sem querystring quando defaults estão ativos', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(lastRoutesListPath(client)).toBe('/systems/routes');
+  });
+
+  it('coluna Sistema renderiza nome do sistema vindo do lookup', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: [SAMPLE_ROUTE_AUTH],
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    // Aparece em desktop + mobile.
+    expect(screen.getAllByText('lfc-authenticator').length).toBeGreaterThan(0);
+  });
+
+  it('renderiza badge "Inativo" para rotas soft-deletadas quando includeDeleted=true', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: [
+        makeRoute({
+          id: ID_ROUTE_LIST,
+          systemId: ID_SYS_AUTH,
+          name: 'Listar sistemas',
+          deletedAt: '2026-02-01T00:00:00Z',
+        }),
+      ],
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    fireEvent.click(screen.getByTestId('routes-global-include-deleted'));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Inativ/).length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('RoutesGlobalListShellPage — coluna Sistema linka para drill-down', () => {
+  it('renderiza <a href="/systems/:systemId/routes"> na coluna Sistema', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: [SAMPLE_ROUTE_AUTH],
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    const link = screen.getByTestId(
+      `routes-global-system-link-${SAMPLE_ROUTE_AUTH.id}`,
+    );
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute(
+      'href',
+      `/systems/${SAMPLE_ROUTE_AUTH.systemId}/routes`,
+    );
+  });
+
+  it('cards mobile também exibem link para drill-down', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: [SAMPLE_ROUTE_KURTTO],
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    const cardLink = screen.getByTestId(
+      `routes-global-card-system-link-${SAMPLE_ROUTE_KURTTO.id}`,
+    );
+    expect(cardLink).toBeInTheDocument();
+    expect(cardLink).toHaveAttribute(
+      'href',
+      `/systems/${SAMPLE_ROUTE_KURTTO.systemId}/routes`,
+    );
+  });
+
+  it('quando o lookup ainda não respondeu, exibe systemId como fallback (sem quebrar o link)', async () => {
+    const client = createRoutesGlobalClientStub();
+    // Sistemas demoram a responder; rotas chegam primeiro.
+    let resolveSystems: (value: unknown) => void = () => undefined;
+    const pendingSystems = new Promise<unknown>((resolve) => {
+      resolveSystems = resolve;
+    });
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems/routes')) {
+        return Promise.resolve(makePagedRoutes([SAMPLE_ROUTE_AUTH]));
+      }
+      return pendingSystems;
+    });
+
+    renderRoutesGlobalListPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('routes-global-loading'),
+      ).not.toBeInTheDocument();
+    });
+
+    // Antes do catálogo de sistemas chegar, exibe o systemId.
+    expect(screen.getAllByText(SAMPLE_ROUTE_AUTH.systemId).length).toBeGreaterThan(0);
+
+    // Resolve catálogo de sistemas — a coluna passa a exibir o nome.
+    await act(async () => {
+      resolveSystems(makePagedSystems(SAMPLE_SYSTEMS));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('lfc-authenticator').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('RoutesGlobalListShellPage — busca debounced', () => {
+  it('digitar não dispara request imediato; após 300ms refaz GET com q na querystring', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    const callsBefore = countRoutesListCalls(client);
+
+    fireEvent.change(screen.getByTestId('routes-global-search'), {
+      target: { value: 'auth' },
+    });
+
+    expect(countRoutesListCalls(client)).toBe(callsBefore);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+    expect(lastRoutesListPath(client)).toBe('/systems/routes?q=auth');
+  });
+
+  it('teclas em sequência só disparam a última busca', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+    const callsBefore = countRoutesListCalls(client);
+
+    const input = screen.getByTestId(
+      'routes-global-search',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'au' } });
+    fireEvent.change(input, { target: { value: 'auth' } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+  });
+});
+
+describe('RoutesGlobalListShellPage — filtro por sistema', () => {
+  it('selecionar sistema envia systemId na querystring', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+    const callsBefore = countRoutesListCalls(client);
+
+    fireEvent.change(screen.getByTestId('routes-global-system-filter'), {
+      target: { value: ID_SYS_AUTH },
+    });
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+    expect(lastRoutesListPath(client)).toBe(
+      `/systems/routes?systemId=${ID_SYS_AUTH}`,
+    );
+  });
+
+  it('voltar para "Todos os sistemas" remove o param systemId da querystring', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+    const callsBefore = countRoutesListCalls(client);
+
+    fireEvent.change(screen.getByTestId('routes-global-system-filter'), {
+      target: { value: ID_SYS_AUTH },
+    });
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+
+    fireEvent.change(screen.getByTestId('routes-global-system-filter'), {
+      target: { value: 'ALL' },
+    });
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 2),
+    );
+    expect(lastRoutesListPath(client)).toBe('/systems/routes');
+  });
+
+  it('dropdown popula opções a partir do catálogo de sistemas (ordem alfabética)', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      // Inversão de ordem para validar o sort por nome.
+      systems: [
+        makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
+        makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
+      ],
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    const select = screen.getByTestId(
+      'routes-global-system-filter',
+    ) as HTMLSelectElement;
+    const optionTexts = Array.from(select.options).map(
+      (opt) => opt.textContent,
+    );
+    expect(optionTexts[0]).toBe('Todos os sistemas');
+    expect(optionTexts[1]).toBe('lfc-authenticator');
+    expect(optionTexts[2]).toBe('lfc-kurtto');
+  });
+});
+
+describe('RoutesGlobalListShellPage — paginação server-side', () => {
+  it('clicar "próxima" envia page=2 na querystring; "anterior" volta para page omitido (default)', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+      routesPagedOverrides: { total: 25, page: 1 },
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(screen.getByTestId('routes-global-page-info')).toHaveTextContent(
+      /Página 1 de 2/i,
+    );
+
+    const callsBefore = countRoutesListCalls(client);
+    fireEvent.click(screen.getByTestId('routes-global-next'));
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+    expect(lastRoutesListPath(client)).toBe('/systems/routes?page=2');
+
+    fireEvent.click(screen.getByTestId('routes-global-prev'));
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 2),
+    );
+    expect(lastRoutesListPath(client)).toBe('/systems/routes');
+  });
+
+  it('botão "anterior" desabilita na primeira página', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+      routesPagedOverrides: { total: 25 },
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(screen.getByTestId('routes-global-prev')).toBeDisabled();
+    expect(screen.getByTestId('routes-global-next')).toBeEnabled();
+  });
+
+  it('botão "próxima" desabilita quando totalPages é 1', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(screen.getByTestId('routes-global-prev')).toBeDisabled();
+    expect(screen.getByTestId('routes-global-next')).toBeDisabled();
+  });
+});
+
+describe('RoutesGlobalListShellPage — filtro de inativos', () => {
+  it('liga toggle dispara request com includeDeleted=true', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: SAMPLE_ROUTES,
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+    const callsBefore = countRoutesListCalls(client);
+
+    fireEvent.click(screen.getByTestId('routes-global-include-deleted'));
+
+    await waitFor(() =>
+      expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+    );
+    expect(lastRoutesListPath(client)).toBe(
+      '/systems/routes?includeDeleted=true',
+    );
+  });
+});
+
+describe('RoutesGlobalListShellPage — estados vazios', () => {
+  it('vazio com busca: exibe termo + botão limpar', async () => {
+    const client = createRoutesGlobalClientStub();
+    // Primeira chamada retorna lista cheia; segunda (após busca) vazia.
+    let firstRoutesCallSeen = false;
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems/routes')) {
+        if (!firstRoutesCallSeen) {
+          firstRoutesCallSeen = true;
+          return Promise.resolve(makePagedRoutes(SAMPLE_ROUTES));
+        }
+        return Promise.resolve(makePagedRoutes([]));
+      }
+      return Promise.resolve(makePagedSystems(SAMPLE_SYSTEMS));
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    fireEvent.change(screen.getByTestId('routes-global-search'), {
+      target: { value: 'naoexiste' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhuma rota encontrada para/i).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getAllByTestId('routes-global-empty-clear').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('vazio sem busca: mensagem dedicada + dica sobre toggle', async () => {
+    const client = createRoutesGlobalClientStub();
+    mockGlobalRoutesInitialResponses(client, {
+      routes: [],
+      systems: SAMPLE_SYSTEMS,
+    });
+
+    renderRoutesGlobalListPage(client);
+    await waitForInitialGlobalList(client);
+
+    expect(
+      screen.getAllByText(/Nenhuma rota cadastrada\./i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Rotas removidas podem ser visualizadas/i).length,
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('RoutesGlobalListShellPage — erro de listagem', () => {
+  it('exibe Alert + botão "Tentar novamente" quando o GET de rotas falha', async () => {
+    const client = createRoutesGlobalClientStub();
+    client.get.mockImplementation((path: string) => {
+      if (path.startsWith('/systems/routes')) {
+        return Promise.reject({
+          kind: 'http',
+          status: 500,
+          message: 'Erro interno ao listar rotas.',
+        });
+      }
+      return Promise.resolve(makePagedSystems(SAMPLE_SYSTEMS));
+    });
+
+    renderRoutesGlobalListPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('routes-global-loading'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Erro interno ao listar rotas.')).toBeInTheDocument();
+    expect(screen.getByTestId('routes-global-retry')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexto

O item de menu "Rotas" (Sidebar #02 → `/routes`) renderizava um `<PlaceholderPage>` estático com o texto "Para listar as rotas de um sistema específico, abra o sistema correspondente." (`src/routes/index.tsx`). Clicar no menu não disparava nenhuma chamada ao backend — UX confusa.

## Objetivo

Substituir o placeholder por uma **listagem global cross-system** real (paralela ao que `/systems` é para sistemas), consumindo `GET /api/v1/systems/routes` com `systemId` opcional. Cada linha linka para `/systems/:systemId/routes` (drill-down).

Closes #172

## O que foi feito

### Frontend
- **`src/pages/routes/RoutesGlobalListShellPage.tsx`** (novo): página da listagem global. Espelha o padrão de `ClientsListShellPage` (sem `:systemId` na URL, com `extraFilter` no `<ListingToolbar>`). Mostra coluna Sistema clicável via `<Link>` para `/systems/:systemId/routes`.
- **`src/pages/routes/routeRenderHelpers.tsx`** (novo): helpers de renderização compartilhados entre `RoutesPage` (drill-down) e `RoutesGlobalListShellPage` (global) — `renderTokenPolicy`, `renderRouteDescription`, `RouteCardTopSection` (header de card mobile), e `useRoutesListShellState` (paginação + estado vazio via `useListingEmptyContent` shared).
- **`src/pages/RoutesPage.tsx`**: refatorado para reusar os helpers compartilhados (elimina duplicação JSCPD entre as duas pages que era prevista pelas lições PR #134/#135).
- **`src/routes/index.tsx`**: substitui o `<PlaceholderPage>` em `/routes` pela `<RoutesGlobalListShellPage>` (mantém gating `AUTH_V1_SYSTEMS_ROUTES_LIST`).

### API wrapper
- **`src/shared/api/routes.ts`**: torna `systemId` opcional em `ListRoutesParams` (backend já aceita `systemId: Guid? = null` no `RoutesController.GetAll`; antes o contrato TS forçava obrigatório).

### Testes
- **`tests/pages/routes/RoutesGlobalListShellPage.test.tsx`** (novo): 20 cenários cobrindo render inicial, busca debounced (300ms), filtro por sistema (sentinel "ALL" + UUIDs), paginação server-side, toggle "Mostrar inativas", estados vazios (com/sem busca), erro de fetch, link de drill-down (desktop + mobile cards), fallback do lookup quando o catálogo de sistemas ainda não respondeu.
- **`tests/pages/__helpers__/routesTestHelpers.tsx`**: estende com `makeSystem`/`makePagedSystems`/`mockGlobalRoutesInitialResponses`/`renderRoutesGlobalListPage`/`waitForInitialGlobalList`/`lastRoutesListPath`/`countRoutesListCalls`. Roteamento por path no `client.get.mockImplementation` evita fragilidade de ordem entre os 2 GETs paralelos do mount.

## Arquivos impactados

- `src/pages/routes/RoutesGlobalListShellPage.tsx` (novo)
- `src/pages/routes/routeRenderHelpers.tsx` (novo)
- `src/pages/routes/index.ts` (novo)
- `src/pages/RoutesPage.tsx` (modificado — refator p/ reusar helpers)
- `src/routes/index.tsx` (modificado — substitui placeholder)
- `src/shared/api/routes.ts` (modificado — `systemId` opcional)
- `tests/pages/__helpers__/routesTestHelpers.tsx` (modificado — helpers da listagem global)
- `tests/pages/routes/RoutesGlobalListShellPage.test.tsx` (novo)

## Testes

Quality gate completo via container:

```bash
docker compose run --rm web npm run lint        # 0 erros, 0 warnings
docker compose run --rm web npm run typecheck   # 0 erros
docker compose run --rm web npm test            # 1579/1579 passando (83 arquivos)
docker compose run --rm web npx jscpd src \
  --threshold 3 --min-lines 10                  # 1.52% < 3%; 0 clones novos no diff
```

JSCPD baseline em `origin/development`: 1.6%. Após este PR: 1.52% (refator do `RoutesPage` para reusar helpers reduz duplicação líquida).

## Visual

- Coluna Sistema com `<Link>` clicável (cor `--fg1`, hover muda para `--accent` + underline, focus ring via `outline: var(--border-thick) solid var(--accent)`).
- Reusa `<ListingToolbar>` (busca + filtro Select por sistema + toggle inativos), `<ListingResultArea>` (loading/error/table+overlay/pagination), `<EntityCard>` mobile, `StatusBadge`, `<Mono>`, `<Placeholder>` — todos via design system local. Nenhum hardcode de cor.
- Estados loading/error/empty/empty-com-busca + ARIA-live (`useListingLiveMessage`) cobrindo `singular: 'rota'`.
- Mobile cards via `<CardListForMobile>` com `RouteCardTopSection` reutilizado.
- Tabela desktop oculta em mobile (`@media (min-width: 48em)`).

## Segurança

- Nenhum impacto: a página segue o gating existente (`<RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST">` no `AppRoutes`).
- Não há mutação — apenas leitura via `listRoutes`/`listSystems` que já passam pelo `apiClient` singleton com JWT no header.
- Links `<Link to="/systems/${row.systemId}/routes">` usam `systemId` interno (UUID v4 vindo do backend), não string arbitrária do usuário — `react-router` faz o encoding canônico.

## Riscos

- Catálogo de sistemas é carregado em paralelo via `useSingleFetchWithAbort` (`pageSize=100`, `includeDeleted=true`); enquanto não chega, a coluna Sistema mostra o `systemId` cru como fallback (UX defensiva — não quebra o link).
- `systemId` opcional em `ListRoutesParams` afeta `RoutesPage.tsx` (drill-down): mantida retrocompatibilidade — o `RoutesPage` sempre passa `systemId` quando `hasValidSystemId === true`, e o `usePaginatedFetch` recebe `skip: true` quando inválido (não chama o fetcher). Testes existentes da `RoutesPage` continuam verdes.

## Issue relacionada

Closes #172