### PR TITLE
feat(ui): toggle de visibilidade em Input type=password (#181)

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,4 +1,5 @@
-import React, { useId } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import React, { useId, useState } from 'react';
 import styled from 'styled-components';
 
 const DANGER_COLOR = 'var(--danger)';
@@ -7,6 +8,19 @@ interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, '
   label?: string;
   error?: string;
   icon?: React.ReactNode;
+  /**
+   * Controla a renderização do toggle de visibilidade no slot
+   * direito do input. Significativo apenas quando `type="password"`:
+   *
+   * - `undefined` (default) ou `true` em `type="password"` → renderiza
+   *   o botão `Eye`/`EyeOff` que alterna o `type` real do input
+   *   entre `password` e `text`.
+   * - `false` → preserva o comportamento "cego" original (sem toggle).
+   *
+   * Para qualquer `type !== 'password'`, esta prop é ignorada (o
+   * toggle só faz sentido em campos mascarados).
+   */
+  revealable?: boolean;
   onChange?: (value: string) => void;
 }
 
@@ -40,7 +54,11 @@ const IconSlot = styled.span`
   pointer-events: none;
 `;
 
-const StyledInput = styled.input<{ $hasError?: boolean; $hasIcon?: boolean }>`
+const StyledInput = styled.input<{
+  $hasError?: boolean;
+  $hasIcon?: boolean;
+  $hasTrailingAction?: boolean;
+}>`
   flex: 1;
   min-width: 0;
   background: var(--bg-elevated);
@@ -48,6 +66,7 @@ const StyledInput = styled.input<{ $hasError?: boolean; $hasIcon?: boolean }>`
   border-radius: var(--radius-md);
   padding: 9px 12px;
   padding-left: ${({ $hasIcon }) => ($hasIcon ? '34px' : '12px')};
+  padding-right: ${({ $hasTrailingAction }) => ($hasTrailingAction ? '38px' : '12px')};
   font-family: var(--font-sans);
   font-size: 14px;
   color: var(--fg1);
@@ -71,6 +90,65 @@ const StyledInput = styled.input<{ $hasError?: boolean; $hasIcon?: boolean }>`
   }
 `;
 
+/**
+ * Botão do slot direito que alterna a visibilidade da senha.
+ *
+ * Decisões visuais:
+ *
+ * - `position: absolute` à direita do `InputWrap` para coexistir com
+ *   o `IconSlot` esquerdo sem reflow do layout.
+ * - Cor base `var(--fg3)` (paridade com `IconSlot`); hover/focus
+ *   migram para `var(--fg1)` mantendo contraste suficiente.
+ * - `:focus-visible` herda o ring `var(--focus-ring-accent)` para
+ *   coerência com o restante dos controles do design system.
+ * - `disabled` herda do input pai via `disabled` prop — quando o
+ *   form bloqueia interação durante submit, o toggle também é
+ *   desabilitado e perde a interatividade visual.
+ * - Tamanho 28×28 cabe folgadamente nos `9px` de padding vertical do
+ *   input (altura final ≈ 38px) sem causar overflow.
+ */
+const RevealButton = styled.button`
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  color: var(--fg3);
+  cursor: pointer;
+  padding: 0;
+  transition: color 150ms var(--ease-default), background 150ms var(--ease-default),
+    box-shadow 150ms var(--ease-default);
+
+  &:hover:not(:disabled) {
+    color: var(--fg1);
+    background: var(--bg-surface);
+  }
+
+  &:focus-visible {
+    outline: none;
+    color: var(--fg1);
+    box-shadow: var(--focus-ring-accent);
+  }
+
+  &:disabled {
+    color: var(--text-disabled);
+    cursor: not-allowed;
+  }
+
+  & > svg {
+    display: block;
+    width: 16px;
+    height: 16px;
+  }
+`;
+
 const ErrorMsg = styled.span`
   font-size: 11px;
   color: var(--danger);
@@ -82,10 +160,33 @@ export const Input: React.FC<InputProps> = ({
   icon,
   onChange,
   id: idProp,
+  type,
+  revealable,
+  disabled,
   ...props
 }) => {
   const generatedId = useId();
   const inputId = idProp ?? generatedId;
+
+  // Estado local de visibilidade da senha. Não vaza para fora do
+  // componente: cada `<Input>` mantém o próprio toggle, e nenhum
+  // caller controla o "está revelado?".
+  const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
+
+  // O toggle só faz sentido em campos `type="password"`. Quando o
+  // caller passa `revealable={false}`, preservamos o comportamento
+  // cego original (showcase, casos defensivos como confirmação de
+  // delete crítico).
+  const showRevealButton = type === 'password' && revealable !== false;
+
+  // Quando o input é password e o operador clicou no toggle, trocamos
+  // o `type` real para `text` para que o conteúdo digitado fique
+  // visível. Em qualquer outro caso, mantemos o `type` original.
+  const effectiveType = showRevealButton && isPasswordVisible ? 'text' : type;
+
+  const handleToggleVisibility = (): void => {
+    setIsPasswordVisible(prev => !prev);
+  };
 
   return (
     <InputGroup>
@@ -98,11 +199,31 @@ export const Input: React.FC<InputProps> = ({
         {icon && <IconSlot>{icon}</IconSlot>}
         <StyledInput
           id={inputId}
+          type={effectiveType}
+          disabled={disabled}
           $hasError={!!error}
           $hasIcon={!!icon}
+          $hasTrailingAction={showRevealButton}
           onChange={e => onChange?.(e.target.value)}
           {...props}
         />
+        {showRevealButton && (
+          <RevealButton
+            type="button"
+            onClick={handleToggleVisibility}
+            disabled={disabled}
+            aria-label={isPasswordVisible ? 'Ocultar senha' : 'Mostrar senha'}
+            aria-pressed={isPasswordVisible}
+            aria-controls={inputId}
+            data-testid="input-password-toggle"
+          >
+            {isPasswordVisible ? (
+              <EyeOff aria-hidden="true" focusable={false} strokeWidth={1.6} />
+            ) : (
+              <Eye aria-hidden="true" focusable={false} strokeWidth={1.6} />
+            )}
+          </RevealButton>
+        )}
       </InputWrap>
       {error && <ErrorMsg>{error}</ErrorMsg>}
     </InputGroup>

--- a/src/pages/showcase/Inputs.tsx
+++ b/src/pages/showcase/Inputs.tsx
@@ -41,6 +41,8 @@ const Row = styled.div`
 
 export const Inputs: React.FC = () => {
   const [text, setText] = useState('admin@lfc.com.br');
+  const [password, setPassword] = useState('senha-revelavel');
+  const [secret, setSecret] = useState('senha-cega');
   const [bio, setBio] = useState('');
   const [system, setSystem] = useState('auth');
   const [agree, setAgree] = useState(false);
@@ -76,6 +78,29 @@ export const Inputs: React.FC = () => {
             value="senha123"
             error="Senha incorreta"
             onChange={() => undefined}
+          />
+        </Grid>
+      </Stack>
+
+      <Stack>
+        <Label>Input · senha (toggle de visibilidade)</Label>
+        <Grid>
+          <Input
+            label="Senha (com toggle)"
+            type="password"
+            value={password}
+            onChange={setPassword}
+            placeholder="Sua senha"
+            autoComplete="new-password"
+          />
+          <Input
+            label="Senha (sem toggle, opt-out)"
+            type="password"
+            value={secret}
+            onChange={setSecret}
+            placeholder="Sua senha"
+            autoComplete="new-password"
+            revealable={false}
           />
         </Grid>
       </Stack>

--- a/tests/components/ui/Input.test.tsx
+++ b/tests/components/ui/Input.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Input } from '@/components/ui/Input';
+
+describe('Input', () => {
+  it('renderiza label associado ao input', () => {
+    render(<Input label="E-mail" />);
+    const input = screen.getByLabelText('E-mail');
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('dispara onChange com o valor digitado', () => {
+    const handleChange = vi.fn();
+    render(<Input label="Nome" onChange={handleChange} />);
+    fireEvent.change(screen.getByLabelText('Nome'), { target: { value: 'Alice' } });
+    expect(handleChange).toHaveBeenCalledWith('Alice');
+  });
+
+  it('exibe error quando informado', () => {
+    render(<Input label="Obrigatório" error="Campo obrigatório" />);
+    expect(screen.getByText('Campo obrigatório')).toBeInTheDocument();
+  });
+
+  it('aplica disabled', () => {
+    render(<Input label="Read only" disabled />);
+    expect(screen.getByLabelText('Read only')).toBeDisabled();
+  });
+
+  describe('quando type="password"', () => {
+    it('renderiza botão de toggle por default com aria-label "Mostrar senha"', () => {
+      render(<Input label="Senha" type="password" />);
+      const toggle = screen.getByRole('button', { name: 'Mostrar senha' });
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toHaveAttribute('type', 'button');
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('renderiza input como type="password" antes do click', () => {
+      render(<Input label="Senha" type="password" />);
+      const input = screen.getByLabelText('Senha') as HTMLInputElement;
+      expect(input.type).toBe('password');
+    });
+
+    it('alterna type para "text" e atualiza aria-label/aria-pressed ao clicar no toggle', () => {
+      render(<Input label="Senha" type="password" />);
+      const input = screen.getByLabelText('Senha') as HTMLInputElement;
+      const toggle = screen.getByRole('button', { name: 'Mostrar senha' });
+
+      fireEvent.click(toggle);
+
+      expect(input.type).toBe('text');
+      const reverseToggle = screen.getByRole('button', { name: 'Ocultar senha' });
+      expect(reverseToggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('volta para type="password" ao clicar duas vezes', () => {
+      render(<Input label="Senha" type="password" />);
+      const input = screen.getByLabelText('Senha') as HTMLInputElement;
+      const toggle = screen.getByRole('button', { name: 'Mostrar senha' });
+
+      fireEvent.click(toggle);
+      fireEvent.click(screen.getByRole('button', { name: 'Ocultar senha' }));
+
+      expect(input.type).toBe('password');
+      expect(screen.getByRole('button', { name: 'Mostrar senha' })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('é focável via Tab (não usa tabIndex=-1)', () => {
+      render(<Input label="Senha" type="password" />);
+      const toggle = screen.getByRole('button', { name: 'Mostrar senha' });
+      expect(toggle).not.toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('toggle herda disabled do input pai', () => {
+      render(<Input label="Senha" type="password" disabled />);
+      const toggle = screen.getByRole('button', { name: 'Mostrar senha' });
+      expect(toggle).toBeDisabled();
+    });
+
+    it('omite o toggle quando revealable={false}', () => {
+      render(<Input label="Senha" type="password" revealable={false} />);
+      expect(
+        screen.queryByRole('button', { name: /Mostrar senha|Ocultar senha/ }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('mantém autoComplete fornecido pelo caller', () => {
+      render(
+        <Input
+          label="Senha"
+          type="password"
+          autoComplete="new-password"
+        />,
+      );
+      const input = screen.getByLabelText('Senha') as HTMLInputElement;
+      expect(input.autocomplete).toBe('new-password');
+    });
+  });
+
+  it('não renderiza toggle para type="text" mesmo com revealable={true}', () => {
+    render(<Input label="Texto" type="text" revealable />);
+    expect(
+      screen.queryByRole('button', { name: /Mostrar senha|Ocultar senha/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('não renderiza toggle quando type não é informado', () => {
+    render(<Input label="Texto livre" />);
+    expect(
+      screen.queryByRole('button', { name: /Mostrar senha|Ocultar senha/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -126,14 +126,14 @@ describe('LoginPage — render inicial', () => {
 
     expect(screen.getByRole('img', { name: /LF Calegari Admin/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/E-mail/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Senha/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Senha')).toBeInTheDocument();
     expect(screen.getByTestId('login-submit')).toBeInTheDocument();
   });
 
   it('campos começam vazios e botão habilitado', () => {
     renderLogin();
     const email = screen.getByLabelText(/E-mail/i) as HTMLInputElement;
-    const password = screen.getByLabelText(/Senha/i) as HTMLInputElement;
+    const password = screen.getByLabelText('Senha') as HTMLInputElement;
     const submit = screen.getByTestId('login-submit');
 
     expect(email.value).toBe('');
@@ -216,7 +216,7 @@ describe('LoginPage — validação client-side', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'naoeumemail' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -261,7 +261,7 @@ describe('LoginPage — submit feliz', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -291,7 +291,7 @@ describe('LoginPage — submit feliz', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -308,7 +308,7 @@ describe('LoginPage — submit feliz', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: '  ada@lfc.com.br  ' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -338,7 +338,7 @@ describe('LoginPage — submit com erro', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'errada' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -361,7 +361,7 @@ describe('LoginPage — submit com erro', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -378,7 +378,7 @@ describe('LoginPage — submit com erro', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -409,7 +409,7 @@ describe('LoginPage — submit com erro', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
@@ -439,13 +439,13 @@ describe('LoginPage — submit com erro', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'errada' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));
     await screen.findByRole('alert');
 
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'errada2' },
     });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
@@ -471,7 +471,7 @@ describe('LoginPage — estado loading', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByTestId('login-submit'));
@@ -496,7 +496,7 @@ describe('LoginPage — já autenticado', () => {
     fireEvent.change(screen.getByLabelText(/E-mail/i), {
       target: { value: 'ada@lfc.com.br' },
     });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
+    fireEvent.change(screen.getByLabelText('Senha'), {
       target: { value: 'segredo' },
     });
     fireEvent.click(screen.getByRole('button', { name: /Entrar/i }));


### PR DESCRIPTION
## Contexto

Issue [#181](https://github.com/LF-Calegari/lfc-admin-gui/issues/181) — todos os campos `<Input type="password">` da app eram "cegos". Padrão UX consolidado é oferecer toggle de visibilidade (Eye / EyeOff) controlado pelo próprio componente.

## Objetivo

Adicionar suporte nativo a toggle de visibilidade ao `<Input>` do design system, com opt-out via prop `revealable={false}`. Os 3 callers em produção (`LoginPage`, `ResetUserPasswordConfirm`, `UserFormFields`) ganham o toggle automaticamente, sem mudanças no código de produção desses arquivos.

## O que foi feito

- `src/components/ui/Input.tsx`
  - Nova prop `revealable?: boolean`. Significativa apenas em `type="password"` (default `true`); `false` preserva o comportamento "cego" original.
  - Estado local `isPasswordVisible` (não vaza para o caller).
  - Botão `<button type="button">` no slot direito quando `type === 'password' && revealable !== false`, com ícone `Eye` (oculto) ou `EyeOff` (revelado) de `lucide-react`.
  - Click alterna `type` real do input entre `password` e `text`.
  - A11y: `aria-label` dinâmico ("Mostrar senha" / "Ocultar senha"), `aria-pressed` reflete o estado, `aria-controls` aponta para o id do input, focável via Tab.
  - Tokens do design system para cor base (`--fg3`), hover (`--fg1` + `--bg-surface`), `:focus-visible` (`--focus-ring-accent`), e `:disabled` (`--text-disabled`). Sem hardcode de cor.
  - `padding-right` do input ajustado para `38px` quando o botão é renderizado, evitando sobreposição visual.
- `src/pages/showcase/Inputs.tsx` — bloco novo "Senha (toggle)" com dois exemplos: um com toggle ativo (default) e outro com `revealable={false}`.
- `tests/components/ui/Input.test.tsx` — novo arquivo (não existia teste para `Input`). Cobre: render do label, `onChange`, error, disabled, e o toggle (presente por default em `type="password"`, alterna o tipo do input ao click, atualiza `aria-label`/`aria-pressed`, focável via Tab, herda `disabled`, opt-out via `revealable={false}`, ausente em `type="text"`).
- `tests/pages/LoginPage.test.tsx` — substituído `getByLabelText(/Senha/i)` (regex laxo) por `getByLabelText('Senha')` (texto exato) para evitar match duplo (label do input vs aria-label do novo botão "Mostrar/Ocultar senha"). Nenhuma mudança no `LoginPage.tsx` em si.

## Arquivos impactados

- `src/components/ui/Input.tsx`
- `src/pages/showcase/Inputs.tsx`
- `tests/components/ui/Input.test.tsx` (novo)
- `tests/pages/LoginPage.test.tsx`

## Testes

Quality gate completo aprovado em container:

- `docker compose run --rm web npm run lint` — `0` erros, `0` warnings (`--max-warnings 0`).
- `docker compose run --rm web npm run typecheck` — `0` erros (`tsc --noEmit`).
- `docker compose run --rm web npm test` — `Test Files 84 passed (84)` · `Tests 1593 passed (1593)`.
- `docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10` — `Total: 1.51%` (< 3%); `0` clones envolvendo `Input.tsx` ou `Inputs.tsx`.

## Visual

- Botão `Eye`/`EyeOff` 28×28 alinhado à direita do input.
- Cores: base `--fg3`; hover `--fg1` + `--bg-surface`; focus ring `--focus-ring-accent`; disabled `--text-disabled`.
- Coexiste com o slot esquerdo (`icon`) sem reflow — `padding-right: 38px` quando ativo.
- Transição suave (`150ms var(--ease-default)`) em color/background/box-shadow.

## Segurança

Sem impacto. `autoComplete` (`current-password` / `new-password`) preservado em todos os callers. O estado de "revelado" é local ao componente e nunca persiste — refresh ou desmontagem zera. Não loga senha no console.

## Riscos

- Baixo: 3 callers em produção herdam o toggle por default. Já validado por test suite (1593 testes verdes, incluindo `LoginPage`, `UsersPage.create`, `UserResetPassword`).
- Substituição do regex `/Senha/i` em `LoginPage.test.tsx` é por causa do novo `aria-label` "Mostrar/Ocultar senha" (mandato da issue). O `LoginPage.tsx` em si não foi tocado.

## Issue relacionada

Closes #181