### PR TITLE
feat(routes): botão 'Nova rota' cross-system em /routes (#187)

### DIFF
--- a/src/pages/routes/NewRouteModal.tsx
+++ b/src/pages/routes/NewRouteModal.tsx
@@ -1,21 +1,29 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { Modal, useToast } from '../../components/ui';
-import { createRoute } from '../../shared/api';
+import { Modal, Select, useToast } from '../../components/ui';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import { createRoute, listSystems } from '../../shared/api';
+import { useCreateEntitySubmit } from '../../shared/forms';
 
 import { RouteFormBody } from './RouteFormFields';
 import {
   INITIAL_ROUTE_FORM_STATE,
-  classifyRouteSubmitError,
+  type RouteFieldErrors,
   type RouteSubmitErrorCopy,
 } from './routeFormShared';
 import { useRouteForm } from './useRouteForm';
 import { useRouteTokenTypes } from './useRouteTokenTypes';
 
-import type { ApiClient } from '../../shared/api';
+import type {
+  ApiClient,
+  CreateRoutePayload,
+  PagedResponse,
+  SafeRequestOptions,
+  SystemDto,
+} from '../../shared/api';
 
 /**
- * Copy injetada em `classifyRouteSubmitError` para o caminho de
+ * Copy injetada em `classifyApiSubmitError` para o caminho de
  * criação. Os literais aqui são os únicos pontos onde "criar"/"uma
  * rota" diferem do "atualizar"/"outra rota" no `EditRouteModal` —
  * o resto da lógica de classificação é compartilhado (lição PR #128).
@@ -30,8 +38,25 @@ const SUBMIT_ERROR_COPY: RouteSubmitErrorCopy = {
 const CONFLICT_INLINE_MESSAGE = 'Já existe uma rota com este código neste sistema.';
 
 /**
- * Modal de criação de rota (Issue #63 — primeira mutação no recurso
- * Rotas, espelhando o padrão do `NewSystemModal` da EPIC #45).
+ * Mensagem inline exibida abaixo do `<Select>` de sistema quando o
+ * usuário tenta submeter sem ter escolhido nenhum. Espelha a copy de
+ * "Selecione a política JWT alvo." que `validateRouteForm` injeta em
+ * `systemTokenTypeId`. Issue #187 critério de aceite explícito.
+ */
+const SYSTEM_REQUIRED_MESSAGE = 'Selecione um sistema.';
+
+/**
+ * Limite de sistemas carregados para popular o `<Select>` no modo
+ * global. Espelha o `MAX_*_PAGE_SIZE` aceito por `GET /systems` no
+ * backend; o ecossistema de sistemas cadastrados é pequeno (≤ 10 em
+ * produção projetada), então 100 cobre todos os cenários sem
+ * paginação adicional. Não incluímos soft-deletados — não faz sentido
+ * criar rota em um sistema inativo.
+ */
+const SYSTEMS_LOOKUP_PAGE_SIZE = 100;
+
+/**
+ * Modal de criação de rota — Issues #63 e #187.
  *
  * Decisões:
  *
@@ -44,7 +69,7 @@ const CONFLICT_INLINE_MESSAGE = 'Já existe uma rota com este código neste sist
  *   feedback imediato e evitar round-trip por erro trivial. As regras
  *   vivem em `routeFormShared.ts` para serem reusadas pelo
  *   `EditRouteModal` (#64) sem duplicação (lição PR #127/#128).
- * - Mapeamento de erro do backend:
+ * - Mapeamento de erro do backend (delegado a `useCreateEntitySubmit`):
  *   - 409 → mensagem inline no campo `code` ("Já existe uma rota com
  *     este código neste sistema.").
  *   - 400 → `details.errors[Field]` mapeado para `fieldErrors[field]`,
@@ -54,6 +79,23 @@ const CONFLICT_INLINE_MESSAGE = 'Já existe uma rota com este código neste sist
  *   - Demais → toast vermelho com mensagem genérica.
  * - Sucesso: chama `onCreated` (refetch responsabilidade do pai),
  *   fecha o modal e dispara toast verde "Rota criada.".
+ *
+ * **Modo per-system vs global** (Issue #187):
+ *
+ * O modal aceita `systemId` opcional na prop:
+ *
+ * - **Per-system** (caller `RoutesPage`, fluxo `/systems/:systemId/routes`
+ *   da #63): `systemId` chega como prop fixa e o form **não** renderiza
+ *   o `<Select>` de sistema — comportamento original preservado.
+ * - **Global** (caller `RoutesGlobalListShellPage`, fluxo `/routes` da
+ *   #187): `systemId` é `undefined`; carregamos `listSystems` e
+ *   renderizamos um `<Select>` obrigatório no topo do form para o
+ *   operador escolher antes de submeter.
+ *
+ * Tornamos a prop opcional (em vez de criar dois modals separados)
+ * para evitar duplicação ≥ 50 linhas com `EditRouteModal`/state do
+ * form/handler de erros (lição PR #128/#134/#135 reforçada). O custo
+ * de uma branch interna no JSX é menor que o custo do clone.
  *
  * **Token types** (política JWT alvo):
  *
@@ -68,15 +110,25 @@ const CONFLICT_INLINE_MESSAGE = 'Já existe uma rota com este código neste sist
 interface NewRouteModalProps {
   /** Estado de visibilidade controlado pelo pai. */
   open: boolean;
-  /** UUID do sistema dono da rota — vem da URL `/systems/:systemId/routes`. */
-  systemId: string;
+  /**
+   * UUID do sistema dono da rota.
+   *
+   * - **Definido**: caller per-system (`RoutesPage`) injeta o
+   *   `:systemId` lido da URL — o modal usa direto, sem renderizar
+   *   dropdown.
+   * - **Omitido / `undefined`**: caller global
+   *   (`RoutesGlobalListShellPage`) deixa o modal carregar
+   *   `listSystems` e renderizar `<Select>` obrigatório (Issue #187).
+   */
+  systemId?: string;
   /** Fecha o modal sem persistir. Chamada também após sucesso. */
   onClose: () => void;
   /** Callback disparado após criação bem-sucedida (para refetch da lista). */
   onCreated: () => void;
   /**
    * Cliente HTTP injetável para isolar testes — em produção, omitido,
-   * `createRoute`/`listTokenTypes` caem no singleton `apiClient`.
+   * `createRoute`/`listTokenTypes`/`listSystems` caem no singleton
+   * `apiClient`.
    */
   client?: ApiClient;
 }
@@ -111,9 +163,88 @@ export const NewRouteModal: React.FC<NewRouteModalProps> = ({
   const {
     tokenTypes,
     tokenTypesHelperText,
-    submitDisabled,
+    submitDisabled: tokenTypesSubmitDisabled,
     resolveEffectiveSubmitError,
   } = useRouteTokenTypes(open, client);
+
+  /**
+   * Modo "global": quando o caller não fornece `systemId`, exibimos um
+   * `<Select>` de sistema. O estado do dropdown vive aqui (em vez de
+   * expandir `RouteFormState`) para preservar o shape compartilhado com
+   * `EditRouteModal` e os testes da #64. `selectedSystemId` começa
+   * vazio e o usuário escolhe.
+   */
+  const showSystemSelect = systemId === undefined;
+  const [selectedSystemId, setSelectedSystemId] = useState<string>('');
+  const [systemIdError, setSystemIdError] = useState<string | null>(null);
+
+  /**
+   * Carrega o catálogo de sistemas apenas quando o modal está aberto e
+   * em modo global. `useSingleFetchWithAbort` cuida do AbortController
+   * e do retry bumper. A request reage à abertura do modal — fechar +
+   * reabrir cancela a request anterior.
+   *
+   * Skipamos a request quando: (a) o modal está fechado, ou (b) o
+   * caller passou `systemId` (modo per-system, dropdown não é
+   * renderizado e ninguém precisa do catálogo).
+   */
+  const systemsFetcher = useCallback(
+    (options: SafeRequestOptions): Promise<PagedResponse<SystemDto>> =>
+      listSystems({ pageSize: SYSTEMS_LOOKUP_PAGE_SIZE }, options, client),
+    [client],
+  );
+
+  const {
+    data: systemsResponse,
+    isInitialLoading: loadingSystems,
+    errorMessage: systemsErrorMessage,
+  } = useSingleFetchWithAbort<PagedResponse<SystemDto>>({
+    fetcher: systemsFetcher,
+    fallbackErrorMessage:
+      'Não foi possível carregar a lista de sistemas. Feche o modal e tente novamente.',
+    skip: !open || !showSystemSelect,
+  });
+
+  const systemOptions = useMemo<ReadonlyArray<SystemDto>>(() => {
+    if (!systemsResponse) return [];
+    return [...systemsResponse.data].sort((a, b) =>
+      a.name.localeCompare(b.name, 'pt-BR'),
+    );
+  }, [systemsResponse]);
+
+  /**
+   * `<Select>` em estado vazio (carregado mas sem nenhum sistema).
+   * Cenário extremo (instalação nova sem nenhum sistema cadastrado),
+   * mas o operador precisa de feedback claro de que não dá pra criar
+   * rota agora.
+   */
+  const systemsEmpty =
+    showSystemSelect &&
+    !loadingSystems &&
+    systemsErrorMessage === null &&
+    systemOptions.length === 0;
+
+  const handleSelectedSystemIdChange = useCallback((value: string) => {
+    setSelectedSystemId(value);
+    setSystemIdError(null);
+  }, []);
+
+  /**
+   * `submitDisabled` agregando todos os bloqueios do form:
+   *
+   * - Bloqueios oriundos de token types (carregando, erro ou vazio) —
+   *   delegados a `useRouteTokenTypes`.
+   * - No modo global: catálogo de sistemas carregando, erro de carga
+   *   ou vazio.
+   *
+   * Não bloqueamos por `selectedSystemId` vazio — deixamos o usuário
+   * tentar submeter para receber a mensagem inline "Selecione um
+   * sistema.". Espelha a UX dos demais campos obrigatórios do form
+   * (que validam só no submit).
+   */
+  const submitDisabled =
+    tokenTypesSubmitDisabled ||
+    (showSystemSelect && (loadingSystems || systemsErrorMessage !== null || systemsEmpty));
 
   /**
    * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
@@ -125,103 +256,171 @@ export const NewRouteModal: React.FC<NewRouteModalProps> = ({
     setFormState(INITIAL_ROUTE_FORM_STATE);
     setFieldErrors({});
     setSubmitError(null);
+    setSelectedSystemId('');
+    setSystemIdError(null);
     onClose();
   }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
 
-  const handleSubmit = useCallback(
-    async (event: React.SyntheticEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      if (isSubmitting) return;
+  /**
+   * Reset disparado pelo helper `useCreateEntitySubmit` no caminho
+   * feliz (antes de `onCreated`/`onClose`). Mantemos uma referência
+   * dedicada (em vez de reusar `handleClose`) porque `handleClose` é
+   * gateado por `isSubmitting` — o submit feliz roda exatamente
+   * quando `isSubmitting === true`, então o gate inverteria o
+   * comportamento esperado. Espelha o padrão de `NewRoleModal`/
+   * `NewUserModal`.
+   */
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_ROUTE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    setSelectedSystemId('');
+    setSystemIdError(null);
+  }, [setFormState, setFieldErrors, setSubmitError]);
 
-      // `prepareSubmit` valida + zera erros + marca submitting +
-      // devolve payload trimado, ou `null` quando há erros client-
-      // side. Mesma rotina será usada pelo `EditRouteModal` (lição
-      // PR #128).
-      const payload = prepareSubmit(systemId);
-      if (!payload) return;
+  /**
+   * Wrapper de `prepareSubmit` que injeta o `systemId` correto
+   * dependendo do modo. No modo global, valida o dropdown antes —
+   * se estiver vazio, popula o erro inline e devolve `null` para
+   * abortar o submit (mesmo padrão de `prepareSubmit` quando os
+   * outros campos falham na validação).
+   *
+   * Devolve `CreateRoutePayload | null` — preserva a tipagem
+   * exigida por `useCreateEntitySubmit.callbacks.prepareSubmit`.
+   */
+  const prepareSubmitForRoute = useCallback((): CreateRoutePayload | null => {
+    const effectiveSystemId = showSystemSelect ? selectedSystemId.trim() : systemId;
+    if (showSystemSelect && (effectiveSystemId === undefined || effectiveSystemId.length === 0)) {
+      setSystemIdError(SYSTEM_REQUIRED_MESSAGE);
+      // Não chamamos `prepareSubmit` — assim os outros erros inline
+      // só aparecem na próxima tentativa, depois que o operador
+      // resolver o sistema. Espelha o early-return do
+      // `validateRouteForm` quando há erros.
+      return null;
+    }
+    if (effectiveSystemId === undefined) {
+      // Defensivo: caller per-system não pode passar undefined
+      // (TypeScript já garante), mas o branch existe pra que o tipo
+      // do retorno seja correto sem `!`.
+      return null;
+    }
+    setSystemIdError(null);
+    return prepareSubmit(effectiveSystemId);
+  }, [prepareSubmit, selectedSystemId, showSystemSelect, systemId]);
 
-      try {
-        await createRoute(payload, undefined, client);
-        // Mensagem de sucesso fixa (não precisa do nome — o usuário
-        // acabou de digitar e a lista será atualizada).
-        show('Rota criada.', { variant: 'success' });
-        // Reset local antes de delegar para o pai. Ordem importa:
-        // chamamos `onCreated` (refetch) antes de `onClose` para que
-        // o pai não tenha que coordenar dois ticks separados.
-        setFormState(INITIAL_ROUTE_FORM_STATE);
-        setFieldErrors({});
-        setSubmitError(null);
-        onCreated();
-        onClose();
-      } catch (error: unknown) {
-        // `classifyRouteSubmitError` separa a decisão (puro) do efeito
-        // (com setState/show). Tabela única + switch curto evitam a
-        // cascata `if (status === 409) { ... } if (... === 400) { ... }`
-        // que duplicaria ~25 linhas com o `EditRouteModal` quando a
-        // #64 chegar (lição PR #128 — 4ª recorrência de duplicação
-        // Sonar foi exatamente esse padrão em `systemFormShared.ts`).
-        const action = classifyRouteSubmitError(error, SUBMIT_ERROR_COPY);
-        switch (action.kind) {
-          case 'conflict':
-            // Mensagem inline customizada (citando "neste sistema") em
-            // vez de propagar a do backend ("Já existe uma route com
-            // este Code.") — mais clara para o operador.
-            setFieldErrors({ [action.field]: CONFLICT_INLINE_MESSAGE });
-            setSubmitError(null);
-            break;
-          case 'bad-request':
-            applyBadRequest(action.details, action.fallbackMessage);
-            break;
-          case 'toast':
-            show(action.message, { variant: 'danger', title: action.title });
-            break;
-          // `not-found` (404) não chega no fluxo de create — backend
-          // nunca devolve 404 nesse path. Tratamos como `unhandled`
-          // por segurança (mostra toast genérico).
-          case 'not-found':
-          case 'unhandled':
-            show(
-              action.kind === 'unhandled' ? action.fallback : SUBMIT_ERROR_COPY.genericFallback,
-              {
-                variant: 'danger',
-                title:
-                  action.kind === 'unhandled' ? action.title : SUBMIT_ERROR_COPY.forbiddenTitle,
-              },
-            );
-            break;
-        }
-      } finally {
-        setIsSubmitting(false);
-      }
-    },
-    [
-      applyBadRequest,
-      client,
-      isSubmitting,
-      onClose,
-      onCreated,
-      prepareSubmit,
-      setFieldErrors,
-      setFormState,
-      setIsSubmitting,
-      setSubmitError,
-      show,
-      systemId,
-    ],
+  /**
+   * `mutationFn` injetada no helper genérico. Tipa o payload via
+   * cast porque o helper aceita `unknown` — `prepareSubmit` só
+   * devolve `CreateRoutePayload | null` e o helper já filtrou
+   * `null` antes de chamar `mutationFn`.
+   */
+  const mutationFn = useCallback(
+    (payload: unknown) =>
+      createRoute(payload as CreateRoutePayload, undefined, client),
+    [client],
   );
+
+  const handleSubmit = useCreateEntitySubmit<keyof RouteFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: {
+      successMessage: 'Rota criada.',
+      conflictInlineMessage: CONFLICT_INLINE_MESSAGE,
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    },
+    callbacks: {
+      prepareSubmit: prepareSubmitForRoute,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: 'code',
+  });
+
+  /**
+   * `submitError` exibido no Alert do topo: prioriza o erro do submit
+   * (vem do backend), depois o erro de carga de token types, depois o
+   * de carga de sistemas (modo global). `useRouteTokenTypes` já cobre
+   * a parte de token types via `resolveEffectiveSubmitError`; aqui
+   * acrescentamos a layer de sistemas.
+   */
+  const effectiveSubmitError = (() => {
+    const tokenLayer = resolveEffectiveSubmitError(submitError);
+    if (tokenLayer !== null) return tokenLayer;
+    if (showSystemSelect) {
+      if (systemsErrorMessage !== null) return systemsErrorMessage;
+      if (systemsEmpty) {
+        return 'Nenhum sistema cadastrado. Cadastre um sistema antes de criar rotas.';
+      }
+    }
+    return null;
+  })();
+
+  /**
+   * Helper text do `<Select>` enquanto a request inicial de sistemas
+   * está em curso. Mostra "Carregando sistemas..." em vez de deixar o
+   * controle vazio — espelha o padrão usado por `useRouteTokenTypes`
+   * para o `<Select>` de política JWT.
+   */
+  const systemsHelperText = loadingSystems ? 'Carregando sistemas…' : undefined;
+
+  /**
+   * Slot opcional renderizado dentro do `<form>`, **acima** dos
+   * campos padrão. Quando o modal está em modo global, contém o
+   * `<Select>` de sistema; em modo per-system, é `null` e o body
+   * renderiza igual ao original.
+   */
+  const headerSlot = showSystemSelect ? (
+    <Select
+      label="Sistema"
+      value={selectedSystemId}
+      onChange={handleSelectedSystemIdChange}
+      error={systemIdError ?? undefined}
+      helperText={
+        systemIdError
+          ? undefined
+          : systemsHelperText ?? 'Selecione o sistema dono da nova rota.'
+      }
+      disabled={isSubmitting || loadingSystems || systemsErrorMessage !== null || systemsEmpty}
+      required
+      data-testid="new-route-system-id"
+      aria-label="Sistema dono da nova rota"
+    >
+      <option value="" disabled={systemOptions.length > 0}>
+        {systemOptions.length > 0
+          ? 'Selecione um sistema'
+          : 'Nenhum sistema disponível'}
+      </option>
+      {systemOptions.map((system) => (
+        <option key={system.id} value={system.id}>
+          {system.name}
+        </option>
+      ))}
+    </Select>
+  ) : null;
 
   return (
     <Modal
       open={open}
       onClose={handleClose}
       title="Nova rota"
-      description="Cadastre uma rota vinculada ao sistema selecionado."
+      description={
+        showSystemSelect
+          ? 'Cadastre uma rota escolhendo o sistema dono.'
+          : 'Cadastre uma rota vinculada ao sistema selecionado.'
+      }
       closeOnEsc={!isSubmitting}
       closeOnBackdrop={!isSubmitting}
     >
       <RouteFormBody
         idPrefix="new-route"
-        submitError={resolveEffectiveSubmitError(submitError)}
+        submitError={effectiveSubmitError}
         values={formState}
         errors={fieldErrors}
         tokenTypes={tokenTypes}
@@ -235,6 +434,7 @@ export const NewRouteModal: React.FC<NewRouteModalProps> = ({
         submitLabel="Criar rota"
         submitDisabled={submitDisabled}
         tokenTypesHelperText={tokenTypesHelperText}
+        headerSlot={headerSlot}
       />
     </Modal>
   );

--- a/src/pages/routes/RouteFormFields.tsx
+++ b/src/pages/routes/RouteFormFields.tsx
@@ -266,6 +266,16 @@ interface RouteFormBodyProps {
    * token types está sendo carregada. Repassado para `RouteFormFields`.
    */
   tokenTypesHelperText?: string;
+  /**
+   * Slot opcional renderizado **acima** dos campos padrão (Nome/Código/
+   * Descrição/Política JWT) e **abaixo** do Alert de `submitError`.
+   * Usado pelo modo "criar rota global" (Issue #187) para injetar o
+   * `<Select>` de sistema sem expandir o `RouteFormState` compartilhado
+   * com `EditRouteModal` — o caller controla `selectedSystemId` e o
+   * erro inline localmente. No fluxo per-system (`RoutesPage` da
+   * #63/#64), o slot é omitido e o body renderiza igual ao original.
+   */
+  headerSlot?: React.ReactNode;
 }
 
 /**
@@ -301,6 +311,7 @@ export const RouteFormBody: React.FC<RouteFormBodyProps> = ({
   submitLabel,
   submitDisabled = false,
   tokenTypesHelperText,
+  headerSlot,
 }) => (
   <RouteFormShell onSubmit={onSubmit} noValidate data-testid={`${idPrefix}-form`}>
     {submitError && (
@@ -308,6 +319,7 @@ export const RouteFormBody: React.FC<RouteFormBodyProps> = ({
         {submitError}
       </Alert>
     )}
+    {headerSlot}
     <RouteFormFields
       idPrefix={idPrefix}
       values={values}

--- a/src/pages/routes/RoutesGlobalListShellPage.tsx
+++ b/src/pages/routes/RoutesGlobalListShellPage.tsx
@@ -1,10 +1,12 @@
+import { Plus } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PageHeader } from '../../components/layout/PageHeader';
-import { Select, Table } from '../../components/ui';
+import { Button, Select, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useToggleModalState } from '../../hooks/useListModalState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
 import {
@@ -14,6 +16,7 @@ import {
   listRoutes,
   listSystems,
 } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
 import {
   CardListForMobile,
   CardMeta,
@@ -29,6 +32,7 @@ import {
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import { NewRouteModal } from './NewRouteModal';
 import {
   RouteCardTopSection,
   renderRouteDescription,
@@ -75,6 +79,19 @@ const SYSTEM_FILTER_ALL = 'ALL' as const;
  * nome do sistema na coluna Sistema, em vez de "—".
  */
 const SYSTEMS_LOOKUP_PAGE_SIZE = 100;
+
+/**
+ * Code de permissão exigido para o botão "Nova rota" — Issue #187.
+ *
+ * Espelha o `AUTH_V1_SYSTEMS_ROUTES_CREATE` cadastrado pelo
+ * `AuthenticatorRoutesSeeder` no `lfc-authenticator` e o usado na
+ * `RoutesPage` (per-system). O backend é a fonte autoritativa
+ * (`POST /systems/routes` valida via
+ * `[Authorize(Policy = PermissionPolicies.SystemsRoutesCreate)]`); o
+ * gating client-side é apenas UX — esconder ações que o usuário não
+ * pode executar.
+ */
+const ROUTES_CREATE_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_CREATE';
 
 interface RoutesGlobalListShellPageProps {
   /**
@@ -178,10 +195,18 @@ export const RoutesGlobalListShellPage: React.FC<RoutesGlobalListShellPageProps>
 }) => {
   // A rota inteira é gateada por
   // `RequirePermission code="AUTH_V1_SYSTEMS_ROUTES_LIST"` em
-  // `AppRoutes`, então a página não precisa chamar `useAuth()` para
-  // gating local — caso futuras sub-issues adicionem ações por linha
-  // condicionais (ex.: drill-down restrito), reintroduzir o hook na
-  // ocasião.
+  // `AppRoutes`. A partir da Issue #187 também usamos `useAuth` para
+  // gating local do botão "Nova rota" — esconde a ação para operadores
+  // sem `AUTH_V1_SYSTEMS_ROUTES_CREATE`.
+  const { hasPermission } = useAuth();
+  const canCreateRoute = hasPermission(ROUTES_CREATE_PERMISSION);
+
+  // Estado de abertura do modal "Nova rota" (Issue #187 — paridade
+  // visual com `SystemsPage`/`RoutesPage`/`RolesGlobalListShellPage`).
+  // Usamos `useToggleModalState` para colapsar o trio
+  // `[isOpen, open, close]` e evitar a 7ª recorrência potencial de
+  // duplicação Sonar (lição PR #134/#135).
+  const createModal = useToggleModalState();
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -555,11 +580,33 @@ export const RoutesGlobalListShellPage: React.FC<RoutesGlobalListShellPageProps>
         includeDeletedHelperText="Inclui rotas com remoção lógica."
         includeDeletedTestId="routes-global-include-deleted"
         extraFilter={systemFilterSelect}
+        actions={
+          canCreateRoute && (
+            <Button
+              variant="primary"
+              size="md"
+              icon={<Plus size={14} strokeWidth={1.75} />}
+              onClick={createModal.open}
+              data-testid="routes-global-create-open"
+            >
+              Nova rota
+            </Button>
+          )
+        }
       />
 
       <LiveRegion message={liveMessage} testId="routes-global-live" />
 
       {resultArea}
+
+      {canCreateRoute && (
+        <NewRouteModal
+          open={createModal.isOpen}
+          onClose={createModal.close}
+          onCreated={handleRefetch}
+          client={client}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/routes/index.ts
+++ b/src/pages/routes/index.ts
@@ -1,1 +1,2 @@
+export { NewRouteModal } from './NewRouteModal';
 export { RoutesGlobalListShellPage } from './RoutesGlobalListShellPage';

--- a/tests/pages/__helpers__/routesTestHelpers.tsx
+++ b/tests/pages/__helpers__/routesTestHelpers.tsx
@@ -871,3 +871,122 @@ export function countRoutesListCalls(client: ApiClientStub): number {
       (call[0] as string).startsWith("/systems/routes"),
   ).length;
 }
+
+/* ─── Helpers para criação global (Issue #187) ──────────────── */
+
+/**
+ * Mocka as respostas do backend para a sequência típica da
+ * `RoutesGlobalListShellPage` quando o modal "Nova rota" é aberto:
+ *
+ * 1. `GET /systems/routes` (listagem global de rotas — disparado no
+ *    mount).
+ * 2. `GET /systems` (catálogo de sistemas — disparado no mount para
+ *    popular o dropdown de filtro **e** novamente quando o modal
+ *    abrir, para popular o `<Select>` de sistema dono da nova rota).
+ * 3. `GET /tokens/types` (carregamento da lista do `<Select>` de
+ *    política JWT ao abrir o modal).
+ *
+ * Usa `mockImplementation` em vez de `mockResolvedValueOnce` em
+ * sequência porque os GETs disparam em paralelo (mount da página +
+ * efeitos do modal). Roteamento por `path` elimina a fragilidade de
+ * ordem — espelha `mockGlobalRoutesInitialResponses` mas inclui o
+ * caminho de `/tokens/types` que vive só no modal.
+ *
+ * Lição PR #128/#134/#135 — projetar shared helpers desde o primeiro
+ * PR do recurso, não esperar a duplicação aparecer e refatorar.
+ */
+export function mockGlobalRoutesWithCreateModalResponses(
+  client: ApiClientStub,
+  options: {
+    /** Linhas devolvidas pelo GET de rotas. Default: 1 rota fake. */
+    routes?: ReadonlyArray<RouteDto>;
+    /** Sistemas devolvidos pelo GET de sistemas. Default: `[lfc-authenticator]`. */
+    systems?: ReadonlyArray<SystemDto>;
+    /** Token types devolvidos pelo GET. Default: `[default]`. */
+    tokenTypes?: ReadonlyArray<TokenTypeDto>;
+    /** Overrides do envelope paginado de rotas. */
+    routesPagedOverrides?: Partial<PagedResponse<RouteDto>>;
+  } = {},
+): void {
+  const routes = options.routes ?? [makeRoute()];
+  const systems = options.systems ?? [makeSystem()];
+  const tokenTypes = options.tokenTypes ?? [makeTokenType()];
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith("/systems/routes")) {
+      return Promise.resolve(
+        makePagedRoutes(routes, options.routesPagedOverrides),
+      );
+    }
+    if (path.startsWith("/tokens/types")) {
+      return Promise.resolve(tokenTypes);
+    }
+    if (path.startsWith("/systems")) {
+      return Promise.resolve(makePagedSystems(systems));
+    }
+    return Promise.reject(
+      new Error(
+        `mockGlobalRoutesWithCreateModalResponses: path inesperado ${path}`,
+      ),
+    );
+  });
+}
+
+/**
+ * Mocka as respostas iniciais (rotas + sistemas + token types),
+ * renderiza a `RoutesGlobalListShellPage`, espera a listagem inicial
+ * carregar e clica no botão "Nova rota" do toolbar para abrir o
+ * modal global. Aguarda o `<Select>` de política JWT sair do estado
+ * disabled (request de token types resolvida) — assim os asserts
+ * subsequentes podem interagir com o form sem race.
+ *
+ * Análogo a `openCreateRouteModal` (per-system) mas para o caminho
+ * global da Issue #187. Mantém a fila de respostas via
+ * `mockGlobalRoutesWithCreateModalResponses` — pré-fabricado para
+ * cada teste que precise abrir o modal não duplicar ~10 linhas de
+ * "render + waitFor + click + waitFor" (lição PR #127 — Sonar marca
+ * trechos de 5+ linhas em 2+ testes como duplicação).
+ *
+ * Quem precisar de mocks diferentes pode chamar `client.get.mockXxx`
+ * antes para sobrescrever — a detecção de mocks pré-existentes
+ * preserva o caso "fila customizada" (ex.: cenários de erro 5xx no
+ * carregamento de sistemas dentro do modal).
+ */
+export async function openCreateRouteModalFromGlobalShell(
+  client: ApiClientStub,
+  options: {
+    routes?: ReadonlyArray<RouteDto>;
+    systems?: ReadonlyArray<SystemDto>;
+    tokenTypes?: ReadonlyArray<TokenTypeDto>;
+  } = {},
+): Promise<void> {
+  // Detecta mocks pré-existentes via `mock.calls`/`results` **e** via
+  // `getMockImplementation()` — caller que rodou
+  // `mockGlobalRoutesWithCreateModalResponses(...)` antes não tem
+  // chamadas registradas ainda, mas tem implementação setada. Sem essa
+  // segunda checagem, o helper sobrescreveria o mock pré-existente
+  // com defaults vazios.
+  const hasPreExistingMocks =
+    client.get.mock.calls.length > 0 ||
+    client.get.mock.results.length > 0 ||
+    client.get.getMockImplementation() !== undefined;
+  if (!hasPreExistingMocks) {
+    mockGlobalRoutesWithCreateModalResponses(client, options);
+  }
+  renderRoutesGlobalListPage(client);
+  await waitForInitialGlobalList(client);
+  fireEvent.click(screen.getByTestId("routes-global-create-open"));
+  // Aguarda os GETs do modal (tokenTypes + systems) e que ambos os
+  // `<Select>` saiam do estado disabled — assim os asserts
+  // subsequentes podem interagir com o form sem race.
+  await waitFor(() => {
+    expect(screen.getByTestId("new-route-form")).toBeInTheDocument();
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("new-route-system-id")).not.toBeDisabled();
+  });
+  await waitFor(() => {
+    expect(
+      screen.getByTestId("new-route-system-token-type-id"),
+    ).not.toBeDisabled();
+  });
+}

--- a/tests/pages/routes/RoutesGlobalListShellPage.test.tsx
+++ b/tests/pages/routes/RoutesGlobalListShellPage.test.tsx
@@ -6,6 +6,7 @@ import { buildAuthMock } from '../__helpers__/mockUseAuth';
 import {
   countRoutesListCalls,
   createRoutesGlobalClientStub,
+  fillNewRouteForm,
   ID_ROUTE_LIST,
   ID_ROUTE_CREATE,
   ID_SYS_AUTH,
@@ -16,8 +17,12 @@ import {
   makePagedSystems,
   makeRoute,
   makeSystem,
+  makeTokenType,
   mockGlobalRoutesInitialResponses,
+  mockGlobalRoutesWithCreateModalResponses,
+  openCreateRouteModalFromGlobalShell,
   renderRoutesGlobalListPage,
+  submitNewRouteForm,
   waitForInitialGlobalList,
 } from '../__helpers__/routesTestHelpers';
 /* eslint-enable import/order */
@@ -26,17 +31,25 @@ import type { RouteDto } from '@/shared/api';
 
 /**
  * Suíte da `RoutesGlobalListShellPage` (Issue #172 — listagem global
- * cross-system de rotas).
+ * cross-system de rotas; Issue #187 — botão "Nova rota" cross-system).
  *
  * Estratégia espelha `ClientsListShellPage.test.tsx`/`SystemsPage.test.tsx`:
  * stub de `ApiClient` injetado, asserts sobre estados visuais, busca
  * debounced, paginação, filtro por sistema (dropdown), toggle "Mostrar
  * inativas", coluna Sistema com `<Link>` clicável e cards mobile.
+ *
+ * A partir da Issue #187, `permissionsMock` é mutável (em vez do
+ * static array original) para que o gating do botão "Nova rota" possa
+ * ser exercido sem mexer no `vi.mock`. Mesmo padrão usado pelas
+ * suítes de mutação per-system (ex.: `RoutesPage.create.test.tsx`).
  */
 
-vi.mock('@/shared/auth', () =>
-  buildAuthMock(() => ['AUTH_V1_SYSTEMS_ROUTES_LIST']),
-);
+const ROUTES_LIST_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_LIST';
+const ROUTES_CREATE_PERMISSION = 'AUTH_V1_SYSTEMS_ROUTES_CREATE';
+
+let permissionsMock: ReadonlyArray<string> = [ROUTES_LIST_PERMISSION];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -71,6 +84,7 @@ const SAMPLE_SYSTEMS = [
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
+  permissionsMock = [ROUTES_LIST_PERMISSION];
 });
 
 afterEach(() => {
@@ -564,5 +578,241 @@ describe('RoutesGlobalListShellPage — erro de listagem', () => {
 
     expect(screen.getByText('Erro interno ao listar rotas.')).toBeInTheDocument();
     expect(screen.getByTestId('routes-global-retry')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Issue #187 — botão "Nova rota" cross-system na listagem global.
+ *
+ * Diferenças vs. fluxo per-system (`RoutesPage.create.test.tsx`):
+ *
+ * - Botão vive no toolbar da `RoutesGlobalListShellPage` (testid
+ *   `routes-global-create-open` em vez de `routes-create-open`).
+ * - O modal é aberto **sem** prop `systemId` — renderiza um
+ *   `<Select>` adicional no topo do form (`new-route-system-id`)
+ *   que o operador precisa preencher antes de submeter.
+ * - Após sucesso, a listagem global recarrega via `handleRefetch`.
+ */
+describe('RoutesGlobalListShellPage — botão "Nova rota" (Issue #187)', () => {
+  describe('gating do botão', () => {
+    it('não exibe o botão quando o usuário não possui AUTH_V1_SYSTEMS_ROUTES_CREATE', async () => {
+      // Apenas LIST: o botão de criação fica oculto.
+      permissionsMock = [ROUTES_LIST_PERMISSION];
+      const client = createRoutesGlobalClientStub();
+      mockGlobalRoutesInitialResponses(client, {
+        routes: SAMPLE_ROUTES,
+        systems: SAMPLE_SYSTEMS,
+      });
+
+      renderRoutesGlobalListPage(client);
+      await waitForInitialGlobalList(client);
+
+      expect(
+        screen.queryByTestId('routes-global-create-open'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('exibe o botão quando o usuário possui AUTH_V1_SYSTEMS_ROUTES_CREATE', async () => {
+      permissionsMock = [ROUTES_LIST_PERMISSION, ROUTES_CREATE_PERMISSION];
+      const client = createRoutesGlobalClientStub();
+      mockGlobalRoutesInitialResponses(client, {
+        routes: SAMPLE_ROUTES,
+        systems: SAMPLE_SYSTEMS,
+      });
+
+      renderRoutesGlobalListPage(client);
+      await waitForInitialGlobalList(client);
+
+      const openBtn = screen.getByTestId('routes-global-create-open');
+      expect(openBtn).toBeInTheDocument();
+      expect(openBtn).toHaveTextContent(/Nova rota/i);
+    });
+  });
+
+  describe('abertura do modal e dropdown de sistema', () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_LIST_PERMISSION, ROUTES_CREATE_PERMISSION];
+    });
+
+    it('clicar em "Nova rota" abre o diálogo com dropdown de sistema visível', async () => {
+      const client = createRoutesGlobalClientStub();
+      await openCreateRouteModalFromGlobalShell(client, {
+        systems: SAMPLE_SYSTEMS,
+      });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      // O `<Select>` extra do modo global aparece (test id dedicado).
+      expect(screen.getByTestId('new-route-system-id')).toBeInTheDocument();
+      // Os campos padrão também estão presentes.
+      expect(screen.getByTestId('new-route-name')).toBeInTheDocument();
+      expect(screen.getByTestId('new-route-code')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('new-route-system-token-type-id'),
+      ).toBeInTheDocument();
+    });
+
+    it('dropdown de sistema lista os sistemas em ordem alfabética', async () => {
+      const client = createRoutesGlobalClientStub();
+      await openCreateRouteModalFromGlobalShell(client, {
+        // Inversão proposital — o `<Select>` deve ordenar.
+        systems: [
+          makeSystem({ id: ID_SYS_KURTTO, name: 'lfc-kurtto', code: 'KURTTO' }),
+          makeSystem({ id: ID_SYS_AUTH, name: 'lfc-authenticator', code: 'AUTH' }),
+        ],
+      });
+
+      const select = screen.getByTestId('new-route-system-id') as HTMLSelectElement;
+      const optionTexts = Array.from(select.options).map((opt) => opt.textContent);
+      // Placeholder + 2 sistemas em ordem alfabética.
+      expect(optionTexts[0]).toBe('Selecione um sistema');
+      expect(optionTexts[1]).toBe('lfc-authenticator');
+      expect(optionTexts[2]).toBe('lfc-kurtto');
+    });
+  });
+
+  describe('validação e submissão do modal global', () => {
+    beforeEach(() => {
+      permissionsMock = [ROUTES_LIST_PERMISSION, ROUTES_CREATE_PERMISSION];
+    });
+
+    it('submeter sem escolher sistema mostra erro inline e não chama POST', async () => {
+      const client = createRoutesGlobalClientStub();
+      await openCreateRouteModalFromGlobalShell(client, {
+        systems: SAMPLE_SYSTEMS,
+      });
+
+      // Preenche os outros campos para isolar o erro do `<Select>`
+      // de sistema. O usuário tenta submeter sem escolher sistema.
+      fillNewRouteForm({
+        name: 'Listar X',
+        code: 'X_LIST',
+        systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+      });
+      fireEvent.submit(screen.getByTestId('new-route-form'));
+
+      expect(screen.getByText('Selecione um sistema.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('escolher sistema, preencher campos e submeter envia POST com systemId selecionado', async () => {
+      const created = makeRoute({
+        id: ID_ROUTE_CREATE,
+        systemId: ID_SYS_KURTTO,
+        name: 'Criar pedido',
+        code: 'KURTTO_V1_ORDERS_CREATE',
+        description: null,
+      });
+      const client = createRoutesGlobalClientStub();
+      mockGlobalRoutesWithCreateModalResponses(client, {
+        routes: SAMPLE_ROUTES,
+        systems: SAMPLE_SYSTEMS,
+        tokenTypes: [makeTokenType()],
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateRouteModalFromGlobalShell(client);
+
+      // Escolhe o segundo sistema do dropdown (KURTTO) — deliberado
+      // para validar que o systemId enviado vem do dropdown e não de
+      // um valor hardcoded.
+      fireEvent.change(screen.getByTestId('new-route-system-id'), {
+        target: { value: ID_SYS_KURTTO },
+      });
+      fillNewRouteForm({
+        name: 'Criar pedido',
+        code: 'KURTTO_V1_ORDERS_CREATE',
+        systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+      });
+      await submitNewRouteForm(client);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/systems/routes',
+        {
+          systemId: ID_SYS_KURTTO,
+          name: 'Criar pedido',
+          code: 'KURTTO_V1_ORDERS_CREATE',
+          systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+        },
+        undefined,
+      );
+
+      // Modal fecha após sucesso.
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+
+      // Toast verde "Rota criada.".
+      expect(await screen.findByText('Rota criada.')).toBeInTheDocument();
+    });
+
+    it('após sucesso, a listagem global é refetch (chamada extra a /systems/routes)', async () => {
+      const created = makeRoute({
+        id: ID_ROUTE_CREATE,
+        systemId: ID_SYS_AUTH,
+        name: 'Nova',
+        code: 'NEW_ROUTE',
+      });
+      const client = createRoutesGlobalClientStub();
+      mockGlobalRoutesWithCreateModalResponses(client, {
+        routes: SAMPLE_ROUTES,
+        systems: SAMPLE_SYSTEMS,
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      await openCreateRouteModalFromGlobalShell(client);
+      const callsBefore = countRoutesListCalls(client);
+
+      fireEvent.change(screen.getByTestId('new-route-system-id'), {
+        target: { value: ID_SYS_AUTH },
+      });
+      fillNewRouteForm({
+        name: 'Nova',
+        code: 'NEW_ROUTE',
+        systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+      });
+      await submitNewRouteForm(client);
+
+      // O refetch da listagem global após sucesso aumenta o contador
+      // de chamadas a `/systems/routes`.
+      await waitFor(() =>
+        expect(countRoutesListCalls(client)).toBe(callsBefore + 1),
+      );
+    });
+
+    it('409 (code duplicado) exibe mensagem inline no campo code', async () => {
+      const client = createRoutesGlobalClientStub();
+      mockGlobalRoutesWithCreateModalResponses(client, {
+        routes: SAMPLE_ROUTES,
+        systems: SAMPLE_SYSTEMS,
+      });
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 409,
+        message: 'Já existe uma route com este Code.',
+      });
+
+      await openCreateRouteModalFromGlobalShell(client);
+
+      fireEvent.change(screen.getByTestId('new-route-system-id'), {
+        target: { value: ID_SYS_AUTH },
+      });
+      fillNewRouteForm({
+        name: 'Conflito',
+        code: 'CONFLICT_CODE',
+        systemTokenTypeId: ID_TOKEN_TYPE_DEFAULT,
+      });
+      await submitNewRouteForm(client);
+
+      // Mensagem inline custom citando "neste sistema" (NewRouteModal
+      // sobrescreve a copy do backend).
+      expect(
+        await screen.findByText(
+          /Já existe uma rota com este código neste sistema/i,
+        ),
+      ).toBeInTheDocument();
+
+      // Modal continua aberto.
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Contexto

A listagem global em `/routes` (`RoutesGlobalListShellPage`, entregue na #172) era read-only — operadores só podiam criar rotas via drill-down per-system (`/systems/:id/routes`, fluxo da #63). A Issue #187 alinha a UX da página global com `/sistemas`/`/clientes`/`/usuarios`/`/tokens` (todas com criação inline) ao adicionar um botão **"Nova rota"** no toolbar.

Como rota é um recurso escopado por sistema, o modal precisa de um campo extra (`systemId`) que não existe no fluxo per-system. Refatoramos `NewRouteModal` para aceitar `systemId` opcional e renderizar um `<Select>` obrigatório no topo do form quando ausente — preserva o comportamento original do `RoutesPage` (100% das suítes per-system continuam verdes) sem duplicar código.

## Objetivo

- [x] Botão "Nova rota" visível em `/routes` para usuários com `Routes.Create` (`AUTH_V1_SYSTEMS_ROUTES_CREATE`).
- [x] `NewRouteModal` aceita `systemId` opcional na prop:
  - **Definido** (caller `RoutesPage`): renderiza form sem dropdown, igual hoje.
  - **Omitido** (caller `RoutesGlobalListShellPage`): renderiza dropdown de sistema obrigatório no topo (alimentado por `listSystems({ pageSize: 100 })`, ordenado alfabeticamente).
- [x] Validação inline: "Selecione um sistema." quando o operador tenta submeter sem escolher.
- [x] Após sucesso, listagem global recarrega via `handleRefetch`.
- [x] Sem regressão no fluxo per-system (`RoutesPage`/`useRouteForm`/`useRouteTokenTypes`).

## O que foi feito

### `src/pages/routes/NewRouteModal.tsx`
- `systemId?: string` opcional na prop. Quando ausente (`showSystemSelect = systemId === undefined`), o modal:
  - Carrega `listSystems({ pageSize: 100 })` via `useSingleFetchWithAbort` (skip quando modal fechado ou em modo per-system — não desperdiça request).
  - Renderiza `<Select>` no topo do form via slot `headerSlot` do `RouteFormBody`, preservando o estado do form compartilhado com `EditRouteModal`.
  - Trata estados visuais completos: loading ("Carregando sistemas…"), erro de carga, lista vazia ("Nenhum sistema cadastrado…"), erro inline de validação ("Selecione um sistema.").
  - `submitDisabled` agrega bloqueios de token types + sistemas (carregando/erro/vazio).
- Migrado `handleSubmit` para `useCreateEntitySubmit` — paridade com `NewRoleModal`/`NewUserModal`/`NewClientModal`/`NewTokenTypeModal`. Eliminou o switch manual de erros que duplicaria 25+ linhas com o restante do CRUD.
- `prepareSubmitForRoute` injeta o `systemId` correto (prop ou estado local) e valida o dropdown antes de chamar `prepareSubmit` da chave compartilhada.

### `src/pages/routes/RouteFormFields.tsx`
- Adicionada prop `headerSlot?: React.ReactNode` em `RouteFormBody` — renderizada acima dos campos padrão e abaixo do Alert de `submitError`. Mantém o gap consistente (`var(--space-4)` do `RouteFormShell`) sem styled extra.

### `src/pages/routes/RoutesGlobalListShellPage.tsx`
- `useAuth` + `hasPermission(AUTH_V1_SYSTEMS_ROUTES_CREATE)` para gating do botão.
- `useToggleModalState` controla visibilidade do modal (alinhado com `SystemsPage`/`UsersListShellPage`/`ClientsListShellPage`).
- Botão "Nova rota" no `ListingToolbar.actions`, com `<Plus>` icon do `lucide-react`.
- `<NewRouteModal>` renderizado sem `systemId` (caller global), com `onCreated={handleRefetch}` para reload da listagem.

### Testes
- `tests/pages/routes/RoutesGlobalListShellPage.test.tsx`: 8 novos cenários cobrindo gating do botão (com/sem permissão), abertura do modal, dropdown ordenado alfabeticamente, validação de "selecione um sistema", submissão com sucesso (POST com `systemId` selecionado), refetch após sucesso, 409 inline. `permissionsMock` agora é mutável (mesmo padrão do `RoutesPage.create.test.tsx`).
- `tests/pages/__helpers__/routesTestHelpers.tsx`: helpers `mockGlobalRoutesWithCreateModalResponses` (mocka rotas+sistemas+tokenTypes via `mockImplementation`) e `openCreateRouteModalFromGlobalShell` (render+wait+click+wait); detecção de mock pré-existente via `getMockImplementation()` evita sobrescrever fila customizada do caller.

## Arquivos impactados

- `src/pages/routes/NewRouteModal.tsx` — refator para `systemId` opcional + `useCreateEntitySubmit`.
- `src/pages/routes/RouteFormFields.tsx` — prop `headerSlot` opcional.
- `src/pages/routes/RoutesGlobalListShellPage.tsx` — botão "Nova rota" + modal.
- `src/pages/routes/index.ts` — exporta `NewRouteModal`.
- `tests/pages/__helpers__/routesTestHelpers.tsx` — 2 novos helpers para o modal global.
- `tests/pages/routes/RoutesGlobalListShellPage.test.tsx` — 8 novos cenários para #187.

## Testes

Quality gate completo (todos os comandos via container):

| Etapa | Resultado |
|---|---|
| `npm run lint` | ✅ 0 erros, 0 warnings |
| `npm run typecheck` | ✅ 0 erros |
| `npm test` | ✅ 1601/1601 passando (incluindo as 8 novas + 20 existentes da `RoutesGlobalListShellPage.test.tsx`) |
| `jscpd --threshold 3 --min-lines 10` | ✅ 1.48% total; nenhum clone envolvendo arquivos do diff |

Suítes verificadas explicitamente:
- `RoutesGlobalListShellPage.test.tsx` — 28/28 ✅ (8 novos cenários de #187)
- `RoutesPage.test.tsx` / `RoutesPage.create.test.tsx` / `RoutesPage.edit.test.tsx` / `RoutesPage.delete.test.tsx` — 82/82 ✅ (sem regressão no fluxo per-system)

## Visual

- `<Select>` de sistema reusa o componente do design system — mesmo hover/focus/disabled tratados.
- Loading text "Carregando sistemas…" no `helperText` enquanto `useSingleFetchWithAbort` resolve.
- Erro inline ("Selecione um sistema.") usa o token `--danger` do componente Select.
- Erros de carga (sistemas/token types) propagam como `Alert variant="danger"` no topo do form.
- Spacing consistente — `headerSlot` herda `var(--space-4)` do `RouteFormShell`, sem styled específico.
- Sem hardcode de cor; tokens do design system em todos os pontos.
- Modal preserva todos os estados visuais críticos: loading, empty, error, hover/focus/disabled.

## Segurança

- `Routes.Create` é gateado client-side (UX) **e** server-side (`[Authorize(Policy = SystemsRoutesCreate)]` no `RoutesController`). Esconder o botão é apenas conforto visual — backend é a fonte da verdade.
- `selectedSystemId` é apenas um UUID lido do `<option value>`. Sem `dangerouslySetInnerHTML`, sem URL externa, sem token logado em console.
- Nenhuma alteração de superfície de segurança: o backend já aceitava `systemId` no body de `POST /systems/routes` desde a #63 — só estamos expondo o controle no UI quando faltava.

## Riscos

- Fluxo per-system (`RoutesPage`) coberto por 82 testes pré-existentes — todos verdes pós-refator. Risco de regressão baixo.
- Migração de `handleSubmit` para `useCreateEntitySubmit` muda o ordering de side-effects (resetForm → onCreated → onClose) para o padrão dos demais New*Modals. Comportamento equivalente do ponto de vista do usuário; testes confirmam.
- `mockGlobalRoutesWithCreateModalResponses` usa `mockImplementation` (não `mockResolvedValueOnce`) — testes que misturarem helpers podem encontrar conflito. O helper checa `getMockImplementation()` antes de sobrescrever.

## Issue relacionada

Closes #187