### PR TITLE
#190 | QA/E2E: tela Permissões da role após GET /roles/{id}/permissions no authenticator

### DIFF
--- a/src/pages/roles/RolePermissionsShellPage.tsx
+++ b/src/pages/roles/RolePermissionsShellPage.tsx
@@ -144,6 +144,11 @@ function extractErrorMessage(error: unknown, fallback: string): string {
  *    via toast (idempotência cobre divergências raras).
  * 5. Após o salvar, refetch sincroniza o estado com o backend.
  *
+ * **Issue #190 (QA):** cobertura de testes garante o carregamento via
+ * `GET /roles/{roleId}/permissions` em paralelo ao catálogo, erro
+ * quando o GET falha ou o corpo diverge do contrato, e o salvar com
+ * diff (`POST`/`DELETE` nos paths reais do authenticator).
+ *
  * **Visível com** `Roles.Update` (code `AUTH_V1_ROLES_UPDATE`,
  * espelho do gating do botão "Editar" da `RolesPage`). O gating na
  * rota é feito por `RequirePermission`. A página assume que a
@@ -412,7 +417,7 @@ export const RolePermissionsShellPage: React.FC<
       <PageHeader
         eyebrow="03 Roles · Permissões"
         title="Permissões da role"
-        desc="Vincule ou desvincule permissões à role selecionada. Apenas permissões pertencentes ao mesmo sistema da role são listadas — alterações entram em vigor imediatamente após salvar."
+        desc="Vincule ou desvincule permissões à role selecionada. O catálogo lista apenas permissões do mesmo sistema (filtro por systemId). Cada vínculo é uma permissão concreta — combinação de rota e tipo de acesso — e precisa existir antes em Permissões; não basta existir só a rota. As alterações passam a valer após Salvar."
         actions={
           <>
             <Button

--- a/src/shared/api/roles.ts
+++ b/src/shared/api/roles.ts
@@ -503,9 +503,9 @@ export function isRolePermissionLinkDto(
  * Devolve **apenas os ids** das permissões ativas vinculadas — a UI
  * da Issue #69 cruza com o catálogo (`listPermissions(systemId)`)
  * para construir a matriz de checkboxes. Backend devolve um array
- * cru de `permissionId` (ou de objetos `{ permissionId }`); aceitamos
- * ambos os formatos para tolerar evoluções pequenas no contrato (já
- * vimos esse padrão de evolução em `tokenTypes.ts`).
+ * cru de `permissionId`, objetos `{ permissionId }` enxutos ou
+ * `RolePermissionLinkDto` completo; aceitamos os três formatos para
+ * tolerar evoluções pequenas no contrato (Issue #190 / QA do GET).
  *
  * Lança `ApiError` em qualquer falha (404 quando a role não existe,
  * parse quando o shape diverge). Cancelamento via `signal` em
@@ -529,13 +529,22 @@ export async function listRolePermissions(
 /**
  * Normaliza a resposta do backend para um array imutável de
  * `permissionId`. Aceita tanto o formato cru `string[]` (mais
- * comum em endpoints "leves" no `lfc-authenticator`) quanto o
- * formato `RolePermissionLinkDto[]` (mais simétrico com `assign`/
- * `remove`); a UI só precisa do conjunto de ids para o checkbox.
+ * comum em endpoints "leves" no `lfc-authenticator`) quanto linhas
+ * `{ permissionId }` enxutas ou `RolePermissionLinkDto[]` completo; a
+ * UI só precisa do conjunto de ids para o checkbox (Issue #190).
  *
  * Lança `ApiError(parse)` em qualquer outro shape — protege contra
  * divergência silenciosa de versão.
  */
+function isRolePermissionIdRow(
+  value: unknown,
+): value is { permissionId: string } {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  return typeof (value as Record<string, unknown>).permissionId === "string";
+}
+
 function parseRolePermissionIds(data: unknown): ReadonlyArray<string> {
   if (!Array.isArray(data)) {
     throw makeParseError();
@@ -546,8 +555,8 @@ function parseRolePermissionIds(data: unknown): ReadonlyArray<string> {
   if (data.every((item) => typeof item === "string")) {
     return data;
   }
-  if (data.every(isRolePermissionLinkDto)) {
-    return data.map((link) => link.permissionId);
+  if (data.every(isRolePermissionIdRow)) {
+    return data.map((row) => row.permissionId);
   }
   throw makeParseError();
 }
@@ -568,6 +577,9 @@ function parseRolePermissionIds(data: unknown): ReadonlyArray<string> {
  * - 400 → `permissionId` inválido/inexistente (toast + reverter o
  *   checkbox).
  * - 404 → role não encontrada (fechar a tela e voltar).
+ * - 405 → em geral indica **método HTTP incorreto** para o recurso
+ *   (ex.: `GET` sem corpo em vez de `POST` com JSON
+ *   `{"permissionId":"<guid>"}` no path `/roles/{roleId}/permissions`).
  * - 401/403 → cliente HTTP já lidou com `onUnauthorized`/falta de
  *   permissão; UI exibe toast.
  *

--- a/tests/pages/roles/RolePermissionsShellPage.test.tsx
+++ b/tests/pages/roles/RolePermissionsShellPage.test.tsx
@@ -30,11 +30,32 @@ const NEVER_RESOLVES = (): Promise<never> =>
   new Promise<never>(() => undefined);
 
 /**
- * Suíte da `RolePermissionsShellPage` (Issue #69).
+ * Catálogo `GET /permissions` em estado feliz + resposta customizada
+ * para `GET /roles/{id}/permissions` (Issue #190 — erros de carga
+ * específicos do endpoint da role).
+ */
+function stubCatalogOkAndRolePermissionsGet(
+  client: ReturnType<typeof createRolePermissionsClientStub>,
+  rolePermissionsResult: Promise<unknown>,
+): void {
+  client.get.mockImplementation((path: string) => {
+    if (path.startsWith("/permissions")) {
+      return Promise.resolve(makePagedPermissions([makePermission()]));
+    }
+    if (path.match(/^\/roles\/[^/]+\/permissions$/)) {
+      return rolePermissionsResult;
+    }
+    return Promise.reject(new Error("unexpected path"));
+  });
+}
+
+/**
+ * Suíte da `RolePermissionsShellPage` (Issue #69, QA #190).
  *
  * Cobre: estados de loading, erro, vazio, render do agrupamento por
  * sistema, badge "Vinculada", diff client-side ao salvar (assign +
- * remove em paralelo), tratamento de :systemId/:roleId inválidos, e
+ * remove em paralelo), tratamento de :systemId/:roleId inválidos,
+ * falha do `GET /roles/{id}/permissions` (carregamento inicial) e
  * tratamento de falha parcial no salvar.
  *
  * Stub do `ApiClient` injetado via prop `client` — espelha o pattern
@@ -121,6 +142,44 @@ describe("RolePermissionsShellPage — loading e erro inicial", () => {
     await waitFor(() => {
       expect(
         screen.getByText("Falha interna no servidor."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("role-permissions-retry")).toBeInTheDocument();
+  });
+
+  it("exibe ErrorRetryBlock quando GET /roles/{id}/permissions falha (catálogo ok)", async () => {
+    const client = createRolePermissionsClientStub();
+    stubCatalogOkAndRolePermissionsGet(
+      client,
+      Promise.reject({
+        kind: "http",
+        status: 404,
+        message: "Role não encontrada ou sem permissões legíveis.",
+      }),
+    );
+
+    renderRolePermissionsPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Role não encontrada ou sem permissões legíveis."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("role-permissions-retry")).toBeInTheDocument();
+  });
+
+  it("exibe erro quando GET /roles/{id}/permissions retorna shape inválido", async () => {
+    const client = createRolePermissionsClientStub();
+    stubCatalogOkAndRolePermissionsGet(
+      client,
+      Promise.resolve([{ broken: true }]),
+    );
+
+    renderRolePermissionsPage(client);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Resposta inválida do servidor."),
       ).toBeInTheDocument();
     });
     expect(screen.getByTestId("role-permissions-retry")).toBeInTheDocument();
@@ -250,6 +309,25 @@ describe("RolePermissionsShellPage — render do catálogo", () => {
       `role-permissions-checkbox-${ID_PERM_A}`,
     ) as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
+  });
+
+  it("checkbox vem marcado quando GET devolve { permissionId }[] (Issue #190)", async () => {
+    const client = createRolePermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([makePermission({ id: ID_PERM_A })]),
+      assigned: [{ permissionId: ID_PERM_A }],
+    });
+
+    renderRolePermissionsPage(client);
+    await waitForInitialFetch();
+
+    const checkbox = screen.getByTestId(
+      `role-permissions-checkbox-${ID_PERM_A}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(
+      screen.getByTestId(`role-permissions-item-${ID_PERM_A}`),
+    ).toHaveTextContent("Vinculada");
   });
 });
 

--- a/tests/pages/roles/__helpers__/rolePermissionsTestHelpers.tsx
+++ b/tests/pages/roles/__helpers__/rolePermissionsTestHelpers.tsx
@@ -87,14 +87,19 @@ export function makePagedPermissions(
   };
 }
 
+/** Corpo típico do `GET /roles/{roleId}/permissions` no authenticator. */
+export type StubRolePermissionsAssigned =
+  | ReadonlyArray<string>
+  | ReadonlyArray<{ permissionId: string }>;
+
 interface SetupOptions {
   /** Catálogo devolvido pelo `listPermissions(systemId)`. */
   catalog?: PagedResponse<PermissionDto>;
   /**
-   * Ids das permissões já vinculadas à role. Se omitido, default é
-   * `[]` (role nova sem permissões).
+   * Resposta simulada do `GET /roles/{roleId}/permissions`: ids em
+   * string[] ou linhas `{ permissionId }` (Issue #190).
    */
-  assigned?: ReadonlyArray<string>;
+  assigned?: StubRolePermissionsAssigned;
 }
 
 /**

--- a/tests/shared/api/roles.test.ts
+++ b/tests/shared/api/roles.test.ts
@@ -597,6 +597,22 @@ describe("listRolePermissions", () => {
     expect(result).toEqual([PERM_ID, "outra-perm"]);
   });
 
+  it("aceita objetos enxutos { permissionId } devolvidos pelo GET (Issue #190)", async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      { permissionId: PERM_ID },
+      { permissionId: "outra-perm" },
+    ]);
+
+    const result = await listRolePermissions(
+      ROLE_ID,
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(result).toEqual([PERM_ID, "outra-perm"]);
+  });
+
   it("aceita array vazio", async () => {
     const client = createStub();
     client.get.mockResolvedValueOnce([]);


### PR DESCRIPTION
## Resumo

QA da tela **Permissões da role** após o `GET /api/v1/roles/{roleId}/permissions` no authenticator: contrato de parse mais tolerante, documentação para operadores (vínculo por **permissão** = rota + tipo), testes de carga/erro e nota operacional sobre **405** no assign.

Closes #190

## Alterações

- **`listRolePermissions`**: aceitar array de objetos enxutos `{ permissionId }` além de `string[]` e `RolePermissionLinkDto[]` completo.
- **`RolePermissionsShellPage`**: copy do `PageHeader` e JSDoc alinhados à operação (cadastro em Permissões antes; vínculo por permissão concreta).
- **`assignPermissionToRole`**: JSDoc com nota sobre 405 (método/corpo incorreto), conforme issue.
- **Testes**: `RolePermissionsShellPage` — erro no GET da role com catálogo OK; corpo inválido (parse); helper `stubCatalogOkAndRolePermissionsGet`; tipo `StubRolePermissionsAssigned` no stub; teste de API para formato enxuto.

## Testes (local, raiz do repo)

- `npm run lint` — OK (0 warnings)
- `npm run typecheck` — OK
- `npm test` — OK (Vitest: 84 arquivos, 1605 testes)

## Riscos

- Backend que devolver mistura de formatos no mesmo array ainda falha no parse (comportamento esperado).


Made with [Cursor](https://cursor.com)