### PR TITLE
#193 | Roles global: botão Nova role com seleção de sistema

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -577,6 +577,7 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
 
       {canCreateRole && hasValidSystemId && (
         <NewRoleModal
+          variant="scoped"
           open={isCreateModalOpen}
           systemId={systemId}
           onClose={handleCloseCreateModal}

--- a/src/pages/roles/NewRoleModal.tsx
+++ b/src/pages/roles/NewRoleModal.tsx
@@ -87,7 +87,7 @@ export type NewRoleModalProps = {
  * Espelha o desenho de `NewSystemModal`/`NewRouteModal`/`NewUserModal`
  * com três diferenças funcionais relevantes:
  *
- * 1. `systemId` cheja como prop na variante `scoped` (URL da
+ * 1. `systemId` chega como prop na variante `scoped` (URL da
  *    `RolesPage`) ou via estado local + catálogo na variante `global`.
  *    O backend `RolesController.Create` exige `SystemId`.
  * 2. 409 mapeia para mensagem inline custom no campo `code`

--- a/src/pages/roles/NewRoleModal.tsx
+++ b/src/pages/roles/NewRoleModal.tsx
@@ -1,8 +1,11 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
-import { Modal, useToast } from "../../components/ui";
+import { Modal, Select, useToast } from "../../components/ui";
 import { createRole } from "../../shared/api";
-import { useCreateEntitySubmit } from "../../shared/forms";
+import {
+  useCreateEntitySubmit,
+  type CreateEntitySubmitSuccessContext,
+} from "../../shared/forms";
 
 import { RoleFormBody } from "./RoleFormFields";
 import {
@@ -12,7 +15,11 @@ import {
 } from "./rolesFormShared";
 import { useRoleForm, useRoleFormFieldProps } from "./useRoleForm";
 
-import type { ApiClient, CreateRolePayload } from "../../shared/api";
+import type {
+  ApiClient,
+  CreateRolePayload,
+  SystemDto,
+} from "../../shared/api";
 
 /**
  * Copy injetada em `classifyApiSubmitError` para o caminho de criação
@@ -36,71 +43,75 @@ const SUBMIT_ERROR_COPY: RoleSubmitErrorCopy = {
 const CONFLICT_INLINE_MESSAGE =
   "Já existe uma role com este código neste sistema.";
 
-interface NewRoleModalProps {
+const EMPTY_SYSTEMS: ReadonlyArray<SystemDto> = [];
+
+export type NewRoleModalProps = {
   /** Estado de visibilidade controlado pelo pai. */
   open: boolean;
-  /**
-   * UUID do sistema dono da role — vem da URL
-   * `/systems/:systemId/roles`. Repassado ao `prepareSubmit(systemId)`
-   * para construir o body do POST (`CreateRoleRequest.SystemId` é
-   * `[Required]` no backend após o enriquecimento do contrato em
-   * `lfc-authenticator#163`/`#164`; tentar omitir devolve 400). A UI
-   * **nunca** expõe o campo no form e sempre repassa o valor lido da
-   * URL — espelha o desenho do `EditRoleModal` e do `NewRouteModal`.
-   */
-  systemId: string;
   /** Fecha o modal sem persistir. Chamada também após sucesso. */
   onClose: () => void;
-  /** Callback disparado após criação bem-sucedida (para refetch da lista). */
-  onCreated: () => void;
+  /**
+   * Callback após criação bem-sucedida (refetch no pai). Recebe o
+   * payload enviado ao POST quando útil (Issue #193 — filtro na lista
+   * global).
+   */
+  onCreated: (context?: CreateEntitySubmitSuccessContext) => void;
   /**
    * Cliente HTTP injetável para isolar testes — em produção, omitido,
    * `createRole` cai no singleton `apiClient`.
    */
   client?: ApiClient;
-}
+} & (
+  | {
+      /**
+       * `systemId` fixo vindo da URL `/systems/:systemId/roles`
+       * (`RolesPage`).
+       */
+      variant: "scoped";
+      systemId: string;
+    }
+  | {
+      /**
+       * Catálogo carregado pelo pai (`listSystems`) — operador escolhe
+       * o sistema dono antes de nome/código (Issue #193).
+       */
+      variant: "global";
+      systems: ReadonlyArray<SystemDto>;
+    }
+);
 
 /**
  * Modal de criação de role (Issue #67 — fluxo "criar role" da EPIC
- * #47).
+ * #47; Issue #193 — variante global com `<Select>` de sistema).
  *
  * Espelha o desenho de `NewSystemModal`/`NewRouteModal`/`NewUserModal`
  * com três diferenças funcionais relevantes:
  *
- * 1. `systemId` chega como prop (lido da URL pela `RolesPage`) e é
- *    injetado no payload via `prepareSubmit(systemId)` — o backend
- *    `RolesController.Create` exige `SystemId` após o enriquecimento
- *    do contrato em `lfc-authenticator#163`/`#164`.
+ * 1. `systemId` cheja como prop na variante `scoped` (URL da
+ *    `RolesPage`) ou via estado local + catálogo na variante `global`.
+ *    O backend `RolesController.Create` exige `SystemId`.
  * 2. 409 mapeia para mensagem inline custom no campo `code`
- *    citando "neste sistema" (unicidade `(SystemId, Code)` no
- *    backend; a copy do controller é "Já existe outro role com este
- *    Code neste sistema." mas a UI usa pt-BR consistente).
+ *    citando "neste sistema".
  * 3. Sucesso dispara toast verde "Role criada." e `onCreated` antes
- *    de `onClose` — pai responsável pelo refetch.
- *
- * Toda a lógica de validação client-side, parsing de
- * `ValidationProblemDetails`, classificação de erros e dispatch de
- * efeitos colaterais vem de helpers compartilhados:
- *
- * - `useRoleForm` — estado/handlers do form + `prepareSubmit`/
- *   `applyBadRequest`. Decora `useNameCodeDescriptionForm` injetando
- *   `systemId` no payload.
- * - `useCreateEntitySubmit` — orquestra `try/catch/finally` +
- *   `classifyApiSubmitError` + `applyCreateSubmitAction` (lição PR
- *   #135 — call-site também duplica entre modals de criação).
- * - `useRoleFormFieldProps` — consolida props sequenciais para
- *   `<RoleFormBody>`, evitando bloco repetido de ~10 linhas com
- *   `EditRoleModal` (lição PR #134/#135).
- * - `RoleFormBody` — wrapper fino do `NameCodeDescriptionFormBody`
- *   compartilhado entre roles e sistemas.
+ *    de `onClose` — pai responsável pelo refetch (com contexto do
+ *    payload quando o hook repassa).
  */
-export const NewRoleModal: React.FC<NewRoleModalProps> = ({
-  open,
-  systemId,
-  onClose,
-  onCreated,
-  client,
-}) => {
+export const NewRoleModal: React.FC<NewRoleModalProps> = (props) => {
+  const { open, variant, onClose, onCreated, client } = props;
+  const scopedSystemId = variant === "scoped" ? props.systemId : "";
+  const systems = variant === "global" ? props.systems : EMPTY_SYSTEMS;
+
+  const [selectedSystemId, setSelectedSystemId] = useState<string>("");
+  const [systemPickerError, setSystemPickerError] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!open || variant !== "global") return;
+    setSystemPickerError(null);
+    setSelectedSystemId("");
+  }, [open, variant]);
+
   const { show } = useToast();
   const roleForm = useRoleForm(INITIAL_ROLE_FORM_STATE);
   const {
@@ -113,54 +124,60 @@ export const NewRoleModal: React.FC<NewRoleModalProps> = ({
     applyBadRequest,
   } = roleForm;
 
-  /**
-   * Reseta tudo ao fechar — handler único para Esc, backdrop, X e
-   * botão Cancelar; previne resíduo entre aberturas. Cancelar
-   * durante submissão é bloqueado para evitar request órfã (sem
-   * `AbortController` nessa primeira iteração — backend é rápido e
-   * o usuário não consegue disparar duas vezes graças ao `disabled`
-   * no botão).
-   */
   const handleClose = useCallback(() => {
     if (isSubmitting) return;
     setFormState(INITIAL_ROLE_FORM_STATE);
     setFieldErrors({});
     setSubmitError(null);
+    if (variant === "global") {
+      setSystemPickerError(null);
+      setSelectedSystemId("");
+    }
     onClose();
-  }, [isSubmitting, onClose, setFormState, setFieldErrors, setSubmitError]);
+  }, [
+    isSubmitting,
+    onClose,
+    setFieldErrors,
+    setFormState,
+    setSubmitError,
+    variant,
+  ]);
 
-  /**
-   * Reset disparado pelo helper `useCreateEntitySubmit` no caminho
-   * feliz (antes de `onCreated`/`onClose`). Mantemos uma referência
-   * dedicada (em vez de reusar `handleClose`) porque `handleClose` é
-   * gateado por `isSubmitting` — o submit feliz roda exatamente
-   * quando `isSubmitting === true`, então o gate inverteria o
-   * comportamento esperado. Espelha o padrão de `NewUserModal`.
-   */
   const resetForm = useCallback(() => {
     setFormState(INITIAL_ROLE_FORM_STATE);
     setFieldErrors({});
     setSubmitError(null);
-  }, [setFormState, setFieldErrors, setSubmitError]);
+    if (variant === "global") {
+      setSystemPickerError(null);
+      setSelectedSystemId("");
+    }
+  }, [setFieldErrors, setFormState, setSubmitError, variant]);
 
-  /**
-   * Wrapper de `prepareSubmit` que injeta o `systemId` (vem da URL
-   * via prop) — preserva a assinatura `() => object | null` exigida
-   * por `useCreateEntitySubmit.callbacks.prepareSubmit`. Idêntico em
-   * espírito ao wrapper do `EditRoleModal` (que faz o mesmo + gate
-   * de `role !== null`).
-   */
-  const prepareSubmitWithSystemId = useCallback(
-    (): CreateRolePayload | null => prepareSubmit(systemId),
-    [prepareSubmit, systemId],
-  );
+  const prepareSubmitWithSystemId = useCallback((): CreateRolePayload | null => {
+    const ownerId =
+      variant === "scoped" ? scopedSystemId : selectedSystemId.trim();
+    if (variant === "global") {
+      if (systems.length === 0) {
+        setSystemPickerError(
+          "Nenhum sistema disponível. Cadastre um sistema antes.",
+        );
+        return null;
+      }
+      if (!ownerId) {
+        setSystemPickerError("Selecione um sistema.");
+        return null;
+      }
+      setSystemPickerError(null);
+    }
+    return prepareSubmit(ownerId);
+  }, [
+    prepareSubmit,
+    scopedSystemId,
+    selectedSystemId,
+    systems.length,
+    variant,
+  ]);
 
-  /**
-   * `mutationFn` injetada no helper genérico. Tipa o payload via cast
-   * para `CreateRolePayload` porque o helper aceita `unknown` (o cast
-   * é seguro — `prepareSubmit` só devolve `CreateRolePayload | null`,
-   * e o helper já filtrou `null` antes de chamar `mutationFn`).
-   */
   const mutationFn = useCallback(
     (payload: unknown) =>
       createRole(payload as CreateRolePayload, undefined, client),
@@ -190,22 +207,50 @@ export const NewRoleModal: React.FC<NewRoleModalProps> = ({
     conflictField: "code",
   });
 
-  // Props compartilhadas com `EditRoleModal` consolidadas num único
-  // hook (`useRoleFormFieldProps`) para evitar New Code Duplication
-  // ≥10 linhas com o caminho de edição — JSCPD/Sonar tokenizam
-  // blocos de props sequenciais como duplicação. Lição PR #134/#135
-  // reforçada.
   const fieldProps = useRoleFormFieldProps(roleForm, handleSubmit, handleClose);
+
+  const modalDescription =
+    variant === "scoped"
+      ? "Cadastre uma role vinculada ao sistema selecionado."
+      : "Escolha o sistema dono da role e preencha nome, código e descrição.";
 
   return (
     <Modal
       open={open}
       onClose={handleClose}
       title="Nova role"
-      description="Cadastre uma role vinculada ao sistema selecionado."
+      description={modalDescription}
       closeOnEsc={!isSubmitting}
       closeOnBackdrop={!isSubmitting}
     >
+      {variant === "global" && (
+        <Select
+          label="Sistema"
+          size="md"
+          value={selectedSystemId}
+          onChange={(value) => {
+            setSelectedSystemId(value);
+            setSystemPickerError(null);
+          }}
+          disabled={isSubmitting || systems.length === 0}
+          error={systemPickerError ?? undefined}
+          data-testid="new-role-system"
+          aria-label="Sistema dono da role"
+        >
+          {systems.length === 0 ? (
+            <option value="">Nenhum sistema cadastrado</option>
+          ) : (
+            <>
+              <option value="">Selecione um sistema</option>
+              {systems.map((sys) => (
+                <option key={sys.id} value={sys.id}>
+                  {sys.name}
+                </option>
+              ))}
+            </>
+          )}
+        </Select>
+      )}
       <RoleFormBody
         {...fieldProps}
         idPrefix="new-role"

--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Plus } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -36,6 +36,7 @@ import {
   useListingLiveMessage,
 } from '../../shared/listing';
 
+import { NewRoleModal } from './NewRoleModal';
 import {
   renderRoleDescription as renderDescription,
   renderRoleCount as renderCount,
@@ -44,11 +45,13 @@ import {
 import type { TableColumn } from '../../components/ui';
 import type {
   ApiClient,
+  CreateRolePayload,
   PagedResponse,
   RoleDto,
   SafeRequestOptions,
   SystemDto,
 } from '../../shared/api';
+import type { CreateEntitySubmitSuccessContext } from '../../shared/forms';
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300ms é
@@ -67,6 +70,12 @@ const SEARCH_DEBOUNCE_MS = 300;
  * estratégia de `TYPE_FILTER_ALL` em `ClientsListShellPage`.
  */
 const SYSTEM_FILTER_ALL = 'ALL' as const;
+
+/**
+ * Botão "Nova role" na listagem global (Issues #67/#193). Espelha
+ * `AUTH_V1_ROLES_CREATE` da `RolesPage` (`Roles.Create`).
+ */
+const ROLES_CREATE_PERMISSION = 'AUTH_V1_ROLES_CREATE';
 
 /**
  * Mensagem genérica de fallback quando o fetch da lista de roles falha
@@ -112,8 +121,8 @@ function buildSystemLookup(
  * - Filtro extra é `systemId` (dropdown carregado de `listSystems`),
  *   não `type`.
  * - Cada linha "drilla" para `/systems/:systemId/roles` (escopo do
- *   CRUD) — não há criação/edição inline; isso fica deferido para a
- *   página por-sistema (`RolesPage`).
+ *   CRUD completo). A criação também está disponível aqui com seleção
+ *   de sistema (Issue #193); edição/exclusão permanecem na `RolesPage`.
  * - Coluna "Sistema" denormaliza o `row.systemId` para o nome do
  *   sistema dono.
  *
@@ -124,11 +133,8 @@ export const RolesGlobalListShellPage: React.FC<
   RolesGlobalListShellPageProps
 > = ({ client }) => {
   const navigate = useNavigate();
-  // `useAuth` é mantido aqui para que evoluções futuras (botão "Nova
-  // role" gateado por `Roles.Create` ou ações inline gateadas por
-  // `Roles.Update`) reutilizem o gating sem refatoração — o gating
-  // de leitura já vive em `<RequirePermission>` no router.
-  useAuth();
+  const { hasPermission } = useAuth();
+  const canCreateRole = hasPermission(ROLES_CREATE_PERMISSION);
 
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
@@ -143,6 +149,16 @@ export const RolesGlobalListShellPage: React.FC<
     DEFAULT_ROLES_INCLUDE_DELETED,
   );
   const [page, setPage] = useState<number>(DEFAULT_ROLES_PAGE);
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState<boolean>(false);
+
+  const handleOpenCreateModal = useCallback(() => {
+    setIsCreateModalOpen(true);
+  }, []);
+
+  const handleCloseCreateModal = useCallback(() => {
+    setIsCreateModalOpen(false);
+  }, []);
 
   /**
    * Reseta a página para 1 sempre que muda um filtro/busca — evita o
@@ -380,6 +396,44 @@ export const RolesGlobalListShellPage: React.FC<
   );
 
   /**
+   * Refetch após criar role + alinha o filtro de sistema ao sistema
+   * escolhido (Issue #193 — nice-to-have de UX documentado na PR).
+   */
+  const handleRoleCreated = useCallback(
+    (ctx?: CreateEntitySubmitSuccessContext) => {
+      handleRefetch();
+      const payload = ctx?.createdPayload as CreateRolePayload | undefined;
+      if (
+        payload &&
+        typeof payload.systemId === 'string' &&
+        payload.systemId.length > 0
+      ) {
+        setSystemFilter(payload.systemId);
+      }
+    },
+    [handleRefetch],
+  );
+
+  /**
+   * CTA "Nova role" — memoização espelha `RolesPage` para limitar
+   * superfície duplicada no JSX da listagem (lição PR #127/#135).
+   */
+  const createRoleButton = useMemo<React.ReactNode>(() => {
+    if (!canCreateRole) return null;
+    return (
+      <Button
+        variant="primary"
+        size="md"
+        icon={<Plus size={14} strokeWidth={1.75} />}
+        onClick={handleOpenCreateModal}
+        data-testid="roles-global-create-open"
+      >
+        Nova role
+      </Button>
+    );
+  }, [canCreateRole, handleOpenCreateModal]);
+
+  /**
    * ARIA-live: anuncia o estado da listagem quando muda. Em loading
    * subsequente, anunciamos "Atualizando..."; em sucesso, anunciamos
    * o total. Em erro, o `<Alert role="alert">` já cobre.
@@ -509,6 +563,7 @@ export const RolesGlobalListShellPage: React.FC<
         includeDeletedHelperText="Inclui roles com remoção lógica."
         includeDeletedTestId="roles-global-include-deleted"
         extraFilter={systemFilterSelect}
+        actions={createRoleButton}
       />
 
       <LiveRegion message={liveMessage} testId="roles-global-live" />
@@ -529,6 +584,17 @@ export const RolesGlobalListShellPage: React.FC<
         onPrev={handlePrevPage}
         onNext={handleNextPage}
       />
+
+      {canCreateRole && (
+        <NewRoleModal
+          variant="global"
+          open={isCreateModalOpen}
+          systems={systemsList ?? []}
+          onClose={handleCloseCreateModal}
+          onCreated={handleRoleCreated}
+          client={client}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -409,9 +409,10 @@ export const RolesGlobalListShellPage: React.FC<
         payload.systemId.length > 0
       ) {
         setSystemFilter(payload.systemId);
+        setPage(DEFAULT_ROLES_PAGE);
       }
     },
-    [handleRefetch],
+    [handleRefetch, setPage],
   );
 
   /**

--- a/src/shared/forms/index.ts
+++ b/src/shared/forms/index.ts
@@ -67,6 +67,7 @@ export {
   type CreateEntitySubmitCallbacks,
   type CreateEntitySubmitCopy,
   type CreateEntitySubmitDispatchers,
+  type CreateEntitySubmitSuccessContext,
   type UseCreateEntitySubmitArgs,
 } from "./useCreateEntitySubmit";
 export {

--- a/src/shared/forms/useCreateEntitySubmit.ts
+++ b/src/shared/forms/useCreateEntitySubmit.ts
@@ -90,6 +90,16 @@ export interface CreateEntitySubmitCopy {
 }
 
 /**
+ * Contexto opcional repassado a `onCreated` após mutação bem-sucedida —
+ * permite ao pai sincronizar filtros (ex.: listagem global de roles —
+ * Issue #193) sem acoplamento forte ao formato interno do form.
+ */
+export interface CreateEntitySubmitSuccessContext {
+  /** Payload enviado ao `mutationFn` (mesmo objeto devolvido por `prepareSubmit`). */
+  createdPayload: unknown;
+}
+
+/**
  * Callbacks de coordenação com o pai e dependências do efeito. Os
  * callbacks devem ser estáveis (memoizados pelo caller) — o hook
  * inclui todos no `useCallback` deps array.
@@ -113,8 +123,8 @@ export interface CreateEntitySubmitCallbacks {
    * `(payload) => createUser(payload, undefined, client)`.
    */
   mutationFn: (payload: unknown) => Promise<unknown>;
-  /** Refetch da lista no pai — disparado após sucesso. */
-  onCreated: () => void;
+  /** Refetch da lista no pai — disparado após sucesso. Recebe o payload criado quando útil ao pai. */
+  onCreated: (context?: CreateEntitySubmitSuccessContext) => void;
   /** Fecha o modal — disparado após sucesso. */
   onClose: () => void;
 }
@@ -225,7 +235,7 @@ export function useCreateEntitySubmit<TField extends string>({
         // Ordem importa: reset local + refetch antes de fechar para o
         // pai não ter que coordenar dois ticks separados.
         resetForm();
-        onCreated();
+        onCreated({ createdPayload: payload });
         onClose();
       } catch (error: unknown) {
         // `classifyApiSubmitError` decide o `kind`; `applyCreateSubmitAction`

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -315,6 +315,22 @@ export async function waitForRolesGlobalInitialList(
 }
 
 /**
+ * Renderiza `/roles`, espera a listagem global e abre o modal **Nova
+ * role** (Issue #193). Configure `client.get` antes — tipicamente com
+ * `primeRolesGlobalStubResponses`.
+ */
+export async function openGlobalCreateRoleModal(
+  client: ApiClientStub,
+): Promise<void> {
+  renderRolesGlobalListPage(client);
+  await waitForRolesGlobalInitialList(client);
+  fireEvent.click(screen.getByTestId("roles-global-create-open"));
+  await waitFor(() => {
+    expect(screen.getByTestId("new-role-form")).toBeInTheDocument();
+  });
+}
+
+/**
  * Helper para extrair o `path` passado a `client.get` na chamada
  * mais recente. Usado em asserts que verificam o endpoint
  * consumido. Espelha `lastGetPath` em `routesTestHelpers.tsx`.

--- a/tests/pages/roles/RolesGlobalListShellPage.test.tsx
+++ b/tests/pages/roles/RolesGlobalListShellPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildAuthMock } from '../__helpers__/mockUseAuth';
 import {
   createRolesClientStub,
+  fillNewRoleForm,
   ID_ROLE_ADMIN,
   ID_ROLE_ROOT,
   ID_ROLE_VIEWER,
@@ -15,8 +16,10 @@ import {
   makePagedSystemsResponseForRoles,
   makeRole,
   makeSystemDtoForRoles,
+  openGlobalCreateRoleModal,
   primeRolesGlobalStubResponses,
   renderRolesGlobalListPage,
+  submitNewRoleForm,
   waitForRolesGlobalInitialList,
 } from '../__helpers__/rolesTestHelpers';
 /* eslint-enable import/order */
@@ -38,14 +41,15 @@ import type { ApiError, RoleDto, SystemDto } from '@/shared/api';
  *   (catálogo do dropdown). O helper `primeRolesGlobalStubResponses`
  *   resolve ambas via `mockImplementation` por path.
  * - Filtro extra é dropdown de sistema (UUID), não Select de tipo.
- * - Não há criação/edição/desativação inline (deferido — a issue
- *   especifica que os fluxos de mutação ficam na `RolesPage`
- *   per-system).
+ * - Criação de role na própria página global com seleção de sistema
+ *   (Issue #193); edição permanece no drill-down por sistema.
  * - Cada linha "drilla" para `/systems/:systemId/roles` via
  *   `useNavigate` ao clicar em "Abrir".
  */
 
-vi.mock('@/shared/auth', () => buildAuthMock(() => ['AUTH_V1_ROLES_LIST']));
+let permissionsMock: ReadonlyArray<string> = ['AUTH_V1_ROLES_LIST'];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
 
 const SEARCH_DEBOUNCE_MS = 300;
 const ID_SYS_OUTRO = '22222222-2222-2222-2222-222222222222';
@@ -81,6 +85,7 @@ const SYSTEMS_SAMPLE: ReadonlyArray<SystemDto> = [
 ];
 
 beforeEach(() => {
+  permissionsMock = ['AUTH_V1_ROLES_LIST'];
   vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
@@ -617,5 +622,131 @@ describe('RolesGlobalListShellPage — cancelamento de request', () => {
     // Anti-warning: também consume `lastGetPath` para evitar import
     // não usado; afirma que pelo menos uma chamada teve path string.
     expect(typeof lastGetPath(client)).toBe('string');
+  });
+});
+
+describe('RolesGlobalListShellPage — Issue #193 criar role global', () => {
+  const ROLES_CREATE_PERMISSION = 'AUTH_V1_ROLES_CREATE';
+
+  it('não exibe o botão Nova role sem AUTH_V1_ROLES_CREATE', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST'];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    expect(
+      screen.queryByTestId('roles-global-create-open'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('exibe Nova role quando o usuário possui AUTH_V1_ROLES_CREATE', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    const btn = screen.getByTestId('roles-global-create-open');
+    expect(btn).toHaveTextContent(/Nova role/i);
+  });
+
+  it('POST /roles usa systemId do sistema selecionado no modal', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const created = makeRole({
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      systemId: ID_SYS_OUTRO,
+      name: 'Operador Kurtto',
+      code: 'kurtto_op',
+    });
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+    client.post.mockResolvedValueOnce(created);
+
+    await openGlobalCreateRoleModal(client);
+
+    fireEvent.change(screen.getByTestId('new-role-system'), {
+      target: { value: ID_SYS_OUTRO },
+    });
+
+    fillNewRoleForm({
+      name: 'Operador Kurtto',
+      code: 'kurtto_op',
+    });
+    await submitNewRoleForm(client);
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/roles',
+      {
+        systemId: ID_SYS_OUTRO,
+        name: 'Operador Kurtto',
+        code: 'kurtto_op',
+      },
+      undefined,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByText('Role criada.')).toBeInTheDocument();
+
+    expect(screen.getByTestId('roles-global-system-filter')).toHaveValue(
+      ID_SYS_OUTRO,
+    );
+  });
+
+  it('submeter sem selecionar sistema mostra erro e não dispara POST', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+
+    await openGlobalCreateRoleModal(client);
+
+    fillNewRoleForm({ name: 'Só nome', code: 'codigo' });
+    fireEvent.submit(screen.getByTestId('new-role-form'));
+
+    expect(screen.getByText('Selecione um sistema.')).toBeInTheDocument();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('exibe toast quando POST falha após tentativa de criar', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(SYSTEMS_SAMPLE),
+    });
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 401,
+      message: 'Sessão expirada. Faça login novamente.',
+    });
+
+    await openGlobalCreateRoleModal(client);
+
+    fireEvent.change(screen.getByTestId('new-role-system'), {
+      target: { value: ID_SYS_AUTH },
+    });
+    fillNewRoleForm({ name: 'Algum Nome', code: 'algum_code' });
+    await submitNewRoleForm(client);
+
+    expect(
+      await screen.findByText(/Sessão expirada/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 });

--- a/tests/shared/forms/useCreateEntitySubmit.test.tsx
+++ b/tests/shared/forms/useCreateEntitySubmit.test.tsx
@@ -123,6 +123,9 @@ describe('useCreateEntitySubmit — caminho feliz', () => {
     });
     expect(spies.resetForm).toHaveBeenCalledTimes(1);
     expect(spies.onCreated).toHaveBeenCalledTimes(1);
+    expect(spies.onCreated).toHaveBeenCalledWith({
+      createdPayload: { payload: 'ok' },
+    });
     expect(spies.onClose).toHaveBeenCalledTimes(1);
     expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);
   });


### PR DESCRIPTION
## Resumo
Implementa a issue [#193](https://github.com/LF-Calegari/lfc-admin-gui/issues/193): na listagem global `/roles`, botão **Nova role** com `AUTH_V1_ROLES_CREATE`, modal reutilizando o fluxo existente com **seleção do sistema** dono da role.

## Alterações
- `NewRoleModal`: discriminated union `variant: 'scoped' | 'global'` (URL vs catálogo de sistemas).
- `useCreateEntitySubmit`: `onCreated` opcionalmente recebe `{ createdPayload }` para o pai sincronizar filtros (lista global).
- `RolesGlobalListShellPage`: toolbar com CTA, modal global, após sucesso refetch + filtro de sistema alinhado ao `systemId` criado.
- Testes: gating, POST com `systemId` escolhido, erro 401 (toast).

## Riscos
- Consumidores de `useCreateEntitySubmit` precisam aceitar assinatura estendida de `onCreated` (compatível com callbacks sem argumentos).

## Evidências de teste
```
npm run test -- --run tests/pages/roles/RolesGlobalListShellPage.test.tsx tests/pages/RolesPage.create.test.tsx tests/shared/forms/useCreateEntitySubmit.test.tsx
npm run lint
npm run typecheck
```
Todos passaram localmente.

Fixes #193

Made with [Cursor](https://cursor.com)