### PR TITLE
#196 | Épico — Permissões por rota para roles recém-criadas (admin-gui)

### DIFF
--- a/src/pages/RolesPage.tsx
+++ b/src/pages/RolesPage.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_ROLES_INCLUDE_DELETED,
   DEFAULT_ROLES_PAGE,
   DEFAULT_ROLES_PAGE_SIZE,
+  isRoleDto,
   listRoles,
 } from "../shared/api";
 import { useAuth } from "../shared/auth";
@@ -46,6 +47,7 @@ import {
 
 import type { TableColumn } from "../components/ui";
 import type { ApiClient, RoleDto, SafeRequestOptions } from "../shared/api";
+import type { CreateEntitySubmitSuccessContext } from "../shared/forms";
 
 /**
  * Atraso entre a última tecla e o disparo da request de busca. 300 ms é
@@ -230,6 +232,27 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
       "Falha ao carregar a lista de roles. Tente novamente.",
     skip: !hasValidSystemId,
   });
+
+  /**
+   * Refetch + navegação para permissões da role recém-criada (épico
+   * #196 / Issue #197). `mutationResult` vem do `createRole` via
+   * `useCreateEntitySubmit`.
+   */
+  const handleRoleCreated = useCallback(
+    (ctx?: CreateEntitySubmitSuccessContext) => {
+      handleRefetch();
+      const created = ctx?.mutationResult;
+      if (
+        hasValidSystemId &&
+        isRoleDto(created) &&
+        typeof created.id === "string" &&
+        created.id.trim().length > 0
+      ) {
+        navigate(`/systems/${systemId}/roles/${created.id}/permissoes`);
+      }
+    },
+    [handleRefetch, hasValidSystemId, navigate, systemId],
+  );
 
   const {
     totalPages,
@@ -581,7 +604,7 @@ export const RolesPage: React.FC<RolesPageProps> = ({ client }) => {
           open={isCreateModalOpen}
           systemId={systemId}
           onClose={handleCloseCreateModal}
-          onCreated={handleRefetch}
+          onCreated={handleRoleCreated}
           client={client}
         />
       )}

--- a/src/pages/roles/RolePermissionsShellPage.tsx
+++ b/src/pages/roles/RolePermissionsShellPage.tsx
@@ -56,11 +56,13 @@ import {
 import {
   buildInitialRolePermissionIds,
   computeRolePermissionDiff,
+  groupPermissionsByRoute,
   groupPermissionsBySystem,
   rolePermissionDiffHasChanges,
 } from "./rolePermissionsHelpers";
 
 import type {
+  PermissionRouteSubgroup,
   PermissionSystemGroup,
   RolePermissionAssignmentFailure,
 } from "./rolePermissionsHelpers";
@@ -134,8 +136,9 @@ function extractErrorMessage(error: unknown, fallback: string): string {
  *    `GET /roles/{roleId}/permissions` (estado atual da role).
  * 2. Inicializa o set `selectedAssigned` com as permissões já
  *    vinculadas à role.
- * 3. UI exibe lista agrupada por sistema (apenas o sistema da role,
- *    em geral); cada permissão tem um checkbox controlado e badge
+ * 3. UI exibe lista agrupada por sistema e, dentro de cada sistema,
+ *    por rota (épico #196 / Issue #198); cada permissão tem um checkbox
+ *    controlado e badge
  *    "Vinculada" para o estado original e badge "Adição/Remoção
  *    pendente" para mudanças não salvas.
  * 4. Salvar calcula o diff client-side e dispara
@@ -417,7 +420,7 @@ export const RolePermissionsShellPage: React.FC<
       <PageHeader
         eyebrow="03 Roles · Permissões"
         title="Permissões da role"
-        desc="Vincule ou desvincule permissões à role selecionada. O catálogo lista apenas permissões do mesmo sistema (filtro por systemId). Cada vínculo é uma permissão concreta — combinação de rota e tipo de acesso — e precisa existir antes em Permissões; não basta existir só a rota. As alterações passam a valer após Salvar."
+        desc="Vincule ou desvincule permissões à role selecionada. O catálogo lista apenas permissões do mesmo sistema (filtro por systemId), agrupadas por rota. Cada vínculo é uma permissão concreta — combinação de rota e tipo de acesso — e precisa existir antes em Permissões; não basta existir só a rota. As alterações passam a valer após Salvar."
         actions={
           <>
             <Button
@@ -536,69 +539,137 @@ const PermissionGroup: React.FC<PermissionGroupProps> = ({
   originalAssigned,
   isSaving,
   onToggle,
-}) => (
-  <AssignmentGroupCard
-    data-testid={`role-permissions-group-${group.systemCode}`}
-  >
-    <AssignmentGroupHeaderRow
-      systemCode={group.systemCode}
-      systemName={group.systemName}
-      count={group.permissions.length}
-      countAriaLabel={`${group.permissions.length} permissões neste sistema`}
-    />
-    <AssignmentItemList>
-      {group.permissions.map((perm) => {
-        const isSelected = selectedAssigned.has(perm.id);
-        const wasOriginallyAssigned = originalAssigned.has(perm.id);
-        const isPending = isSelected !== wasOriginallyAssigned;
-        return (
-          <AssignmentItemRow
-            key={perm.id}
-            data-testid={`role-permissions-item-${perm.id}`}
-            data-pending={isPending || undefined}
-          >
-            <Checkbox
-              checked={isSelected}
-              disabled={isSaving}
-              onChange={(checked) => onToggle(perm.id, checked)}
-              aria-label={`${perm.routeName || perm.routeCode} · ${
-                perm.permissionTypeName || perm.permissionTypeCode
-              }`}
-              data-testid={`role-permissions-checkbox-${perm.id}`}
-            />
-            <AssignmentItemDetails>
-              <AssignmentItemTitleRow>
-                <AssignmentItemPrimaryText>
-                  {perm.routeName || perm.routeCode}
-                </AssignmentItemPrimaryText>
-                <AssignmentItemCodeChip>
-                  <Mono>{perm.permissionTypeCode}</Mono>
-                </AssignmentItemCodeChip>
-              </AssignmentItemTitleRow>
-              <AssignmentItemMetaRow>
-                <Mono>{perm.routeCode || "—"}</Mono>
-                {perm.description && (
-                  <AssignmentItemDescription>
-                    {perm.description}
-                  </AssignmentItemDescription>
-                )}
-              </AssignmentItemMetaRow>
-              <AssignmentItemBadges>
-                {wasOriginallyAssigned && (
-                  <Badge variant="success" dot>
-                    Vinculada
-                  </Badge>
-                )}
-                {isPending && (
-                  <Badge variant="warning">
-                    {isSelected ? "Adição pendente" : "Remoção pendente"}
-                  </Badge>
-                )}
-              </AssignmentItemBadges>
-            </AssignmentItemDetails>
-          </AssignmentItemRow>
-        );
-      })}
-    </AssignmentItemList>
-  </AssignmentGroupCard>
-);
+}) => {
+  const routeSubgroups = useMemo(
+    () => groupPermissionsByRoute(group.permissions),
+    [group.permissions],
+  );
+
+  return (
+    <AssignmentGroupCard
+      data-testid={`role-permissions-group-${group.systemCode}`}
+    >
+      <AssignmentGroupHeaderRow
+        systemCode={group.systemCode}
+        systemName={group.systemName}
+        count={group.permissions.length}
+        countAriaLabel={`${group.permissions.length} permissões neste sistema`}
+      />
+      {routeSubgroups.map((sub, idx) => (
+        <RoutePermissionSubgroup
+          key={`${sub.routeId}-${sub.routeCode}`}
+          subgroup={sub}
+          subgroupIndex={idx}
+          systemCode={group.systemCode}
+          selectedAssigned={selectedAssigned}
+          originalAssigned={originalAssigned}
+          isSaving={isSaving}
+          onToggle={onToggle}
+        />
+      ))}
+    </AssignmentGroupCard>
+  );
+};
+
+interface RoutePermissionSubgroupProps {
+  subgroup: PermissionRouteSubgroup;
+  subgroupIndex: number;
+  systemCode: string;
+  selectedAssigned: ReadonlySet<string>;
+  originalAssigned: ReadonlySet<string>;
+  isSaving: boolean;
+  onToggle: (permissionId: string, checked: boolean) => void;
+}
+
+const RoutePermissionSubgroup: React.FC<RoutePermissionSubgroupProps> = ({
+  subgroup,
+  subgroupIndex,
+  systemCode,
+  selectedAssigned,
+  originalAssigned,
+  isSaving,
+  onToggle,
+}) => {
+  const headingId = `role-permissions-route-${systemCode}-${subgroup.routeId}`;
+  return (
+    <section
+      role="group"
+      aria-labelledby={headingId}
+      data-testid={`role-permissions-route-${subgroup.routeId}`}
+      style={{
+        borderTop:
+          subgroupIndex > 0
+            ? "var(--border-thin) solid var(--border-subtle)"
+            : undefined,
+        paddingTop: subgroupIndex > 0 ? "var(--space-4)" : "var(--space-3)",
+      }}
+    >
+      <div
+        id={headingId}
+        style={{
+          fontSize: "var(--text-sm)",
+          fontWeight: "var(--weight-semibold)",
+          color: "var(--fg2)",
+          padding: "0 var(--space-4) var(--space-3)",
+        }}
+      >
+        <span>{subgroup.routeName}</span>{" "}
+        <Mono>{subgroup.routeCode}</Mono>
+      </div>
+      <AssignmentItemList>
+        {subgroup.permissions.map((perm) => {
+          const isSelected = selectedAssigned.has(perm.id);
+          const wasOriginallyAssigned = originalAssigned.has(perm.id);
+          const isPending = isSelected !== wasOriginallyAssigned;
+          return (
+            <AssignmentItemRow
+              key={perm.id}
+              data-testid={`role-permissions-item-${perm.id}`}
+              data-pending={isPending || undefined}
+            >
+              <Checkbox
+                checked={isSelected}
+                disabled={isSaving}
+                onChange={(checked) => onToggle(perm.id, checked)}
+                aria-label={`${perm.routeName || perm.routeCode} · ${
+                  perm.permissionTypeName || perm.permissionTypeCode
+                }`}
+                data-testid={`role-permissions-checkbox-${perm.id}`}
+              />
+              <AssignmentItemDetails>
+                <AssignmentItemTitleRow>
+                  <AssignmentItemPrimaryText>
+                    {perm.routeName || perm.routeCode}
+                  </AssignmentItemPrimaryText>
+                  <AssignmentItemCodeChip>
+                    <Mono>{perm.permissionTypeCode}</Mono>
+                  </AssignmentItemCodeChip>
+                </AssignmentItemTitleRow>
+                <AssignmentItemMetaRow>
+                  <Mono>{perm.routeCode || "—"}</Mono>
+                  {perm.description && (
+                    <AssignmentItemDescription>
+                      {perm.description}
+                    </AssignmentItemDescription>
+                  )}
+                </AssignmentItemMetaRow>
+                <AssignmentItemBadges>
+                  {wasOriginallyAssigned && (
+                    <Badge variant="success" dot>
+                      Vinculada
+                    </Badge>
+                  )}
+                  {isPending && (
+                    <Badge variant="warning">
+                      {isSelected ? "Adição pendente" : "Remoção pendente"}
+                    </Badge>
+                  )}
+                </AssignmentItemBadges>
+              </AssignmentItemDetails>
+            </AssignmentItemRow>
+          );
+        })}
+      </AssignmentItemList>
+    </section>
+  );
+};

--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_ROLES_INCLUDE_DELETED,
   DEFAULT_ROLES_PAGE,
   DEFAULT_ROLES_PAGE_SIZE,
+  isRoleDto,
   listRoles,
   listSystems,
   MAX_ROLES_PAGE_SIZE,
@@ -411,8 +412,18 @@ export const RolesGlobalListShellPage: React.FC<
         setSystemFilter(payload.systemId);
         setPage(DEFAULT_ROLES_PAGE);
       }
+      const created = ctx?.mutationResult;
+      const ownerSystemId = payload?.systemId?.trim();
+      if (
+        ownerSystemId &&
+        isRoleDto(created) &&
+        typeof created.id === 'string' &&
+        created.id.trim().length > 0
+      ) {
+        navigate(`/systems/${ownerSystemId}/roles/${created.id}/permissoes`);
+      }
     },
-    [handleRefetch, setPage],
+    [handleRefetch, navigate, setPage],
   );
 
   /**

--- a/src/pages/roles/rolePermissionsHelpers.ts
+++ b/src/pages/roles/rolePermissionsHelpers.ts
@@ -14,6 +14,8 @@
  * desde o primeiro consumer adicional.
  */
 
+import type { PermissionDto } from "../../shared/api";
+
 /**
  * Re-exports dos tipos compartilhados — evita que `RolePermissionsShellPage`
  * tenha que importar diretamente de `pages/users/userPermissionsHelpers`,
@@ -74,6 +76,63 @@ export interface RolePermissionAssignmentFailure {
  */
 function compareStrings(a: string, b: string): number {
   return a.localeCompare(b, "pt-BR", { sensitivity: "base" });
+}
+
+function comparePermissionsByType(a: PermissionDto, b: PermissionDto): number {
+  const byType = compareStrings(a.permissionTypeCode, b.permissionTypeCode);
+  if (byType !== 0) return byType;
+  return compareStrings(a.id, b.id);
+}
+
+/**
+ * Subgrupo visual: permissões da mesma rota (épico #196 / Issue #198).
+ */
+export interface PermissionRouteSubgroup {
+  routeId: string;
+  routeCode: string;
+  routeName: string;
+  permissions: ReadonlyArray<PermissionDto>;
+}
+
+/**
+ * Agrupa por `routeId` (fallback estável por `routeCode` quando o id
+ * vem vazio), ordena rotas por `routeCode` e permissões por tipo.
+ */
+export function groupPermissionsByRoute(
+  permissions: ReadonlyArray<PermissionDto>,
+): ReadonlyArray<PermissionRouteSubgroup> {
+  const map = new Map<string, PermissionDto[]>();
+  for (const p of permissions) {
+    const rid = p.routeId.trim();
+    const key = rid.length > 0 ? rid : `code:${p.routeCode}`;
+    const bucket = map.get(key);
+    if (bucket) {
+      bucket.push(p);
+    } else {
+      map.set(key, [p]);
+    }
+  }
+
+  const result: PermissionRouteSubgroup[] = [];
+  for (const items of map.values()) {
+    const sortedItems = [...items].sort(comparePermissionsByType);
+    const head = sortedItems[0];
+    if (!head) continue;
+    const ridHead = head.routeId.trim();
+    const routeCode =
+      head.routeCode.trim().length > 0 ? head.routeCode.trim() : "—";
+    const routeName =
+      head.routeName.trim().length > 0 ? head.routeName.trim() : routeCode;
+    result.push({
+      routeId: ridHead.length > 0 ? ridHead : routeCode,
+      routeCode,
+      routeName,
+      permissions: sortedItems,
+    });
+  }
+
+  result.sort((a, b) => compareStrings(a.routeCode, b.routeCode));
+  return result;
 }
 
 /**

--- a/src/pages/roles/rolePermissionsHelpers.ts
+++ b/src/pages/roles/rolePermissionsHelpers.ts
@@ -14,7 +14,10 @@
  * desde o primeiro consumer adicional.
  */
 
+import { groupByRoute } from "../../shared/listing";
+
 import type { PermissionDto } from "../../shared/api";
+import type { RouteGroup } from "../../shared/listing";
 
 /**
  * Re-exports dos tipos compartilhados — evita que `RolePermissionsShellPage`
@@ -78,6 +81,12 @@ function compareStrings(a: string, b: string): number {
   return a.localeCompare(b, "pt-BR", { sensitivity: "base" });
 }
 
+/**
+ * Compara duas permissões dentro do mesmo subgrupo de rota: primeiro
+ * por `permissionTypeCode` (Read/Create/Update/Delete em ordem natural),
+ * depois por `id` em desempate. Mantido fora do agrupador para preservar
+ * a complexidade cognitiva baixa (regra Sonar).
+ */
 function comparePermissionsByType(a: PermissionDto, b: PermissionDto): number {
   const byType = compareStrings(a.permissionTypeCode, b.permissionTypeCode);
   if (byType !== 0) return byType;
@@ -86,6 +95,11 @@ function comparePermissionsByType(a: PermissionDto, b: PermissionDto): number {
 
 /**
  * Subgrupo visual: permissões da mesma rota (épico #196 / Issue #198).
+ *
+ * O shape preserva o vocabulário do recurso (`permissions` em vez de
+ * `items`) para manter os call-sites legíveis. Internamente é um
+ * adapter sobre `RouteGroup<PermissionDto>` devolvido pelo helper
+ * genérico `groupByRoute` (`src/shared/listing/`).
  */
 export interface PermissionRouteSubgroup {
   routeId: string;
@@ -95,44 +109,47 @@ export interface PermissionRouteSubgroup {
 }
 
 /**
- * Agrupa por `routeId` (fallback estável por `routeCode` quando o id
- * vem vazio), ordena rotas por `routeCode` e permissões por tipo.
+ * Adapter `RouteGroup<PermissionDto>` → `PermissionRouteSubgroup`. Só
+ * renomeia `items` → `permissions` para preservar a leitura natural
+ * nos call-sites do recurso.
+ */
+function toRouteSubgroup(
+  group: RouteGroup<PermissionDto>,
+): PermissionRouteSubgroup {
+  return {
+    routeId: group.routeId,
+    routeCode: group.routeCode,
+    routeName: group.routeName,
+    permissions: group.items,
+  };
+}
+
+/**
+ * Agrupa um catálogo de permissões por rota. Itens cujo `routeCode` é
+ * vazio (LEFT JOIN do backend não encontrou a rota — soft-delete em
+ * cascata) ficam num grupo virtual com `routeCode` "—" para que a UI
+ * ainda mostre o item em vez de descartá-lo silenciosamente.
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `routeCode` (estabilidade visual; órfãos vão pro fim).
+ * 2. Permissões dentro de cada grupo por `permissionTypeCode` então
+ *    `id` em desempate.
+ *
+ * Implementação delega ao helper genérico `groupByRoute` em
+ * `src/shared/listing/groupByRoute.ts` — mesmo corpo do algoritmo que
+ * `groupBySystem` consome (`groupByEntityField`), parametrizado apenas
+ * pela tripla de campos `route*`. Centralizar lá previne a recorrência
+ * de New Code Duplication no Sonar (lições PR #134/#135).
  */
 export function groupPermissionsByRoute(
   permissions: ReadonlyArray<PermissionDto>,
 ): ReadonlyArray<PermissionRouteSubgroup> {
-  const map = new Map<string, PermissionDto[]>();
-  for (const p of permissions) {
-    const rid = p.routeId.trim();
-    const key = rid.length > 0 ? rid : `code:${p.routeCode}`;
-    const bucket = map.get(key);
-    if (bucket) {
-      bucket.push(p);
-    } else {
-      map.set(key, [p]);
-    }
-  }
-
-  const result: PermissionRouteSubgroup[] = [];
-  for (const items of map.values()) {
-    const sortedItems = [...items].sort(comparePermissionsByType);
-    const head = sortedItems[0];
-    if (!head) continue;
-    const ridHead = head.routeId.trim();
-    const routeCode =
-      head.routeCode.trim().length > 0 ? head.routeCode.trim() : "—";
-    const routeName =
-      head.routeName.trim().length > 0 ? head.routeName.trim() : routeCode;
-    result.push({
-      routeId: ridHead.length > 0 ? ridHead : routeCode,
-      routeCode,
-      routeName,
-      permissions: sortedItems,
-    });
-  }
-
-  result.sort((a, b) => compareStrings(a.routeCode, b.routeCode));
-  return result;
+  const groups = groupByRoute(permissions, {
+    compareItems: comparePermissionsByType,
+    orphanFallbackName: "Sem rota",
+  });
+  return groups.map(toRouteSubgroup);
 }
 
 /**

--- a/src/shared/forms/useCreateEntitySubmit.ts
+++ b/src/shared/forms/useCreateEntitySubmit.ts
@@ -97,6 +97,12 @@ export interface CreateEntitySubmitCopy {
 export interface CreateEntitySubmitSuccessContext {
   /** Payload enviado ao `mutationFn` (mesmo objeto devolvido por `prepareSubmit`). */
   createdPayload: unknown;
+  /**
+   * Retorno da `mutationFn` em sucesso (ex.: `RoleDto` do `createRole`).
+   * Opcional para não quebrar call sites que só precisam do payload —
+   * Issue #197 (épico #196) usa para navegar à tela de permissões.
+   */
+  mutationResult?: unknown;
 }
 
 /**
@@ -228,14 +234,14 @@ export function useCreateEntitySubmit<TField extends string>({
       if (payload === null) return;
 
       try {
-        await mutationFn(payload);
+        const mutationResult = await mutationFn(payload);
         // Mensagem de sucesso fixa (não citamos o nome — o usuário
         // acabou de digitar e a lista será atualizada).
         showToast(successMessage, { variant: 'success' });
         // Ordem importa: reset local + refetch antes de fechar para o
         // pai não ter que coordenar dois ticks separados.
         resetForm();
-        onCreated({ createdPayload: payload });
+        onCreated({ createdPayload: payload, mutationResult });
         onClose();
       } catch (error: unknown) {
         // `classifyApiSubmitError` decide o `kind`; `applyCreateSubmitAction`

--- a/src/shared/listing/groupByEntityField.ts
+++ b/src/shared/listing/groupByEntityField.ts
@@ -1,0 +1,173 @@
+/**
+ * Helper genérico que centraliza o algoritmo de agrupamento de itens
+ * por uma entidade denormalizada (sistema, rota, etc.). Os wrappers
+ * concretos (`groupBySystem`, `groupByRoute`) fixam apenas os
+ * accessors `getId`/`getCode`/`getName` — todo o restante (ordenação
+ * dos grupos, tratamento de órfãos, ordenação dos itens dentro do
+ * grupo) vive aqui.
+ *
+ * **Por que existe (lição PR #134/#135):** introduzir um wrapper novo
+ * (`groupByRoute` para a Issue #198) replicando o corpo de
+ * `groupBySystem` tokenizaria como bloco duplicado no Sonar — a única
+ * variação entre os dois agrupadores é a tripla de campos lidos do
+ * item (`system*` versus `route*`). Centralizar aqui parametriza
+ * exatamente essa diferença e mantém um único caminho lógico.
+ *
+ * Função pura — entrada imutável, saída nova. Não importa do React,
+ * pode ser usada em testes, hooks de memo ou efeitos sem custo.
+ */
+
+/** Marcador visível do grupo órfão no `code` retornado. */
+export const ORPHAN_DISPLAY_CODE = '—';
+/** Chave do bucket virtual para itens sem entidade. Privada ao módulo. */
+const ORPHAN_BUCKET_KEY = '__orphan__';
+
+/**
+ * Compara strings com `localeCompare` em pt-BR — mesmo critério usado
+ * em outros pontos da UI para estabilidade entre browsers.
+ */
+function compareStrings(a: string, b: string): number {
+  return a.localeCompare(b, 'pt-BR', { sensitivity: 'base' });
+}
+
+/**
+ * Acessores que cada agrupador concreto fornece para extrair a tripla
+ * `id`/`code`/`name` da entidade denormalizada do item. Mantemos como
+ * funções puras (em vez de chaves) porque preservam tipagem forte e
+ * evitam `keyof T` que perderia o `string` literal nos call-sites.
+ */
+export interface EntityFieldAccessors<T> {
+  getId: (item: T) => string;
+  getCode: (item: T) => string;
+  getName: (item: T) => string;
+}
+
+/**
+ * Argumentos comuns aceitos pelos agrupadores. `compareItems` define
+ * a ordenação dos itens dentro de cada grupo (cada recurso tem seu
+ * critério natural — `permissionTypeCode`, `code`, etc.).
+ */
+export interface GroupByEntityFieldOptions<T> {
+  compareItems: (a: T, b: T) => number;
+  /** Nome exibido no grupo virtual quando o item não tem `name`. */
+  orphanFallbackName?: string;
+}
+
+/**
+ * Bloco visual: todos os itens pertencentes à mesma entidade
+ * denormalizada. Os wrappers (`SystemGroup`, `RouteGroup`) re-tipam
+ * essa shape com nomes específicos do recurso para preservar o
+ * vocabulário do call-site.
+ */
+export interface EntityGroup<T> {
+  id: string;
+  code: string;
+  name: string;
+  items: ReadonlyArray<T>;
+}
+
+interface EntityMeta {
+  id: string;
+  code: string;
+  name: string;
+}
+
+interface BucketsResult<T> {
+  buckets: Map<string, T[]>;
+  meta: Map<string, EntityMeta>;
+}
+
+/**
+ * Constrói os buckets indexados por `code` (ou `__orphan__` quando o
+ * item não tem entidade denormalizada). Função separada do agrupador
+ * principal para reduzir complexidade cognitiva conforme regra do
+ * `eslint-plugin-sonarjs` (limite 15).
+ */
+function buildBuckets<T>(
+  items: ReadonlyArray<T>,
+  accessors: EntityFieldAccessors<T>,
+  orphanFallbackName: string,
+): BucketsResult<T> {
+  const buckets = new Map<string, T[]>();
+  const meta = new Map<string, EntityMeta>();
+
+  for (const item of items) {
+    const code = accessors.getCode(item);
+    const isOrphan = code.length === 0;
+    const key = isOrphan ? ORPHAN_BUCKET_KEY : code;
+    const existingBucket = buckets.get(key);
+    if (existingBucket) {
+      existingBucket.push(item);
+      continue;
+    }
+    buckets.set(key, [item]);
+    const name = accessors.getName(item);
+    meta.set(key, {
+      id: accessors.getId(item),
+      code: isOrphan ? ORPHAN_DISPLAY_CODE : code,
+      name: name.length > 0 ? name : orphanFallbackName,
+    });
+  }
+
+  return { buckets, meta };
+}
+
+/**
+ * Compara dois grupos: empurra o grupo órfão (`code === '—'`) para o
+ * final independentemente da ordenação alfabética, e em seguida ordena
+ * por `code` em ordem natural. Mantido fora do agrupador principal
+ * para reduzir a contagem cognitiva (regra Sonar) — espelha o pattern
+ * herdado de `groupBySystem`.
+ */
+function compareEntityGroups<T>(a: EntityGroup<T>, b: EntityGroup<T>): number {
+  const aOrphan = a.code === ORPHAN_DISPLAY_CODE;
+  const bOrphan = b.code === ORPHAN_DISPLAY_CODE;
+  if (aOrphan && !bOrphan) return 1;
+  if (!aOrphan && bOrphan) return -1;
+  return compareStrings(a.code, b.code);
+}
+
+/**
+ * Agrupa um catálogo de itens pela tripla `id/code/name` extraída via
+ * `accessors`. Itens cujo `code` é vazio (LEFT JOIN do backend não
+ * encontrou a entidade — soft-delete em cascata, por exemplo) ficam
+ * num grupo virtual com `code` "—" para que a UI ainda mostre o item
+ * em vez de descartá-lo silenciosamente.
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `code` (estabilidade visual; órfãos vão pro fim).
+ * 2. Itens dentro de cada grupo via `options.compareItems`.
+ *
+ * Genérico em `T` — preserva o tipo do item para o caller (sem `as`
+ * nem perda de inferência) e isola o algoritmo dos nomes específicos
+ * de campo (system/route/etc.).
+ */
+export function groupByEntityField<T>(
+  items: ReadonlyArray<T>,
+  accessors: EntityFieldAccessors<T>,
+  options: GroupByEntityFieldOptions<T>,
+): ReadonlyArray<EntityGroup<T>> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const orphanFallbackName = options.orphanFallbackName ?? 'Sem entidade';
+  const { buckets, meta } = buildBuckets(items, accessors, orphanFallbackName);
+
+  const groups: EntityGroup<T>[] = [];
+  for (const [key, bucketItems] of buckets) {
+    const entry = meta.get(key);
+    if (!entry) continue;
+    bucketItems.sort(options.compareItems);
+    groups.push({
+      id: entry.id,
+      code: entry.code,
+      name: entry.name,
+      items: bucketItems,
+    });
+  }
+
+  groups.sort(compareEntityGroups);
+  return groups;
+}

--- a/src/shared/listing/groupByRoute.ts
+++ b/src/shared/listing/groupByRoute.ts
@@ -1,0 +1,97 @@
+import {
+  groupByEntityField,
+  type EntityFieldAccessors,
+  type GroupByEntityFieldOptions,
+} from './groupByEntityField';
+
+/**
+ * Helper de agrupamento por rota (Issue #198). Wrapper fino sobre
+ * `groupByEntityField` que fixa os accessors (`routeId`/`routeCode`/
+ * `routeName`) e re-tipa a saída para preservar o vocabulário do
+ * recurso (campos `routeId`/`routeCode`/`routeName`/`items`).
+ *
+ * Espelha `groupBySystem` — ambos os agrupadores compartilham o corpo
+ * via `groupByEntityField`. Manter wrappers paralelos por nome
+ * preserva a leitura natural nos call-sites (`groupBySystem(roles)`,
+ * `groupByRoute(permissions)`) sem custo extra de tokens.
+ */
+
+/**
+ * Contrato mínimo que cada item agrupável por rota precisa expor.
+ * Só consumimos `routeId`/`routeCode`/`routeName` — o resto do shape
+ * é livre, preservando o tipo do item ao ser passado por generics.
+ *
+ * **Decisão de tipagem:** declaramos os campos como `string` (não
+ * `string | undefined`) porque o backend (`PermissionResponse`)
+ * devolve string vazia em vez de `null` quando o LEFT JOIN não tem
+ * match (rota soft-deletada). Itens "órfãos" são detectados via
+ * `routeCode.length === 0`.
+ */
+export interface RouteGroupItem {
+  routeId: string;
+  routeCode: string;
+  routeName: string;
+}
+
+/**
+ * Bloco visual: todos os itens pertencentes a uma mesma rota.
+ * Resultado de `groupByRoute<T>` é `ReadonlyArray<RouteGroup<T>>`,
+ * onde `T` extende `RouteGroupItem`.
+ */
+export interface RouteGroup<T> {
+  routeId: string;
+  routeCode: string;
+  routeName: string;
+  items: ReadonlyArray<T>;
+}
+
+/**
+ * Argumentos do `groupByRoute`. `compareItems` define a ordenação dos
+ * itens dentro de cada grupo (cada recurso tem seu critério natural —
+ * `permissionTypeCode` para permissões, por exemplo).
+ *
+ * `orphanFallbackName` default vira `'Sem rota'` quando o item não
+ * tem `routeName` (LEFT JOIN do backend devolveu vazio).
+ */
+export type GroupByRouteOptions<T> = GroupByEntityFieldOptions<T>;
+
+const ROUTE_ACCESSORS: EntityFieldAccessors<RouteGroupItem> = {
+  getId: (item) => item.routeId,
+  getCode: (item) => item.routeCode,
+  getName: (item) => item.routeName,
+};
+
+/**
+ * Agrupa um catálogo de itens por rota. Itens cujo `routeCode` é
+ * vazio ficam num grupo virtual com `routeCode` "—" para que a UI
+ * ainda mostre o item em vez de descartá-lo silenciosamente.
+ *
+ * Resultado é ordenado:
+ *
+ * 1. Grupos por `routeCode` (estabilidade visual; órfãos vão pro fim).
+ * 2. Itens dentro de cada grupo via `options.compareItems` (caller
+ *    define o critério).
+ *
+ * Genérico em `T` que extende `RouteGroupItem` — preserva o tipo do
+ * item para o caller (sem `as` nem perda de inferência).
+ */
+export function groupByRoute<T extends RouteGroupItem>(
+  items: ReadonlyArray<T>,
+  options: GroupByRouteOptions<T>,
+): ReadonlyArray<RouteGroup<T>> {
+  const groups = groupByEntityField<T>(
+    items,
+    ROUTE_ACCESSORS as EntityFieldAccessors<T>,
+    {
+      compareItems: options.compareItems,
+      orphanFallbackName: options.orphanFallbackName ?? 'Sem rota',
+    },
+  );
+
+  return groups.map((group) => ({
+    routeId: group.id,
+    routeCode: group.code,
+    routeName: group.name,
+    items: group.items,
+  }));
+}

--- a/src/shared/listing/groupBySystem.ts
+++ b/src/shared/listing/groupBySystem.ts
@@ -1,19 +1,27 @@
+import {
+  groupByEntityField,
+  type EntityFieldAccessors,
+  type GroupByEntityFieldOptions,
+} from './groupByEntityField';
+
 /**
- * Helper genérico de agrupamento por sistema. Usado por:
+ * Helper de agrupamento por sistema. Wrapper fino sobre
+ * `groupByEntityField` que fixa os accessors (`systemId`/`systemCode`/
+ * `systemName`) e re-tipa a saída para preservar o vocabulário do
+ * recurso (campos `systemId`/`systemCode`/`systemName`/`items`).
+ *
+ * **Por que existe (lições PR #134/#135):** o corpo do agrupador é
+ * compartilhado com `groupByRoute` (Issue #198) — manter implementação
+ * paralela tokenizaria como bloco duplicado no Sonar. Centralizar em
+ * `groupByEntityField` parametriza apenas a tripla de campos lidos do
+ * item, mantendo um único caminho lógico.
+ *
+ * Usado por:
  *
  * - `userPermissionsHelpers.groupPermissionsBySystem` (Issue #70).
  * - `userRolesHelpers.groupRolesBySystem` (Issue #71).
  * - Listagens futuras que precisem agrupar entidades denormalizadas
  *   por `systemCode`/`systemName`/`systemId`.
- *
- * **Por que vive em `src/shared/listing/`:** o corpo das duas funções
- * de agrupamento (build buckets, ordenar grupos, push de "órfãos"
- * para o final) tinha ~52 linhas idênticas entre os dois recursos,
- * divergindo apenas em (i) tipo do item e (ii) critério de ordenação
- * dentro do grupo. Sonar tokeniza isso como bloco duplicado (lição
- * PR #134/#135). Centralizar aqui parametriza o critério de ordem e
- * mantém o tipo do item via generics — call-site fica reduzido a 1
- * chamada por recurso.
  *
  * Função pura — entrada imutável, saída nova. Não importa do React,
  * pode ser usada em testes, hooks de memo ou efeitos sem custo.
@@ -53,94 +61,20 @@ export interface SystemGroup<T> {
 }
 
 /**
- * Argumentos do `groupBySystem`.
+ * Argumentos do `groupBySystem`. `compareItems` define a ordenação
+ * dos itens dentro de cada grupo (cada recurso tem seu critério
+ * natural — `routeCode` para permissões, `code` para roles).
  *
- * - `compareItems` — comparador estável dos itens dentro de um mesmo
- *   grupo (ex.: por `routeCode` em PermissionDto, por `code` em
- *   RoleDto). Mantido como parâmetro porque a ordem natural varia
- *   entre recursos.
- * - `orphanFallbackName` — nome exibido no grupo virtual quando o
- *   item não tem `systemName` (LEFT JOIN do backend devolveu vazio).
- *   Default: `'Sem sistema'` para casar com o pattern já adotado.
+ * `orphanFallbackName` default vira `'Sem sistema'` quando o item não
+ * tem `systemName` (LEFT JOIN do backend devolveu vazio).
  */
-export interface GroupBySystemOptions<T> {
-  compareItems: (a: T, b: T) => number;
-  orphanFallbackName?: string;
-}
+export type GroupBySystemOptions<T> = GroupByEntityFieldOptions<T>;
 
-/** Marcador visível do grupo órfão no `systemCode`. */
-const ORPHAN_DISPLAY_CODE = '—';
-/** Chave do bucket virtual para itens sem sistema. Privada ao módulo. */
-const ORPHAN_BUCKET_KEY = '__orphan__';
-
-/**
- * Compara strings com `localeCompare` em pt-BR — mesmo critério usado
- * em outros pontos da UI para estabilidade entre browsers.
- */
-function compareStrings(a: string, b: string): number {
-  return a.localeCompare(b, 'pt-BR', { sensitivity: 'base' });
-}
-
-/**
- * Compara dois grupos: empurra o grupo órfão (`systemCode === '—'`)
- * para o final independentemente da ordenação alfabética, e em seguida
- * ordena por `systemCode` em ordem natural. Mantido fora de
- * `groupBySystem` para que a complexidade cognitiva do algoritmo
- * principal fique abaixo do limite Sonar (15) — espelha o pattern de
- * `userPermissionsHelpers.compareSystemGroups` (lição PR #134/#135 —
- * isolar comparadores reduz a contagem cognitiva).
- */
-function compareSystemGroups<T>(a: SystemGroup<T>, b: SystemGroup<T>): number {
-  const aOrphan = a.systemCode === ORPHAN_DISPLAY_CODE;
-  const bOrphan = b.systemCode === ORPHAN_DISPLAY_CODE;
-  if (aOrphan && !bOrphan) return 1;
-  if (!aOrphan && bOrphan) return -1;
-  return compareStrings(a.systemCode, b.systemCode);
-}
-
-interface SystemMeta {
-  systemId: string;
-  systemCode: string;
-  systemName: string;
-}
-
-interface BucketsResult<T> {
-  buckets: Map<string, T[]>;
-  systemMeta: Map<string, SystemMeta>;
-}
-
-/**
- * Constrói os buckets indexados por `systemCode` (ou `__orphan__`
- * quando o item não tem sistema denormalizado). Função separada de
- * `groupBySystem` para reduzir complexidade cognitiva conforme regra
- * do `eslint-plugin-sonarjs` (limite 15) — espelha o pattern de
- * `userPermissionsHelpers.buildBuckets`.
- */
-function buildBuckets<T extends SystemGroupItem>(
-  items: ReadonlyArray<T>,
-  orphanFallbackName: string,
-): BucketsResult<T> {
-  const buckets = new Map<string, T[]>();
-  const systemMeta = new Map<string, SystemMeta>();
-
-  for (const item of items) {
-    const isOrphan = item.systemCode.length === 0;
-    const key = isOrphan ? ORPHAN_BUCKET_KEY : item.systemCode;
-    const existingBucket = buckets.get(key);
-    if (existingBucket) {
-      existingBucket.push(item);
-      continue;
-    }
-    buckets.set(key, [item]);
-    systemMeta.set(key, {
-      systemId: item.systemId,
-      systemCode: isOrphan ? ORPHAN_DISPLAY_CODE : item.systemCode,
-      systemName: item.systemName.length > 0 ? item.systemName : orphanFallbackName,
-    });
-  }
-
-  return { buckets, systemMeta };
-}
+const SYSTEM_ACCESSORS: EntityFieldAccessors<SystemGroupItem> = {
+  getId: (item) => item.systemId,
+  getCode: (item) => item.systemCode,
+  getName: (item) => item.systemName,
+};
 
 /**
  * Agrupa um catálogo de itens por sistema. Itens cujo `systemCode` é
@@ -152,7 +86,7 @@ function buildBuckets<T extends SystemGroupItem>(
  *
  * 1. Grupos por `systemCode` (estabilidade visual; órfãos vão pro fim).
  * 2. Itens dentro de cada grupo via `options.compareItems` (caller
- *    define o critério: `routeCode` para permissões, `code` para roles).
+ *    define o critério).
  *
  * Genérico em `T` que extende `SystemGroupItem` — preserva o tipo do
  * item para o caller (sem `as` nem perda de inferência).
@@ -161,26 +95,19 @@ export function groupBySystem<T extends SystemGroupItem>(
   items: ReadonlyArray<T>,
   options: GroupBySystemOptions<T>,
 ): ReadonlyArray<SystemGroup<T>> {
-  if (items.length === 0) {
-    return [];
-  }
+  const groups = groupByEntityField<T>(
+    items,
+    SYSTEM_ACCESSORS as EntityFieldAccessors<T>,
+    {
+      compareItems: options.compareItems,
+      orphanFallbackName: options.orphanFallbackName ?? 'Sem sistema',
+    },
+  );
 
-  const orphanFallbackName = options.orphanFallbackName ?? 'Sem sistema';
-  const { buckets, systemMeta } = buildBuckets(items, orphanFallbackName);
-
-  const groups: SystemGroup<T>[] = [];
-  for (const [key, bucketItems] of buckets) {
-    const meta = systemMeta.get(key);
-    if (!meta) continue;
-    bucketItems.sort(options.compareItems);
-    groups.push({
-      systemId: meta.systemId,
-      systemCode: meta.systemCode,
-      systemName: meta.systemName,
-      items: bucketItems,
-    });
-  }
-
-  groups.sort(compareSystemGroups);
-  return groups;
+  return groups.map((group) => ({
+    systemId: group.id,
+    systemCode: group.code,
+    systemName: group.name,
+    items: group.items,
+  }));
 }

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -80,6 +80,19 @@ export {
 } from './AssignmentMatrixStyles';
 export { ErrorRetryBlock } from './ErrorRetryBlock';
 export {
+  groupByEntityField,
+  ORPHAN_DISPLAY_CODE,
+  type EntityFieldAccessors,
+  type EntityGroup,
+  type GroupByEntityFieldOptions,
+} from './groupByEntityField';
+export {
+  groupByRoute,
+  type GroupByRouteOptions,
+  type RouteGroup,
+  type RouteGroupItem,
+} from './groupByRoute';
+export {
   groupBySystem,
   type GroupBySystemOptions,
   type SystemGroup,

--- a/tests/pages/RolesPage.create.test.tsx
+++ b/tests/pages/RolesPage.create.test.tsx
@@ -229,11 +229,14 @@ describe("RolesPage — criação (Issue #67)", () => {
       // Toast verde "Role criada.".
       expect(await screen.findByText("Role criada.")).toBeInTheDocument();
 
-      // Refetch da lista — `client.get` chamado uma 2ª vez (inicial
-      // + refetch).
-      await waitFor(() => {
-        expect(client.get).toHaveBeenCalledTimes(2);
-      });
+      // Épico #196 / Issue #197 — navegação direta para permissões da role nova.
+      expect(
+        await screen.findByTestId("roles-page-after-create-permissions"),
+      ).toBeInTheDocument();
+
+      // O refetch após criar pode ser abortado ao desmontar a página pela
+      // navegação — não exigimos contagem fixa de `GET`.
+      expect(client.get).toHaveBeenCalled();
     });
 
     it("envia body sem o campo description quando o usuário deixa vazio", async () => {

--- a/tests/pages/__helpers__/rolesTestHelpers.tsx
+++ b/tests/pages/__helpers__/rolesTestHelpers.tsx
@@ -215,6 +215,10 @@ export function renderRolesPage(
             path="/systems/:systemId/roles"
             element={<RolesPage client={client} />}
           />
+          <Route
+            path="/systems/:systemId/roles/:roleId/permissoes"
+            element={<div data-testid="roles-page-after-create-permissions" />}
+          />
         </Routes>
       </MemoryRouter>
     </ToastProvider>,
@@ -251,6 +255,10 @@ export function renderRolesGlobalListPage(client: ApiClientStub): void {
             element={<RolesGlobalListShellPage client={client} />}
           />
           <Route path="/systems/:systemId/roles" element={<div>drill</div>} />
+          <Route
+            path="/systems/:systemId/roles/:roleId/permissoes"
+            element={<div data-testid="roles-global-after-create-permissions" />}
+          />
         </Routes>
       </MemoryRouter>
     </ToastProvider>,

--- a/tests/pages/roles/RolePermissionsShellPage.test.tsx
+++ b/tests/pages/roles/RolePermissionsShellPage.test.tsx
@@ -252,6 +252,37 @@ describe("RolePermissionsShellPage — render do catálogo", () => {
     ).toHaveTextContent("Listar usuários");
   });
 
+  it("renderiza subgrupos por rota quando o catálogo tem mais de uma rota (épico #196)", async () => {
+    const client = createRolePermissionsClientStub();
+    primeStubResponses(client, {
+      catalog: makePagedPermissions([
+        makePermission({
+          id: ID_PERM_A,
+          routeId: "route-a",
+          routeCode: "AUTH_A",
+          routeName: "Rota A",
+        }),
+        makePermission({
+          id: ID_PERM_B,
+          routeId: "route-b",
+          routeCode: "AUTH_B",
+          routeName: "Rota B",
+        }),
+      ]),
+      assigned: [],
+    });
+
+    renderRolePermissionsPage(client);
+    await waitForInitialFetch();
+
+    expect(
+      screen.getByTestId("role-permissions-route-route-a"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("role-permissions-route-route-b"),
+    ).toBeInTheDocument();
+  });
+
   it("exibe estado vazio quando o catálogo é vazio", async () => {
     const client = createRolePermissionsClientStub();
     primeStubResponses(client, {

--- a/tests/pages/roles/RolesGlobalListShellPage.test.tsx
+++ b/tests/pages/roles/RolesGlobalListShellPage.test.tsx
@@ -701,9 +701,11 @@ describe('RolesGlobalListShellPage — Issue #193 criar role global', () => {
     });
     expect(await screen.findByText('Role criada.')).toBeInTheDocument();
 
-    expect(screen.getByTestId('roles-global-system-filter')).toHaveValue(
-      ID_SYS_OUTRO,
-    );
+    // Épico #196 / Issue #197 — navegação para permissões da role nova.
+    // O filtro global deixa de estar visível neste fluxo (nova rota).
+    expect(
+      await screen.findByTestId('roles-global-after-create-permissions'),
+    ).toBeInTheDocument();
   });
 
   it('submeter sem selecionar sistema mostra erro e não dispara POST', async () => {

--- a/tests/pages/roles/rolePermissionsHelpers.test.ts
+++ b/tests/pages/roles/rolePermissionsHelpers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import { makePermission } from "./__helpers__/rolePermissionsTestHelpers";
+
 import {
   buildInitialRolePermissionIds,
   computeRolePermissionDiff,
+  groupPermissionsByRoute,
   rolePermissionDiffHasChanges,
 } from "@/pages/roles/rolePermissionsHelpers";
 
@@ -135,5 +138,64 @@ describe("rolePermissionDiffHasChanges", () => {
     expect(
       rolePermissionDiffHasChanges({ toAdd: [PERM_A], toRemove: [PERM_B] }),
     ).toBe(true);
+  });
+});
+
+describe("groupPermissionsByRoute", () => {
+  it("agrupa permissões da mesma rota e ordena tipos por código", () => {
+    const p1 = makePermission({
+      id: PERM_B,
+      routeId: "route-z",
+      routeCode: "AUTH_Z",
+      routeName: "Zeta",
+      permissionTypeCode: "Write",
+    });
+    const p2 = makePermission({
+      id: PERM_A,
+      routeId: "route-z",
+      routeCode: "AUTH_Z",
+      routeName: "Zeta",
+      permissionTypeCode: "Read",
+    });
+    const groups = groupPermissionsByRoute([p1, p2]);
+    expect(groups).toHaveLength(1);
+    const [first] = groups;
+    expect(first?.permissions.map((p) => p.id)).toEqual([PERM_A, PERM_B]);
+  });
+
+  it("separa rotas distintas e ordena subgrupos por routeCode", () => {
+    const pa = makePermission({
+      id: PERM_A,
+      routeId: "route-b",
+      routeCode: "AUTH_B",
+      routeName: "B",
+    });
+    const pb = makePermission({
+      id: PERM_B,
+      routeId: "route-a",
+      routeCode: "AUTH_A",
+      routeName: "A",
+    });
+    const groups = groupPermissionsByRoute([pa, pb]);
+    expect(groups.map((g) => g.routeCode)).toEqual(["AUTH_A", "AUTH_B"]);
+  });
+
+  it("usa bucket por routeCode quando routeId vem vazio", () => {
+    const p1 = makePermission({
+      id: PERM_A,
+      routeId: "   ",
+      routeCode: "AUTH_EMPTY_RID",
+      routeName: "X",
+    });
+    const p2 = makePermission({
+      id: PERM_B,
+      routeId: "",
+      routeCode: "AUTH_EMPTY_RID",
+      routeName: "X",
+    });
+    const groups = groupPermissionsByRoute([p1, p2]);
+    expect(groups).toHaveLength(1);
+    const [first] = groups;
+    expect(first?.permissions).toHaveLength(2);
   });
 });

--- a/tests/shared/forms/useCreateEntitySubmit.test.tsx
+++ b/tests/shared/forms/useCreateEntitySubmit.test.tsx
@@ -125,6 +125,7 @@ describe('useCreateEntitySubmit — caminho feliz', () => {
     expect(spies.onCreated).toHaveBeenCalledTimes(1);
     expect(spies.onCreated).toHaveBeenCalledWith({
       createdPayload: { payload: 'ok' },
+      mutationResult: { id: 'ok' },
     });
     expect(spies.onClose).toHaveBeenCalledTimes(1);
     expect(spies.setIsSubmitting).toHaveBeenCalledWith(false);


### PR DESCRIPTION
## Resumo

Fecha o **épico #196** implementando **#197** (CTA/navegação pós-criação) e **#198** (agrupamento por rota na tela de permissões da role).

## Alterações

- `useCreateEntitySubmit`: repassa `mutationResult` retornado pela `mutationFn` no contexto de sucesso (`CreateEntitySubmitSuccessContext`) — habilita pais a navegar usando o DTO recém-criado.
- **#197 — pós-create**: Após criar role, `RolesPage` (escopo sistema) e `RolesGlobalListShellPage` navegam para `/systems/:systemId/roles/:roleId/permissoes` usando o `RoleDto` devolvido pelo POST. Ambas as variantes do `NewRoleModal` (`scoped` e `global`) cobertas.
- **#198 — agrupamento por rota**: `groupPermissionsByRoute` em `rolePermissionsHelpers`; `RolePermissionsShellPage` renderiza, dentro de cada sistema, subseções por rota (heading com `routeName` + `routeCode` em mono + lista de permissões ordenada por `permissionTypeCode`).
- **Refator anti-duplicação (lições PR #134/#135)**: extrai `groupByEntityField` genérico em `src/shared/listing/`, parametrizado por accessors `getId/getCode/getName`. `groupBySystem` e o novo `groupByRoute` viram wrappers finos sobre o helper genérico, evitando 6ª recorrência de Sonar New Code Duplication.
- Testes ajustados (stub de rota nos helpers de renderização; assert de navegação após create; agrupamento por rota; fonte única em `groupBySystem.test.ts`).

## Riscos

- Refetch imediato após criar pode ser abortado ao desmontar a página pela navegação — comportamento esperado; ao voltar via `BackLink`, a listagem refaz o fetch normalmente.

## Evidências (gate de qualidade pré-PR via Docker)

```
docker compose run --rm web npm run lint        # 0 erros, 0 warnings
docker compose run --rm web npm run typecheck   # 0 erros
docker compose run --rm web npm test            # 1614/1614 ✓
docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10 \
  --reporters console,json --output ./jscpd-report
# total: 1.47% (≤ 3%) — 0 clones em arquivos do diff
```

## Issues relacionadas

Closes #196
Closes #197
Closes #198

**Sem merge** (conforme fluxo do time).