### PR TITLE
#201 | admin-gui: criar permissão a partir do catálogo /permissoes (POST)

### DIFF
--- a/src/hooks/useModalListSystemsFetch.ts
+++ b/src/hooks/useModalListSystemsFetch.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import { listSystems } from '../shared/api';
+
+import { useSingleFetchWithAbort } from './useSingleFetchWithAbort';
+
+import type { ApiClient, PagedResponse, SafeRequestOptions, SystemDto } from '../shared/api';
+
+/**
+ * Catálogo de sistemas para modais que precisam de `<Select>` de sistema
+ * (`NewRouteModal` modo global, `NewPermissionModal`). Centraliza o par
+ * `useCallback` + `useSingleFetchWithAbort` que o JSCPD tokenizava como
+ * duplicação ≥10 linhas (Issue #201).
+ */
+export function useModalListSystemsFetch(params: {
+  open: boolean;
+  /** Quando `true`, não dispara request mesmo com `open` (ex.: rota per-system). */
+  skip: boolean;
+  pageSize: number;
+  client?: ApiClient;
+  fallbackErrorMessage: string;
+}): ReturnType<
+  typeof useSingleFetchWithAbort<PagedResponse<SystemDto>>
+> {
+  const { open, skip, pageSize, client, fallbackErrorMessage } = params;
+
+  const fetcher = useCallback(
+    (options: SafeRequestOptions): Promise<PagedResponse<SystemDto>> =>
+      listSystems({ pageSize }, options, client),
+    [client, pageSize],
+  );
+
+  return useSingleFetchWithAbort({
+    fetcher,
+    fallbackErrorMessage,
+    skip: !open || skip,
+  });
+}

--- a/src/pages/permissions/NewPermissionModal.tsx
+++ b/src/pages/permissions/NewPermissionModal.tsx
@@ -1,0 +1,359 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import styled from 'styled-components';
+
+import { Alert, Modal, Select, Textarea, useToast } from '../../components/ui';
+import { useModalListSystemsFetch } from '../../hooks/useModalListSystemsFetch';
+import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
+import {
+  createPermission,
+  listPermissionTypes,
+  listRoutes,
+} from '../../shared/api';
+import {
+  FormFooter,
+  useCreateEntitySubmit,
+  type CreateEntitySubmitCopy,
+} from '../../shared/forms';
+
+import {
+  buildRoutePlaceholder,
+  buildRoutesHelperText,
+  buildSystemsHelperText,
+  buildTypesHelperText,
+  computeNewPermissionSubmitDisabled,
+  resolveCatalogAlertMessage,
+} from './newPermissionModalHelpers';
+import {
+  INITIAL_PERMISSION_CREATE_FORM_STATE,
+  PERMISSION_DESCRIPTION_MAX,
+  type PermissionCreateFieldErrors,
+  type PermissionCreateSubmitErrorCopy,
+} from './permissionFormShared';
+import { usePermissionCreateForm } from './usePermissionCreateForm';
+
+import type {
+  ApiClient,
+  CreatePermissionPayload,
+  PagedResponse,
+  RouteDto,
+  SafeRequestOptions,
+} from '../../shared/api';
+
+const SYSTEMS_LOOKUP_PAGE_SIZE = 100;
+const ROUTES_LOOKUP_PAGE_SIZE = 100;
+
+const SUBMIT_ERROR_COPY: PermissionCreateSubmitErrorCopy = {
+  conflictDefault: 'Esta combinação de rota e tipo de permissão já existe.',
+  forbiddenTitle: 'Falha ao criar permissão',
+  genericFallback: 'Não foi possível criar a permissão. Tente novamente.',
+};
+
+const FormStack = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+`;
+
+interface NewPermissionModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+  client?: ApiClient;
+}
+
+/**
+ * Modal de criação de permissão — Issue #201. POST `/permissions`
+ * com `routeId`, `permissionTypeId` e `description` opcional,
+ * espelhando `PermissionsController.CreatePermissionRequest`.
+ */
+export const NewPermissionModal: React.FC<NewPermissionModalProps> = ({
+  open,
+  onClose,
+  onCreated,
+  client,
+}) => {
+  const { show } = useToast();
+  const {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleDescriptionChange,
+    handleSystemIdChange,
+    handleRouteIdChange,
+    handlePermissionTypeIdChange,
+    prepareSubmit,
+    applyBadRequest,
+  } = usePermissionCreateForm(INITIAL_PERMISSION_CREATE_FORM_STATE);
+
+  useEffect(() => {
+    if (!open) return;
+    setFormState(INITIAL_PERMISSION_CREATE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [open, setFieldErrors, setFormState, setSubmitError]);
+
+  const {
+    data: systemsResponse,
+    isInitialLoading: loadingSystems,
+    errorMessage: systemsErrorMessage,
+  } = useModalListSystemsFetch({
+    open,
+    skip: false,
+    pageSize: SYSTEMS_LOOKUP_PAGE_SIZE,
+    client,
+    fallbackErrorMessage: 'Falha ao carregar sistemas.',
+  });
+
+  const typesFetcher = useCallback(
+    (options: SafeRequestOptions) => listPermissionTypes(options, client),
+    [client],
+  );
+
+  const {
+    data: permissionTypes,
+    isInitialLoading: loadingTypes,
+    errorMessage: typesErrorMessage,
+  } = useSingleFetchWithAbort({
+    fetcher: typesFetcher,
+    fallbackErrorMessage: 'Falha ao carregar tipos de permissão.',
+    skip: !open,
+  });
+
+  const routesFetcher = useCallback(
+    (options: SafeRequestOptions): Promise<PagedResponse<RouteDto>> =>
+      listRoutes(
+        {
+          systemId: formState.systemId.trim(),
+          pageSize: ROUTES_LOOKUP_PAGE_SIZE,
+        },
+        options,
+        client,
+      ),
+    [client, formState.systemId],
+  );
+
+  const systemIdTrimmed = formState.systemId.trim();
+  const {
+    data: routesResponse,
+    isInitialLoading: loadingRoutes,
+    errorMessage: routesErrorMessage,
+  } = useSingleFetchWithAbort({
+    fetcher: routesFetcher,
+    fallbackErrorMessage: 'Falha ao carregar rotas do sistema.',
+    skip: !open || systemIdTrimmed.length === 0,
+  });
+
+  const systemOptions = systemsResponse?.data ?? [];
+  const routeOptions = routesResponse?.data ?? [];
+  const typeOptions = permissionTypes ?? [];
+
+  const systemsEmpty = !loadingSystems && systemOptions.length === 0 && systemsErrorMessage === null;
+  const typesEmpty = !loadingTypes && typeOptions.length === 0 && typesErrorMessage === null;
+  const routesEmpty =
+    systemIdTrimmed.length > 0 &&
+    !loadingRoutes &&
+    routeOptions.length === 0 &&
+    routesErrorMessage === null;
+
+  const catalogAlert = resolveCatalogAlertMessage({
+    systemsErrorMessage,
+    typesErrorMessage,
+    routesErrorMessage,
+    systemIdTrimmedLength: systemIdTrimmed.length,
+  });
+
+  const systemsHelperText = buildSystemsHelperText(loadingSystems, systemsEmpty);
+  const routesHelperText = buildRoutesHelperText(
+    systemIdTrimmed.length === 0,
+    loadingRoutes,
+    routesEmpty,
+  );
+  const typesHelperText = buildTypesHelperText(loadingTypes, typesEmpty);
+
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return;
+    setFormState(INITIAL_PERMISSION_CREATE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+    onClose();
+  }, [isSubmitting, onClose, setFieldErrors, setFormState, setSubmitError]);
+
+  const resetForm = useCallback(() => {
+    setFormState(INITIAL_PERMISSION_CREATE_FORM_STATE);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [setFieldErrors, setFormState, setSubmitError]);
+
+  const prepareSubmitSafe = useCallback((): CreatePermissionPayload | null => {
+    if (isSubmitting) return null;
+    return prepareSubmit();
+  }, [isSubmitting, prepareSubmit]);
+
+  const mutationFn = useCallback(
+    (payload: unknown) =>
+      createPermission(payload as CreatePermissionPayload, undefined, client),
+    [client],
+  );
+
+  const submitCopy = useMemo<CreateEntitySubmitCopy>(
+    () => ({
+      successMessage: 'Permissão criada.',
+      submitErrorCopy: SUBMIT_ERROR_COPY,
+    }),
+    [],
+  );
+
+  const handleSubmit = useCreateEntitySubmit<keyof PermissionCreateFieldErrors>({
+    dispatchers: {
+      setFieldErrors,
+      setSubmitError,
+      setIsSubmitting,
+      applyBadRequest,
+      showToast: show,
+      resetForm,
+    },
+    copy: submitCopy,
+    callbacks: {
+      prepareSubmit: prepareSubmitSafe,
+      mutationFn,
+      onCreated,
+      onClose,
+    },
+    conflictField: 'routeId',
+  });
+
+  const submitDisabled = computeNewPermissionSubmitDisabled({
+    isSubmitting,
+    loadingSystems,
+    loadingTypes,
+    systemsErrorMessage,
+    typesErrorMessage,
+    systemsEmpty,
+    typesEmpty,
+    systemIdTrimmedLength: systemIdTrimmed.length,
+    loadingRoutes,
+    routesErrorMessage,
+    routesEmpty,
+  });
+
+  const routePlaceholder = buildRoutePlaceholder(
+    systemIdTrimmed.length === 0,
+    routeOptions.length > 0,
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Nova permissão"
+      description="Associe uma rota cadastrada a um tipo de permissão. A descrição é opcional."
+      closeOnEsc={!isSubmitting}
+      closeOnBackdrop={!isSubmitting}
+    >
+      <FormStack onSubmit={handleSubmit} noValidate data-testid="new-permission-form">
+        {catalogAlert !== null && <Alert variant="danger">{catalogAlert}</Alert>}
+        {submitError !== null && <Alert variant="danger">{submitError}</Alert>}
+
+        <Select
+          label="Sistema"
+          value={formState.systemId}
+          onChange={handleSystemIdChange}
+          error={fieldErrors.systemId}
+          helperText={fieldErrors.systemId ? undefined : systemsHelperText}
+          disabled={isSubmitting || loadingSystems || systemsErrorMessage !== null || systemsEmpty}
+          required
+          data-testid="new-permission-system-id"
+          aria-label="Sistema da rota"
+        >
+          <option value="" disabled={systemOptions.length > 0}>
+            {systemOptions.length > 0 ? 'Selecione um sistema' : 'Nenhum sistema disponível'}
+          </option>
+          {systemOptions.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          label="Rota"
+          value={formState.routeId}
+          onChange={handleRouteIdChange}
+          error={fieldErrors.routeId}
+          helperText={fieldErrors.routeId ? undefined : routesHelperText}
+          disabled={
+            isSubmitting ||
+            systemIdTrimmed.length === 0 ||
+            loadingRoutes ||
+            routesErrorMessage !== null ||
+            routesEmpty
+          }
+          required
+          data-testid="new-permission-route-id"
+          aria-label="Rota da permissão"
+        >
+          <option value="" disabled={routeOptions.length > 0}>
+            {routePlaceholder}
+          </option>
+          {routeOptions.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.code} — {r.name}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          label="Tipo de permissão"
+          value={formState.permissionTypeId}
+          onChange={handlePermissionTypeIdChange}
+          error={fieldErrors.permissionTypeId}
+          helperText={fieldErrors.permissionTypeId ? undefined : typesHelperText}
+          disabled={isSubmitting || loadingTypes || typesErrorMessage !== null || typesEmpty}
+          required
+          data-testid="new-permission-type-id"
+          aria-label="Tipo de permissão"
+        >
+          <option value="" disabled={typeOptions.length > 0}>
+            {typeOptions.length > 0 ? 'Selecione um tipo' : 'Nenhum tipo disponível'}
+          </option>
+          {typeOptions.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </Select>
+
+        <Textarea
+          label="Descrição"
+          value={formState.description}
+          onChange={handleDescriptionChange}
+          error={fieldErrors.description}
+          helperText={
+            fieldErrors.description
+              ? undefined
+              : `Opcional — até ${PERMISSION_DESCRIPTION_MAX} caracteres.`
+          }
+          disabled={isSubmitting}
+          rows={3}
+          maxLength={PERMISSION_DESCRIPTION_MAX}
+          data-testid="new-permission-description"
+          aria-label="Descrição da permissão"
+        />
+
+        <FormFooter
+          idPrefix="new-permission"
+          onCancel={handleClose}
+          isSubmitting={isSubmitting}
+          submitLabel="Criar permissão"
+          submitDisabled={submitDisabled}
+        />
+      </FormStack>
+    </Modal>
+  );
+};

--- a/src/pages/permissions/PermissionsListShellPage.tsx
+++ b/src/pages/permissions/PermissionsListShellPage.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { PageHeader } from '../../components/layout/PageHeader';
 import { Button, Select, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
+import { useToggleModalState } from '../../hooks/useListModalState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
 import { usePaginationControls } from '../../hooks/usePaginationControls';
 import {
@@ -13,6 +14,7 @@ import {
   listPermissions,
   listSystems,
 } from '../../shared/api';
+import { useAuth } from '../../shared/auth';
 import {
   CardCode,
   CardDescription,
@@ -34,8 +36,11 @@ import {
   Placeholder,
   StatusBadge,
   TableForDesktop,
+  ToolbarPrimaryCreateButton,
   useListingLiveMessage,
 } from '../../shared/listing';
+
+import { NewPermissionModal } from './NewPermissionModal';
 
 import type { TableColumn } from '../../components/ui';
 import type {
@@ -103,6 +108,13 @@ const PERMISSION_TYPE_LABELS: Record<PermissionTypeCode, string> = {
  */
 const SYSTEMS_FILTER_PAGE_SIZE = 100;
 
+/**
+ * Code exigido pelo `lfc-authenticator` para `POST /permissions`
+ * (`PermissionPolicies.PermissionsCreate`) — espelha
+ * `AUTH_V1_PERMISSIONS_CREATE` do `AuthenticatorRoutesSeeder`.
+ */
+const PERMISSIONS_CREATE_PERMISSION_CODE = 'AUTH_V1_PERMISSIONS_CREATE';
+
 interface PermissionsListShellPageProps {
   /**
    * Cliente HTTP injetável para isolar testes. Em produção, omitido —
@@ -153,6 +165,10 @@ function renderTextOrPlaceholder(value: string): React.ReactNode {
 export const PermissionsListShellPage: React.FC<PermissionsListShellPageProps> = ({
   client,
 }) => {
+  const { hasPermission } = useAuth();
+  const canCreatePermission = hasPermission(PERMISSIONS_CREATE_PERMISSION_CODE);
+  const createModal = useToggleModalState();
+
   // Termo digitado pelo usuário em tempo real (input controlado).
   const [searchTerm, setSearchTerm] = useState<string>('');
   const debouncedSearch = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS);
@@ -627,11 +643,29 @@ export const PermissionsListShellPage: React.FC<PermissionsListShellPageProps> =
         includeDeletedHelperText="Inclui permissões com remoção lógica."
         includeDeletedTestId="permissions-include-deleted"
         extraFilter={filtersNode}
+        actions={
+          canCreatePermission && (
+            <ToolbarPrimaryCreateButton
+              testId="permissions-create-open"
+              label="Nova permissão"
+              onClick={createModal.open}
+            />
+          )
+        }
       />
 
       <LiveRegion message={liveMessage} testId="permissions-live" />
 
       <ListingResultArea {...listingResultProps} />
+
+      {canCreatePermission && (
+        <NewPermissionModal
+          open={createModal.isOpen}
+          onClose={createModal.close}
+          onCreated={handleRefetch}
+          client={client}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/permissions/newPermissionModalHelpers.ts
+++ b/src/pages/permissions/newPermissionModalHelpers.ts
@@ -1,0 +1,84 @@
+/**
+ * Helpers puros do `NewPermissionModal` — extraídos para manter o
+ * componente abaixo do limite de Cognitive Complexity do Sonar (Issue #201).
+ */
+
+export function resolveCatalogAlertMessage(params: {
+  systemsErrorMessage: string | null;
+  typesErrorMessage: string | null;
+  routesErrorMessage: string | null;
+  systemIdTrimmedLength: number;
+}): string | null {
+  if (params.systemsErrorMessage !== null) {
+    return params.systemsErrorMessage;
+  }
+  if (params.typesErrorMessage !== null) {
+    return params.typesErrorMessage;
+  }
+  if (params.systemIdTrimmedLength > 0 && params.routesErrorMessage !== null) {
+    return params.routesErrorMessage;
+  }
+  return null;
+}
+
+export function computeNewPermissionSubmitDisabled(params: {
+  isSubmitting: boolean;
+  loadingSystems: boolean;
+  loadingTypes: boolean;
+  systemsErrorMessage: string | null;
+  typesErrorMessage: string | null;
+  systemsEmpty: boolean;
+  typesEmpty: boolean;
+  systemIdTrimmedLength: number;
+  loadingRoutes: boolean;
+  routesErrorMessage: string | null;
+  routesEmpty: boolean;
+}): boolean {
+  if (
+    params.isSubmitting ||
+    params.loadingSystems ||
+    params.loadingTypes ||
+    params.systemsErrorMessage !== null ||
+    params.typesErrorMessage !== null ||
+    params.systemsEmpty ||
+    params.typesEmpty
+  ) {
+    return true;
+  }
+  if (params.systemIdTrimmedLength === 0) {
+    return false;
+  }
+  return params.loadingRoutes || params.routesErrorMessage !== null || params.routesEmpty;
+}
+
+export function buildSystemsHelperText(loading: boolean, empty: boolean): string {
+  if (loading) return 'Carregando sistemas…';
+  if (empty) return 'Nenhum sistema disponível.';
+  return 'Sistema ao qual a rota pertence.';
+}
+
+export function buildRoutesHelperText(
+  systemIdEmpty: boolean,
+  loading: boolean,
+  empty: boolean,
+): string {
+  if (systemIdEmpty) return 'Selecione um sistema para listar rotas.';
+  if (loading) return 'Carregando rotas…';
+  if (empty) return 'Nenhuma rota ativa neste sistema.';
+  return 'Rota que receberá o tipo de permissão.';
+}
+
+export function buildTypesHelperText(loading: boolean, empty: boolean): string {
+  if (loading) return 'Carregando tipos…';
+  if (empty) return 'Nenhum tipo de permissão disponível.';
+  return 'Ação (criar, ler, atualizar, etc.) aplicada à rota.';
+}
+
+export function buildRoutePlaceholder(
+  systemIdEmpty: boolean,
+  hasRoutes: boolean,
+): string {
+  if (systemIdEmpty) return 'Selecione um sistema';
+  if (hasRoutes) return 'Selecione uma rota';
+  return 'Nenhuma rota disponível';
+}

--- a/src/pages/permissions/permissionFormShared.ts
+++ b/src/pages/permissions/permissionFormShared.ts
@@ -1,0 +1,87 @@
+import {
+  extractValidationErrorsByField,
+  type ApiSubmitErrorCopy,
+  type ApplyBadRequestDecision,
+} from '../../shared/forms';
+
+/** Limite do backend (`CreatePermissionRequest.Description`). */
+export const PERMISSION_DESCRIPTION_MAX = 500;
+
+export interface PermissionCreateFormState {
+  systemId: string;
+  routeId: string;
+  permissionTypeId: string;
+  description: string;
+}
+
+export const INITIAL_PERMISSION_CREATE_FORM_STATE: PermissionCreateFormState = {
+  systemId: '',
+  routeId: '',
+  permissionTypeId: '',
+  description: '',
+};
+
+export type PermissionCreateFieldErrors = Partial<{
+  systemId: string;
+  routeId: string;
+  permissionTypeId: string;
+  description: string;
+}>;
+
+export type PermissionCreateSubmitErrorCopy = ApiSubmitErrorCopy;
+
+function normalizePermissionCreateFieldName(
+  serverField: string,
+): keyof PermissionCreateFieldErrors | null {
+  const map: Record<string, keyof PermissionCreateFieldErrors> = {
+    RouteId: 'routeId',
+    PermissionTypeId: 'permissionTypeId',
+    Description: 'description',
+  };
+  return map[serverField] ?? null;
+}
+
+export function extractPermissionCreateValidationErrors(
+  details: unknown,
+): PermissionCreateFieldErrors | null {
+  return extractValidationErrorsByField<PermissionCreateFieldErrors>(
+    details,
+    normalizePermissionCreateFieldName,
+  );
+}
+
+export function decidePermissionCreateBadRequestHandling(
+  details: unknown,
+  fallbackMessage: string,
+): ApplyBadRequestDecision<PermissionCreateFieldErrors> {
+  const extracted = extractPermissionCreateValidationErrors(details);
+  if (extracted && Object.keys(extracted).length > 0) {
+    return { kind: 'field-errors', errors: extracted };
+  }
+  return { kind: 'submit-error', message: fallbackMessage };
+}
+
+/**
+ * Validação client-side alinhada a `CreatePermissionRequest` — campos de
+ * sistema/rota/tipo são obrigatórios na UI (o POST usa só `routeId` +
+ * `permissionTypeId`).
+ */
+export function validatePermissionCreateForm(
+  state: PermissionCreateFormState,
+): PermissionCreateFieldErrors | null {
+  const errors: PermissionCreateFieldErrors = {};
+  if (state.systemId.trim().length === 0) {
+    errors.systemId = 'Selecione um sistema.';
+  }
+  if (state.routeId.trim().length === 0) {
+    errors.routeId = 'Selecione uma rota.';
+  }
+  if (state.permissionTypeId.trim().length === 0) {
+    errors.permissionTypeId = 'Selecione um tipo de permissão.';
+  }
+  const desc = state.description.trim();
+  if (desc.length > PERMISSION_DESCRIPTION_MAX) {
+    errors.description = `Descrição deve ter no máximo ${PERMISSION_DESCRIPTION_MAX} caracteres.`;
+  }
+  return Object.keys(errors).length > 0 ? errors : null;
+}

--- a/src/pages/permissions/usePermissionCreateForm.ts
+++ b/src/pages/permissions/usePermissionCreateForm.ts
@@ -1,0 +1,116 @@
+import { useCallback, useState } from 'react';
+
+import { useApplyBadRequest, useFieldChangeHandlers } from '../../shared/forms';
+
+import {
+  decidePermissionCreateBadRequestHandling,
+  validatePermissionCreateForm,
+  type PermissionCreateFieldErrors,
+  type PermissionCreateFormState,
+} from './permissionFormShared';
+
+import type { CreatePermissionPayload } from '../../shared/api';
+
+const DESCRIPTION_ONLY = ['description'] as const;
+
+export interface UsePermissionCreateFormReturn {
+  formState: PermissionCreateFormState;
+  fieldErrors: PermissionCreateFieldErrors;
+  submitError: string | null;
+  isSubmitting: boolean;
+  setFormState: React.Dispatch<React.SetStateAction<PermissionCreateFormState>>;
+  setFieldErrors: React.Dispatch<React.SetStateAction<PermissionCreateFieldErrors>>;
+  setSubmitError: React.Dispatch<React.SetStateAction<string | null>>;
+  setIsSubmitting: React.Dispatch<React.SetStateAction<boolean>>;
+  handleDescriptionChange: (value: string) => void;
+  handleSystemIdChange: (value: string) => void;
+  handleRouteIdChange: (value: string) => void;
+  handlePermissionTypeIdChange: (value: string) => void;
+  prepareSubmit: () => CreatePermissionPayload | null;
+  applyBadRequest: (details: unknown, fallbackMessage: string) => void;
+}
+
+export function usePermissionCreateForm(
+  initialState: PermissionCreateFormState,
+): UsePermissionCreateFormReturn {
+  const [formState, setFormState] = useState<PermissionCreateFormState>(initialState);
+  const [fieldErrors, setFieldErrors] = useState<PermissionCreateFieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const { description: handleDescriptionChange } = useFieldChangeHandlers<
+    PermissionCreateFormState,
+    PermissionCreateFieldErrors
+  >(DESCRIPTION_ONLY, setFormState, setFieldErrors);
+
+  const handleSystemIdChange = useCallback((value: string) => {
+    setFormState((prev) => ({ ...prev, systemId: value, routeId: '' }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next.systemId;
+      delete next.routeId;
+      return next;
+    });
+  }, []);
+
+  const handleRouteIdChange = useCallback((value: string) => {
+    setFormState((prev) => ({ ...prev, routeId: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next.routeId;
+      return next;
+    });
+  }, []);
+
+  const handlePermissionTypeIdChange = useCallback((value: string) => {
+    setFormState((prev) => ({ ...prev, permissionTypeId: value }));
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      delete next.permissionTypeId;
+      return next;
+    });
+  }, []);
+
+  const prepareSubmit = useCallback((): CreatePermissionPayload | null => {
+    const clientErrors = validatePermissionCreateForm(formState);
+    if (clientErrors) {
+      setFieldErrors(clientErrors);
+      setSubmitError(null);
+      return null;
+    }
+    setFieldErrors({});
+    setSubmitError(null);
+    setIsSubmitting(true);
+    const payload: CreatePermissionPayload = {
+      routeId: formState.routeId.trim(),
+      permissionTypeId: formState.permissionTypeId.trim(),
+    };
+    const d = formState.description.trim();
+    if (d.length > 0) {
+      payload.description = d;
+    }
+    return payload;
+  }, [formState]);
+
+  const applyBadRequest = useApplyBadRequest<PermissionCreateFieldErrors>(
+    decidePermissionCreateBadRequestHandling,
+    { setFieldErrors, setSubmitError },
+  );
+
+  return {
+    formState,
+    fieldErrors,
+    submitError,
+    isSubmitting,
+    setFormState,
+    setFieldErrors,
+    setSubmitError,
+    setIsSubmitting,
+    handleDescriptionChange,
+    handleSystemIdChange,
+    handleRouteIdChange,
+    handlePermissionTypeIdChange,
+    prepareSubmit,
+    applyBadRequest,
+  };
+}

--- a/src/pages/routes/NewRouteModal.tsx
+++ b/src/pages/routes/NewRouteModal.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { Modal, Select, useToast } from '../../components/ui';
-import { useSingleFetchWithAbort } from '../../hooks/useSingleFetchWithAbort';
-import { createRoute, listSystems } from '../../shared/api';
+import { useModalListSystemsFetch } from '../../hooks/useModalListSystemsFetch';
+import { createRoute } from '../../shared/api';
 import { useCreateEntitySubmit } from '../../shared/forms';
 
 import { RouteFormBody } from './RouteFormFields';
@@ -14,13 +14,7 @@ import {
 import { useRouteForm } from './useRouteForm';
 import { useRouteTokenTypes } from './useRouteTokenTypes';
 
-import type {
-  ApiClient,
-  CreateRoutePayload,
-  PagedResponse,
-  SafeRequestOptions,
-  SystemDto,
-} from '../../shared/api';
+import type { ApiClient, CreateRoutePayload, SystemDto } from '../../shared/api';
 
 /**
  * Copy injetada em `classifyApiSubmitError` para o caminho de
@@ -179,30 +173,20 @@ export const NewRouteModal: React.FC<NewRouteModalProps> = ({
   const [systemIdError, setSystemIdError] = useState<string | null>(null);
 
   /**
-   * Carrega o catálogo de sistemas apenas quando o modal está aberto e
-   * em modo global. `useSingleFetchWithAbort` cuida do AbortController
-   * e do retry bumper. A request reage à abertura do modal — fechar +
-   * reabrir cancela a request anterior.
-   *
-   * Skipamos a request quando: (a) o modal está fechado, ou (b) o
-   * caller passou `systemId` (modo per-system, dropdown não é
-   * renderizado e ninguém precisa do catálogo).
+   * Catálogo de sistemas — modo global apenas (`useModalListSystemsFetch`,
+   * Issue #201 extrai o pair fetch/hook compartilhado com `NewPermissionModal`).
    */
-  const systemsFetcher = useCallback(
-    (options: SafeRequestOptions): Promise<PagedResponse<SystemDto>> =>
-      listSystems({ pageSize: SYSTEMS_LOOKUP_PAGE_SIZE }, options, client),
-    [client],
-  );
-
   const {
     data: systemsResponse,
     isInitialLoading: loadingSystems,
     errorMessage: systemsErrorMessage,
-  } = useSingleFetchWithAbort<PagedResponse<SystemDto>>({
-    fetcher: systemsFetcher,
+  } = useModalListSystemsFetch({
+    open,
+    skip: !showSystemSelect,
+    pageSize: SYSTEMS_LOOKUP_PAGE_SIZE,
+    client,
     fallbackErrorMessage:
       'Não foi possível carregar a lista de sistemas. Feche o modal e tente novamente.',
-    skip: !open || !showSystemSelect,
   });
 
   const systemOptions = useMemo<ReadonlyArray<SystemDto>>(() => {

--- a/src/pages/routes/RoutesGlobalListShellPage.tsx
+++ b/src/pages/routes/RoutesGlobalListShellPage.tsx
@@ -1,10 +1,9 @@
-import { Plus } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { PageHeader } from '../../components/layout/PageHeader';
-import { Button, Select, Table } from '../../components/ui';
+import { Select, Table } from '../../components/ui';
 import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { useToggleModalState } from '../../hooks/useListModalState';
 import { usePaginatedFetch } from '../../hooks/usePaginatedFetch';
@@ -29,6 +28,7 @@ import {
   Mono,
   StatusBadge,
   TableForDesktop,
+  ToolbarPrimaryCreateButton,
   useListingLiveMessage,
 } from '../../shared/listing';
 
@@ -582,15 +582,11 @@ export const RoutesGlobalListShellPage: React.FC<RoutesGlobalListShellPageProps>
         extraFilter={systemFilterSelect}
         actions={
           canCreateRoute && (
-            <Button
-              variant="primary"
-              size="md"
-              icon={<Plus size={14} strokeWidth={1.75} />}
+            <ToolbarPrimaryCreateButton
+              testId="routes-global-create-open"
+              label="Nova rota"
               onClick={createModal.open}
-              data-testid="routes-global-create-open"
-            >
-              Nova rota
-            </Button>
+            />
           )
         }
       />

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -213,20 +213,25 @@ export type {
 } from './users';
 export {
   assignPermissionToUser,
+  createPermission,
   DEFAULT_PERMISSIONS_INCLUDE_DELETED,
   DEFAULT_PERMISSIONS_PAGE,
   DEFAULT_PERMISSIONS_PAGE_SIZE,
   isPagedPermissionsResponse,
   isPermissionDto,
+  isPermissionTypeDto,
   listEffectiveUserPermissions,
+  listPermissionTypes,
   listPermissions,
   MAX_PERMISSIONS_PAGE_SIZE,
   removePermissionFromUser,
 } from './permissions';
 export type {
+  CreatePermissionPayload,
   EffectivePermissionDto,
   EffectivePermissionSource,
   ListPermissionsParams,
   PermissionDto,
+  PermissionTypeDto,
   UserPermissionLinkDto,
 } from './permissions';

--- a/src/shared/api/permissions.ts
+++ b/src/shared/api/permissions.ts
@@ -1,3 +1,5 @@
+import { isNameCodeDescriptionDto } from './nameCodeDescriptionDto';
+
 import { apiClient } from './index';
 
 import type { PagedResponse } from './systems';
@@ -261,6 +263,81 @@ export async function listPermissions(
   const path = `/permissions${buildPermissionsQueryString(params)}`;
   const data = await client.get<unknown>(path, options);
   if (!isPagedPermissionsResponse(data)) {
+    throw makeParseError();
+  }
+  return data;
+}
+
+/**
+ * Espelho do `PermissionTypeResponse` do `lfc-authenticator`
+ * (`PermissionTypesController.PermissionTypeResponse`).
+ */
+export interface PermissionTypeDto {
+  id: string;
+  name: string;
+  code: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export function isPermissionTypeDto(value: unknown): value is PermissionTypeDto {
+  // Mesmo shape que `NameCodeDescriptionDto` (`PermissionTypeResponse`).
+  return isNameCodeDescriptionDto(value);
+}
+
+function isPermissionTypeDtoArray(value: unknown): value is ReadonlyArray<PermissionTypeDto> {
+  return Array.isArray(value) && value.every(isPermissionTypeDto);
+}
+
+/**
+ * Lista tipos de permissão ativos via `GET /permissions/types`
+ * (`PermissionTypesController.GetAll`). Ordenação definida pelo backend
+ * (`CreatedAt`). Usado pelo fluxo de criação de permissão na UI para
+ * popular o `<Select>` com UUIDs reais — espelha o contrato do POST
+ * (`PermissionTypeId` obrigatório).
+ */
+export async function listPermissionTypes(
+  options?: SafeRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<ReadonlyArray<PermissionTypeDto>> {
+  const data = await client.get<unknown>('/permissions/types', options);
+  if (!isPermissionTypeDtoArray(data)) {
+    throw makeParseError();
+  }
+  return data.filter((t) => t.deletedAt === null || t.deletedAt === undefined);
+}
+
+/**
+ * Payload de `POST /permissions` (`PermissionsController.CreatePermissionRequest`).
+ * `description` omitida ou vazia é tratada como `null` no servidor.
+ */
+export interface CreatePermissionPayload {
+  routeId: string;
+  permissionTypeId: string;
+  /** Opcional — máx. 500 caracteres no backend. */
+  description?: string;
+}
+
+/**
+ * Cria uma permissão via `POST /permissions` (`PermissionsController.Create`).
+ * Devolve o `PermissionDto` enriquecido do `201 Created`.
+ */
+export async function createPermission(
+  payload: CreatePermissionPayload,
+  options?: BodyRequestOptions,
+  client: ApiClient = apiClient,
+): Promise<PermissionDto> {
+  const body: Record<string, unknown> = {
+    routeId: payload.routeId.trim(),
+    permissionTypeId: payload.permissionTypeId.trim(),
+  };
+  if (payload.description !== undefined && payload.description.trim().length > 0) {
+    body.description = payload.description.trim();
+  }
+  const data = await client.post<unknown>('/permissions', body, options);
+  if (!isPermissionDto(data)) {
     throw makeParseError();
   }
   return data;

--- a/src/shared/listing/ToolbarPrimaryCreateButton.tsx
+++ b/src/shared/listing/ToolbarPrimaryCreateButton.tsx
@@ -1,0 +1,33 @@
+import { Plus } from 'lucide-react';
+import React from 'react';
+
+import { Button } from '../../components/ui';
+
+export interface ToolbarPrimaryCreateButtonProps {
+  /** `data-testid` estável por página (ex.: `permissions-create-open`). */
+  testId: string;
+  /** Texto do botão (ex.: "Nova permissão"). */
+  label: string;
+  onClick: () => void;
+}
+
+/**
+ * CTA primária "+ Novo …" do slot `actions` do `ListingToolbar` —
+ * extraída para evitar blocos ≥10 linhas idênticos entre páginas de
+ * listagem (Issue #201 vs listagem global de rotas — JSCPD/Sonar).
+ */
+export const ToolbarPrimaryCreateButton: React.FC<ToolbarPrimaryCreateButtonProps> = ({
+  testId,
+  label,
+  onClick,
+}) => (
+  <Button
+    variant="primary"
+    size="md"
+    icon={<Plus size={14} strokeWidth={1.75} />}
+    onClick={onClick}
+    data-testid={testId}
+  >
+    {label}
+  </Button>
+);

--- a/src/shared/listing/index.ts
+++ b/src/shared/listing/index.ts
@@ -101,6 +101,10 @@ export {
 export { InitialLoadingSpinner } from './InitialLoadingSpinner';
 export { ListingResultArea } from './ListingResultArea';
 export { ListingToolbar } from './ListingToolbar';
+export {
+  ToolbarPrimaryCreateButton,
+  type ToolbarPrimaryCreateButtonProps,
+} from './ToolbarPrimaryCreateButton';
 export { LiveRegion } from './LiveRegion';
 export { PaginationFooter } from './PaginationFooter';
 export { RefetchOverlay } from './RefetchOverlay';

--- a/tests/pages/PermissionsListShellPage.create.test.tsx
+++ b/tests/pages/PermissionsListShellPage.create.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/* eslint-disable import/order */
+import { buildAuthMock } from './__helpers__/mockUseAuth';
+import {
+  createPermissionsClientStub,
+  ID_ROUTE_USERS_CREATE,
+  ID_ROUTE_USERS_LIST,
+  ID_SYSTEM_AUTH,
+  ID_TYPE_CREATE,
+  ID_TYPE_READ,
+  makePagedPermissionsResponse,
+  makePagedRoutesResponse,
+  makePagedSystemsResponse,
+  makePermission,
+  makePermissionType,
+  makeRouteDto,
+  makeSystem,
+  renderPermissionsListPage,
+  seedPermissionsListGetMock,
+  waitForInitialList,
+} from './__helpers__/permissionsTestHelpers';
+/* eslint-enable import/order */
+
+import type { PermissionDto } from '@/shared/api';
+
+/**
+ * Suíte do fluxo "Nova permissão" na `PermissionsListShellPage` (Issue #201).
+ */
+
+const PERMISSIONS_LIST_PERMISSION = 'AUTH_V1_PERMISSIONS_LIST';
+const PERMISSIONS_CREATE_PERMISSION = 'AUTH_V1_PERMISSIONS_CREATE';
+
+let permissionsMock: ReadonlyArray<string> = [
+  PERMISSIONS_LIST_PERMISSION,
+  PERMISSIONS_CREATE_PERMISSION,
+];
+
+vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
+
+const SAMPLE_SYSTEMS = makePagedSystemsResponse([
+  makeSystem({ id: ID_SYSTEM_AUTH, code: 'authenticator', name: 'Authenticator' }),
+]);
+
+const ROW_ALICE: PermissionDto = makePermission({
+  id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  routeCode: 'AUTH_V1_USERS_LIST',
+});
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  permissionsMock = [PERMISSIONS_LIST_PERMISSION, PERMISSIONS_CREATE_PERMISSION];
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+async function openCreateModal(client: ReturnType<typeof createPermissionsClientStub>): Promise<void> {
+  seedPermissionsListGetMock({
+    client,
+    systemsResponse: SAMPLE_SYSTEMS,
+    permissionsQueue: [makePagedPermissionsResponse([ROW_ALICE])],
+    routesPaged: makePagedRoutesResponse([
+      makeRouteDto({ id: ID_ROUTE_USERS_LIST }),
+      makeRouteDto({
+        id: ID_ROUTE_USERS_CREATE,
+        code: 'AUTH_V1_USERS_CREATE',
+        name: 'POST /api/v1/users',
+      }),
+    ]),
+    permissionTypes: [
+      makePermissionType({ id: ID_TYPE_READ, name: 'Ler', code: 'read' }),
+      makePermissionType({ id: ID_TYPE_CREATE, name: 'Criar', code: 'create' }),
+    ],
+  });
+
+  renderPermissionsListPage(client);
+  await waitForInitialList(client);
+
+  fireEvent.click(screen.getByTestId('permissions-create-open'));
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  await waitFor(() => {
+    expect(screen.getByTestId('new-permission-type-id')).not.toBeDisabled();
+  });
+}
+
+describe('PermissionsListShellPage — Nova permissão (Issue #201)', () => {
+  describe('gating do botão', () => {
+    it('oculta o CTA sem AUTH_V1_PERMISSIONS_CREATE', async () => {
+      permissionsMock = [PERMISSIONS_LIST_PERMISSION];
+      const client = createPermissionsClientStub();
+      seedPermissionsListGetMock({
+        client,
+        systemsResponse: SAMPLE_SYSTEMS,
+        permissionsQueue: [makePagedPermissionsResponse([ROW_ALICE])],
+      });
+      renderPermissionsListPage(client);
+      await waitForInitialList(client);
+
+      expect(screen.queryByTestId('permissions-create-open')).not.toBeInTheDocument();
+    });
+
+    it('exibe "Nova permissão" quando o usuário possui CREATE', async () => {
+      const client = createPermissionsClientStub();
+      seedPermissionsListGetMock({
+        client,
+        systemsResponse: SAMPLE_SYSTEMS,
+        permissionsQueue: [makePagedPermissionsResponse([ROW_ALICE])],
+      });
+      renderPermissionsListPage(client);
+      await waitForInitialList(client);
+
+      const btn = screen.getByTestId('permissions-create-open');
+      expect(btn).toHaveTextContent(/Nova permissão/i);
+    });
+  });
+
+  describe('modal — validação e submissão', () => {
+    it('submeter sem preencher campos obrigatórios mantém POST ausente', async () => {
+      const client = createPermissionsClientStub();
+      await openCreateModal(client);
+
+      fireEvent.submit(screen.getByTestId('new-permission-form'));
+
+      expect(screen.getByText('Selecione um sistema.')).toBeInTheDocument();
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('caminho feliz: POST /permissions e mensagem de sucesso', async () => {
+      const client = createPermissionsClientStub();
+      await openCreateModal(client);
+
+      const created = makePermission({
+        id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        routeId: ID_ROUTE_USERS_CREATE,
+        permissionTypeId: ID_TYPE_CREATE,
+        permissionTypeCode: 'create',
+        permissionTypeName: 'Criar',
+      });
+      client.post.mockResolvedValueOnce(created);
+
+      fireEvent.change(screen.getByTestId('new-permission-system-id'), {
+        target: { value: ID_SYSTEM_AUTH },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('new-permission-route-id')).not.toBeDisabled();
+      });
+
+      fireEvent.change(screen.getByTestId('new-permission-route-id'), {
+        target: { value: ID_ROUTE_USERS_CREATE },
+      });
+      fireEvent.change(screen.getByTestId('new-permission-type-id'), {
+        target: { value: ID_TYPE_CREATE },
+      });
+
+      fireEvent.submit(screen.getByTestId('new-permission-form'));
+
+      await waitFor(() => {
+        expect(client.post).toHaveBeenCalledTimes(1);
+      });
+
+      expect(client.post.mock.calls[0][0]).toBe('/permissions');
+      expect(client.post.mock.calls[0][1]).toEqual({
+        routeId: ID_ROUTE_USERS_CREATE,
+        permissionTypeId: ID_TYPE_CREATE,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Permissão criada.')).toBeInTheDocument();
+      });
+    });
+
+    it('400 do backend mapeia erro no campo da rota', async () => {
+      const client = createPermissionsClientStub();
+      await openCreateModal(client);
+
+      client.post.mockRejectedValueOnce({
+        kind: 'http',
+        status: 400,
+        message: 'One or more validation errors occurred.',
+        details: {
+          errors: {
+            RouteId: ['RouteId inválido ou rota inativa.'],
+          },
+        },
+      });
+
+      fireEvent.change(screen.getByTestId('new-permission-system-id'), {
+        target: { value: ID_SYSTEM_AUTH },
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId('new-permission-route-id')).not.toBeDisabled();
+      });
+      fireEvent.change(screen.getByTestId('new-permission-route-id'), {
+        target: { value: ID_ROUTE_USERS_LIST },
+      });
+      fireEvent.change(screen.getByTestId('new-permission-type-id'), {
+        target: { value: ID_TYPE_READ },
+      });
+
+      fireEvent.submit(screen.getByTestId('new-permission-form'));
+
+      await waitFor(() => {
+        expect(screen.getByText('RouteId inválido ou rota inativa.')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/tests/pages/__helpers__/permissionsTestHelpers.tsx
+++ b/tests/pages/__helpers__/permissionsTestHelpers.tsx
@@ -6,6 +6,8 @@ import type {
   ApiClient,
   PagedResponse,
   PermissionDto,
+  PermissionTypeDto,
+  RouteDto,
   SystemDto,
 } from '@/shared/api';
 
@@ -184,6 +186,89 @@ export function makePagedSystemsResponse(
 }
 
 /**
+ * Envelope paginado para `GET /systems/routes` — usado pelo modal
+ * "Nova permissão" (Issue #201).
+ */
+export function makePagedRoutesResponse(
+  data: ReadonlyArray<RouteDto>,
+  overrides: Partial<PagedResponse<RouteDto>> = {},
+): PagedResponse<RouteDto> {
+  return makePagedResponse(data, overrides);
+}
+
+/**
+ * `RouteDto` mínimo para testes do fluxo de criação — evita acoplar a
+ * suíte de permissões ao módulo `routesTestHelpers.tsx`.
+ */
+export function makeRouteDto(overrides: Partial<RouteDto> = {}): RouteDto {
+  return {
+    id: ID_ROUTE_USERS_LIST,
+    systemId: ID_SYSTEM_AUTH,
+    name: 'GET /api/v1/users',
+    code: 'AUTH_V1_USERS_LIST',
+    description: null,
+    systemTokenTypeId: 'aaaaaaaa-9999-9999-9999-999999999999',
+    systemTokenTypeCode: 'default',
+    systemTokenTypeName: 'Acesso padrão',
+    createdAt: '2026-01-01T12:00:00Z',
+    updatedAt: '2026-01-01T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+export function makePermissionType(
+  overrides: Partial<PermissionTypeDto> = {},
+): PermissionTypeDto {
+  return {
+    id: ID_TYPE_READ,
+    name: 'Ler',
+    code: 'read',
+    description: null,
+    createdAt: '2026-01-01T12:00:00Z',
+    updatedAt: '2026-01-01T12:00:00Z',
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+export interface PermissionsListGetMockConfig {
+  client: ApiClientStub;
+  systemsResponse: PagedResponse<SystemDto>;
+  permissionsQueue: ReadonlyArray<PagedResponse<PermissionDto>>;
+  /** Resposta para `GET /systems/routes` — default página vazia. */
+  routesPaged?: PagedResponse<RouteDto>;
+  /** Resposta para `GET /permissions/types` — default array vazio. */
+  permissionTypes?: ReadonlyArray<PermissionTypeDto>;
+}
+
+/**
+ * Router completo para `client.get` na `PermissionsListShellPage` e no
+ * modal de criação (Issue #201 — endpoints extras sem quebrar a fila
+ * legada de `seedDualGetMock`).
+ */
+export function seedPermissionsListGetMock(config: PermissionsListGetMockConfig): void {
+  const queue: PagedResponse<PermissionDto>[] = [...config.permissionsQueue];
+  const emptyRoutes = makePagedRoutesResponse([]);
+  config.client.get.mockImplementation((path: string): Promise<unknown> => {
+    if (path.startsWith('/systems/routes')) {
+      return Promise.resolve(config.routesPaged ?? emptyRoutes);
+    }
+    if (path.startsWith('/permissions/types')) {
+      return Promise.resolve(config.permissionTypes ?? []);
+    }
+    if (path.startsWith('/systems')) {
+      return Promise.resolve(config.systemsResponse);
+    }
+    const next = queue.shift();
+    if (next === undefined) {
+      return Promise.resolve(makePagedPermissionsResponse([]));
+    }
+    return Promise.resolve(next);
+  });
+}
+
+/**
  * Configura `client.get` como um router que despacha para 2 endpoints:
  *
  * - `path` começando com `/systems` (incluindo `/systems?pageSize=100`)
@@ -205,21 +290,10 @@ export function seedDualGetMock(
   systemsResponse: PagedResponse<SystemDto>,
   ...permissionsResponses: ReadonlyArray<PagedResponse<PermissionDto>>
 ): void {
-  const queue: PagedResponse<PermissionDto>[] = [...permissionsResponses];
-  client.get.mockImplementation((path: string): Promise<unknown> => {
-    if (path.startsWith('/systems')) {
-      return Promise.resolve(systemsResponse);
-    }
-    const next = queue.shift();
-    if (next === undefined) {
-      // Fallback: devolve uma página vazia em vez de `undefined` — o
-      // type guard `isPagedPermissionsResponse` rejeita undefined e
-      // a UI exibiria erro genérico que mascararia a real falha do
-      // teste. Devolver `[]` torna o "fim de fila" legível no UI
-      // (empty state) e ainda assim falha asserts sobre rows.
-      return Promise.resolve(makePagedPermissionsResponse([]));
-    }
-    return Promise.resolve(next);
+  seedPermissionsListGetMock({
+    client,
+    systemsResponse,
+    permissionsQueue: permissionsResponses,
   });
 }
 
@@ -269,7 +343,11 @@ export function lastPermissionsGetPath(client: ApiClientStub): string {
   const calls = client.get.mock.calls;
   for (let i = calls.length - 1; i >= 0; i -= 1) {
     const path = calls[i][0];
-    if (typeof path === 'string' && path.startsWith('/permissions')) {
+    if (
+      typeof path === 'string' &&
+      path.startsWith('/permissions') &&
+      !path.startsWith('/permissions/types')
+    ) {
       return path;
     }
   }
@@ -284,6 +362,9 @@ export function lastPermissionsGetPath(client: ApiClientStub): string {
  */
 export function countPermissionsGetCalls(client: ApiClientStub): number {
   return client.get.mock.calls.filter(
-    (call) => typeof call[0] === 'string' && call[0].startsWith('/permissions'),
+    (call) =>
+      typeof call[0] === 'string' &&
+      call[0].startsWith('/permissions') &&
+      !call[0].startsWith('/permissions/types'),
   ).length;
 }

--- a/tests/shared/api/permissions.test.ts
+++ b/tests/shared/api/permissions.test.ts
@@ -8,9 +8,12 @@ import type {
 
 import {
   assignPermissionToUser,
+  createPermission,
   isPagedPermissionsResponse,
   isPermissionDto,
+  isPermissionTypeDto,
   listEffectiveUserPermissions,
+  listPermissionTypes,
   listPermissions,
   removePermissionFromUser,
 } from '@/shared/api';
@@ -36,6 +39,7 @@ import {
  *   `EffectivePermissionResponse` com `sources`).
  * - `assignPermissionToUser` (POST `/users/{id}/permissions`).
  * - `removePermissionFromUser` (DELETE `/users/{id}/permissions/{permissionId}`).
+ * - `listPermissionTypes` / `createPermission` (Issue #201 — POST `/permissions`).
  */
 
 const USER_ID = '11111111-1111-1111-1111-111111111111';
@@ -416,6 +420,119 @@ describe('assignPermissionToUser', () => {
     await expect(
       assignPermissionToUser(USER_ID, PERM_ID, undefined, client as unknown as ApiClient),
     ).rejects.toEqual(apiError);
+  });
+});
+
+describe('isPermissionTypeDto', () => {
+  it('aceita payload válido', () => {
+    expect(
+      isPermissionTypeDto({
+        id: PERM_ID,
+        name: 'Ler',
+        code: 'read',
+        description: null,
+        createdAt: '2026-01-01T12:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+        deletedAt: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejeita payload incompleto', () => {
+    expect(isPermissionTypeDto({ id: PERM_ID })).toBe(false);
+  });
+});
+
+describe('listPermissionTypes', () => {
+  it('emite GET /permissions/types e remove tipos soft-deletados', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce([
+      {
+        id: PERM_ID,
+        name: 'Ler',
+        code: 'read',
+        description: null,
+        createdAt: '2026-01-01T12:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+        deletedAt: null,
+      },
+      {
+        id: SYS_ID,
+        name: 'Velho',
+        code: 'old',
+        description: null,
+        createdAt: '2026-01-01T12:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+        deletedAt: '2026-02-01T12:00:00Z',
+      },
+    ]);
+
+    const rows = await listPermissionTypes(undefined, client as unknown as ApiClient);
+    expect(client.get).toHaveBeenCalledWith('/permissions/types', undefined);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(PERM_ID);
+  });
+
+  it('lança parse quando o payload não é array válido', async () => {
+    const client = createStub();
+    client.get.mockResolvedValueOnce({});
+    await expect(
+      listPermissionTypes(undefined, client as unknown as ApiClient),
+    ).rejects.toMatchObject({ kind: 'parse' });
+  });
+});
+
+describe('createPermission', () => {
+  it('POST /permissions sem description — só routeId e permissionTypeId', async () => {
+    const client = createStub();
+    const dto = makePermissionDto();
+    client.post.mockResolvedValueOnce(dto);
+
+    const result = await createPermission(
+      { routeId: 'route-a', permissionTypeId: 'type-b' },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/permissions',
+      { routeId: 'route-a', permissionTypeId: 'type-b' },
+      undefined,
+    );
+    expect(result.id).toBe(PERM_ID);
+  });
+
+  it('POST /permissions inclui description quando preenchida', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce(makePermissionDto());
+
+    await createPermission(
+      {
+        routeId: 'route-a',
+        permissionTypeId: 'type-b',
+        description: '  Nota  ',
+      },
+      undefined,
+      client as unknown as ApiClient,
+    );
+
+    expect(client.post.mock.calls[0][1]).toEqual({
+      routeId: 'route-a',
+      permissionTypeId: 'type-b',
+      description: 'Nota',
+    });
+  });
+
+  it('lança parse quando o body não é PermissionDto', async () => {
+    const client = createStub();
+    client.post.mockResolvedValueOnce({ broken: true });
+    await expect(
+      createPermission(
+        { routeId: 'r', permissionTypeId: 't' },
+        undefined,
+        client as unknown as ApiClient,
+      ),
+    ).rejects.toMatchObject({ kind: 'parse' });
   });
 });
 


### PR DESCRIPTION
## Resumo

Implementa o fluxo de **criação de permissão** na listagem `/permissoes`: CTA na toolbar (com `RequirePermission` via `hasPermission('AUTH_V1_PERMISSIONS_CREATE')`), modal com sistema → rotas do sistema → tipo de permissão (via `GET /permissions/types`) e descrição opcional, submetendo `POST /permissions` conforme `PermissionsController.CreatePermissionRequest` no lfc-authenticator (`routeId`, `permissionTypeId`, `description` opcional). Sucesso dispara toast e `refetch` da lista.

## Alterações

- `createPermission`, `listPermissionTypes`, `PermissionTypeDto` em `src/shared/api/permissions.ts`
- `NewPermissionModal` + form shared + `useCreateEntitySubmit`
- Refactors menores para gate JSCPD: `ToolbarPrimaryCreateButton`, `useModalListSystemsFetch` (também usados em rotas)

## Testes (Docker)

- `npm run lint` — OK (0 warnings)
- `npm run typecheck` — OK
- `npm test` — OK (**1626** testes)
- `npx jscpd src --threshold 3 --min-lines 10` — duplicação total ~**1,47%**; `newClones === 0` nos arquivos do diff (ver `jscpd-report/jscpd-report.json`)

## Riscos

- Operador precisa de permissão separada para **tipos** (`GET /permissions/types`); na prática quem tem CREATE de permissões costuma ter o pacote admin completo. Se não tiver, o modal exibe erro ao carregar tipos.

## Backend

Nenhum blocker: `POST /api/v1/permissions` e contrato validados contra `AuthService/Controllers/Permissions/PermissionsController.cs`.

Closes #201

Made with [Cursor](https://cursor.com)