### PR TITLE
#207 | Roles: criação e consulta intuitiva por sistema

### DIFF
--- a/src/pages/roles/RolesGlobalListShellPage.tsx
+++ b/src/pages/roles/RolesGlobalListShellPage.tsx
@@ -275,6 +275,21 @@ export const RolesGlobalListShellPage: React.FC<
   const hasActiveSearch = trimmedSearch.length > 0;
 
   /**
+   * Nome do sistema ativo no filtro (Issue #207 — estado vazio
+   * compreensível quando não há roles para o sistema selecionado).
+   * Fallback para prefixo do UUID quando o catálogo ainda não
+   * carregou ou o sistema saiu do top-100 do dropdown.
+   */
+  const activeSystemFilterName = useMemo(() => {
+    if (systemFilter === SYSTEM_FILTER_ALL) return null;
+    const fromLookup = systemLookup.get(systemFilter);
+    if (fromLookup) return fromLookup.name;
+    return systemFilter.length > 0 ? systemFilter.slice(0, 8) : null;
+  }, [systemFilter, systemLookup]);
+
+  const hasActiveSystemFilter = activeSystemFilterName !== null;
+
+  /**
    * `emptyContent` delegado ao hook compartilhado `useListingEmptyContent`
    * para evitar duplicação JSCPD/Sonar com `RolesPage` per-system
    * (lição PR #134/#135 — bloco de 26 linhas com `useMemo` + árvore
@@ -286,9 +301,12 @@ export const RolesGlobalListShellPage: React.FC<
     onClearSearch: handleClearSearch,
     copy: {
       searchPrefix: 'Nenhuma role encontrada para',
-      emptyTitle: 'Nenhuma role cadastrada.',
-      hintWhenIncludeDeletedOff:
-        'Roles removidas podem ser visualizadas ativando "Mostrar inativas".',
+      emptyTitle: hasActiveSystemFilter
+        ? `Nenhuma role cadastrada para ${activeSystemFilterName}.`
+        : 'Nenhuma role cadastrada.',
+      hintWhenIncludeDeletedOff: hasActiveSystemFilter
+        ? 'Cadastre uma nova role para este sistema ou altere o filtro acima.'
+        : 'Roles removidas podem ser visualizadas ativando "Mostrar inativas".',
       clearTestId: 'roles-global-empty-clear',
     },
   });

--- a/tests/pages/roles/RolesGlobalListShellPage.test.tsx
+++ b/tests/pages/roles/RolesGlobalListShellPage.test.tsx
@@ -53,6 +53,8 @@ vi.mock('@/shared/auth', () => buildAuthMock(() => permissionsMock));
 
 const SEARCH_DEBOUNCE_MS = 300;
 const ID_SYS_OUTRO = '22222222-2222-2222-2222-222222222222';
+/** Sistema kurtto — critério de aceite da Issue #207. */
+const ID_SYS_KURTTO = '33333333-3333-3333-3333-333333333333';
 
 const ROLES_SAMPLE: ReadonlyArray<RoleDto> = [
   makeRole({
@@ -750,5 +752,145 @@ describe('RolesGlobalListShellPage — Issue #193 criar role global', () => {
       await screen.findByText(/Sessão expirada/i),
     ).toBeInTheDocument();
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Issue #207 — criação e consulta intuitiva por sistema em `/roles`.
+ */
+describe('RolesGlobalListShellPage — Issue #207', () => {
+  const ROLES_CREATE_PERMISSION = 'AUTH_V1_ROLES_CREATE';
+  const KURTTO_SYSTEMS: ReadonlyArray<SystemDto> = [
+    makeSystemDtoForRoles({ id: ID_SYS_AUTH, name: 'lfc-authenticator' }),
+    makeSystemDtoForRoles({
+      id: ID_SYS_KURTTO,
+      name: 'kurtto',
+      code: 'kurtto',
+    }),
+  ];
+
+  it('vazio com filtro de sistema kurtto: mensagem cita o sistema', async () => {
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse([]),
+      systems: makePagedSystemsResponseForRoles(KURTTO_SYSTEMS),
+    });
+
+    renderRolesGlobalListPage(client);
+    await waitForRolesGlobalInitialList(client);
+
+    fireEvent.change(screen.getByTestId('roles-global-system-filter'), {
+      target: { value: ID_SYS_KURTTO },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Nenhuma role cadastrada para kurtto\./i).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getAllByText(/Cadastre uma nova role para este sistema/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('criação para kurtto: POST vincula ao sistema e confirma navegação pós-sucesso', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const created = makeRole({
+      id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+      systemId: ID_SYS_KURTTO,
+      name: 'Operador Kurtto',
+      code: 'kurtto_op',
+    });
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(KURTTO_SYSTEMS),
+    });
+    client.post.mockResolvedValueOnce(created);
+
+    await openGlobalCreateRoleModal(client);
+
+    fireEvent.change(screen.getByTestId('new-role-system'), {
+      target: { value: ID_SYS_KURTTO },
+    });
+    fillNewRoleForm({ name: 'Operador Kurtto', code: 'kurtto_op' });
+    await submitNewRoleForm(client);
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/roles',
+      {
+        systemId: ID_SYS_KURTTO,
+        name: 'Operador Kurtto',
+        code: 'kurtto_op',
+      },
+      undefined,
+    );
+
+    expect(
+      await screen.findByTestId('roles-global-after-create-permissions'),
+    ).toBeInTheDocument();
+  });
+
+  it('400 com errors de validação mapeia mensagens nos campos do form', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(KURTTO_SYSTEMS),
+    });
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 400,
+      message: 'Erro de validação.',
+      details: {
+        errors: {
+          Name: ['Name é obrigatório e não pode ser apenas espaços.'],
+          Code: ['Code deve ter no máximo 50 caracteres.'],
+        },
+      },
+    });
+
+    await openGlobalCreateRoleModal(client);
+
+    fireEvent.change(screen.getByTestId('new-role-system'), {
+      target: { value: ID_SYS_KURTTO },
+    });
+    fillNewRoleForm({ name: 'X', code: 'y' });
+    await submitNewRoleForm(client);
+
+    expect(
+      await screen.findByText(
+        'Name é obrigatório e não pode ser apenas espaços.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('403 ao criar exibe toast de autorização sem travar o fluxo', async () => {
+    permissionsMock = ['AUTH_V1_ROLES_LIST', ROLES_CREATE_PERMISSION];
+    const client = createRolesClientStub();
+    primeRolesGlobalStubResponses(client, {
+      roles: makePagedRolesResponse(ROLES_SAMPLE),
+      systems: makePagedSystemsResponseForRoles(KURTTO_SYSTEMS),
+    });
+    client.post.mockRejectedValueOnce({
+      kind: 'http',
+      status: 403,
+      message: 'Você não tem permissão para esta ação.',
+    });
+
+    await openGlobalCreateRoleModal(client);
+
+    fireEvent.change(screen.getByTestId('new-role-system'), {
+      target: { value: ID_SYS_KURTTO },
+    });
+    fillNewRoleForm({ name: 'Role Kurtto', code: 'kurtto_role' });
+    await submitNewRoleForm(client);
+
+    expect(
+      await screen.findByText(/Você não tem permissão para esta ação/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('roles-global-search')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Contexto

Issue #207 (épico #206): tornar `/roles` intuitiva para criar e consultar roles por sistema — exibir sistema por role, selecionar sistema ao criar, filtrar por sistema e tratar estados loading/vazio/erro com RBAC.

A base da listagem global, filtro, criação com `<Select>` de sistema e coluna "Sistema" já existia (#173/#193). Este PR fecha os gaps de UX e cobertura de testes pedidos na issue.

## Objetivo

Estado vazio compreensível ao filtrar por sistema e testes automatizados dos critérios de aceite (kurtto, validação, permissão, vazio).

## O que foi feito

- Mensagem e dica de empty state contextualizam o sistema selecionado no filtro (`Nenhuma role cadastrada para {sistema}.`).
- Suíte `Issue #207` em `RolesGlobalListShellPage.test.tsx`: vazio filtrado por kurtto, criação vinculada ao kurtto, 400 de validação nos campos, 403 sem travar a listagem.

## Arquivos impactados

- `src/pages/roles/RolesGlobalListShellPage.tsx`
- `tests/pages/roles/RolesGlobalListShellPage.test.tsx`

## Testes

```bash
docker compose run --rm web npm run lint      # OK (0 warnings)
docker compose run --rm web npm run typecheck # OK
docker compose run --rm web npm test          # 1641 passed
docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10 --reporters console,json --output ./jscpd-report
# Total duplication 1.12% (≤ 3%)
```

## Visual

- Empty state com copy específica por sistema filtrado; demais estados já cobertos por `ListingResultArea` e modais existentes.

## Segurança

- Sem alteração de auth; RBAC continua via `RequirePermission` e gating de `AUTH_V1_ROLES_CREATE` no botão/modal.

## Riscos

- Catálogo de sistemas no dropdown limitado a `MAX_ROLES_PAGE_SIZE` (100) — pendência já documentada em outras listagens.

Closes #207

Made with [Cursor](https://cursor.com)