### PR TITLE
#208 | Usuários: visualizar, atribuir e remover roles por sistema

### DIFF
--- a/src/pages/users/UserDetailShellPage.tsx
+++ b/src/pages/users/UserDetailShellPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../shared/listing';
 
 import { UserDirectPermissionsPanel } from './UserDirectPermissionsPanel';
+import { UserRolesPanel } from './UserRolesPanel';
 
 import type { ApiClient, UserDto } from '../../shared/api';
 
@@ -150,7 +151,9 @@ export const UserDetailShellPage: React.FC<UserDetailShellPageProps> = ({ client
   const { hasPermission } = useAuth();
   const canManageDirectPermissions =
     hasPermission(PERMISSIONS_LIST) && hasPermission(USERS_PERMISSIONS_ASSIGN);
-  const canOpenRolesPage = hasPermission(ROLES_LIST) && hasPermission(USERS_ROLES_ASSIGN);
+  const canManageRoles =
+    hasPermission(ROLES_LIST) && hasPermission(USERS_ROLES_ASSIGN);
+  const canOpenRolesPage = canManageRoles;
   const canOpenEffectivePage =
     hasPermission(PERMISSIONS_LIST) && hasPermission(USERS_GET_BY_ID);
 
@@ -264,7 +267,7 @@ export const UserDetailShellPage: React.FC<UserDetailShellPageProps> = ({ client
       <PageHeader
         eyebrow="06 Usuários · Detalhe"
         title={userState.user ? userState.user.name : 'Detalhe do usuário'}
-        desc="Dados cadastrais, atalhos para roles e permissões efetivas, e atribuição de permissões diretas (sem alterar roles)."
+        desc="Dados cadastrais, roles por sistema, permissões diretas e atalhos para permissões efetivas."
       />
 
       {userState.isLoading && (
@@ -337,6 +340,29 @@ export const UserDetailShellPage: React.FC<UserDetailShellPageProps> = ({ client
               )}
             </QuickLinks>
           </SummaryCard>
+
+          {canManageRoles ? (
+            <DirectSection aria-labelledby="user-detail-roles-heading">
+              <SectionHeading id="user-detail-roles-heading">
+                Roles por sistema
+              </SectionHeading>
+              <SectionHelp>
+                Vínculos entre este usuário e roles do catálogo, agrupados por sistema.
+                Marque ou desmarque as roles desejadas e use &quot;Salvar alterações&quot; —
+                a role permanece no catálogo ao remover o vínculo. Roles já vinculadas
+                aparecem com o selo &quot;Vinculada&quot;.
+              </SectionHelp>
+              <UserRolesPanel userId={userId} mode="embedded" client={client} />
+            </DirectSection>
+          ) : (
+            <div data-testid="user-detail-roles-locked">
+              <Alert variant="info">
+                Para atribuir ou remover roles aqui, é necessário permissão de listagem do
+                catálogo de roles e de atualização de usuários (mesmo conjunto exigido pela
+                rota &quot;Roles do usuário&quot; em tela cheia).
+              </Alert>
+            </div>
+          )}
 
           {canManageDirectPermissions ? (
             <DirectSection aria-labelledby="user-detail-direct-permissions-heading">

--- a/src/pages/users/UserRolesPanel.tsx
+++ b/src/pages/users/UserRolesPanel.tsx
@@ -1,0 +1,490 @@
+import { Info } from 'lucide-react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+
+import { Badge, Checkbox, Spinner, useToast } from '../../components/ui';
+import {
+  assignRoleToUser,
+  getUserById,
+  isFetchAborted,
+  listRoles,
+  listSystems,
+  MAX_ROLES_PAGE_SIZE,
+  removeRoleFromUser,
+} from '../../shared/api';
+import { computeIdSetDiff, idSetDiffHasChanges } from '../../shared/forms';
+import {
+  AssignmentDiffToolbar,
+  AssignmentEmptyHint,
+  AssignmentEmptyShell,
+  AssignmentEmptyTitle,
+  AssignmentGroupCard,
+  AssignmentGroupHeaderRow,
+  AssignmentGroupList,
+  AssignmentItemBadges,
+  AssignmentItemCodeChip,
+  AssignmentItemDescription,
+  AssignmentItemDetails,
+  AssignmentItemList,
+  AssignmentItemPrimaryText,
+  AssignmentItemRow,
+  AssignmentItemTitleRow,
+  AssignmentLegendBar,
+  AssignmentLegendCopy,
+  AssignmentLegendItem,
+  AssignmentLoadingCopy,
+  AssignmentLoadingShell,
+  AssignmentMatrixShell,
+  ErrorRetryBlock,
+  Mono,
+} from '../../shared/listing';
+
+import {
+  buildInitialUserRoleIds,
+  formatUserRoleMutationError,
+  formatUserRolesPanelLoadError,
+  groupRolesBySystem,
+} from './userRolesHelpers';
+
+import type {
+  RoleAssignmentFailure,
+  RoleSystemGroup,
+  SystemLookupMap,
+} from './userRolesHelpers';
+import type {
+  ApiClient,
+  RoleDto,
+  SystemDto,
+  UserDto,
+} from '../../shared/api';
+
+const EmbeddedToolbar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+`;
+
+interface FetchedState {
+  user: UserDto;
+  roles: ReadonlyArray<RoleDto>;
+  systemLookup: SystemLookupMap;
+}
+
+interface UserRolesPanelState {
+  isInitialLoading: boolean;
+  isSaving: boolean;
+  errorMessage: string | null;
+  fetched: FetchedState | null;
+  chosenRoleIds: ReadonlySet<string>;
+  baselineRoleIds: ReadonlySet<string>;
+  refreshTick: number;
+}
+
+export interface UserRolesPanelProps {
+  /** Usuário alvo (já validado pelo caller). */
+  userId: string;
+  /**
+   * `fullPage` — rota `/usuarios/:id/roles` (Issue #71).
+   * `embedded` — seção no detalhe do usuário (Issue #208).
+   */
+  mode: 'fullPage' | 'embedded';
+  /**
+   * Cliente HTTP injetável para isolar testes — em produção, omitido
+   * (cada wrapper de API usa o singleton `apiClient`).
+   */
+  client?: ApiClient;
+}
+
+function buildSystemLookup(
+  systems: ReadonlyArray<SystemDto>,
+): SystemLookupMap {
+  const map = new Map<string, { code: string; name: string }>();
+  for (const system of systems) {
+    map.set(system.id, { code: system.code, name: system.name });
+  }
+  return map;
+}
+
+/**
+ * Painel de atribuição de roles por sistema (POST/DELETE em
+ * `/users/{id}/roles`). Reutilizado pela página dedicada (Issue #71)
+ * e pelo detalhe do usuário (Issue #208).
+ */
+export const UserRolesPanel: React.FC<UserRolesPanelProps> = ({
+  userId,
+  mode,
+  client,
+}) => {
+  const toast = useToast();
+
+  const [state, setState] = useState<UserRolesPanelState>({
+    isInitialLoading: true,
+    isSaving: false,
+    errorMessage: null,
+    fetched: null,
+    chosenRoleIds: new Set<string>(),
+    baselineRoleIds: new Set<string>(),
+    refreshTick: 0,
+  });
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const handleRefetch = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      isInitialLoading: true,
+      errorMessage: null,
+      refreshTick: prev.refreshTick + 1,
+    }));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = controller;
+
+    Promise.all([
+      listRoles({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
+      listSystems({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
+      getUserById(userId, { signal: controller.signal }, client),
+    ])
+      .then(([rolesResponse, systemsResponse, user]) => {
+        if (cancelled) return;
+        const baselineRoleIds = buildInitialUserRoleIds(user.roles);
+        setState({
+          isInitialLoading: false,
+          isSaving: false,
+          errorMessage: null,
+          fetched: {
+            user,
+            roles: rolesResponse.data,
+            systemLookup: buildSystemLookup(systemsResponse.data),
+          },
+          chosenRoleIds: new Set(baselineRoleIds),
+          baselineRoleIds,
+          refreshTick: 0,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        if (isFetchAborted(error)) return;
+        setState((prev) => ({
+          ...prev,
+          isInitialLoading: false,
+          errorMessage: formatUserRolesPanelLoadError(
+            error,
+            'Falha ao carregar as roles do usuário. Tente novamente.',
+          ),
+        }));
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, userId, state.refreshTick]);
+
+  const groups = useMemo<ReadonlyArray<RoleSystemGroup>>(() => {
+    if (!state.fetched) return [];
+    return groupRolesBySystem(state.fetched.roles, state.fetched.systemLookup);
+  }, [state.fetched]);
+
+  const diff = useMemo(
+    () => computeIdSetDiff(state.baselineRoleIds, state.chosenRoleIds),
+    [state.baselineRoleIds, state.chosenRoleIds],
+  );
+  const hasUnsavedChanges = idSetDiffHasChanges(diff);
+  const pendingCount = diff.toAdd.length + diff.toRemove.length;
+
+  const handleToggleRole = useCallback((roleId: string, checked: boolean) => {
+    setState((prev) => {
+      const next = new Set(prev.chosenRoleIds);
+      if (checked) {
+        next.add(roleId);
+      } else {
+        next.delete(roleId);
+      }
+      return { ...prev, chosenRoleIds: next };
+    });
+  }, []);
+
+  const handleResetChanges = useCallback(() => {
+    setState((prev) => ({ ...prev, chosenRoleIds: new Set(prev.baselineRoleIds) }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!hasUnsavedChanges || state.isSaving) {
+      return;
+    }
+    setState((prev) => ({ ...prev, isSaving: true }));
+    const failures: RoleAssignmentFailure[] = [];
+    let addedSuccess = 0;
+    let removedSuccess = 0;
+
+    const addOps = diff.toAdd.map(async (roleId) => {
+      try {
+        await assignRoleToUser(userId, roleId, undefined, client);
+        addedSuccess += 1;
+      } catch (error: unknown) {
+        failures.push({
+          roleId,
+          kind: 'add',
+          message: formatUserRoleMutationError(
+            error,
+            'Falha ao atribuir role. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    const removeOps = diff.toRemove.map(async (roleId) => {
+      try {
+        await removeRoleFromUser(userId, roleId, undefined, client);
+        removedSuccess += 1;
+      } catch (error: unknown) {
+        failures.push({
+          roleId,
+          kind: 'remove',
+          message: formatUserRoleMutationError(
+            error,
+            'Falha ao remover role. Tente novamente.',
+          ),
+        });
+      }
+    });
+
+    await Promise.all([...addOps, ...removeOps]);
+
+    if (failures.length === 0) {
+      const appliedCount = addedSuccess + removedSuccess;
+      toast.show(
+        appliedCount === 1
+          ? '1 alteração de role aplicada com sucesso.'
+          : `${appliedCount} alterações de roles aplicadas com sucesso.`,
+        { variant: 'success', title: 'Roles atualizadas' },
+      );
+    } else {
+      const appliedCount = addedSuccess + removedSuccess;
+      const failureCount = failures.length;
+      const appliedSuffix = appliedCount > 0 ? `, ${appliedCount} aplicada(s)` : '';
+      toast.show(
+        `${failureCount} alteração(ões) falharam${appliedSuffix}. Revise e tente novamente.`,
+        { variant: 'warning', title: 'Algumas atualizações falharam' },
+      );
+    }
+
+    setState((prev) => ({
+      ...prev,
+      isSaving: false,
+      isInitialLoading: true,
+      errorMessage: null,
+      refreshTick: prev.refreshTick + 1,
+    }));
+  }, [client, diff, hasUnsavedChanges, state.isSaving, toast, userId]);
+
+  const legend = (
+    <>
+      <AssignmentLegendItem>
+        <Badge variant="success" dot>
+          Vinculada
+        </Badge>
+        <AssignmentLegendCopy>
+          role atualmente vinculada ao usuário.
+        </AssignmentLegendCopy>
+      </AssignmentLegendItem>
+      <AssignmentLegendItem>
+        <Badge variant="warning">Pendente</Badge>
+        <AssignmentLegendCopy>alteração ainda não salva.</AssignmentLegendCopy>
+      </AssignmentLegendItem>
+    </>
+  );
+
+  const toolbar = (
+    <AssignmentDiffToolbar
+      resetTestId="user-roles-reset"
+      saveTestId="user-roles-save"
+      hasUnsavedChanges={hasUnsavedChanges}
+      isSaving={state.isSaving}
+      pendingCount={pendingCount}
+      onReset={handleResetChanges}
+      onSave={handleSave}
+    />
+  );
+
+  const matrixBody = (
+    <>
+      <AssignmentLegendBar role="note" aria-label="Legenda de status das roles">
+        {legend}
+      </AssignmentLegendBar>
+
+      {state.isInitialLoading && (
+        <AssignmentLoadingShell data-testid="user-roles-loading" aria-live="polite">
+          <Spinner size="md" tone="accent" />
+          <AssignmentLoadingCopy>Carregando roles…</AssignmentLoadingCopy>
+        </AssignmentLoadingShell>
+      )}
+
+      {!state.isInitialLoading && state.errorMessage && (
+        <ErrorRetryBlock
+          message={state.errorMessage}
+          onRetry={handleRefetch}
+          retryTestId="user-roles-retry"
+        />
+      )}
+
+      {!state.isInitialLoading && !state.errorMessage && groups.length === 0 && (
+        <AssignmentEmptyShell data-testid="user-roles-empty">
+          <Info size={20} strokeWidth={1.5} aria-hidden="true" />
+          <AssignmentEmptyTitle>
+            Nenhuma role cadastrada no catálogo.
+          </AssignmentEmptyTitle>
+          <AssignmentEmptyHint>
+            Cadastre roles na seção Roles antes de atribuir a um usuário.
+          </AssignmentEmptyHint>
+        </AssignmentEmptyShell>
+      )}
+
+      {!state.isInitialLoading && !state.errorMessage && groups.length > 0 && (
+        <AssignmentGroupList aria-label="Roles agrupadas por sistema">
+          {groups.map((group) => (
+            <RoleGroup
+              key={group.systemId || group.systemCode}
+              group={group}
+              chosenRoleIds={state.chosenRoleIds}
+              baselineRoleIds={state.baselineRoleIds}
+              isSaving={state.isSaving}
+              onToggle={handleToggleRole}
+            />
+          ))}
+        </AssignmentGroupList>
+      )}
+    </>
+  );
+
+  if (mode === 'embedded') {
+    return (
+      <>
+        <EmbeddedToolbar>{toolbar}</EmbeddedToolbar>
+        {matrixBody}
+      </>
+    );
+  }
+
+  return (
+    <AssignmentMatrixShell<RoleSystemGroup>
+      eyebrow="06 Usuários · Roles"
+      title="Roles do usuário"
+      desc="Atribuição de roles por sistema. Permissões herdadas via roles ficam visíveis no painel de permissões efetivas após salvar."
+      backLink={{
+        to: `/usuarios/${userId}`,
+        label: 'Voltar para o usuário',
+      }}
+      legend={legend}
+      legendAriaLabel="Legenda de status das roles"
+      groupsAriaLabel="Roles agrupadas por sistema"
+      isInitialLoading={state.isInitialLoading}
+      errorMessage={state.errorMessage}
+      isEmpty={groups.length === 0}
+      isSaving={state.isSaving}
+      hasUnsavedChanges={hasUnsavedChanges}
+      pendingCount={pendingCount}
+      groups={groups}
+      onReset={handleResetChanges}
+      onSave={handleSave}
+      onRetry={handleRefetch}
+      emptyTitle="Nenhuma role cadastrada no catálogo."
+      emptyHint="Cadastre roles na seção Roles antes de atribuir a um usuário."
+      loadingCopy="Carregando roles…"
+      testIdPrefix="user-roles"
+      renderGroup={(group) => (
+        <RoleGroup
+          key={group.systemId || group.systemCode}
+          group={group}
+          chosenRoleIds={state.chosenRoleIds}
+          baselineRoleIds={state.baselineRoleIds}
+          isSaving={state.isSaving}
+          onToggle={handleToggleRole}
+        />
+      )}
+    />
+  );
+};
+
+interface RoleGroupProps {
+  group: RoleSystemGroup;
+  chosenRoleIds: ReadonlySet<string>;
+  baselineRoleIds: ReadonlySet<string>;
+  isSaving: boolean;
+  onToggle: (roleId: string, checked: boolean) => void;
+}
+
+const RoleGroup: React.FC<RoleGroupProps> = ({
+  group,
+  chosenRoleIds,
+  baselineRoleIds,
+  isSaving,
+  onToggle,
+}) => (
+  <AssignmentGroupCard data-testid={`user-roles-group-${group.systemCode}`}>
+    <AssignmentGroupHeaderRow
+      systemCode={group.systemCode}
+      systemName={group.systemName}
+      count={group.items.length}
+      countAriaLabel={`${group.items.length} roles neste sistema`}
+    />
+    <AssignmentItemList>
+      {group.items.map((role) => {
+        const checkboxChecked = chosenRoleIds.has(role.id);
+        const wasInitiallyLinked = baselineRoleIds.has(role.id);
+        const hasUnsavedChange = checkboxChecked !== wasInitiallyLinked;
+        return (
+          <AssignmentItemRow
+            key={role.id}
+            data-testid={`user-roles-item-${role.id}`}
+            data-pending={hasUnsavedChange || undefined}
+          >
+            <Checkbox
+              checked={checkboxChecked}
+              disabled={isSaving}
+              onChange={(checked) => onToggle(role.id, checked)}
+              aria-label={`${role.name} · ${role.code}`}
+              data-testid={`user-roles-checkbox-${role.id}`}
+            />
+            <AssignmentItemDetails>
+              <AssignmentItemTitleRow>
+                <AssignmentItemPrimaryText>{role.name}</AssignmentItemPrimaryText>
+                <AssignmentItemCodeChip>
+                  <Mono>{role.code}</Mono>
+                </AssignmentItemCodeChip>
+              </AssignmentItemTitleRow>
+              {role.description && (
+                <AssignmentItemDescription>{role.description}</AssignmentItemDescription>
+              )}
+              <AssignmentItemBadges>
+                {wasInitiallyLinked && (
+                  <Badge variant="success" dot>
+                    Vinculada
+                  </Badge>
+                )}
+                {hasUnsavedChange && (
+                  <Badge variant="warning">
+                    {checkboxChecked ? 'Adição pendente' : 'Remoção pendente'}
+                  </Badge>
+                )}
+              </AssignmentItemBadges>
+            </AssignmentItemDetails>
+          </AssignmentItemRow>
+        );
+      })}
+    </AssignmentItemList>
+  </AssignmentGroupCard>
+);

--- a/src/pages/users/UserRolesShellPage.tsx
+++ b/src/pages/users/UserRolesShellPage.tsx
@@ -1,63 +1,18 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { ArrowLeft } from 'lucide-react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { Badge, Checkbox, useToast } from '../../components/ui';
-import {
-  assignRoleToUser,
-  extractErrorMessage,
-  getUserById,
-  isFetchAborted,
-  listRoles,
-  listSystems,
-  MAX_ROLES_PAGE_SIZE,
-  removeRoleFromUser,
-} from '../../shared/api';
-import { computeIdSetDiff, idSetDiffHasChanges } from '../../shared/forms';
-import {
-  AssignmentGroupCard,
-  AssignmentGroupHeaderRow,
-  AssignmentItemBadges,
-  AssignmentItemCodeChip,
-  AssignmentItemDescription,
-  AssignmentItemDetails,
-  AssignmentItemList,
-  AssignmentItemPrimaryText,
-  AssignmentItemRow,
-  AssignmentItemTitleRow,
-  AssignmentLegendCopy,
-  AssignmentLegendItem,
-  AssignmentMatrixShell,
-  Mono,
-} from '../../shared/listing';
+import { PageHeader } from '../../components/layout/PageHeader';
+import { Alert } from '../../components/ui';
+import { BackLink, InvalidIdNotice } from '../../shared/listing';
 
-import {
-  buildInitialUserRoleIds,
-  groupRolesBySystem,
-} from './userRolesHelpers';
+import { UserRolesPanel } from './UserRolesPanel';
 
-import type {
-  RoleAssignmentFailure,
-  RoleSystemGroup,
-  SystemLookupMap,
-} from './userRolesHelpers';
-import type {
-  ApiClient,
-  RoleDto,
-  SystemDto,
-  UserDto,
-} from '../../shared/api';
+import type { ApiClient } from '../../shared/api';
 
 /**
  * Heurística leve para descartar `:id` claramente inválido antes de
- * bater no backend — espelha `UserPermissionsShellPage`/`RolesPage`/
- * `RolePermissionsShellPage`. Aceita qualquer string não-vazia com
- * pelo menos um caractere não-whitespace.
+ * bater no backend — espelha `UserPermissionsShellPage`/`RolesPage`.
  */
 function isProbablyValidUserId(value: string | undefined): value is string {
   return typeof value === 'string' && value.trim().length > 0;
@@ -71,378 +26,39 @@ interface UserRolesShellPageProps {
   client?: ApiClient;
 }
 
-interface FetchedState {
-  user: UserDto;
-  roles: ReadonlyArray<RoleDto>;
-  systemLookup: SystemLookupMap;
-}
-
 /**
- * Constrói o mapa `systemId -> {code, name}` a partir do array de
- * `SystemDto` devolvido por `listSystems`. Mantido fora do componente
- * para tornar testes baratos.
+ * Atribuição de roles a um usuário (Issue #71 / EPIC #48, Issue #208).
+ * Orquestração de rota + id inválido; o painel compartilhado está em
+ * `UserRolesPanel`.
+ *
+ * **Visível com** `Roles.Read` + `Users.Update` (gating duplo na rota).
  */
-function buildSystemLookup(
-  systems: ReadonlyArray<SystemDto>,
-): SystemLookupMap {
-  const map = new Map<string, { code: string; name: string }>();
-  for (const system of systems) {
-    map.set(system.id, { code: system.code, name: system.name });
-  }
-  return map;
-}
+export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({ client }) => {
+  const { id: rawUserId } = useParams<{ id: string }>();
+  const hasValidUserId = isProbablyValidUserId(rawUserId);
+  const userId = hasValidUserId ? rawUserId.trim() : '';
 
-/**
- * Atribuição de roles a um usuário (Issue #71 / EPIC #48).
- *
- * Fluxo (espelhando `UserPermissionsShellPage` da Issue #70 e
- * `RolePermissionsShellPage` da Issue #69):
- *
- * 1. Carrega em paralelo `GET /roles` (catálogo paginado),
- *    `GET /systems` (lookup de `systemId -> {code, name}`) e
- *    `GET /users/{id}` (estado atual do usuário, incluindo array
- *    `roles`).
- * 2. Inicializa o set `chosenRoleIds` com os ids das roles do array
- *    `user.roles`.
- * 3. UI exibe lista agrupada por sistema; cada role tem um checkbox
- *    controlado e badges visuais (vínculo atual / pendente).
- * 4. Salvar calcula o diff client-side via `computeIdSetDiff` e
- *    dispara `assignRoleToUser`/`removeRoleFromUser` em paralelo.
- *    Falhas individuais não abortam o lote — agregamos um relatório.
- * 5. Após o salvar, refetch do `getUserById` sincroniza o estado com
- *    o backend (idempotência cobre divergências raras), e a UI
- *    automaticamente reflete em `effective-permissions` na Issue #70
- *    quando o usuário voltar para essa tela.
- *
- * **Visível com** `Roles.Read` + `Users.Update` (gating duplo via
- * `RequirePermission` na rota — ver `src/routes/index.tsx`). A página
- * assume que ambas as permissões já estão garantidas — não duplica a
- * checagem aqui.
- *
- * **Reuso (lição PR #134/#135):** o JSX da matriz vem de
- * `<AssignmentMatrixShell>` em `src/shared/listing/`, compartilhado
- * com `UserPermissionsShellPage`/`RolePermissionsShellPage`. O diff
- * usa `computeIdSetDiff`/`idSetDiffHasChanges` em
- * `src/shared/forms/`. O agrupamento usa `groupBySystem` em
- * `src/shared/listing/` (delegado por `groupRolesBySystem`). O que
- * fica **local** é apenas a copy da legenda e o render do `RoleGroup`.
- */
-export const UserRolesShellPage: React.FC<UserRolesShellPageProps> = ({
-  client,
-}) => {
-  const { id: userId } = useParams<{ id: string }>();
-  const hasValidUserId = isProbablyValidUserId(userId);
-
-  const toast = useToast();
-
-  const [matrixState, setMatrixState] = useState<{
-    isInitialLoading: boolean;
-    isSaving: boolean;
-    errorMessage: string | null;
-    fetched: FetchedState | null;
-    chosenRoleIds: ReadonlySet<string>;
-    baselineRoleIds: ReadonlySet<string>;
-    refreshTick: number;
-  }>({
-    isInitialLoading: true,
-    isSaving: false,
-    errorMessage: null,
-    fetched: null,
-    chosenRoleIds: new Set<string>(),
-    baselineRoleIds: new Set<string>(),
-    refreshTick: 0,
-  });
-
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  const handleRefetch = useCallback(() => {
-    setMatrixState((prev) => ({
-      ...prev,
-      isInitialLoading: true,
-      errorMessage: null,
-      refreshTick: prev.refreshTick + 1,
-    }));
-  }, []);
-
-  useEffect(() => {
-    if (!hasValidUserId) {
-      setMatrixState((prev) => ({ ...prev, isInitialLoading: false }));
-      return undefined;
-    }
-
-    let cancelled = false;
-    const controller = new AbortController();
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = controller;
-
-    Promise.all([
-      listRoles({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
-      listSystems({ pageSize: MAX_ROLES_PAGE_SIZE }, { signal: controller.signal }, client),
-      getUserById(userId, { signal: controller.signal }, client),
-    ])
-      .then(([rolesResponse, systemsResponse, user]) => {
-        if (cancelled) return;
-        const baselineRoleIds = buildInitialUserRoleIds(user.roles);
-        setMatrixState({
-          isInitialLoading: false,
-          isSaving: false,
-          errorMessage: null,
-          fetched: {
-            user,
-            roles: rolesResponse.data,
-            systemLookup: buildSystemLookup(systemsResponse.data),
-          },
-          chosenRoleIds: new Set(baselineRoleIds),
-          baselineRoleIds,
-          refreshTick: 0,
-        });
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
-        if (isFetchAborted(error)) return;
-        setMatrixState((prev) => ({
-          ...prev,
-          isInitialLoading: false,
-          errorMessage: extractErrorMessage(
-            error,
-            'Falha ao carregar as roles do usuário. Tente novamente.',
-          ),
-        }));
-      });
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [client, hasValidUserId, userId, matrixState.refreshTick]);
-
-  const groups = useMemo<ReadonlyArray<RoleSystemGroup>>(() => {
-    if (!matrixState.fetched) return [];
-    return groupRolesBySystem(matrixState.fetched.roles, matrixState.fetched.systemLookup);
-  }, [matrixState.fetched]);
-
-  const diff = useMemo(
-    () => computeIdSetDiff(matrixState.baselineRoleIds, matrixState.chosenRoleIds),
-    [matrixState.baselineRoleIds, matrixState.chosenRoleIds],
-  );
-  const hasUnsavedChanges = idSetDiffHasChanges(diff);
-
-  const handleToggleRole = useCallback((roleId: string, checked: boolean) => {
-    setMatrixState((prev) => {
-      const next = new Set(prev.chosenRoleIds);
-      if (checked) {
-        next.add(roleId);
-      } else {
-        next.delete(roleId);
-      }
-      return { ...prev, chosenRoleIds: next };
-    });
-  }, []);
-
-  const handleResetChanges = useCallback(() => {
-    setMatrixState((prev) => ({ ...prev, chosenRoleIds: new Set(prev.baselineRoleIds) }));
-  }, []);
-
-  const handleSave = useCallback(async () => {
-    if (!hasValidUserId || !hasUnsavedChanges || matrixState.isSaving) {
-      return;
-    }
-    setMatrixState((prev) => ({ ...prev, isSaving: true }));
-    const failures: RoleAssignmentFailure[] = [];
-    let addedSuccess = 0;
-    let removedSuccess = 0;
-
-    const addOps = diff.toAdd.map(async (roleId) => {
-      try {
-        await assignRoleToUser(userId, roleId, undefined, client);
-        addedSuccess += 1;
-      } catch (error: unknown) {
-        failures.push({
-          roleId,
-          kind: 'add',
-          message: extractErrorMessage(
-            error,
-            'Falha ao atribuir role. Tente novamente.',
-          ),
-        });
-      }
-    });
-
-    const removeOps = diff.toRemove.map(async (roleId) => {
-      try {
-        await removeRoleFromUser(userId, roleId, undefined, client);
-        removedSuccess += 1;
-      } catch (error: unknown) {
-        failures.push({
-          roleId,
-          kind: 'remove',
-          message: extractErrorMessage(
-            error,
-            'Falha ao remover role. Tente novamente.',
-          ),
-        });
-      }
-    });
-
-    await Promise.all([...addOps, ...removeOps]);
-
-    if (failures.length === 0) {
-      const appliedCount = addedSuccess + removedSuccess;
-      toast.show(
-        appliedCount === 1
-          ? '1 alteração de role aplicada com sucesso.'
-          : `${appliedCount} alterações de roles aplicadas com sucesso.`,
-        { variant: 'success', title: 'Roles atualizadas' },
-      );
-    } else {
-      const appliedCount = addedSuccess + removedSuccess;
-      const failureCount = failures.length;
-      const appliedSuffix = appliedCount > 0 ? `, ${appliedCount} aplicada(s)` : '';
-      toast.show(
-        `${failureCount} alteração(ões) falharam${appliedSuffix}. Revise e tente novamente.`,
-        { variant: 'warning', title: 'Algumas atualizações falharam' },
-      );
-    }
-
-    // Refetch após o salvar — backend é a fonte da verdade. Se houve
-    // falha parcial, o estado reflete o backend (não o esforço local).
-    setMatrixState((prev) => ({
-      ...prev,
-      isSaving: false,
-      isInitialLoading: true,
-      errorMessage: null,
-      refreshTick: prev.refreshTick + 1,
-    }));
-  }, [client, diff, hasUnsavedChanges, hasValidUserId, matrixState.isSaving, toast, userId]);
-
-  const pendingCount = diff.toAdd.length + diff.toRemove.length;
-
-  return (
-    <AssignmentMatrixShell<RoleSystemGroup>
-      eyebrow="06 Usuários · Roles"
-      title="Roles do usuário"
-      desc="Atribuição de roles. Permissões herdadas via roles ficam visíveis no painel de permissões efetivas após salvar."
-      backLink={{
-        to: hasValidUserId ? `/usuarios/${userId}` : '/usuarios',
-        label: hasValidUserId ? 'Voltar para o usuário' : 'Voltar para Usuários',
-      }}
-      invalidIdMessage={
-        hasValidUserId
-          ? undefined
-          : 'ID de usuário ausente ou inválido na URL. Volte para a listagem de usuários e selecione um para gerenciar roles.'
-      }
-      legendAriaLabel="Legenda de status das roles"
-      legend={
-        <>
-          <AssignmentLegendItem>
-            <Badge variant="success" dot>
-              Vinculada
-            </Badge>
-            <AssignmentLegendCopy>
-              role atualmente vinculada ao usuário.
-            </AssignmentLegendCopy>
-          </AssignmentLegendItem>
-          <AssignmentLegendItem>
-            <Badge variant="warning">Pendente</Badge>
-            <AssignmentLegendCopy>alteração ainda não salva.</AssignmentLegendCopy>
-          </AssignmentLegendItem>
-        </>
-      }
-      isInitialLoading={matrixState.isInitialLoading}
-      errorMessage={matrixState.errorMessage}
-      isEmpty={groups.length === 0}
-      isSaving={matrixState.isSaving}
-      hasUnsavedChanges={hasUnsavedChanges}
-      pendingCount={pendingCount}
-      groups={groups}
-      onReset={handleResetChanges}
-      onSave={handleSave}
-      onRetry={handleRefetch}
-      emptyTitle="Nenhuma role cadastrada no catálogo."
-      emptyHint="Cadastre roles na seção Roles antes de atribuir a um usuário."
-      loadingCopy="Carregando roles…"
-      groupsAriaLabel="Roles agrupadas por sistema"
-      testIdPrefix="user-roles"
-      renderGroup={(group) => (
-        <RoleGroup
-          key={group.systemId || group.systemCode}
-          group={group}
-          chosenRoleIds={matrixState.chosenRoleIds}
-          baselineRoleIds={matrixState.baselineRoleIds}
-          isSaving={matrixState.isSaving}
-          onToggle={handleToggleRole}
+  if (!hasValidUserId) {
+    return (
+      <>
+        <BackLink to="/usuarios" data-testid="user-roles-back">
+          <ArrowLeft size={12} strokeWidth={1.75} aria-hidden="true" />
+          Voltar para Usuários
+        </BackLink>
+        <PageHeader
+          eyebrow="06 Usuários · Roles"
+          title="Roles do usuário"
+          desc="Selecione um usuário para gerenciar roles por sistema."
         />
-      )}
-    />
-  );
+        <InvalidIdNotice data-testid="user-roles-invalid-id">
+          <Alert variant="warning">
+            ID de usuário ausente ou inválido na URL. Volte para a listagem de
+            usuários e selecione um para gerenciar roles.
+          </Alert>
+        </InvalidIdNotice>
+      </>
+    );
+  }
+
+  return <UserRolesPanel userId={userId} mode="fullPage" client={client} />;
 };
-
-interface RoleGroupProps {
-  group: RoleSystemGroup;
-  chosenRoleIds: ReadonlySet<string>;
-  baselineRoleIds: ReadonlySet<string>;
-  isSaving: boolean;
-  onToggle: (roleId: string, checked: boolean) => void;
-}
-
-const RoleGroup: React.FC<RoleGroupProps> = ({
-  group,
-  chosenRoleIds,
-  baselineRoleIds,
-  isSaving,
-  onToggle,
-}) => (
-  <AssignmentGroupCard data-testid={`user-roles-group-${group.systemCode}`}>
-    <AssignmentGroupHeaderRow
-      systemCode={group.systemCode}
-      systemName={group.systemName}
-      count={group.items.length}
-      countAriaLabel={`${group.items.length} roles neste sistema`}
-    />
-    <AssignmentItemList>
-      {group.items.map((role) => {
-        const checkboxChecked = chosenRoleIds.has(role.id);
-        const wasInitiallyLinked = baselineRoleIds.has(role.id);
-        const hasUnsavedChange = checkboxChecked !== wasInitiallyLinked;
-        return (
-          <AssignmentItemRow
-            key={role.id}
-            data-testid={`user-roles-item-${role.id}`}
-            data-pending={hasUnsavedChange || undefined}
-          >
-            <Checkbox
-              checked={checkboxChecked}
-              disabled={isSaving}
-              onChange={(checked) => onToggle(role.id, checked)}
-              aria-label={`${role.name} · ${role.code}`}
-              data-testid={`user-roles-checkbox-${role.id}`}
-            />
-            <AssignmentItemDetails>
-              <AssignmentItemTitleRow>
-                <AssignmentItemPrimaryText>{role.name}</AssignmentItemPrimaryText>
-                <AssignmentItemCodeChip>
-                  <Mono>{role.code}</Mono>
-                </AssignmentItemCodeChip>
-              </AssignmentItemTitleRow>
-              {role.description && (
-                <AssignmentItemDescription>{role.description}</AssignmentItemDescription>
-              )}
-              <AssignmentItemBadges>
-                {wasInitiallyLinked && (
-                  <Badge variant="success" dot>
-                    Vinculada
-                  </Badge>
-                )}
-                {hasUnsavedChange && (
-                  <Badge variant="warning">
-                    {checkboxChecked ? 'Adição pendente' : 'Remoção pendente'}
-                  </Badge>
-                )}
-              </AssignmentItemBadges>
-            </AssignmentItemDetails>
-          </AssignmentItemRow>
-        );
-      })}
-    </AssignmentItemList>
-  </AssignmentGroupCard>
-);

--- a/src/pages/users/userRolesHelpers.ts
+++ b/src/pages/users/userRolesHelpers.ts
@@ -1,3 +1,4 @@
+import { extractErrorMessage, isApiError } from '../../shared/api';
 import { groupBySystem, type SystemGroup } from '../../shared/listing';
 
 import type { RoleDto, UserRoleSummary } from '../../shared/api';
@@ -154,4 +155,70 @@ export function buildInitialUserRoleIds(
     ids.add(role.id);
   }
   return ids;
+}
+
+/**
+ * Mensagem ao falhar o carregamento inicial (catálogo de roles,
+ * sistemas ou usuário) — Issue #208.
+ */
+export function formatUserRolesPanelLoadError(
+  error: unknown,
+  fallback: string,
+): string {
+  if (isApiError(error) && error.kind === 'http') {
+    if (error.status === 404) {
+      return (
+        error.message ||
+        'Usuário não encontrado ou sem permissão para consultar as roles.'
+      );
+    }
+    if (error.status === 403) {
+      return (
+        error.message ||
+        'Você não tem permissão para carregar o catálogo de roles ou os vínculos deste usuário.'
+      );
+    }
+    if (error.status === 400) {
+      return error.message || 'Requisição inválida ao carregar roles.';
+    }
+  }
+  return extractErrorMessage(error, fallback);
+}
+
+/**
+ * Mensagem por falha em `assignRoleToUser` / `removeRoleFromUser`
+ * (Issue #208 — duplicidade idempotente no backend retorna 200/201;
+ * mensagens orientam 400/403/404).
+ */
+export function formatUserRoleMutationError(
+  error: unknown,
+  fallback: string,
+): string {
+  if (isApiError(error) && error.kind === 'http') {
+    if (error.status === 403) {
+      return (
+        error.message ||
+        'Permissão negada: sua conta não pode atribuir ou remover esta role.'
+      );
+    }
+    if (error.status === 404) {
+      return (
+        error.message ||
+        'Usuário, role ou vínculo não encontrado. Recarregue a página para sincronizar.'
+      );
+    }
+    if (error.status === 400) {
+      return (
+        error.message ||
+        'Não foi possível alterar o vínculo da role (dados inválidos ou role já vinculada).'
+      );
+    }
+    if (error.status === 409) {
+      return (
+        error.message ||
+        'Esta role já está vinculada a este usuário.'
+      );
+    }
+  }
+  return extractErrorMessage(error, fallback);
 }

--- a/tests/pages/users/UserDetailShellPage.test.tsx
+++ b/tests/pages/users/UserDetailShellPage.test.tsx
@@ -12,7 +12,13 @@ import {
   makePagedPermissions,
   makePermission,
 } from './__helpers__/userPermissionsTestHelpers';
-import { makeUser } from './__helpers__/userRolesTestHelpers';
+import {
+  makePagedRoles,
+  makePagedSystems,
+  makeRole,
+  makeSystem,
+  makeUser,
+} from './__helpers__/userRolesTestHelpers';
 
 import { ToastProvider } from '@/components/ui';
 import { UserDetailShellPage } from '@/pages/users';
@@ -46,6 +52,12 @@ function primeUserDetailHappyPath(
     }
     if (path.includes('/effective-permissions')) {
       return Promise.resolve([makeEffective()]);
+    }
+    if (path.startsWith('/roles')) {
+      return Promise.resolve(makePagedRoles([makeRole()]));
+    }
+    if (path.startsWith('/systems')) {
+      return Promise.resolve(makePagedSystems([makeSystem()]));
     }
     return Promise.reject(new Error(`URL não coberta pelo stub: ${path}`));
   });
@@ -89,12 +101,47 @@ describe('UserDetailShellPage', () => {
     expect(screen.getByTestId('user-detail-link-roles')).toBeInTheDocument();
     expect(screen.getByTestId('user-detail-link-effective')).toBeInTheDocument();
     expect(screen.getByTestId('user-detail-link-permissions-full')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Roles por sistema' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Permissões diretas' })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('user-roles-loading')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('user-roles-group-authenticator')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.queryByTestId('user-permissions-loading')).not.toBeInTheDocument();
     });
     expect(screen.getByTestId('user-permissions-group-authenticator')).toBeInTheDocument();
+  });
+
+  it('sem AUTH_V1_USERS_ROLES_ASSIGN: oculta painel de roles e exibe aviso', async () => {
+    permissionsMock = [
+      'AUTH_V1_USERS_GET_BY_ID',
+      'AUTH_V1_ROLES_LIST',
+      'AUTH_V1_PERMISSIONS_LIST',
+      'AUTH_V1_USERS_PERMISSIONS_ASSIGN',
+    ];
+
+    const client = createUserPermissionsClientStub();
+    primeUserDetailHappyPath(client);
+
+    render(
+      <ToastProvider>
+        <MemoryRouter initialEntries={[`/usuarios/${ID_USER}`]}>
+          <Routes>
+            <Route path="/usuarios/:id" element={<UserDetailShellPage client={client} />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-detail-summary')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('user-detail-roles-locked')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Roles por sistema' })).not.toBeInTheDocument();
   });
 
   it('sem AUTH_V1_USERS_PERMISSIONS_ASSIGN: oculta painel e exibe aviso', async () => {

--- a/tests/pages/users/UserRolesPage.test.tsx
+++ b/tests/pages/users/UserRolesPage.test.tsx
@@ -483,4 +483,74 @@ describe('UserRolesShellPage — salvar diff', () => {
       expect(client.get.mock.calls.length).toBeGreaterThan(initialGetCalls);
     });
   });
+
+  it('403 no assign refetch sincroniza estado anterior (checkbox desmarcado)', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([makeRole({ id: ID_ROLE_VIEWER, code: 'viewer' })]),
+      user: makeUser({ roles: [] }),
+    });
+    client.post.mockRejectedValue({
+      kind: 'http',
+      status: 403,
+      message: 'Sem permissão para vincular roles.',
+    });
+
+    renderUserRolesPage(client);
+    await waitForInitialFetch();
+
+    fireEvent.click(screen.getByTestId(`user-roles-checkbox-${ID_ROLE_VIEWER}`));
+    fireEvent.click(screen.getByTestId('user-roles-save'));
+
+    await waitFor(() => {
+      expect(client.post).toHaveBeenCalledTimes(1);
+    });
+
+    await waitForInitialFetch();
+    const checkbox = screen.getByTestId(
+      `user-roles-checkbox-${ID_ROLE_VIEWER}`,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(screen.getByTestId('user-roles-save')).toBeDisabled();
+  });
+});
+
+describe('UserRolesShellPage — ARO Issue #208', () => {
+  it('role já vinculada exibe selo Vinculada e checkbox marcado (kurtto)', async () => {
+    const client = createUserRolesClientStub();
+    primeStubResponses(client, {
+      roles: makePagedRoles([
+        makeRole({
+          id: 'r-kurtto-admin',
+          systemId: ID_SYS_KURTTO,
+          code: 'kurtto-admin',
+          name: 'Kurtto Admin',
+        }),
+      ]),
+      systems: makePagedSystems([
+        makeSystem({ id: ID_SYS_KURTTO, code: 'kurtto', name: 'Kurtto' }),
+      ]),
+      user: makeUser({
+        roles: [
+          makeUserRoleSummary({
+            id: 'r-kurtto-admin',
+            code: 'kurtto-admin',
+            name: 'Kurtto Admin',
+            systemId: ID_SYS_KURTTO,
+          }),
+        ],
+      }),
+    });
+
+    renderUserRolesPage(client);
+    await waitForInitialFetch();
+
+    expect(screen.getByTestId('user-roles-group-kurtto')).toBeInTheDocument();
+    const item = screen.getByTestId('user-roles-item-r-kurtto-admin');
+    expect(item).toHaveTextContent('Vinculada');
+    expect(
+      (screen.getByTestId('user-roles-checkbox-r-kurtto-admin') as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(screen.getByTestId('user-roles-save')).toBeDisabled();
+  });
 });

--- a/tests/pages/users/userRolesHelpers.test.ts
+++ b/tests/pages/users/userRolesHelpers.test.ts
@@ -4,6 +4,8 @@ import type { RoleDto, UserRoleSummary } from '@/shared/api';
 
 import {
   buildInitialUserRoleIds,
+  formatUserRoleMutationError,
+  formatUserRolesPanelLoadError,
   groupRolesBySystem,
 } from '@/pages/users/userRolesHelpers';
 
@@ -146,5 +148,39 @@ describe('buildInitialUserRoleIds', () => {
 
   it('undefined (array ausente) devolve set vazio', () => {
     expect(buildInitialUserRoleIds(undefined).size).toBe(0);
+  });
+});
+
+describe('formatUserRolesPanelLoadError (Issue #208)', () => {
+  it.each([
+    { status: 403 as const, needle: /permissão para carregar/ },
+    { status: 404 as const, needle: /não encontrado/ },
+    { status: 400 as const, needle: /inválida ao carregar/ },
+  ])('status $status — fallback orientativo', ({ status, needle }) => {
+    expect(formatUserRolesPanelLoadError({ kind: 'http', status, message: '' }, 'f')).toMatch(
+      needle,
+    );
+  });
+});
+
+describe('formatUserRoleMutationError (Issue #208)', () => {
+  it('prioriza message do backend em 403', () => {
+    expect(
+      formatUserRoleMutationError(
+        { kind: 'http', status: 403, message: 'Policy negada.' },
+        'f',
+      ),
+    ).toBe('Policy negada.');
+  });
+
+  it.each([
+    { status: 403 as const, needle: /Permissão negada/ },
+    { status: 404 as const, needle: /Recarregue a página/ },
+    { status: 400 as const, needle: /já vinculada/ },
+    { status: 409 as const, needle: /já está vinculada/ },
+  ])('status $status — fallback orientativo', ({ status, needle }) => {
+    expect(formatUserRoleMutationError({ kind: 'http', status, message: '' }, 'f')).toMatch(
+      needle,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Extrai `UserRolesPanel` (modos `fullPage` e `embedded`) reutilizado pela rota `/usuarios/:id/roles` e pelo detalhe do usuário.
- Integra gestão de roles por sistema na tela de detalhe (`UserDetailShellPage`), espelhando o padrão de `UserDirectPermissionsPanel` (#203).
- Adiciona mensagens orientativas para erros de carregamento e mutação (400/403/404/409) via `formatUserRolesPanelLoadError` e `formatUserRoleMutationError`.

## Test plan

- [x] Visualizar roles agrupadas por sistema (selo **Vinculada** quando já atribuída)
- [x] Atribuir role kurtto via checkbox + Salvar
- [x] Remover vínculo sem apagar role do catálogo
- [x] Refetch após salvar / falha 403 preserva baseline
- [x] Detalhe do usuário exibe painel embedded com RBAC
- [x] `docker compose run --rm web npm run lint`
- [x] `docker compose run --rm web npm run typecheck`
- [x] `docker compose run --rm web npm test` (1652 testes)
- [x] `docker compose run --rm web npx jscpd src --threshold 3 --min-lines 10` (1.11% total)

## Riscos

- Alteração de autorização de usuários — fluxo já existia na rota dedicada; agora também no detalhe.

Closes #208

Made with [Cursor](https://cursor.com)