### PR TITLE
#212 | E2E: Infraestrutura Playwright no repositório

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ VITE_AUTH_VERIFY_INTERVAL_MS=300000
 # o boot do apiClient falha imediatamente (fail-fast em src/shared/api/index.ts).
 VITE_SYSTEM_ID=dc9e6357-4a98-4058-865e-a41e474c45b7
 PORT=3002
+# URL do SPA nos testes E2E (sobrescreve o padrão do playwright.config.ts)
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3002

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,6 +40,13 @@ module.exports = {
         'sonarjs/cognitive-complexity': 'off',
       },
     },
+    {
+      files: ['e2e/**/*.{ts,tsx,js,jsx}'],
+      rules: {
+        'sonarjs/no-duplicate-string': 'off',
+        'sonarjs/cognitive-complexity': 'off',
+      },
+    },
   ],
   rules: {
     'react/react-in-jsx-scope': 'off',
@@ -58,7 +65,10 @@ module.exports = {
     // por isso ignoramos esse padrão para evitar falso-positivo no lint
     // sem precisar adicionar `eslint-import-resolver-typescript` (que tem
     // conflito de peer deps com a versão atual do `@typescript-eslint`).
-    'import/no-unresolved': ['error', { ignore: ['^@/'] }],
+    'import/no-unresolved': [
+      'error',
+      { ignore: ['^@/', '^@playwright/'] },
+    ],
     'import/order': [
       'error',
       {

--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,9 @@ jscpd-report/
 jscpd-report-base/
 
 .claude/worktrees/*
+
+# Playwright E2E
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ lfc-admin-gui/
 | `start` | Alias para `dev` |
 | `build` | Typecheck e build de produção |
 | `preview` | Sobe o bundle de produção localmente |
-| `test` | Executa testes com Vitest |
+| `test` | Executa testes unitários/de componente com Vitest |
+| `e2e` | Executa testes E2E com Playwright (sobe o dev server automaticamente) |
+| `e2e:ui` | Abre o Playwright UI Mode para depuração interativa dos E2E |
 
 ---
 
@@ -273,13 +275,49 @@ docker compose down
 
 ## Testes automatizados
 
-<!-- TODO: definir estratégia de testes ao longo das primeiras issues. Sugestão de pirâmide:
+### Unitários e componentes (Vitest)
 
-- **Unitários**: Vitest / Jest — utils, hooks, formatadores
-- **Componentes**: React Testing Library — renderização, interação, acessibilidade
-- **E2E**: Playwright ou Cypress — fluxos críticos (login, CRUD de sistemas, atribuição de permissões)
-- **Mocks do auth-service**: MSW (Mock Service Worker) para isolar o SPA em CI
--->
+```bash
+docker compose run --rm web npm test
+```
+
+### E2E (Playwright)
+
+Os testes E2E usam a **imagem oficial do Playwright** (`docker compose` serviço `e2e`), pois o container `web` (Alpine) não executa o Chromium do Playwright.
+
+Na **primeira vez fora do Docker** (ou após atualizar `@playwright/test`), instale o Chromium:
+
+```bash
+npm run e2e:install
+```
+
+Equivalente: `npx playwright install chromium` após `npm ci`.
+
+Variáveis relevantes (ver também `.env.example`):
+
+| Variável | Descrição |
+|----------|-----------|
+| `PLAYWRIGHT_BASE_URL` | URL do SPA sob teste (padrão: `http://127.0.0.1:3002`) |
+| `VITE_SYSTEM_ID` / `VITE_AUTH_API_BASE_URL` | Injetadas no `webServer` do Playwright para o Vite subir sem `.env` local |
+
+Executar a suíte smoke (sobe o dev server via `playwright.config.ts`):
+
+```bash
+docker compose run --rm e2e
+```
+
+Fora do Docker: `npm run e2e`.
+
+Modo UI (depuração interativa; requer display ou X11):
+
+```bash
+docker compose run --rm e2e npm run e2e:ui
+```
+
+Estrutura:
+
+- `e2e/` — specs, fixtures (`e2e/fixtures`) e page objects (`e2e/pages`)
+- `playwright.config.ts` — projeto Chromium, `baseURL` via `PLAYWRIGHT_BASE_URL`
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,18 @@
 services:
+  # E2E: imagem oficial do Playwright (glibc + browsers). O serviço `web` usa
+  # Alpine e não suporta execução do Chromium do Playwright.
+  e2e:
+    image: mcr.microsoft.com/playwright:v1.52.0-noble
+    working_dir: /app
+    volumes:
+      - .:/app
+      - e2e_node_modules:/app/node_modules
+    environment:
+      CI: "true"
+    ipc: host
+    init: true
+    command: sh -c "npm ci --include=dev && npm run e2e"
+
   web:
     build:
       context: .
@@ -14,3 +28,6 @@ services:
     volumes:
       - .:/app
       - /app/node_modules
+
+volumes:
+  e2e_node_modules:

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,0 +1,9 @@
+import { test as base } from '@playwright/test';
+
+/**
+ * Fixture base do projeto. Estenda aqui (`test.extend`) quando precisar de
+ * contexto compartilhado (ex.: sessão autenticada, API helpers).
+ */
+export const test = base;
+
+export { expect } from '@playwright/test';

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -1,0 +1,14 @@
+import type { Locator, Page } from '@playwright/test';
+
+/** Page Object da rota `/login` (smoke e fluxos futuros de autenticação). */
+export class LoginPage {
+  readonly heading: Locator;
+
+  constructor(private readonly page: Page) {
+    this.heading = page.getByRole('heading', { name: 'Entrar no painel' });
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/login');
+  }
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from './fixtures';
+import { LoginPage } from './pages/login.page';
+
+test.describe('smoke', () => {
+  test('carrega a página de login', async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await expect(loginPage.heading).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "styled-components": "^6.4.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.8.1",
         "@types/react": "^19.2.2",
@@ -1384,6 +1385,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -6288,6 +6305,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "styled-components": "^6.4.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.8.1",
     "@types/react": "^19.2.2",
@@ -40,8 +41,11 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "e2e": "PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0 playwright test",
+    "e2e:install": "playwright install chromium",
+    "e2e:ui": "PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0 playwright test --ui",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint \"{src,tests}/**/*.{ts,tsx,js,jsx}\" --max-warnings 0",
+    "lint": "eslint \"{src,tests,e2e}/**/*.{ts,tsx,js,jsx}\" --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"{src,public}/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"{src,public}/**/*.{ts,tsx,js,jsx,json,css,md}\"",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * URL do SPA sob teste. Sobrescreva com `PLAYWRIGHT_BASE_URL` (ex.: em CI ou
+ * quando o dev server roda em outra porta/host).
+ */
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3002';
+
+/** Variáveis mínimas para o Vite subir sem `.env` local (smoke E2E). */
+const webServerEnv: Record<string, string> = {
+  VITE_SYSTEM_ID:
+    process.env.VITE_SYSTEM_ID ?? '00000000-0000-0000-0000-000000000000',
+  VITE_AUTH_API_BASE_URL:
+    process.env.VITE_AUTH_API_BASE_URL ?? 'http://127.0.0.1:8080/api/v1',
+  PORT: process.env.PORT ?? '3002',
+  HOST: '127.0.0.1',
+};
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    launchOptions: {
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 3002',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: webServerEnv,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src", "tests", "vite.config.ts"]
+  "include": ["src", "tests", "e2e", "vite.config.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Adiciona `@playwright/test` com `playwright.config.ts` (Chromium, `PLAYWRIGHT_BASE_URL`, webServer Vite)
- Estrutura `e2e/` com fixtures, page object de login e smoke (`goto /login`)
- Scripts `npm run e2e`, `e2e:ui`, `e2e:install`; artifacts ignorados no `.gitignore`
- Serviço Docker `e2e` (imagem oficial Playwright) — container `web` (Alpine) não executa Chromium
- README documenta instalação de browsers e execução via Docker

Closes #212

## Alterações realizadas

| Área | Detalhe |
|------|---------|
| Deps | `@playwright/test@^1.52.0` |
| Config | `playwright.config.ts`, `tsconfig` inclui `e2e` |
| E2E | `e2e/fixtures`, `e2e/pages/login.page.ts`, `e2e/smoke.spec.ts` |
| Docker | `docker compose run --rm e2e` |
| Lint | `e2e/` no glob; ignore `@playwright/*` no import resolver |

## Riscos

- Token do programmer sem escopo `read:project` — card no Command Center não pôde ser movido para **In progress** via API (pendência operacional)
- E2E no serviço `web` (Alpine) falha ao lançar Chromium; usar serviço `e2e` ou host com `npm run e2e:install`
- `PLAYWRIGHT_CHROMIUM_USE_HEADLESS_SHELL=0` nos scripts evita ENOENT em ambientes sem headless shell

## Evidências de teste

```bash
docker compose run --rm web sh -c 'npm ci --include=dev && npm run lint && npm run typecheck && npm test'
docker compose run --rm web sh -c 'npm ci --include=dev && npx jscpd src --threshold 3 --min-lines 10 --reporters console,json --output ./jscpd-report'
docker compose run --rm e2e
```

- **lint**: 0 erros, 0 warnings
- **typecheck**: OK
- **test (Vitest)**: suíte verde
- **jscpd**: `statistics.total.percentage` ≤ 3%, `newClones === 0` nos arquivos do diff
- **e2e**: `1 passed` — smoke login (`Entrar no painel` visível)

## Test plan

- [ ] `docker compose run --rm e2e` passa no CI/review
- [ ] `npm run lint` e `npm run typecheck` no container `web`
- [ ] README E2E revisado

Made with [Cursor](https://cursor.com)