### PR TITLE
#213 | E2E: Ambiente Docker E2E (GUI + authenticator)

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,35 @@
+# Copie para .env.e2e na raiz do lfc-admin-gui:
+#   cp .env.e2e.example .env.e2e
+#
+# Use em todos os comandos do stack E2E:
+#   docker compose --env-file .env.e2e -f docker-compose.e2e.yml ...
+
+# Caminho do repositório lfc-authenticator (auth-service) relativo à raiz deste repo.
+# Padrão no compose: ../auth-service (sibling checkout).
+# LFC_AUTH_SERVICE_PATH=../auth-service
+
+# PostgreSQL do stack E2E (serviço db).
+POSTGRES_PASSWORD=DevPassword123!
+
+# Senha do usuário root seedado pelo authenticator (Development).
+DEFAULT_SYSTEM_USER_PASSWORD=toor
+
+# Porta do SPA no host (serviço web).
+PORT=3002
+
+# Porta do authenticator no host (HTTPS Kestrel 5042 no container).
+AUTH_HOST_PORT=8080
+
+# UUID do sistema "authenticator" — obrigatório para login no SPA.
+# Após a primeira subida da stack, obtenha com:
+#   docker compose -f docker-compose.e2e.yml exec -T db \
+#     psql -U auth -d AuthenticatorDb -tAc \
+#     "SELECT \"Id\" FROM \"Systems\" WHERE \"Code\" = 'authenticator' LIMIT 1;"
+# Cole o valor abaixo e reinicie o serviço web:
+#   docker compose -f docker-compose.e2e.yml up -d web
+VITE_SYSTEM_ID=00000000-0000-0000-0000-000000000000
+
+VITE_APP_NAME=Auth Admin E2E
+
+# Playwright (serviço e2e com profile e2e)
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3002

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### dotenv ###
 .env
+.env.e2e
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:

--- a/README.md
+++ b/README.md
@@ -285,6 +285,69 @@ docker compose run --rm web npm test
 
 Os testes E2E usam a **imagem oficial do Playwright** (`docker compose` serviço `e2e`), pois o container `web` (Alpine) não executa o Chromium do Playwright.
 
+#### Pré-requisitos
+
+- Docker e Docker Compose v2
+- Repositório [`lfc-authenticator`](https://github.com/LF-Calegari/lfc-authenticator) (`auth-service`) clonado como **sibling** do `lfc-admin-gui` (padrão: `../auth-service` a partir da raiz deste repo)
+- Arquivo `.env.e2e` na raiz (copie de `.env.e2e.example`)
+
+```bash
+cp .env.e2e.example .env.e2e
+```
+
+Se o `auth-service` estiver em outro caminho, defina `LFC_AUTH_SERVICE_PATH` no `.env.e2e` ou exporte antes do `compose`.
+
+#### Stack E2E completa (GUI + API + PostgreSQL)
+
+O arquivo `docker-compose.e2e.yml` sobe, em uma rede isolada:
+
+| Serviço | Função |
+|---------|--------|
+| `db` | PostgreSQL do authenticator |
+| `migrate` | Aplica migrations EF (one-shot) |
+| `authenticator` | API `lfc-authenticator` (HTTPS na porta 5042 do container) |
+| `web` | Dev server Vite do admin-gui com proxy `/api/v1` → authenticator |
+
+Subir a stack (primeira execução pode levar alguns minutos por `npm ci` e `dotnet ef`):
+
+```bash
+docker compose --env-file .env.e2e -f docker-compose.e2e.yml up --build
+```
+
+Use `--env-file .env.e2e` para interpolar variáveis do compose (`AUTH_HOST_PORT`, `PORT`, etc.). Se a porta `8080` já estiver em uso no host, defina `AUTH_HOST_PORT=8081` no `.env.e2e`.
+
+**Healthchecks:** `db`, `authenticator` e `web` ficam *healthy* quando a API e o Vite respondem. O authenticator expõe `https://localhost:8080` no host (porta configurável via `AUTH_HOST_PORT`).
+
+**Proxy `/api/v1`:** o SPA usa `VITE_AUTH_API_BASE_URL=/api/v1` (URL relativa). O Vite encaminha para `AUTH_API_PROXY_TARGET=https://authenticator:5042` na rede Docker. Validar no host:
+
+```bash
+# API direta (HTTPS, certificado de desenvolvimento)
+curl -sk https://localhost:8080/api/v1/health
+
+# Mesmo endpoint via proxy do Vite
+curl -s http://localhost:3002/api/v1/health
+```
+
+Ambos devem retornar JSON com `"status":"ok"`.
+
+**`VITE_SYSTEM_ID`:** após a primeira subida com migrations, o UUID do sistema `authenticator` é gerado no banco. Obtenha e atualize `.env.e2e`:
+
+```bash
+docker compose --env-file .env.e2e -f docker-compose.e2e.yml exec -T db \
+  psql -U auth -d AuthenticatorDb -tAc \
+  "SELECT \"Id\" FROM \"Systems\" WHERE \"Code\" = 'authenticator' LIMIT 1;"
+```
+
+Reinicie o serviço `web` (`docker compose --env-file .env.e2e -f docker-compose.e2e.yml up -d web`). Personas E2E seedadas ficam na issue **#214**; o usuário root padrão do Development usa `DEFAULT_SYSTEM_USER_PASSWORD` (ver `.env.e2e.example`).
+
+**Testes Playwright na stack** (não sobe outro dev server — usa `PLAYWRIGHT_SKIP_WEBSERVER`):
+
+```bash
+docker compose --env-file .env.e2e -f docker-compose.e2e.yml --profile e2e run --rm e2e
+```
+
+#### Playwright sem stack completa (apenas GUI)
+
 Na **primeira vez fora do Docker** (ou após atualizar `@playwright/test`), instale o Chromium:
 
 ```bash
@@ -293,12 +356,14 @@ npm run e2e:install
 
 Equivalente: `npx playwright install chromium` após `npm ci`.
 
-Variáveis relevantes (ver também `.env.example`):
+Variáveis relevantes (ver também `.env.example` e `.env.e2e.example`):
 
 | Variável | Descrição |
 |----------|-----------|
 | `PLAYWRIGHT_BASE_URL` | URL do SPA sob teste (padrão: `http://127.0.0.1:3002`) |
+| `PLAYWRIGHT_SKIP_WEBSERVER` | `1` na stack E2E — reutiliza o serviço `web` já em execução |
 | `VITE_SYSTEM_ID` / `VITE_AUTH_API_BASE_URL` | Injetadas no `webServer` do Playwright para o Vite subir sem `.env` local |
+| `AUTH_API_PROXY_TARGET` | Alvo do proxy Vite (`/api/v1`); usado na stack E2E, não commitar segredo |
 
 Executar a suíte smoke (sobe o dev server via `playwright.config.ts`):
 
@@ -318,6 +383,7 @@ Estrutura:
 
 - `e2e/` — specs, fixtures (`e2e/fixtures`) e page objects (`e2e/pages`)
 - `playwright.config.ts` — projeto Chromium, `baseURL` via `PLAYWRIGHT_BASE_URL`
+- `docker-compose.e2e.yml` — stack GUI + authenticator + DB para E2E local
 
 ---
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,150 @@
+# Stack E2E: admin-gui + lfc-authenticator (auth-service) + PostgreSQL.
+# Uso: cp .env.e2e.example .env.e2e
+#      docker compose --env-file .env.e2e -f docker-compose.e2e.yml up --build
+# Testes: docker compose --env-file .env.e2e -f docker-compose.e2e.yml --profile e2e run --rm e2e
+#
+# Requer o repositório auth-service como sibling (../auth-service) ou LFC_AUTH_SERVICE_PATH.
+
+name: lfc-admin-gui-e2e
+
+services:
+  db:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_USER: auth
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-DevPassword123!}
+      POSTGRES_DB: AuthenticatorDb
+    volumes:
+      - e2e_pg_data:/var/lib/postgresql/data
+    networks:
+      - e2e
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U auth -d AuthenticatorDb']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  migrate:
+    build:
+      context: ${LFC_AUTH_SERVICE_PATH:-../auth-service}
+      dockerfile: Dockerfile
+    environment:
+      ConnectionStrings__DefaultConnection: 'Host=db;Port=5432;Database=AuthenticatorDb;Username=auth;Password=${POSTGRES_PASSWORD:-DevPassword123!}'
+    volumes:
+      - ${LFC_AUTH_SERVICE_PATH:-../auth-service}/AuthService:/app
+    working_dir: /app
+    networks:
+      - e2e
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: 'no'
+    command:
+      [
+        'sh',
+        '-c',
+        'rm -rf obj bin && dotnet restore && dotnet tool restore && dotnet ef database update',
+      ]
+
+  authenticator:
+    build:
+      context: ${LFC_AUTH_SERVICE_PATH:-../auth-service}
+      dockerfile: Dockerfile
+    container_name: lfc-e2e-authenticator
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: 'Host=db;Port=5432;Database=AuthenticatorDb;Username=auth;Password=${POSTGRES_PASSWORD:-DevPassword123!}'
+      DEFAULT_SYSTEM_USER_PASSWORD: '${DEFAULT_SYSTEM_USER_PASSWORD:-toor}'
+    ports:
+      - '${AUTH_HOST_PORT:-8080}:5042'
+    volumes:
+      - ${LFC_AUTH_SERVICE_PATH:-../auth-service}/AuthService:/app
+    working_dir: /app
+    networks:
+      - e2e
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    # dotnet run (sem watch) — mais estável que hot-reload na stack E2E.
+    command: sh -c 'dotnet restore && dotnet run --no-launch-profile'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -fk https://127.0.0.1:5042/api/v1/health | grep -q ok',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env.e2e
+    environment:
+      PORT: ${PORT:-3002}
+      HOST: 0.0.0.0
+      CHOKIDAR_USEPOLLING: 'true'
+      # Browser usa URL relativa; Vite faz proxy para o authenticator na rede interna.
+      VITE_AUTH_API_BASE_URL: /api/v1
+      AUTH_API_PROXY_TARGET: https://authenticator:5042
+      VITE_SYSTEM_ID: ${VITE_SYSTEM_ID:-00000000-0000-0000-0000-000000000000}
+      VITE_APP_NAME: ${VITE_APP_NAME:-Auth Admin E2E}
+    ports:
+      - '${PORT:-3002}:${PORT:-3002}'
+    volumes:
+      - .:/app
+      - e2e_web_node_modules:/app/node_modules
+    networks:
+      - e2e
+    depends_on:
+      authenticator:
+        condition: service_healthy
+    command: sh -c "npm ci --include=dev && npm run dev -- --host 0.0.0.0 --port ${PORT:-3002}"
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:' + (process.env.PORT || 3002)).then((r) => process.exit(r.status < 500 ? 0 : 1)).catch(() => process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 120s
+
+  e2e:
+    image: mcr.microsoft.com/playwright:v1.52.0-noble
+    profiles: [e2e]
+    working_dir: /app
+    volumes:
+      - .:/app
+      - e2e_node_modules:/app/node_modules
+    environment:
+      CI: 'true'
+      PLAYWRIGHT_SKIP_WEBSERVER: '1'
+      PLAYWRIGHT_BASE_URL: http://web:${PORT:-3002}
+      VITE_SYSTEM_ID: ${VITE_SYSTEM_ID:-00000000-0000-0000-0000-000000000000}
+      VITE_AUTH_API_BASE_URL: /api/v1
+    ipc: host
+    init: true
+    networks:
+      - e2e
+    depends_on:
+      web:
+        condition: service_healthy
+    command: sh -c 'npm ci --include=dev && npm run e2e'
+
+volumes:
+  e2e_pg_data:
+  e2e_web_node_modules:
+  e2e_node_modules:
+
+networks:
+  e2e:
+    driver: bridge

--- a/docs/e2e/pr-checklist.md
+++ b/docs/e2e/pr-checklist.md
@@ -8,7 +8,7 @@ Use este checklist em **toda PR** que adiciona ou altera testes Playwright no `l
 
 - [ ] Branch no padrão `feature/<issue>/descricao-curta` (ex.: `feature/220/e2e-systems`)
 - [ ] Card da issue filha em **In progress** no [LFC Command Center](https://github.com/orgs/LF-Calegari/projects/2)
-- [ ] Spec executada localmente: `docker compose -f docker-compose.e2e.yml run --rm e2e` (ou comando documentado em #212/#213)
+- [ ] Spec executada localmente: `docker compose --env-file .env.e2e -f docker-compose.e2e.yml --profile e2e run --rm e2e` (ou comando documentado em #212/#213)
 - [ ] Cada `test()` novo referencia `@matrix-id` existente em [traceability-matrix.md](./traceability-matrix.md)
 
 ---

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,11 +41,13 @@ export default defineConfig({
       },
     },
   ],
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 3002',
-    url: baseURL,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    env: webServerEnv,
-  },
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command: 'npm run dev -- --host 127.0.0.1 --port 3002',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        env: webServerEnv,
+      },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,16 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const port = Number(env.PORT) || 3002;
+  const proxyTarget = env.AUTH_API_PROXY_TARGET?.trim().replace(/\/$/, '');
+  const apiProxy = proxyTarget
+    ? {
+        '/api/v1': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        },
+      }
+    : undefined;
 
   return {
     plugins: [react()],
@@ -18,10 +28,12 @@ export default defineConfig(({ mode }) => {
     server: {
       host: true,
       port,
+      proxy: apiProxy,
     },
     preview: {
       host: true,
       port,
+      proxy: apiProxy,
     },
     test: {
       globals: true,


### PR DESCRIPTION
## Summary

- Adiciona `docker-compose.e2e.yml` com PostgreSQL, migrate EF, `lfc-authenticator` e admin-gui (`web`) com healthchecks.
- Configura proxy Vite `/api/v1` → authenticator via `AUTH_API_PROXY_TARGET` e `VITE_AUTH_API_BASE_URL=/api/v1`.
- Documenta pré-requisitos, `.env.e2e.example` e comandos com `--env-file .env.e2e`.
- Playwright na stack usa `PLAYWRIGHT_SKIP_WEBSERVER=1` (serviço `web` já em execução).

Closes #213

## Alterações

| Arquivo | Descrição |
|---------|-----------|
| `docker-compose.e2e.yml` | Stack E2E (db, migrate, authenticator, web, profile `e2e`) |
| `.env.e2e.example` | Variáveis do stack (paths, portas, `VITE_SYSTEM_ID`) |
| `vite.config.ts` | Proxy condicional `/api/v1` |
| `playwright.config.ts` | `webServer` opcional quando `PLAYWRIGHT_SKIP_WEBSERVER=1` |
| `README.md` | Seção stack E2E completa |
| `docs/e2e/pr-checklist.md` | Comando compose atualizado |

## Riscos

- Primeira subida do `authenticator` depende de restore NuGet (rede) e migrations; `start_period` ampliado no healthcheck.
- `VITE_SYSTEM_ID` é gerado no seed — após primeira subida é necessário consultar o banco e reiniciar `web` (documentado; personas seed em #214).
- Porta `8080` no host pode conflitar — usar `AUTH_HOST_PORT` no `.env.e2e` e `--env-file`.

## Evidências de teste

### Stack healthy

```bash
cp .env.e2e.example .env.e2e
docker compose --env-file .env.e2e -f docker-compose.e2e.yml up --build -d
docker compose --env-file .env.e2e -f docker-compose.e2e.yml ps
# db, authenticator, web → (healthy)
```

### Proxy `/api/v1`

```bash
curl -sk https://localhost:8081/api/v1/health   # AUTH_HOST_PORT=8081 no ambiente de validação
# {"status":"ok","message":"API is running"}

curl -s http://localhost:3002/api/v1/health
# {"status":"ok","message":"API is running"}
```

### Gate pré-PR (container `web`)

- `npm run lint` — OK (0 warnings)
- `npm run typecheck` — OK (após `npm ci`)
- `npm test` — OK (85 files, 1652 tests)
- `jscpd src` — total 1.11% (< 3%), sem clones novos nos arquivos do diff

## Test plan

- [ ] `docker compose --env-file .env.e2e -f docker-compose.e2e.yml up --build`
- [ ] `curl` direto na API e via proxy do Vite (comandos acima)
- [ ] Obter `VITE_SYSTEM_ID` via `psql` documentado e reiniciar `web`
- [ ] (Opcional) `docker compose --env-file .env.e2e -f docker-compose.e2e.yml --profile e2e run --rm e2e`

Made with [Cursor](https://cursor.com)